### PR TITLE
FOLLOW-244: Show a toast when neuron is refreshed

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -703,6 +703,7 @@
     "created": "Date Created",
     "neuron_state_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account.",
     "dissolve_delay_tooltip": "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and $token to be available again. If your neuron is dissolving, your $token will be available in $duration.",
+    "neuron_stake_refreshed": "Your neuron's stake was refreshed successfully.",
     "change_neuron_make_neuron_public": "Make Neuron Public",
     "change_neuron_make_neuron_private": "Make Neuron Private",
     "change_neuron_make_neuron_public_confirmation": "Are you sure you want to make your neuron public?",

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1037,6 +1037,9 @@ export const refreshNeuronIfNeeded = async (
 
   if (await neuronNeedsRefresh(neuron.fullNeuron)) {
     await reloadNeuron(neuron.neuronId);
+    toastsSuccess({
+      labelKey: "neuron_detail.neuron_stake_refreshed",
+    });
   }
 };
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -729,6 +729,7 @@ interface I18nNeuron_detail {
   created: string;
   neuron_state_tooltip: string;
   dissolve_delay_tooltip: string;
+  neuron_stake_refreshed: string;
   change_neuron_make_neuron_public: string;
   change_neuron_make_neuron_private: string;
   change_neuron_make_neuron_public_confirmation: string;

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -2053,6 +2053,8 @@ describe("neurons-services", () => {
       expect(spyQueryAccountBalance).toBeCalledTimes(0);
       expect(spyClaimOrRefresh).toBeCalledTimes(0);
 
+      expect(get(toastsStore)).toEqual([]);
+
       await refreshNeuronIfNeeded(neuron);
 
       expect(spyQueryAccountBalance).toBeCalledTimes(1);
@@ -2066,6 +2068,13 @@ describe("neurons-services", () => {
         identity: mockIdentity,
         neuronId: neuronId,
       });
+
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "Your neuron's stake was refreshed successfully.",
+        },
+      ]);
     });
 
     it("should not refresh the neuron if its account balance does match", async () => {


### PR DESCRIPTION
# Motivation

When a neuron's account balance is out of sync with the neuron stake, we refresh the neuron in the background when the user visits the neuron detail page.
To make it clear what happened we want to show a toast to the user if the neuron was refreshed.

# Changes

1. Show a toast if the neuron was refreshed in the background.

# Tests

1. Unit test updated.
2. Tested manually after disabling the refresh functionality in the nns-dapp canister locally.

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry