### PR TITLE
Stop using beforeAll and afterAll

### DIFF
--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -160,10 +160,6 @@ describe("neurons api-service", () => {
     resetNeuronsApiService();
   });
 
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   // Read calls
 
   describe("queryNeuron", () => {

--- a/frontend/src/tests/lib/api/accounts.api.spec.ts
+++ b/frontend/src/tests/lib/api/accounts.api.spec.ts
@@ -7,11 +7,8 @@ import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "vitest-mock-extended";
 
 describe("accounts-api", () => {
-  afterAll(() => {
-    vi.clearAllMocks();
-  });
-
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -25,17 +25,10 @@ import { mock } from "vitest-mock-extended";
 describe("ckbtc-minter api", () => {
   const minterCanisterMock = mock<CkBTCMinterCanister>();
 
-  beforeAll(() => {
+  beforeEach(() => {
     vi.spyOn(CkBTCMinterCanister, "create").mockImplementation(
       () => minterCanisterMock
     );
-  });
-
-  afterAll(() => {
-    vi.clearAllMocks();
-  });
-
-  beforeEach(() => {
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -23,6 +23,8 @@ describe("proposals-api", () => {
   let spyListProposals;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+
     vi.spyOn(GovernanceCanister, "create").mockImplementation(
       (): GovernanceCanister => mockGovernanceCanister
     );
@@ -135,10 +137,6 @@ describe("proposals-api", () => {
     const nnsDappMock = mock<NNSDappCanister>();
     nnsDappMock.getProposalPayload.mockResolvedValue({});
     vi.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
-
-    afterAll(() => {
-      vi.clearAllMocks();
-    });
 
     it("should call the canister to get proposal payload", async () => {
       const spyGetProposalPayload = vi.spyOn(nnsDappMock, "getProposalPayload");

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -92,9 +92,7 @@ describe("sns-api", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-  });
 
-  beforeAll(() => {
     vi.spyOn(LedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -76,7 +76,7 @@ describe("sns-api", () => {
   const stakeNeuronSpy = vi.fn().mockResolvedValue(mockSnsNeuron.id);
   const increaseStakeNeuronSpy = vi.fn();
 
-  beforeAll(() => {
+  beforeEach(() => {
     vi.spyOn(LedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );
@@ -107,11 +107,6 @@ describe("sns-api", () => {
         getLifecycle: getLifecycleSpy,
       })
     );
-  });
-
-  afterAll(() => {
-    vi.clearAllMocks();
-    vi.restoreAllMocks();
   });
 
   it("should query sns metadata", async () => {

--- a/frontend/src/tests/lib/components/accounts/CkBTCInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCInfoCard.spec.ts
@@ -22,13 +22,6 @@ import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("CkBTCInfoCard", () => {
-  beforeAll(() => {
-    page.mock({
-      data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Wallet,
-    });
-  });
-
   const props = {
     account: mockCkBTCMainAccount,
     minterCanisterId: CKTESTBTC_MINTER_CANISTER_ID,
@@ -47,6 +40,11 @@ describe("CkBTCInfoCard", () => {
     vi.clearAllMocks();
     bitcoinAddressStore.reset();
     ckBTCInfoStore.reset();
+
+    page.mock({
+      data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
+      routeId: AppPath.Wallet,
+    });
   });
 
   describe("not matching bitcoin address store", () => {

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -66,10 +66,6 @@ describe("CkBTCTransactionList", () => {
     vi.useFakeTimers().setSystemTime(new Date());
   });
 
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   it("should render burn without memo as BTC Sent to BTC Network", async () => {
     const errorLog = [];
     vi.spyOn(console, "error").mockImplementation((msg) => {

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletConnect.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletConnect.spec.ts
@@ -16,7 +16,7 @@ vi.mock("$lib/proxy/icp-ledger.services.proxy");
 describe("HardwareWalletConnect", () => {
   const props = { testComponent: HardwareWalletConnect };
 
-  beforeAll(() => {
+  beforeEach(() => {
     addAccountStoreMock.set({
       type: "hardwareWallet",
       hardwareWalletName: undefined,
@@ -33,16 +33,6 @@ describe("HardwareWalletConnect", () => {
     (registerHardwareWalletProxy as Mock).mockImplementation(async () => {
       // Do nothing test
     });
-  });
-
-  afterAll(() => {
-    addAccountStoreMock.set({
-      type: undefined,
-      hardwareWalletName: undefined,
-    });
-
-    vi.clearAllMocks();
-    vi.restoreAllMocks();
   });
 
   it("should render a connect action", () => {

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
@@ -11,14 +11,9 @@ import WalletContextTest from "./WalletContextTest.svelte";
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 
 describe("HardwareWalletListNeuronsButton", () => {
-  afterAll(() => {
-    vi.clearAllMocks();
-    vi.restoreAllMocks();
-  });
-
   let spy;
 
-  beforeAll(() => {
+  beforeEach(() => {
     spy = (listNeuronsHardwareWalletProxy as Mock).mockImplementation(
       async () => ({
         neurons: [mockNeuron],

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
@@ -88,10 +88,6 @@ describe("IcrcWalletTransactionList", () => {
     vi.useFakeTimers().setSystemTime(new Date());
   });
 
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   it("should call service to load transactions", () => {
     const spy = vi.spyOn(services, "loadIcrcAccountNextTransactions");
 

--- a/frontend/src/tests/lib/components/canisters/CanisterCardCycles.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/CanisterCardCycles.spec.ts
@@ -23,11 +23,8 @@ vitest.mock("$lib/services/worker-cycles.services", () => ({
 }));
 
 describe("CanisterCardCycles", () => {
-  beforeEach(() => (cyclesCallback = undefined));
-
-  afterAll(() => {
-    vitest.clearAllMocks();
-    vitest.resetAllMocks();
+  beforeEach(() => {
+    cyclesCallback = undefined;
   });
 
   const props = { props: { canister: mockCanister } };

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -63,6 +63,7 @@ describe("MenuItems", () => {
   };
 
   beforeEach(() => {
+    resetMockedConstants();
     menuStore.resetForTesting();
     layoutMenuOpen.set(false);
     vi.useFakeTimers();
@@ -267,10 +268,6 @@ describe("MenuItems", () => {
       expect(await menuItemsPo.getTotalValueLockedLinkPo().getHref()).toBe(
         "https://dashboard.internetcomputer.org/neurons"
       );
-
-      afterAll(() => {
-        resetMockedConstants();
-      });
     });
   });
 });

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -171,7 +171,7 @@ describe("ProjectCard", () => {
   });
 
   describe("not signed in", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       setNoIdentity();
     });
 

--- a/frontend/src/tests/lib/components/layout/Layout.spec.ts
+++ b/frontend/src/tests/lib/components/layout/Layout.spec.ts
@@ -17,14 +17,16 @@ vi.mock("$lib/services/public/worker-metrics.services", () => ({
 }));
 
 describe("Layout", () => {
+  beforeEach(() => {
+    layoutTitleStore.set({ title: "" });
+  });
+
   describe("Main layout", () => {
-    beforeAll(() =>
+    beforeEach(() => {
       layoutTitleStore.set({
         title: "the header",
-      })
-    );
-
-    afterAll(() => layoutTitleStore.set({ title: "" }));
+      });
+    });
 
     it("should render a menu button", () => {
       const { getByTestId } = render(LayoutTest, { props: { spy: undefined } });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
@@ -29,17 +29,12 @@ describe("ProposalVotingSection", () => {
     neuronId,
   }));
 
-  beforeAll(() =>
+  beforeEach(() =>
     neuronsStore.setNeurons({
       neurons: [...neurons, ineligibleNeuron],
       certified: true,
     })
   );
-
-  afterAll(() => {
-    neuronsStore.setNeurons({ neurons: [], certified: true });
-    vi.resetAllMocks();
-  });
 
   const proposalInfo = {
     ...mockProposalInfo,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -17,8 +17,10 @@ import {
 } from "@dfinity/sns";
 
 describe("SnsNeuronFollowingCard", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     resetIdentity();
+    resetSnsProjects();
   });
 
   describe("user has permissions to manage followees", () => {
@@ -71,11 +73,6 @@ describe("SnsNeuronFollowingCard", () => {
         Component: SnsNeuronFollowingCard,
         neuron,
       });
-
-    beforeEach(() => {
-      vi.clearAllMocks();
-      resetSnsProjects();
-    });
 
     it("renders followees and their topics", () => {
       // Use same rootCanisterId as in `renderSelectedSnsNeuronContext`
@@ -140,10 +137,6 @@ describe("SnsNeuronFollowingCard", () => {
         Component: SnsNeuronFollowingCard,
         neuron,
       });
-
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
 
     it("does not render button to follow neurons", () => {
       const { queryByTestId } = renderCard(uncontrolledNeuron);

--- a/frontend/src/tests/lib/components/sns-neurons/SetSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SetSnsDissolveDelay.spec.ts
@@ -31,7 +31,7 @@ describe("ConfirmSnsDissolveDelay", () => {
   };
 
   // freeze time
-  beforeAll(() => {
+  beforeEach(() => {
     vi.useFakeTimers().setSystemTime(Date.now());
 
     setSnsProjects([
@@ -39,10 +39,6 @@ describe("ConfirmSnsDissolveDelay", () => {
         rootCanisterId: mockPrincipal,
       },
     ]);
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
   });
 
   it("renders a delay", () => {

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalVotingSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalVotingSection.spec.ts
@@ -52,10 +52,6 @@ describe("SnsProposalVotingSection", () => {
     vi.useFakeTimers().setSystemTime(0);
   });
 
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   it("should render vote results", async () => {
     const po = await renderComponent();
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -39,14 +39,12 @@ describe("SelectUniverseList", () => {
   );
 
   beforeEach(() => {
+    vi.clearAllMocks();
+
     page.mock({
       routeId: AppPath.Accounts,
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
-  });
-
-  afterAll(() => {
-    vi.clearAllMocks();
   });
 
   it("should render universe cards", () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -40,10 +40,6 @@ describe("SelectUniverseNav", () => {
     });
   });
 
-  afterAll(() => {
-    vi.clearAllMocks();
-  });
-
   it("should render select universe component", async () => {
     const po = await renderComponent();
     expect(await po.getSelectUniverseCardPo().isPresent()).toEqual(true);

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
@@ -22,10 +22,6 @@ describe("SelectUniverseNavList", () => {
     });
   });
 
-  afterAll(() => {
-    vi.clearAllMocks();
-  });
-
   it("should render universe cards as buttons", () => {
     const { getAllByRole } = render(SelectUniverseNavList);
     // 1 for Sns project + 1 for Internet Computer / NNS + 1 for ckBTC + 1 for ckTESTBTC

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -41,11 +41,10 @@ import { render } from "@testing-library/svelte";
 
 describe("UniverseAccountsBalance", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     resetSnsProjects();
     icrcAccountsStore.reset();
-  });
 
-  beforeAll(() => {
     page.mock({
       data: { universe: mockSnsCanisterId.toText() },
     });
@@ -57,10 +56,6 @@ describe("UniverseAccountsBalance", () => {
     vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
       mockProjectSubscribe([mockSnsFullProject])
     );
-  });
-
-  afterAll(() => {
-    vi.clearAllMocks();
   });
 
   // Not the same sns canister id to test that the balance is not displayed
@@ -88,10 +83,6 @@ describe("UniverseAccountsBalance", () => {
     vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
       mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
     );
-
-    afterAll(() => {
-      vi.clearAllMocks();
-    });
 
     it("should render a total balance for Nns", () => {
       const { getByTestId } = render(ProjectAccountsBalance, {

--- a/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
+++ b/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
@@ -35,6 +35,7 @@ vi.mock("$lib/constants/environment.constants.ts", async () => {
 
 describe("Warnings", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     metricsCallback = undefined;
   });
 
@@ -42,11 +43,6 @@ describe("Warnings", () => {
     beforeEach(() => {
       metricsStore.set(undefined);
       toastsStore.reset();
-    });
-
-    afterAll(() => {
-      vi.clearAllMocks();
-      vi.resetAllMocks();
     });
 
     const transactionRateHighLoad: DashboardMessageExecutionRateResponse = {

--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -19,7 +19,7 @@ describe("universes-accounts-balance.derived", () => {
   const rootCanisterId = mockSnsFullProject.rootCanisterId;
   const ledgerCanisterId = mockSnsFullProject.summary.ledgerCanisterId;
 
-  beforeAll(() => {
+  beforeEach(() => {
     setSnsProjects([
       {
         rootCanisterId,
@@ -30,10 +30,6 @@ describe("universes-accounts-balance.derived", () => {
       ledgerCanisterId,
       accounts: { accounts: [mockSnsMainAccount], certified: true },
     });
-  });
-
-  afterAll(() => {
-    vi.clearAllMocks();
   });
 
   it("should derive a balance of Nns accounts", () => {

--- a/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
@@ -19,15 +19,15 @@ import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("universes-tokens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe("complete data set", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       vi.spyOn(tokensStore, "subscribe").mockImplementation(
         mockTokensSubscribe(mockUniversesTokens)
       );
-    });
-
-    afterAll(() => {
-      vi.clearAllMocks();
     });
 
     it("should derive Nns token only", () => {
@@ -69,16 +69,12 @@ describe("universes-tokens", () => {
   });
 
   describe("ckBTC empty", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       vi.spyOn(tokensStore, "subscribe").mockImplementation(
         mockTokensSubscribe({
           [OWN_CANISTER_ID.toText()]: NNS_TOKEN,
         })
       );
-    });
-
-    afterAll(() => {
-      vi.clearAllMocks();
     });
 
     it("should derive no ckBTC token", () => {

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -19,10 +19,6 @@ vi.mock("$lib/services/icp-accounts.services", () => {
 });
 
 describe("IcpTransactionModal", () => {
-  beforeAll(() => {
-    resetIdentity();
-  });
-
   const renderTransactionModal = () =>
     renderModal({
       component: IcpTransactionModal,
@@ -36,6 +32,8 @@ describe("IcpTransactionModal", () => {
   };
 
   beforeEach(() => {
+    resetIdentity();
+
     vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
       mockAccountsStoreSubscribe([mockSubAccount])
     );

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
@@ -1,5 +1,6 @@
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import NnsStakeMaturityModal from "$lib/modals/neurons/NnsStakeMaturityModal.svelte";
+import * as neuronsServices from "$lib/services/neurons.services";
 import { stakeMaturity } from "$lib/services/neurons.services";
 import { formattedMaturity } from "$lib/utils/neuron.utils";
 import {
@@ -12,15 +13,16 @@ import { selectPercentage } from "$tests/utils/neurons-modal.test-utils";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-vi.mock("$lib/services/neurons.services", () => {
-  return {
-    stakeMaturity: vi.fn().mockResolvedValue({ success: true }),
-    mergeMaturity: vi.fn().mockResolvedValue({ success: true }),
-    getNeuronFromStore: vi.fn(),
-  };
-});
-
 describe("NnsStakeMaturityModal", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(neuronsServices, "stakeMaturity").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(neuronsServices, "getNeuronFromStore").mockReturnValue(undefined);
+  });
+
   const neuronIc = {
     ...mockNeuron,
     fullNeuron: {
@@ -97,7 +99,7 @@ describe("NnsStakeMaturityModal", () => {
   });
 
   describe("HW", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
         mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
       );

--- a/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -26,15 +26,11 @@ describe("SpawnNeuronModal", () => {
     },
   };
 
-  beforeAll(() =>
+  beforeEach(() => {
     setAccountsForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
-    })
-  );
-
-  afterAll(() => {
-    vi.clearAllMocks();
+    });
   });
 
   it("should display modal", async () => {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
@@ -40,11 +40,8 @@ describe("SnsStakeNeuronModal", () => {
       },
     });
 
-  beforeAll(() => {
-    resetIdentity();
-  });
-
   beforeEach(() => {
+    resetIdentity();
     resetSnsProjects();
     icrcAccountsStore.reset();
 

--- a/frontend/src/tests/lib/modals/sns/neurons/SplitSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SplitSnsNeuronModal.spec.ts
@@ -29,10 +29,6 @@ describe("SplitSnsNeuronModal", () => {
       },
     });
 
-  afterAll(() => {
-    vi.clearAllMocks();
-  });
-
   it("should display modal", async () => {
     const { container } = await renderSplitNeuronModal();
 

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -70,11 +70,8 @@ describe("TransactionModal", () => {
       },
     });
 
-  beforeAll(() => {
-    resetIdentity();
-  });
-
   beforeEach(() => {
+    resetIdentity();
     resetSnsProjects();
     icrcAccountsStore.reset();
 

--- a/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
+++ b/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
@@ -17,14 +17,10 @@ describe("SelectUniverseModal", () => {
     mockProjectSubscribe([mockSnsFullProject])
   );
 
-  beforeAll(() => {
+  beforeEach(() => {
     page.mock({
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
-  });
-
-  afterAll(() => {
-    vi.clearAllMocks();
   });
 
   it("should render title", async () => {

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -115,6 +115,7 @@ describe("CkBTCWallet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.clearAllTimers();
+    vi.useRealTimers();
     tokensStore.reset();
     ckBTCInfoStore.reset();
     bitcoinAddressStore.reset();
@@ -285,10 +286,6 @@ describe("CkBTCWallet", () => {
             : mockCkBTCMainAccount.balanceUlps
         );
       });
-    });
-
-    afterAll(() => {
-      vi.useRealTimers();
     });
 
     it("should render ckTESTBTC name", async () => {

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -116,6 +116,7 @@ describe("IcrcWallet", () => {
     balancesObserverCallback = undefined;
     vi.clearAllMocks();
     vi.clearAllTimers();
+    vi.useRealTimers();
     vi.restoreAllMocks();
     tokensStore.reset();
     overrideFeatureFlagsStore.reset();
@@ -260,10 +261,6 @@ describe("IcrcWallet", () => {
             : mockCkETHMainAccount.balanceUlps
         );
       });
-    });
-
-    afterAll(() => {
-      vi.useRealTimers();
     });
 
     it("should render Icrc token name", async () => {

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -901,10 +901,6 @@ describe("NnsWallet", () => {
       accountIdentifier: mockHardwareWalletAccount.identifier,
     };
 
-    afterAll(() => {
-      vi.clearAllMocks();
-    });
-
     it("should display principal", async () => {
       const po = await renderWallet(props);
 

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -161,7 +161,7 @@ describe("Wallet", () => {
   });
 
   describe("sns context", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       page.mock({
         data: { universe: mockSnsFullProject.rootCanisterId.toText() },
         routeId: AppPath.Wallet,

--- a/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -23,6 +23,11 @@ describe("auth-services", () => {
   });
 
   beforeAll(() => {
+    // CAUTION: This replaces window.location but history.replaceState still
+    // changes the original value of window.location so code looking at the
+    // replaced value of window.location will not see such changes.
+    // So if we do this in beforeEach instead of beforeAll, it results in
+    // changes caused by tests being copied over to the new replaced value.
     Object.defineProperty(window, "location", {
       writable: true,
       value: {
@@ -30,10 +35,6 @@ describe("auth-services", () => {
         reload: vi.fn(),
       },
     });
-  });
-
-  afterAll(() => {
-    window.location = originalLocation;
   });
 
   describe("auth-client", () => {

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -125,7 +125,7 @@ describe("icp-ledger.services", () => {
 
     let spySyncAccounts;
 
-    beforeAll(() => {
+    beforeEach(() => {
       vi.spyOn(NNSDappCanister, "create").mockImplementation(
         (): NNSDappCanister => mockNNSDappCanister
       );
@@ -267,7 +267,7 @@ describe("icp-ledger.services", () => {
   describe("show info on ledger", () => {
     let spy;
 
-    beforeAll(() => {
+    beforeEach(() => {
       vi.spyOn(LedgerIdentity, "create").mockImplementation(
         async (): Promise<LedgerIdentity> => mockLedgerIdentity
       );
@@ -308,14 +308,14 @@ describe("icp-ledger.services", () => {
   describe("query neurons", () => {
     const mockNeurons = [mockNeuron];
 
-    beforeAll(() => {
+    beforeEach(() => {
       vi.spyOn(api, "queryNeurons").mockImplementation(() =>
         Promise.resolve(mockNeurons)
       );
     });
 
     describe("success", () => {
-      beforeAll(() => {
+      beforeEach(() => {
         vi.spyOn(LedgerIdentity, "create").mockImplementation(
           async (): Promise<LedgerIdentity> => mockLedgerIdentity
         );
@@ -336,7 +336,7 @@ describe("icp-ledger.services", () => {
     });
 
     describe("error", () => {
-      beforeAll(() => {
+      beforeEach(() => {
         vi.spyOn(LedgerIdentity, "create").mockImplementation(
           async (): Promise<LedgerIdentity> => {
             throw new LedgerErrorKey({ message: "error__ledger.please_open" });

--- a/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -12,7 +12,7 @@ describe("auth-store", () => {
   mockAuthClient.isAuthenticated.mockResolvedValue(false);
   mockAuthClient.logout.mockResolvedValue(undefined);
 
-  beforeAll(() => {
+  beforeEach(() => {
     vi.spyOn(AuthClient, "create").mockImplementation(
       async (): Promise<AuthClient> => mockAuthClient
     );

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -8,15 +8,8 @@ describe("env-utils", () => {
   describe("isNnsAlternativeOrigin", () => {
     let location;
 
-    beforeAll(() => {
+    beforeEach(() => {
       location = window.location;
-    });
-
-    afterAll(() => {
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: { ...location },
-      });
     });
 
     const setOrigin = (origin: string) => {

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -49,6 +49,7 @@ describe("project-utils", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   describe("filter", () => {
@@ -170,9 +171,6 @@ describe("project-utils", () => {
       vi.useFakeTimers().setSystemTime(now);
     });
 
-    afterAll(() => {
-      vi.useRealTimers();
-    });
     it("should return duration until swap deadline", () => {
       const dueSeconds = 3600;
       const dueTimestampSeconds = BigInt(nowInSeconds() + dueSeconds);
@@ -193,9 +191,6 @@ describe("project-utils", () => {
       vi.useFakeTimers().setSystemTime(now);
     });
 
-    afterAll(() => {
-      vi.useRealTimers();
-    });
     it("should return duration until swap deadline", () => {
       const dueSeconds = 3600;
       const dueTimestampSeconds = BigInt(nowInSeconds() + dueSeconds);

--- a/frontend/src/tests/routes/app/proposals/layout.spec.ts
+++ b/frontend/src/tests/routes/app/proposals/layout.spec.ts
@@ -8,10 +8,6 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Layout", () => {
-  afterAll(() => {
-    vi.clearAllMocks();
-  });
-
   it("should go back to the proposal page", async () => {
     page.mock({
       data: {

--- a/frontend/src/tests/routes/app/settings/layout.spec.ts
+++ b/frontend/src/tests/routes/app/settings/layout.spec.ts
@@ -9,7 +9,7 @@ import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Layout", () => {
-  beforeAll(() => {
+  beforeEach(() => {
     vi.resetAllMocks();
   });
 


### PR DESCRIPTION
# Motivation

We should almost never be using `beforeAll` and `afterAll`.
Cleanup should be done in the top-level `beforeEach`. Setup should be done in `beforeEach` at the appropriate level.
Cleanup in top-level `afterAll` is pointless because the environment stops existing immediately after.
Cleanup `afterAll` in a smaller `describe` block should be done in top-level `beforeEach` instead.

# Changes

1. Remove top-level `afterAll`.
2. Move sub-level `afterAll` to top-level `beforeEach`.
3. Change `beforeAll` to (or merge with) `beforeEach`.
4. In `frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts` moved some mocking from the global scope to `beforeEach` otherwise `restoreAllMocks` undoes that mocking.
5. In `frontend/src/tests/lib/services/auth.services.spec.ts` added a comment explaining the confusing consequences of mocking `window.location` and why it doesn't work in `beforeEach`.

# Tests

Tests still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary