### PR TITLE
Sort svelte imports

### DIFF
--- a/frontend/src/lib/components/accounts/AddAccountType.svelte
+++ b/frontend/src/lib/components/accounts/AddAccountType.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import {
-    type AccountType,
     ADD_ACCOUNT_CONTEXT_KEY,
+    type AccountType,
     type AddAccountContext,
   } from "$lib/types/add-account.context";
   import { Card } from "@dfinity/gix-components";

--- a/frontend/src/lib/components/accounts/CkBTCInfoCard.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCInfoCard.svelte
@@ -18,12 +18,12 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import {
-    SkeletonText,
-    Spinner,
-    QRCode,
     Copy,
     Html,
     IconQRCode,
+    QRCode,
+    SkeletonText,
+    Spinner,
   } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
 

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -14,13 +14,13 @@
   import type { CanisterId } from "$lib/types/canister";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import type {
-    UiTransaction,
     IcrcTransactionData,
+    UiTransaction,
   } from "$lib/types/transaction";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import {
-    mapCkbtcTransactions,
     mapCkbtcPendingUtxo,
+    mapCkbtcTransactions,
   } from "$lib/utils/icrc-transactions.utils";
   import type { PendingUtxo } from "@dfinity/ckbtc";
   import { isNullish } from "@dfinity/utils";

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -4,35 +4,35 @@
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
   import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
   import SignInGuard from "$lib/components/common/SignInGuard.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { debugSelectedAccountStore } from "$lib/derived/debug.derived";
+  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import { syncAccounts as syncWalletAccounts } from "$lib/services/icrc-accounts.services";
+  import { removeImportedTokens } from "$lib/services/imported-tokens.services";
+  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { toastsError } from "$lib/stores/toasts.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import type { Universe } from "$lib/types/universe";
   import type { WalletStore } from "$lib/types/wallet.context";
   import {
     findAccountOrDefaultToMain,
     hasAccounts,
   } from "$lib/utils/accounts.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { isImportedToken as checkImportedToken } from "$lib/utils/imported-tokens.utils";
+  import ImportTokenRemoveConfirmation from "./ImportTokenRemoveConfirmation.svelte";
+  import WalletMorePopover from "./WalletMorePopover.svelte";
   import { IconDots, Island, Spinner, Tag } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
   import { get, type Writable } from "svelte/store";
-  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import WalletMorePopover from "./WalletMorePopover.svelte";
-  import { isImportedToken as checkImportedToken } from "$lib/utils/imported-tokens.utils";
-  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import { removeImportedTokens } from "$lib/services/imported-tokens.services";
-  import ImportTokenRemoveConfirmation from "./ImportTokenRemoveConfirmation.svelte";
-  import type { Universe } from "$lib/types/universe";
-  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
 
   export let testId: string = "icrc-wallet-page";
   export let accountIdentifier: string | undefined | null = undefined;

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
@@ -15,8 +15,8 @@
   import type { CanisterId } from "$lib/types/canister";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import type {
-    UiTransaction,
     IcrcTransactionData,
+    UiTransaction,
   } from "$lib/types/transaction";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import {

--- a/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { Copy } from "@dfinity/gix-components";
-  import { nonNullish } from "@dfinity/utils";
   import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
+  import { Copy } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
+  import { nonNullish } from "@dfinity/utils";
 
   export let label: string;
   export let testId: string = "import-token-canister-id-component";

--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import type { Principal } from "@dfinity/principal";
+  import ImportTokenCanisterId from "$lib/components/accounts/ImportTokenCanisterId.svelte";
+  import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import PrincipalInput from "$lib/components/ui/PrincipalInput.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { Html } from "@dfinity/gix-components";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import { createEventDispatcher } from "svelte";
-  import { isNullish } from "@dfinity/utils";
-  import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
-  import ImportTokenCanisterId from "$lib/components/accounts/ImportTokenCanisterId.svelte";
   import { IconOpenInNew } from "@dfinity/gix-components";
+  import type { Principal } from "@dfinity/principal";
+  import { isNullish } from "@dfinity/utils";
+  import { createEventDispatcher } from "svelte";
 
   export let ledgerCanisterId: Principal | undefined = undefined;
   export let indexCanisterId: Principal | undefined = undefined;

--- a/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
   import UniverseSummary from "$lib/components/universe/UniverseSummary.svelte";
-  import type { Universe } from "$lib/types/universe";
   import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import type { Universe } from "$lib/types/universe";
   import { Tag } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
 

--- a/frontend/src/lib/components/accounts/ImportTokenReview.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenReview.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import type { Principal } from "@dfinity/principal";
-  import { i18n } from "$lib/stores/i18n";
-  import { createEventDispatcher } from "svelte";
-  import type { IcrcTokenMetadata } from "$lib/types/icrc";
-  import Logo from "$lib/components/ui/Logo.svelte";
   import ImportTokenCanisterId from "$lib/components/accounts/ImportTokenCanisterId.svelte";
   import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import type { Principal } from "@dfinity/principal";
+  import { createEventDispatcher } from "svelte";
 
   export let ledgerCanisterId: Principal;
   export let indexCanisterId: Principal | undefined = undefined;

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -5,8 +5,8 @@
   import Identifier from "$lib/components/ui/Identifier.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type {
-    UiTransaction,
     TransactionIconType,
+    UiTransaction,
   } from "$lib/types/transaction";
   import TransactionIcon from "./TransactionIcon.svelte";
   import { KeyValuePair } from "@dfinity/gix-components";

--- a/frontend/src/lib/components/accounts/TransactionIcon.svelte
+++ b/frontend/src/lib/components/accounts/TransactionIcon.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { TransactionIconType } from "$lib/types/transaction";
   import {
-    IconReimbursed,
-    IconErrorOutline,
-    IconUp,
     IconDown,
+    IconErrorOutline,
+    IconReimbursed,
+    IconUp,
   } from "@dfinity/gix-components";
 
   export let type: TransactionIconType;

--- a/frontend/src/lib/components/accounts/WalletMorePopover.svelte
+++ b/frontend/src/lib/components/accounts/WalletMorePopover.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import Separator from "../ui/Separator.svelte";
   import { IconBin, Popover } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { nonNullish } from "@dfinity/utils";
-  import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import Separator from "../ui/Separator.svelte";
   import { createEventDispatcher } from "svelte";
 
   export let anchor: HTMLElement | undefined;

--- a/frontend/src/lib/components/canisters/CanisterCardCycles.svelte
+++ b/frontend/src/lib/components/canisters/CanisterCardCycles.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { CanisterDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import {
-    type CyclesWorker,
     initCyclesWorker,
+    type CyclesWorker,
   } from "$lib/services/worker-cycles.services";
   import { i18n } from "$lib/stores/i18n";
   import type { CanisterSync } from "$lib/types/canister";

--- a/frontend/src/lib/components/header/AccountDetails.svelte
+++ b/frontend/src/lib/components/header/AccountDetails.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
-  import { authStore } from "$lib/stores/auth.store";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
-  import TooltipIcon from "../ui/TooltipIcon.svelte";
-  import IdentifierHash from "../ui/IdentifierHash.svelte";
-  import { nonNullish } from "@dfinity/utils";
+  import { authStore } from "$lib/stores/auth.store";
+  import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import IdentifierHash from "../ui/IdentifierHash.svelte";
+  import TooltipIcon from "../ui/TooltipIcon.svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   let principalId: string | undefined;
   let accountId: string | undefined;

--- a/frontend/src/lib/components/header/LinkToCanisters.svelte
+++ b/frontend/src/lib/components/header/LinkToCanisters.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+  import { beforeNavigate } from "$app/navigation";
+  import { canistersPathStore } from "$lib/derived/paths.derived";
   import { i18n } from "$lib/stores/i18n";
   import { IconExplore } from "@dfinity/gix-components";
-  import { canistersPathStore } from "$lib/derived/paths.derived";
   import { createEventDispatcher } from "svelte";
-  import { beforeNavigate } from "$app/navigation";
 
   const dispatcher = createEventDispatcher();
 

--- a/frontend/src/lib/components/ic/GetTokensModal.svelte
+++ b/frontend/src/lib/components/ic/GetTokensModal.svelte
@@ -7,13 +7,13 @@
     getTestIcpAccountBalance,
   } from "$lib/api/dev.api";
   import Input from "$lib/components/ui/Input.svelte";
+  import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { snsLedgerCanisterIdsStore } from "$lib/derived/sns/sns-canisters.derived";
   import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
   import { tokensByUniverseIdStore } from "$lib/derived/tokens.derived";
   import { universesStore } from "$lib/derived/universes.derived";
-  import { getICPs, getBTC, getIcrcTokens } from "$lib/services/dev.services";
-  import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
+  import { getBTC, getICPs, getIcrcTokens } from "$lib/services/dev.services";
   import { toastsError } from "$lib/stores/toasts.store";
   import type { Universe } from "$lib/types/universe";
   import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -9,7 +9,7 @@
   } from "$lib/types/nns-neuron-detail.context";
   import type { NnsNeuronModalVotingHistory } from "$lib/types/nns-neuron-detail.modal";
   import { emit } from "$lib/utils/events.utils";
-  import { type FolloweesNeuron, getTopicTitle } from "$lib/utils/neuron.utils";
+  import { getTopicTitle, type FolloweesNeuron } from "$lib/utils/neuron.utils";
   import { Copy, Tag } from "@dfinity/gix-components";
   import type { Topic } from "@dfinity/nns";
   import { getContext } from "svelte";

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
@@ -5,10 +5,10 @@
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import {
-    type FolloweesNeuron,
     followeesNeurons,
-    isNeuronControllable,
     isHotKeyControllable,
+    isNeuronControllable,
+    type FolloweesNeuron,
   } from "$lib/utils/neuron.utils";
   import FollowNeuronsButton from "../actions/FollowNeuronsButton.svelte";
   import Followee from "./Followee.svelte";

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { authStore } from "$lib/stores/auth.store";
+  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
   import { secondsToDate, secondsToDateTime } from "$lib/utils/date.utils";
@@ -12,6 +13,7 @@
   } from "$lib/utils/neuron.utils";
   import NnsNeuronAge from "../neurons/NnsNeuronAge.svelte";
   import Hash from "../ui/Hash.svelte";
+  import NnsNeuronPublicVisibilityAction from "./NnsNeuronPublicVisibilityAction.svelte";
   import JoinCommunityFundCheckbox from "./actions/JoinCommunityFundCheckbox.svelte";
   import NnsAutoStakeMaturity from "./actions/NnsAutoStakeMaturity.svelte";
   import SplitNnsNeuronButton from "./actions/SplitNnsNeuronButton.svelte";
@@ -23,8 +25,6 @@
   } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
-  import NnsNeuronPublicVisibilityAction from "./NnsNeuronPublicVisibilityAction.svelte";
-  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
@@ -15,7 +15,7 @@
   import IncreaseDissolveDelayButton from "./actions/IncreaseDissolveDelayButton.svelte";
   import { IconClockNoFill } from "@dfinity/gix-components";
   import { NeuronState, type NeuronInfo } from "@dfinity/nns";
-  import { secondsToDuration, ICPToken } from "@dfinity/utils";
+  import { ICPToken, secondsToDuration } from "@dfinity/utils";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPublicVisibilityAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPublicVisibilityAction.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { i18n } from "$lib/stores/i18n";
   import {
     isNeuronControllableByUser,
     isNeuronControlledByHardwareWallet,
     isPublicNeuron,
   } from "$lib/utils/neuron.utils";
-  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import NnsChangeNeuronVisibilityButton from "./actions/NnsChangeNeuronVisibilityButton.svelte";
   import { IconPublicBadge, Tooltip } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import NnsChangeNeuronVisibilityButton from "./actions/NnsChangeNeuronVisibilityButton.svelte";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/components/neuron-detail/actions/NnsChangeNeuronVisibilityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsChangeNeuronVisibilityButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import { isPublicNeuron } from "$lib/utils/neuron.utils";
-  import { i18n } from "$lib/stores/i18n";
   import type { NeuronInfo } from "@dfinity/nns";
 
   export let neuron: NeuronInfo;

--- a/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import {
-    MIN_NEURON_STAKE,
     MATURITY_MODULATION_VARIANCE_PERCENTAGE,
+    MIN_NEURON_STAKE,
   } from "$lib/constants/neurons.constants";
   import { ULPS_PER_MATURITY } from "$lib/constants/neurons.constants";
   import { i18n } from "$lib/stores/i18n";

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -8,12 +8,12 @@
   import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
   import {
     followeesByTopic,
-    getTopicTitle,
     getTopicSubtitle,
+    getTopicTitle,
   } from "$lib/utils/neuron.utils";
   import FollowTopicSection from "./FollowTopicSection.svelte";
   import { IconClose, Value } from "@dfinity/gix-components";
-  import type { NeuronId, Topic, NeuronInfo } from "@dfinity/nns";
+  import type { NeuronId, NeuronInfo, Topic } from "@dfinity/nns";
 
   export let topic: Topic;
   export let neuron: NeuronInfo;

--- a/frontend/src/lib/components/neurons/MakeNeuronsPublicBanner.svelte
+++ b/frontend/src/lib/components/neurons/MakeNeuronsPublicBanner.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import { IconInfo, IconClose } from "@dfinity/gix-components";
-  import { definedNeuronsStore } from "$lib/stores/neurons.store";
   import { browser } from "$app/environment";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import ChangeNeuronVisibilityModal from "$lib/modals/neurons/ChangeNeuronVisibilityModal.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import { definedNeuronsStore } from "$lib/stores/neurons.store";
   import {
     isNeuronControllableByUser,
     isPublicNeuron,
   } from "$lib/utils/neuron.utils";
-  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
-  import ChangeNeuronVisibilityModal from "$lib/modals/neurons/ChangeNeuronVisibilityModal.svelte";
+  import { IconClose, IconInfo } from "@dfinity/gix-components";
 
   const LOCAL_STORAGE_KEY = "isNeuronsPublicBannerDismissed";
   const CUTOFF_DATE = new Date(2025, 0, 31);

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Hash from "$lib/components/ui/Hash.svelte";
+  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import type { TableNeuron } from "$lib/types/neurons-table";
-  import { Tag, IconPublicBadge, Tooltip } from "@dfinity/gix-components";
-  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
+  import { IconPublicBadge, Tag, Tooltip } from "@dfinity/gix-components";
 
   export let rowData: TableNeuron;
 </script>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -9,8 +9,8 @@
   import { i18n } from "$lib/stores/i18n";
   import { neuronsTableOrderStore } from "$lib/stores/neurons-table.store";
   import type {
-    TableNeuron,
     NeuronsTableColumn,
+    TableNeuron,
   } from "$lib/types/neurons-table";
   import {
     comparatorsByColumnId,

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -2,26 +2,26 @@
   import TransactionFormFee from "$lib/components/transaction/TransactionFormFee.svelte";
   import TransactionFromAccount from "$lib/components/transaction/TransactionFromAccount.svelte";
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
+  import Separator from "$lib/components/ui/Separator.svelte";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import {
-    mainTransactionFeeStoreAsToken,
     mainTransactionFeeE8sStore,
+    mainTransactionFeeStoreAsToken,
   } from "$lib/derived/main-transaction-fee.derived";
   import { loadBalance } from "$lib/services/icp-accounts.services";
   import { stakeNeuron } from "$lib/services/neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
   import type { Account } from "$lib/types/account";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import { getMaxTransactionAmount } from "$lib/utils/token.utils";
-  import { busy, Checkbox } from "@dfinity/gix-components";
+  import { Checkbox, busy } from "@dfinity/gix-components";
   import { ICPToken } from "@dfinity/utils";
   import { isNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
-  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
-  import Separator from "$lib/components/ui/Separator.svelte";
-  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
 
   export let account: Account | undefined;
   let amount: number;

--- a/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
+++ b/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
@@ -2,7 +2,7 @@
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import { ProgressBar } from "@dfinity/gix-components";
-  import { ICPToken, nonNullish, TokenAmountV2 } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2, nonNullish } from "@dfinity/utils";
 
   export let max: bigint;
   export let participationE8s: bigint;

--- a/frontend/src/lib/components/proposal-detail/VotingCard/ExpandableProposalNeurons.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/ExpandableProposalNeurons.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { IconExpandCircleDown, Collapsible } from "@dfinity/gix-components";
+  import { Collapsible, IconExpandCircleDown } from "@dfinity/gix-components";
   import { fade } from "svelte/transition";
 
   export let testId: string;

--- a/frontend/src/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.svelte
@@ -6,7 +6,7 @@
   import { nnsTokenStore } from "$lib/derived/universes-tokens.derived";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { IconExpandCircleDown, Collapsible } from "@dfinity/gix-components";
+  import { Collapsible, IconExpandCircleDown } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
   import { fade } from "svelte/transition";
 

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotableNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotableNeuronList.svelte
@@ -4,8 +4,8 @@
   import VotingNeuronSelectList from "$lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte";
   import { i18n } from "$lib/stores/i18n";
   import {
-    type VoteRegistrationStoreEntry,
     votingNeuronSelectStore,
+    type VoteRegistrationStoreEntry,
   } from "$lib/stores/vote-registration.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { selectedNeuronsVotingPower } from "$lib/utils/proposals.utils";

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
@@ -6,8 +6,8 @@
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
-    type CompactNeuronInfo,
     neuronsVotingPower,
+    type CompactNeuronInfo,
   } from "$lib/utils/neuron.utils";
   import { Vote } from "@dfinity/nns";
 

--- a/frontend/src/lib/components/proposals/ActionableProposalsSignIn.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalsSignIn.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import SignIn from "$lib/components/common/SignIn.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { PageBanner, IconProposalsPage } from "@dfinity/gix-components";
+  import { IconProposalsPage, PageBanner } from "@dfinity/gix-components";
 
   // TODO: to be removed.
 </script>

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -2,8 +2,8 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import ActionableSnsProposals from "$lib/components/proposals/ActionableSnsProposals.svelte";
   import {
-    type ActionableSnsProposalsByUniverseData,
     actionableSnsProposalsByUniverseStore,
+    type ActionableSnsProposalsByUniverseData,
   } from "$lib/derived/actionable-proposals.derived";
 
   let actionableUniverses: ActionableSnsProposalsByUniverseData[] = [];

--- a/frontend/src/lib/components/proposals/NnsProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalCard.svelte
@@ -7,7 +7,7 @@
     mapProposalInfo,
   } from "$lib/utils/proposals.utils";
   import ProposalCard from "./ProposalCard.svelte";
-  import type { NeuronId, ProposalInfo, ProposalId } from "@dfinity/nns";
+  import type { NeuronId, ProposalId, ProposalInfo } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
   export let hidden = false;

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -14,8 +14,8 @@
   import { IconClose, Value } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type {
-    SnsNeuron,
     SnsNervousSystemFunction,
+    SnsNeuron,
     SnsNeuronId,
   } from "@dfinity/sns";
   import { fromNullable } from "@dfinity/utils";

--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
@@ -13,7 +13,7 @@
   import SnsStakeMaturityButton from "./actions/SnsStakeMaturityButton.svelte";
   import { IconExpandCircleDown } from "@dfinity/gix-components";
   import type { SnsNeuron } from "@dfinity/sns";
-  import type { TokenAmountV2, Token } from "@dfinity/utils";
+  import type { Token, TokenAmountV2 } from "@dfinity/utils";
 
   export let neuron: SnsNeuron;
   export let fee: TokenAmountV2;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
@@ -16,7 +16,7 @@
   import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger-icrc";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
-  import { nonNullish, type Token, TokenAmountV2 } from "@dfinity/utils";
+  import { TokenAmountV2, nonNullish, type Token } from "@dfinity/utils";
 
   export let governanceCanisterId: Principal | undefined;
   export let neuron: SnsNeuron;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -16,8 +16,8 @@
     type SelectedSnsNeuronContext,
   } from "$lib/types/sns-neuron-detail.context";
   import {
-    getSnsNeuronHotkeys,
     canIdentityManageHotkeys,
+    getSnsNeuronHotkeys,
   } from "$lib/utils/sns-neuron.utils";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
   import AddSnsHotkeyButton from "./actions/AddSnsHotkeyButton.svelte";

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
@@ -6,7 +6,7 @@
   import SnsStakedMaturityItemAction from "./SnsStakedMaturityItemAction.svelte";
   import { Section } from "@dfinity/gix-components";
   import type { SnsNeuron } from "@dfinity/sns";
-  import type { TokenAmountV2, Token } from "@dfinity/utils";
+  import type { Token, TokenAmountV2 } from "@dfinity/utils";
 
   export let neuron: SnsNeuron;
   export let fee: TokenAmountV2;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -20,7 +20,7 @@
   import { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import { secondsToDuration } from "@dfinity/utils";
-  import { type Token, fromDefinedNullable } from "@dfinity/utils";
+  import { fromDefinedNullable, type Token } from "@dfinity/utils";
 
   export let parameters: SnsNervousSystemParameters;
   export let neuron: SnsNeuron;

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
@@ -3,8 +3,8 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
   import {
-    isVesting,
     hasEnoughStakeToSplit,
+    isVesting,
   } from "$lib/utils/sns-neuron.utils";
   import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
   import { formatTokenE8s } from "$lib/utils/token.utils";

--- a/frontend/src/lib/components/sns-proposals/SnsProposalVotingSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalVotingSection.svelte
@@ -6,8 +6,8 @@
   import type { SnsProposalDataMap } from "$lib/utils/sns-proposals.utils";
   import { basisPointsToPercent } from "$lib/utils/utils";
   import {
-    type SnsProposalData,
     SnsProposalRewardStatus,
+    type SnsProposalData,
     type SnsTally,
   } from "@dfinity/sns";
   import { fromDefinedNullable } from "@dfinity/utils";

--- a/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
+++ b/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { IconOpenInNew } from "@dfinity/gix-components";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { i18n } from "$lib/stores/i18n";
-  import type { Principal } from "@dfinity/principal";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { IconOpenInNew } from "@dfinity/gix-components";
+  import type { Principal } from "@dfinity/principal";
   import { isNullish } from "@dfinity/utils";
 
   export let canisterId: Principal;

--- a/frontend/src/lib/components/tokens/TokensTable/TokenActionsCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenActionsCell.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import {
     UserTokenAction,
-    type UserTokenFailed,
     type UserTokenData,
+    type UserTokenFailed,
     type UserTokenLoading,
   } from "$lib/types/tokens-page";
   import { isUserTokenLoading } from "$lib/utils/user-token.utils";
@@ -12,7 +12,7 @@
   import RemoveButton from "./actions/RemoveButton.svelte";
   import SendButton from "./actions/SendButton.svelte";
   import { nonNullish } from "@dfinity/utils";
-  import type { SvelteComponent, ComponentType } from "svelte";
+  import type { ComponentType, SvelteComponent } from "svelte";
 
   export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 

--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -5,11 +5,11 @@
     UserTokenFailed,
     UserTokenLoading,
   } from "$lib/types/tokens-page";
-  import { Spinner } from "@dfinity/gix-components";
   import {
     isUserTokenData,
     isUserTokenLoading,
   } from "$lib/utils/user-token.utils";
+  import { Spinner } from "@dfinity/gix-components";
 
   export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 </script>

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
+  import Hash from "$lib/components/ui/Hash.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import type {
     UserTokenData,
     UserTokenFailed,
     UserTokenLoading,
   } from "$lib/types/tokens-page";
-  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { isImportedToken } from "$lib/utils/imported-tokens.utils";
-  import Logo from "$lib/components/ui/Logo.svelte";
-  import { nonNullish } from "@dfinity/utils";
-  import { IconError, Tag, Tooltip } from "@dfinity/gix-components";
-  import { i18n } from "$lib/stores/i18n";
-  import Hash from "$lib/components/ui/Hash.svelte";
   import { isUserTokenFailed } from "$lib/utils/user-token.utils";
+  import { IconError, Tag, Tooltip } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { UserToken, TokensTableColumn } from "$lib/types/tokens-page";
+  import type { TokensTableColumn, UserToken } from "$lib/types/tokens-page";
   import TokenActionsCell from "./TokenActionsCell.svelte";
   import TokenBalanceCell from "./TokenBalanceCell.svelte";
   import TokenTitleCell from "./TokenTitleCell.svelte";

--- a/frontend/src/lib/components/tokens/TokensTable/actions/GoToDashboardButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/GoToDashboardButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
   import type { UserTokenData, UserTokenFailed } from "$lib/types/tokens-page";
   import type { Principal } from "@dfinity/principal";
-  import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
 
   export let userToken: UserTokenData | UserTokenFailed;
 

--- a/frontend/src/lib/components/tokens/TokensTable/actions/ReceiveButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/ReceiveButton.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { ActionType } from "$lib/types/actions";
   import type { UserTokenData, UserTokenFailed } from "$lib/types/tokens-page";
+  import { isUserTokenData } from "$lib/utils/user-token.utils";
   import { IconQRCodeScanner } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
-  import { isUserTokenData } from "$lib/utils/user-token.utils";
 
   // The UserTokenFailed type was added to unify the action types. However, this action only works with UserTokenData.
   export let userToken: UserTokenData | UserTokenFailed;

--- a/frontend/src/lib/components/tokens/TokensTable/actions/RemoveButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/RemoveButton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+  import { ActionType } from "$lib/types/actions";
   import type { UserTokenData, UserTokenFailed } from "$lib/types/tokens-page";
   import { IconBin } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
-  import { ActionType } from "$lib/types/actions";
 
   export let userToken: UserTokenData | UserTokenFailed;
 

--- a/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { ActionType } from "$lib/types/actions";
   import type { UserTokenData, UserTokenFailed } from "$lib/types/tokens-page";
+  import { isUserTokenData } from "$lib/utils/user-token.utils";
   import { IconUp } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
-  import { isUserTokenData } from "$lib/utils/user-token.utils";
 
   // The UserTokenFailed type was added to unify the action types. Works only with UserTokenData.
   export let userToken: UserTokenData | UserTokenFailed;

--- a/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { TokenAmountV2, TokenAmount } from "@dfinity/utils";
+  import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
   export let amount: TokenAmountV2 | TokenAmount;
   export let estimation = false;

--- a/frontend/src/lib/components/transaction/TransactionReview.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReview.svelte
@@ -8,7 +8,7 @@
   import type { NewTransaction } from "$lib/types/transaction";
   import type { TransactionNetwork } from "$lib/types/transaction";
   import { busy } from "@dfinity/gix-components";
-  import type { TokenAmountV2, TokenAmount, Token } from "@dfinity/utils";
+  import type { Token, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let transaction: NewTransaction;

--- a/frontend/src/lib/components/ui/AmountInput.svelte
+++ b/frontend/src/lib/components/ui/AmountInput.svelte
@@ -3,7 +3,7 @@
   import { ICP_DISPLAYED_DECIMALS_DETAILED } from "$lib/constants/icp.constants";
   import { i18n } from "$lib/stores/i18n";
   import InputWithError from "./InputWithError.svelte";
-  import { type Token, isNullish } from "@dfinity/utils";
+  import { isNullish, type Token } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let amount: number | undefined = undefined;

--- a/frontend/src/lib/components/ui/Identifier.svelte
+++ b/frontend/src/lib/components/ui/Identifier.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Value, Copy } from "@dfinity/gix-components";
+  import { Copy, Value } from "@dfinity/gix-components";
 
   export let identifier: string;
   export let label: string | undefined = undefined;

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -2,7 +2,7 @@
   import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
   import SelectUniverseNavList from "$lib/components/universe/SelectUniverseNavList.svelte";
   import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
-  import { Nav, BREAKPOINT_LARGE } from "@dfinity/gix-components";
+  import { BREAKPOINT_LARGE, Nav } from "@dfinity/gix-components";
 
   let innerWidth = 0;
   let list = false;

--- a/frontend/src/lib/modals/accounts/AddAccountModal.svelte
+++ b/frontend/src/lib/modals/accounts/AddAccountModal.svelte
@@ -6,15 +6,15 @@
   import { debugAddAccountStore } from "$lib/derived/debug.derived";
   import { i18n } from "$lib/stores/i18n";
   import type {
+    AccountType,
     AddAccountContext,
     AddAccountStore,
-    AccountType,
   } from "$lib/types/add-account.context";
   import { ADD_ACCOUNT_CONTEXT_KEY } from "$lib/types/add-account.context";
   import {
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import { setContext, tick } from "svelte";
   import { writable } from "svelte/store";

--- a/frontend/src/lib/modals/accounts/AddIndexCanisterModal.svelte
+++ b/frontend/src/lib/modals/accounts/AddIndexCanisterModal.svelte
@@ -4,11 +4,11 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import { addIndexCanister } from "../../services/imported-tokens.services";
   import { Modal } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { isNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
-  import { addIndexCanister } from "../../services/imported-tokens.services";
 
   export let ledgerCanisterId: Principal;
 

--- a/frontend/src/lib/modals/accounts/CkBTCAccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCAccountsModals.svelte
@@ -2,11 +2,11 @@
   import CkBTCReceiveModal from "$lib/modals/accounts/CkBTCReceiveModal.svelte";
   import CkBTCTransactionTokenModal from "$lib/modals/accounts/CkBTCTransactionTokenModal.svelte";
   import type {
+    CkBTCReceiveModalData,
+    CkBTCTransactionModalData,
     CkBTCWalletModal,
     CkBTCWalletModalData,
     CkBTCWalletModalType,
-    CkBTCReceiveModalData,
-    CkBTCTransactionModalData,
   } from "$lib/types/ckbtc-accounts.modal";
   import { nonNullish } from "@dfinity/utils";
 

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -30,7 +30,7 @@
   import { numberToE8s } from "$lib/utils/token.utils";
   import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
   import type { WizardStep } from "@dfinity/gix-components";
-  import type { TokenAmountV2, Token } from "@dfinity/utils";
+  import type { Token, TokenAmountV2 } from "@dfinity/utils";
   import { nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 

--- a/frontend/src/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.svelte
+++ b/frontend/src/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.svelte
@@ -7,8 +7,8 @@
   import type { Account } from "$lib/types/account";
   import {
     WALLET_CONTEXT_KEY,
-    type WalletContext,
     type HardwareWalletNeuronInfo,
+    type WalletContext,
   } from "$lib/types/wallet.context";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type { NeuronId } from "@dfinity/nns";

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -1,31 +1,31 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
+  import ImportTokenForm from "$lib/components/accounts/ImportTokenForm.svelte";
+  import ImportTokenReview from "$lib/components/accounts/ImportTokenReview.svelte";
+  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
+  import { getIcrcTokenMetaData } from "$lib/services/icrc-accounts.services";
+  import { matchLedgerIndexPair } from "$lib/services/icrc-index.services";
+  import { addImportedToken } from "$lib/services/imported-tokens.services";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING } from "$lib/stores/feature-flags.store";
+  import { i18n } from "$lib/stores/i18n";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import { isImportantCkToken } from "$lib/utils/icrc-tokens.utils";
+  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
+  import { buildWalletUrl } from "$lib/utils/navigation.utils";
+  import { isSnsLedgerCanisterId } from "$lib/utils/sns.utils";
+  import { LEDGER_CANISTER_ID } from "../../constants/canister-ids.constants";
   import {
     WizardModal,
     type WizardStep,
     type WizardSteps,
   } from "@dfinity/gix-components";
-  import { i18n } from "$lib/stores/i18n";
   import type { Principal } from "@dfinity/principal";
-  import ImportTokenForm from "$lib/components/accounts/ImportTokenForm.svelte";
-  import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import { getIcrcTokenMetaData } from "$lib/services/icrc-accounts.services";
-  import { toastsError } from "$lib/stores/toasts.store";
-  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
-  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import { isSnsLedgerCanisterId } from "$lib/utils/sns.utils";
-  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
-  import { matchLedgerIndexPair } from "$lib/services/icrc-index.services";
-  import { startBusy, stopBusy } from "$lib/stores/busy.store";
-  import { isImportantCkToken } from "$lib/utils/icrc-tokens.utils";
-  import ImportTokenReview from "$lib/components/accounts/ImportTokenReview.svelte";
-  import { addImportedToken } from "$lib/services/imported-tokens.services";
-  import { buildWalletUrl } from "$lib/utils/navigation.utils";
   import { createEventDispatcher } from "svelte";
-  import { goto } from "$app/navigation";
   import { get } from "svelte/store";
-  import { DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING } from "$lib/stores/feature-flags.store";
-  import { LEDGER_CANISTER_ID } from "../../constants/canister-ids.constants";
 
   let currentStep: WizardStep | undefined = undefined;
 

--- a/frontend/src/lib/modals/accounts/RenameSubAccountModal.svelte
+++ b/frontend/src/lib/modals/accounts/RenameSubAccountModal.svelte
@@ -3,8 +3,8 @@
   import { i18n } from "$lib/stores/i18n";
   import {
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
 
   let steps: WizardSteps = [

--- a/frontend/src/lib/modals/canisters/AddCanisterControllerModal.svelte
+++ b/frontend/src/lib/modals/canisters/AddCanisterControllerModal.svelte
@@ -4,8 +4,8 @@
   import { i18n } from "$lib/stores/i18n";
   import {
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
 

--- a/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -22,10 +22,10 @@
   import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
   import { valueSpan } from "$lib/utils/utils";
   import {
-    WizardModal,
     Html,
-    type WizardSteps,
+    WizardModal,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { ICPToken } from "@dfinity/utils";

--- a/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
@@ -25,8 +25,8 @@
   import {
     Html,
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import { ICPToken, nonNullish } from "@dfinity/utils";
   import { createEventDispatcher, onMount } from "svelte";

--- a/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
-  import {
-    isPublicNeuron,
-    isNeuronControllableByUser,
-    createNeuronVisibilityRowData,
-  } from "$lib/utils/neuron.utils";
-  import { sortedNeuronStore } from "$lib/stores/neurons.store";
-  import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
-  import { i18n } from "$lib/stores/i18n";
-  import NeuronVisibilityRow from "$lib/modals/neurons/NeuronVisibilityRow.svelte";
-  import type { NeuronInfo } from "@dfinity/nns";
-  import { Checkbox, Spinner } from "@dfinity/gix-components";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import NeuronVisibilityRow from "$lib/modals/neurons/NeuronVisibilityRow.svelte";
+  import { authStore } from "$lib/stores/auth.store";
+  import { i18n } from "$lib/stores/i18n";
+  import { sortedNeuronStore } from "$lib/stores/neurons.store";
+  import {
+    createNeuronVisibilityRowData,
+    isNeuronControllableByUser,
+    isPublicNeuron,
+  } from "$lib/utils/neuron.utils";
+  import { Checkbox, Spinner } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
+  import { createEventDispatcher } from "svelte";
 
   export let defaultSelectedNeuron: NeuronInfo | null = null;
   export let makePublic: boolean;

--- a/frontend/src/lib/modals/neurons/ChangeNeuronVisibilityModal.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeNeuronVisibilityModal.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
-  import { i18n } from "$lib/stores/i18n";
-  import { Modal } from "@dfinity/gix-components";
-  import type { NeuronInfo } from "@dfinity/nns";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { changeNeuronVisibility } from "$lib/services/neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { i18n } from "$lib/stores/i18n";
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import ChangeBulkNeuronVisibilityForm from "./ChangeBulkNeuronVisibilityForm.svelte";
+  import { Modal } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { createEventDispatcher } from "svelte";
 
   export let defaultSelectedNeuron: NeuronInfo | null = null;
   // makePublic is also passed to ChangeBulkNeuronVisibilityForm

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -17,10 +17,10 @@
   import { formatTokenE8s } from "$lib/utils/token.utils";
   import {
     Html,
-    WizardModal,
-    type WizardSteps,
-    type WizardStep,
     KeyValuePair,
+    WizardModal,
+    type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { assertNonNullish, type Token } from "@dfinity/utils";

--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -17,15 +17,15 @@
   import { neuronStake } from "$lib/utils/neuron.utils";
   import type {
     WizardModal,
-    WizardSteps,
     WizardStep,
+    WizardSteps,
   } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import {
     ICPToken,
-    type Token,
-    assertNonNullish,
     TokenAmountV2,
+    assertNonNullish,
+    type Token,
   } from "@dfinity/utils";
   import { createEventDispatcher, onDestroy } from "svelte";
   import { onMount } from "svelte";

--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -17,8 +17,8 @@
   } from "$lib/utils/sns-neuron.utils";
   import {
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";

--- a/frontend/src/lib/modals/neurons/DissolveActionButtonModal.svelte
+++ b/frontend/src/lib/modals/neurons/DissolveActionButtonModal.svelte
@@ -7,7 +7,7 @@
   } from "$lib/services/neurons.services";
   import { stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { type NeuronId, type NeuronInfo, NeuronState } from "@dfinity/nns";
+  import { NeuronState, type NeuronId, type NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
 
   export let neuron: NeuronInfo;

--- a/frontend/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
@@ -4,8 +4,8 @@
   import { i18n } from "$lib/stores/i18n";
   import {
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";

--- a/frontend/src/lib/modals/neurons/MergeNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/MergeNeuronsModal.svelte
@@ -10,8 +10,8 @@
   } from "$lib/utils/neuron.utils";
   import {
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";

--- a/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
+++ b/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
-  import {
-    Tag,
-    IconPublicBadge,
-    Tooltip,
-    IconLedger,
-    IconKey,
-    Checkbox,
-  } from "@dfinity/gix-components";
-  import type { NeuronVisibilityRowData } from "$lib/types/neuron-visibility-row";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import type { NeuronVisibilityRowData } from "$lib/types/neuron-visibility-row";
+  import {
+    Checkbox,
+    IconKey,
+    IconLedger,
+    IconPublicBadge,
+    Tag,
+    Tooltip,
+  } from "@dfinity/gix-components";
 
   const typeToIcon: {
     hardwareWallet: typeof IconLedger;

--- a/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
@@ -13,7 +13,6 @@
   import SpawnNeuronModal from "$lib/modals/neurons/SpawnNeuronModal.svelte";
   import SplitNeuronModal from "$lib/modals/neurons/SplitNnsNeuronModal.svelte";
   import VotingHistoryModal from "$lib/modals/neurons/VotingHistoryModal.svelte";
-  import ChangeNeuronVisibilityModal from "./ChangeNeuronVisibilityModal.svelte";
   import type {
     NnsNeuronModal,
     NnsNeuronModalData,
@@ -25,6 +24,7 @@
     type FolloweesNeuron,
   } from "$lib/utils/neuron.utils";
   import NnsAddMaturityModal from "../sns/neurons/NnsAddMaturityModal.svelte";
+  import ChangeNeuronVisibilityModal from "./ChangeNeuronVisibilityModal.svelte";
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
 

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -15,8 +15,8 @@
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import {
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import { wizardStepIndex } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -14,10 +14,10 @@
     isNeuronControlledByHardwareWallet,
   } from "$lib/utils/neuron.utils";
   import {
-    WizardModal,
     Html,
-    type WizardSteps,
+    WizardModal,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";

--- a/frontend/src/lib/modals/neurons/StakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/StakeMaturityModal.svelte
@@ -7,8 +7,8 @@
   import {
     Html,
     WizardModal,
-    type WizardSteps,
     type WizardStep,
+    type WizardSteps,
   } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
 

--- a/frontend/src/lib/modals/sns/neurons/NewSnsFolloweeModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/NewSnsFolloweeModal.svelte
@@ -6,7 +6,7 @@
     SELECTED_SNS_NEURON_CONTEXT_KEY,
     type SelectedSnsNeuronContext,
   } from "$lib/types/sns-neuron-detail.context";
-  import { busy, Modal, startBusy, stopBusy } from "@dfinity/gix-components";
+  import { Modal, busy, startBusy, stopBusy } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
   import { createEventDispatcher, getContext } from "svelte";

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -9,7 +9,7 @@
   } from "@dfinity/gix-components";
   import { decodePayment } from "@dfinity/ledger-icrc";
   import type { Token } from "@dfinity/utils";
-  import { isNullish, nonNullish, assertNonNullish } from "@dfinity/utils";
+  import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
 
   export let testId: string | undefined = undefined;
   export let steps: WizardSteps;

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -20,9 +20,9 @@
   } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import {
+    ICPToken,
     TokenAmount,
     TokenAmountV2,
-    ICPToken,
     type Token,
   } from "@dfinity/utils";
   import { isNullish, nonNullish } from "@dfinity/utils";

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -4,8 +4,8 @@
   import ActionableSnses from "$lib/components/proposals/ActionableSnses.svelte";
   import LoadingActionableProposals from "$lib/components/proposals/LoadingActionableProposals.svelte";
   import {
-    actionableProposalsLoadedStore,
     actionableProposalTotalCountStore,
+    actionableProposalsLoadedStore,
   } from "$lib/derived/actionable-proposals.derived";
 </script>
 

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -17,7 +17,7 @@
     type SelectCanisterDetailsStore,
   } from "$lib/types/canister-detail.context";
   import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
-  import { busy, Island } from "@dfinity/gix-components";
+  import { Island, busy } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { onMount, setContext } from "svelte";
   import { writable } from "svelte/store";

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -3,9 +3,12 @@
   import IcrcWalletPage from "$lib/components/accounts/IcrcWalletPage.svelte";
   import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTransactionsList.svelte";
   import NoTransactions from "$lib/components/accounts/NoTransactions.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
   import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { tokensByUniverseIdStore } from "$lib/derived/tokens.derived";
+  import AddIndexCanisterModal from "$lib/modals/accounts/AddIndexCanisterModal.svelte";
+  import { i18n } from "$lib/stores/i18n";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import type { CanisterId } from "$lib/types/canister";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
@@ -14,9 +17,6 @@
   import { Html, IconCanistersPage, IconPlus } from "@dfinity/gix-components";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { writable } from "svelte/store";
-  import AddIndexCanisterModal from "$lib/modals/accounts/AddIndexCanisterModal.svelte";
-  import { i18n } from "$lib/stores/i18n";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let accountIdentifier: string | undefined | null = undefined;
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -7,12 +7,17 @@
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
   import RenameSubAccountButton from "$lib/components/accounts/RenameSubAccountButton.svelte";
   import UiTransactionsList from "$lib/components/accounts/UiTransactionsList.svelte";
+  import WalletMorePopover from "$lib/components/accounts/WalletMorePopover.svelte";
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
   import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
   import SignInGuard from "$lib/components/common/SignInGuard.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import Footer from "$lib/components/layout/Footer.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import {
+    INDEX_CANISTER_ID,
+    LEDGER_CANISTER_ID,
+  } from "$lib/constants/canister-ids.constants";
   import { AppPath } from "$lib/constants/routes.constants";
   import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { authSignedInStore } from "$lib/derived/auth.derived";
@@ -32,6 +37,7 @@
   } from "$lib/services/icp-transactions.services";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
+  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
   import {
@@ -66,14 +72,8 @@
     isNullish,
     nonNullish,
   } from "@dfinity/utils";
-  import { onMount, onDestroy, setContext } from "svelte";
+  import { onDestroy, onMount, setContext } from "svelte";
   import { writable, type Readable } from "svelte/store";
-  import {
-    INDEX_CANISTER_ID,
-    LEDGER_CANISTER_ID,
-  } from "$lib/constants/canister-ids.constants";
-  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
-  import WalletMorePopover from "$lib/components/accounts/WalletMorePopover.svelte";
 
   $: if ($authSignedInStore) {
     pollAccounts();

--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -3,7 +3,7 @@
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { UserTokenData } from "$lib/types/tokens-page";
-  import { PageBanner, IconAccountsPage } from "@dfinity/gix-components";
+  import { IconAccountsPage, PageBanner } from "@dfinity/gix-components";
 
   export let userTokensData: UserTokenData[] = [];
 </script>

--- a/frontend/src/lib/pages/SignInCanisters.svelte
+++ b/frontend/src/lib/pages/SignInCanisters.svelte
@@ -2,7 +2,7 @@
   import EmptyCards from "$lib/components/common/EmptyCards.svelte";
   import SignIn from "$lib/components/common/SignIn.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { PageBanner, IconCanistersPage } from "@dfinity/gix-components";
+  import { IconCanistersPage, PageBanner } from "@dfinity/gix-components";
 </script>
 
 <main>

--- a/frontend/src/lib/pages/SignInNeurons.svelte
+++ b/frontend/src/lib/pages/SignInNeurons.svelte
@@ -3,7 +3,7 @@
   import SignIn from "$lib/components/common/SignIn.svelte";
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { PageBanner, IconNeuronsPage } from "@dfinity/gix-components";
+  import { IconNeuronsPage, PageBanner } from "@dfinity/gix-components";
 </script>
 
 <main>

--- a/frontend/src/lib/pages/SignInSettings.svelte
+++ b/frontend/src/lib/pages/SignInSettings.svelte
@@ -2,7 +2,7 @@
   import EmptyCards from "$lib/components/common/EmptyCards.svelte";
   import SignIn from "$lib/components/common/SignIn.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { PageBanner, IconSettingsPage } from "@dfinity/gix-components";
+  import { IconSettingsPage, PageBanner } from "@dfinity/gix-components";
 </script>
 
 <main>

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -3,7 +3,7 @@
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { UserToken } from "$lib/types/tokens-page";
-  import { PageBanner, IconAccountsPage } from "@dfinity/gix-components";
+  import { IconAccountsPage, PageBanner } from "@dfinity/gix-components";
 
   export let userTokensData: UserToken[];
 </script>

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -3,20 +3,20 @@
   import HideZeroBalancesToggle from "$lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+  import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
+  import ImportTokenModal from "$lib/modals/accounts/ImportTokenModal.svelte";
+  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
   import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
   import { i18n } from "$lib/stores/i18n";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import type { ImportedTokenData } from "$lib/types/imported-tokens";
   import type { UserToken } from "$lib/types/tokens-page";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
   import { heightTransition } from "$lib/utils/transition.utils";
   import { IconPlus, IconSettings, Tooltip } from "@dfinity/gix-components";
   import { Popover } from "@dfinity/gix-components";
   import { TokenAmountV2, nonNullish } from "@dfinity/utils";
-  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
-  import ImportTokenModal from "$lib/modals/accounts/ImportTokenModal.svelte";
-  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
-  import type { ImportedTokenData } from "$lib/types/imported-tokens";
 
   export let userTokensData: UserToken[];
 

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
   import {
     isCkBTCUniverseStore,
     isIcrcTokenUniverseStore,
@@ -14,13 +17,10 @@
   import NnsWallet from "$lib/pages/NnsWallet.svelte";
   import SnsWallet from "$lib/pages/SnsWallet.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { layoutTitleStore } from "$lib/stores/layout.store";
-  import { nonNullish, isNullish } from "@dfinity/utils";
-  import { AppPath } from "$lib/constants/routes.constants";
-  import { goto } from "$app/navigation";
-  import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+  import { isNullish, nonNullish } from "@dfinity/utils";
 
   export let accountIdentifier: string | undefined | null = undefined;
 

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
+  import ImportTokenRemoveConfirmation from "$lib/components/accounts/ImportTokenRemoveConfirmation.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
+  import {
+    icrcCanistersStore,
+    type IcrcCanistersStoreData,
+  } from "$lib/derived/icrc-canisters.derived";
   import { snsLedgerCanisterIdsStore } from "$lib/derived/sns/sns-canisters.derived";
   import {
     snsProjectsCommittedStore,
@@ -19,12 +24,10 @@
   import Tokens from "$lib/pages/Tokens.svelte";
   import { updateBalance } from "$lib/services/ckbtc-minter.services";
   import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
+  import { removeImportedTokens } from "$lib/services/imported-tokens.services";
   import { uncertifiedLoadSnsesAccountsBalances } from "$lib/services/sns-accounts-balance.services";
   import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-uncertified-accounts.services";
-  import {
-    icrcCanistersStore,
-    type IcrcCanistersStoreData,
-  } from "$lib/derived/icrc-canisters.derived";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import type { Account } from "$lib/types/account";
   import { ActionType, type Action } from "$lib/types/actions";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
@@ -34,21 +37,18 @@
     UserTokenFailed,
   } from "$lib/types/tokens-page";
   import type { Universe, UniverseCanisterIdText } from "$lib/types/universe";
+  import { compareTokensForTokensTable } from "$lib/utils/tokens-table.utils";
   import {
     isIcrcTokenUniverse,
     isUniverseCkBTC,
     isUniverseNns,
   } from "$lib/utils/universe.utils";
+  import { isUserTokenData } from "$lib/utils/user-token.utils";
   import { isArrayEmpty } from "$lib/utils/utils";
+  import type { CanisterIdString } from "@dfinity/nns";
   import { Principal } from "@dfinity/principal";
   import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
-  import { compareTokensForTokensTable } from "$lib/utils/tokens-table.utils";
-  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import ImportTokenRemoveConfirmation from "$lib/components/accounts/ImportTokenRemoveConfirmation.svelte";
-  import { isUserTokenData } from "$lib/utils/user-token.utils";
-  import { removeImportedTokens } from "$lib/services/imported-tokens.services";
-  import type { CanisterIdString } from "@dfinity/nns";
 
   onMount(() => {
     loadCkBTCTokens();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
   import {
-    type AuthWorker,
     initAuthWorker,
+    type AuthWorker,
   } from "$lib/services/worker-auth.services";
   import type { AuthStoreData } from "$lib/stores/auth.store";
   import { authStore } from "$lib/stores/auth.store";

--- a/frontend/src/tests/lib/components/ContextWrapperTest.svelte
+++ b/frontend/src/tests/lib/components/ContextWrapperTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
 
   export let Component: SvelteComponent;
   export let contextKey: symbol;

--- a/frontend/src/tests/lib/components/accounts/AddAccountTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/AddAccountTest.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import {
-    AccountType,
     ADD_ACCOUNT_CONTEXT_KEY,
+    AccountType,
     AddAccountContext,
   } from "$lib/types/add-account.context";
   import { addAccountStoreMock } from "$tests/mocks/add-account.store.mock";
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
 
   export let testComponent: typeof SvelteComponent;
   export let nextCallback: () => void | undefined = undefined;

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte
@@ -4,7 +4,7 @@
     mockHardwareWalletNeuronsStore,
     mockNeuronStake,
   } from "$tests/mocks/hardware-wallet-neurons.store.mock";
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
 
   export let testComponent: typeof SvelteComponent;
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletNeuronsTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletNeuronsTest.svelte
@@ -4,7 +4,7 @@
     type WalletContext,
   } from "$lib/types/wallet.context";
   import { mockHardwareWalletNeuronsStore } from "$tests/mocks/hardware-wallet-neurons.store.mock";
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
 
   export let testComponent: typeof SvelteComponent;
 

--- a/frontend/src/tests/lib/components/accounts/WalletContextTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/WalletContextTest.svelte
@@ -6,7 +6,7 @@
     WalletContext,
     WalletStore,
   } from "$lib/types/wallet.context";
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   export let testComponent: typeof SvelteComponent;

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte
@@ -6,7 +6,7 @@
   } from "$lib/types/nns-neuron-detail.context";
   import { NNS_NEURON_CONTEXT_KEY } from "$lib/types/nns-neuron-detail.context";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   export let testComponent: typeof SvelteComponent;

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronContextTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronContextTest.svelte
@@ -6,7 +6,7 @@
   } from "$lib/types/nns-neuron-detail.context";
   import { NNS_NEURON_CONTEXT_KEY } from "$lib/types/nns-neuron-detail.context";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   export let testComponent: typeof SvelteComponent;

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte
@@ -8,7 +8,7 @@
   import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { setContext, SvelteComponent } from "svelte";
+  import { SvelteComponent, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   export let neuron: SnsNeuron | undefined;

--- a/frontend/src/tests/lib/modals/transaction/TransactionModalTest.svelte
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModalTest.svelte
@@ -3,7 +3,7 @@
   import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
   import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
   import type { WizardStep } from "@dfinity/gix-components";
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { ICPToken, TokenAmount } from "@dfinity/utils";
 
   export let currentStep: WizardStep | undefined;
 


### PR DESCRIPTION
# Motivation

`prettier` sorts imports in TypeScript files but not in Svelte files.
We have a script to sort Svelte imports, which I usually run on files I change.
This often results in unrelated changes in a PR which can be distracting.

# Changes

Run `scripts/sort-svelte-imports`.

# Tests

Should still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary