### PR TITLE
NNS1-3397: Initialize dissolve delay to 7 days

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Provide better error messages when the transaction timestamp is off.
 * A link to the imported tokens documentation page.
 * Refresh NNS neurons from neuron details page if needed.
+* Inform the user in the staking modal that the minimum dissolve delay for NNS neurons is 7 days.
 
 #### Changed
 

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -81,6 +81,8 @@
   on:submit|preventDefault={createNeuron}
   data-tid="nns-stake-neuron-component"
 >
+  <p class="description">{$i18n.neurons.icp_will_be_locked}</p>
+
   <TransactionFromAccount
     bind:selectedAccount={account}
     canSelectSource={true}

--- a/frontend/src/lib/constants/constants.ts
+++ b/frontend/src/lib/constants/constants.ts
@@ -11,6 +11,7 @@ export const MINUTES_IN_HOUR = 60;
 export const HOURS_IN_DAY = 24;
 export const SECONDS_IN_HOUR = SECONDS_IN_MINUTE * MINUTES_IN_HOUR;
 export const SECONDS_IN_DAY = SECONDS_IN_HOUR * HOURS_IN_DAY;
+export const SECONDS_IN_7_DAYS = 7 * SECONDS_IN_DAY;
 // Taking into account 1/4 of leap year
 export const SECONDS_IN_YEAR = ((4 * 365 + 1) * SECONDS_IN_DAY) / 4;
 export const SECONDS_IN_HALF_YEAR = SECONDS_IN_YEAR / 2;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -1,4 +1,7 @@
-import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
+import {
+  SECONDS_IN_7_DAYS,
+  SECONDS_IN_HALF_YEAR,
+} from "$lib/constants/constants";
 import { enumValues } from "$lib/utils/enum.utils";
 import { Topic } from "@dfinity/nns";
 
@@ -12,6 +15,7 @@ export const MAX_NEURON_ID_DIGITS = 20;
 
 export const MAX_DISSOLVE_DELAY_BONUS = 1; // = +100%
 export const MAX_AGE_BONUS = 0.25; // = +25%
+export const NNS_MINIMUM_DISSOLVE_DELAY = SECONDS_IN_7_DAYS;
 export const NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE = SECONDS_IN_HALF_YEAR;
 
 const FIRST_TOPICS = [

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -251,6 +251,7 @@
     "title": "Neurons",
     "text": "Earn voting rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by submitting and voting on Network Nervous System (NNS) proposals.",
     "stake_token": "Stake $token",
+    "icp_will_be_locked": "Your ICP will be locked for at least 7 days.",
     "merge_neurons": "Merge Neurons",
     "merge_neurons_modal_title": "Select two neurons to merge",
     "merge_neurons_modal_confirm": "Confirm merge",

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -119,7 +119,13 @@
       close();
     }
   }
+
   let delayInSeconds = 0;
+
+  const updateDelayFromNeuron = (neuron: NeuronInfo | undefined) => {
+    delayInSeconds = Number(neuron?.dissolveDelaySeconds ?? 0);
+  };
+  $: updateDelayFromNeuron(newNeuron);
 
   // If source account is a hardware wallet, ask user to add a hotkey
   const extendWizardSteps = async () => {

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -125,6 +125,8 @@
   const updateDelayFromNeuron = (neuron: NeuronInfo | undefined) => {
     delayInSeconds = Number(neuron?.dissolveDelaySeconds ?? 0);
   };
+  // If we update delayInSeconds directly, then it doesn't get updated by the
+  // binding from SetNnsDissolveDelay.
   $: updateDelayFromNeuron(newNeuron);
 
   // If source account is a hardware wallet, ask user to add a hotkey

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -263,6 +263,7 @@ interface I18nNeurons {
   title: string;
   text: string;
   stake_token: string;
+  icp_will_be_locked: string;
   merge_neurons: string;
   merge_neurons_modal_title: string;
   merge_neurons_modal_confirm: string;


### PR DESCRIPTION
# Motivation

There was a recent change in the governance canister where new neurons are created with a dissolve delay of 7 days.

# Changes

1. Add a sentence in the stake modal to inform the user that their ICP will be locked.
2. Populate the dissolve delay input field with the current dissolve delay of the neuron instead of 0.

# Tests

1. Change the new neuron returned in the unit test to have a dissolve delay of 7 days.
2. Test that the input field starts out being set to 7.
3. Change the expectation of the dissolve delay increase by reducing by the initial dissolve delay.
4. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [x] Add entry to changelog (if necessary).
