### PR TITLE
Disable confirm button when no neurons are selected

### DIFF
--- a/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
@@ -169,7 +169,12 @@
     >
       {$i18n.core.cancel}
     </button>
-    <button type="submit" class="primary" data-tid="confirm-button">
+    <button
+      type="submit"
+      class="primary"
+      data-tid="confirm-button"
+      disabled={selectedNeurons.length === 0}
+    >
       {$i18n.core.confirm}
     </button>
   </div>

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -382,6 +382,32 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
     });
   });
 
+  it("should disable confirm button when no neurons are selected", async () => {
+    neuronsStore.setNeurons({
+      neurons: [publicNeuron1, publicNeuron2],
+      certified: true,
+    });
+    const onNnsSubmit = vi.fn();
+
+    const po = renderComponent({
+      makePublic: false,
+      onNnsSubmit,
+    });
+
+    expect(await po.getConfirmButton().isDisabled()).toBe(true);
+
+    const checkboxPo = po
+      .getControllableNeuronVisibilityRowPo(publicNeuron2.neuronId.toString())
+      .getCheckboxPo();
+    await checkboxPo.click();
+
+    expect(await po.getConfirmButton().isDisabled()).toBe(false);
+
+    await checkboxPo.click();
+
+    expect(await po.getConfirmButton().isDisabled()).toBe(true);
+  });
+
   it("should display both lists descriptions when there are no neurons to list in controllable neurons", async () => {
     neuronsStore.setNeurons({
       neurons: [hotkeyPublicNeuron],
@@ -525,10 +551,16 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
   });
 
   it("should trigger appropriate events on button clicks", async () => {
+    neuronsStore.setNeurons({
+      neurons: [publicNeuron1],
+      certified: true,
+    });
+
     const onNnsSubmit = vi.fn();
     const onNnsCancel = vi.fn();
     const po = renderComponent({
       makePublic: false,
+      defaultSelectedNeuron: publicNeuron1,
       onNnsSubmit,
       onNnsCancel,
     });


### PR DESCRIPTION
# Motivation

When setting neuron visibility of one neuron, you are offered to select other neurons you might want to change.

<img width="608" alt="image" src="https://github.com/user-attachments/assets/80003b80-05b5-4752-b01b-52626e2e3480">

Currently you can deselect all neurons and click "Confirm" and it will say visibility was changed successfully.

# Changes

1. Disable the Confirm button when all neurons are deselected.

# Tests

1. Unit test added to test that the confirm button is disabled.
2. Unit test updated to make sure the confirm button is enabled when testing the event trigger.
3. Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary