### PR TITLE
Remove preventDefault from 'create as public' checkbox

### DIFF
--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -102,7 +102,6 @@
     <Separator spacing="small" />
 
     <Checkbox
-      preventDefault
       testId="as-public-neuron-checkbox"
       inputId="as-public-neuron-checkbox"
       checked={asPublicNeuron}


### PR DESCRIPTION
# Motivation

`preventDefault` on the `Checkbox` component prevents the checkbox from visibly toggling when the checkbox is clicked directly (as opposed to the text label being clicked).
The underlying `boolean` variable still toggles so it's even possible that a public neuron is created while the checkbox looked unchecked.

# Changes

Remove `preventDefault` from `"as-public-neuron-checkbox"` component in `NnsStakeNeuron`.

# Tests

1. I tried to create a unit test but it doesn't appear to be reproducible in the unit test framework.
2. Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary