### PR TITLE
Replace $ with get

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -23,7 +23,7 @@
   import { IconDots, Island, Spinner, Tag } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
-  import type { Writable } from "svelte/store";
+  import { get, type Writable } from "svelte/store";
   import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import WalletMorePopover from "./WalletMorePopover.svelte";
@@ -84,7 +84,7 @@
     setSelectedAccount();
 
     // We found an account in store for the provided account identifier, all data are set
-    if (nonNullish($selectedAccountStore.account)) {
+    if (nonNullish(get(selectedAccountStore).account)) {
       return { state: "loaded" };
     }
 


### PR DESCRIPTION
# Motivation

After upgrading the test dependencies (https://github.com/dfinity/nns-dapp/pull/5482), the Wallet test doesn’t pass. This could be an issue specific to [the test](https://github.com/dfinity/nns-dapp/pull/5482/files#r1806490235), but using get instead of $ in areas that don’t rely on dynamic updates might be a good idea.

# Changes

- Replace $ with get.

# Tests

- Pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary