### PR TITLE
Keep default neuron selected on deselect-all

### DIFF
--- a/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
@@ -80,7 +80,9 @@
     if (!applyToAllNeurons) {
       selectedNeurons = [...controllableNeurons];
     } else {
-      selectedNeurons = [];
+      selectedNeurons = nonNullish(defaultSelectedNeuron)
+        ? [defaultSelectedNeuron]
+        : [];
     }
     updateApplyToAllNeuronsCheckState();
   }

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -305,28 +305,22 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
 
     await po.getApplyToAllCheckbox().click();
 
-    expect(
+    const isControlledChecked = async (neuron: NeuronInfo) =>
       await po
-        .getControllableNeuronVisibilityRowPo(publicNeuron2.neuronId.toString())
+        .getControllableNeuronVisibilityRowPo(neuron.neuronId.toString())
         .getCheckboxPo()
-        .isChecked()
-    ).toBe(true);
-    expect(
+        .isChecked();
+
+    const isUncontrolledChecked = async (neuron: NeuronInfo) =>
       await po
-        .getControllableNeuronVisibilityRowPo(
-          publicSeedNeuron.neuronId.toString()
-        )
+        .getUncontrollableNeuronVisibilityRowPo(neuron.neuronId.toString())
         .getCheckboxPo()
-        .isChecked()
-    ).toBe(true);
-    expect(
-      await po
-        .getUncontrollableNeuronVisibilityRowPo(
-          hwPublicNeuron.neuronId.toString()
-        )
-        .getCheckboxPo()
-        .isChecked()
-    ).toBe(false);
+        .isChecked();
+
+    expect(await isControlledChecked(publicNeuron1)).toBe(true);
+    expect(await isControlledChecked(publicNeuron2)).toBe(true);
+    expect(await isControlledChecked(publicSeedNeuron)).toBe(true);
+    expect(await isUncontrolledChecked(hwPublicNeuron)).toBe(false);
 
     const controllableNeuronIds = await po.getControllableNeuronIds();
     const uncontrollableNeuronIds = await po.getUncontrollableNeuronIds();
@@ -348,6 +342,69 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
         selectedNeurons: [publicNeuron1, publicNeuron2, publicSeedNeuron],
       },
     });
+  });
+
+  it("should deselect all neurons when 'Apply to all' is clicked when all neurons are select", async () => {
+    neuronsStore.setNeurons({
+      neurons: [publicNeuron1, publicNeuron2, publicSeedNeuron],
+      certified: true,
+    });
+    const onNnsSubmit = vi.fn();
+
+    const po = renderComponent({
+      makePublic: false,
+      onNnsSubmit,
+    });
+
+    await po.getApplyToAllCheckbox().click();
+
+    const isChecked = async (neuron: NeuronInfo) =>
+      await po
+        .getControllableNeuronVisibilityRowPo(neuron.neuronId.toString())
+        .getCheckboxPo()
+        .isChecked();
+
+    expect(await isChecked(publicNeuron1)).toBe(true);
+    expect(await isChecked(publicNeuron2)).toBe(true);
+    expect(await isChecked(publicSeedNeuron)).toBe(true);
+
+    await po.getApplyToAllCheckbox().click();
+
+    expect(await isChecked(publicNeuron1)).toBe(false);
+    expect(await isChecked(publicNeuron2)).toBe(false);
+    expect(await isChecked(publicSeedNeuron)).toBe(false);
+  });
+
+  it("should keep only the default neuron selected when 'Apply to all' is clicked when all neurons are select", async () => {
+    neuronsStore.setNeurons({
+      neurons: [publicNeuron1, publicNeuron2, publicSeedNeuron],
+      certified: true,
+    });
+    const onNnsSubmit = vi.fn();
+
+    const po = renderComponent({
+      defaultSelectedNeuron: publicNeuron2,
+      makePublic: false,
+      onNnsSubmit,
+    });
+
+    await po.getApplyToAllCheckbox().click();
+
+    const isChecked = async (neuron: NeuronInfo) =>
+      await po
+        .getControllableNeuronVisibilityRowPo(neuron.neuronId.toString())
+        .getCheckboxPo()
+        .isChecked();
+
+    expect(await isChecked(publicNeuron1)).toBe(true);
+    expect(await isChecked(publicNeuron2)).toBe(true);
+    expect(await isChecked(publicSeedNeuron)).toBe(true);
+
+    await po.getApplyToAllCheckbox().click();
+
+    expect(await isChecked(publicNeuron1)).toBe(false);
+    expect(await isChecked(publicNeuron2)).toBe(true);
+    expect(await isChecked(publicSeedNeuron)).toBe(false);
   });
 
   it("should call nnsSubmit with selected neurons correctly when deselecting a neuron after 'Apply to all'", async () => {


### PR DESCRIPTION
# Motivation

When setting neuron visibility of one neuron, you are offered to select other neurons you might want to change.

<img width="608" alt="image" src="https://github.com/user-attachments/assets/80003b80-05b5-4752-b01b-52626e2e3480">

If all neurons are selected and you deselect the "Apply to all neurons" checkbox, all neurons become unselected.

If you arrived at this modal from the details page of one specific neuron it would be useful to keep that neuron selected when unselecting all. Because the confirm button is anyway disable when none are selected and you intended to change that neuron to start with.

# Changes

When deselecting all neurons, if there is a default neuron, keep the default neuron selected.

# Tests

1. Refactor checkbox checking in unit test.
2. Add missing unit test for deselecting all without default neuron.
3. Add unit test for deselecting all with default neuron.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary