### PR TITLE
Make e2e-test-metrics-present work on Mac

### DIFF
--- a/scripts/nns-dapp/e2e-test-metrics-present
+++ b/scripts/nns-dapp/e2e-test-metrics-present
@@ -23,7 +23,8 @@ REFERENCE_KEYS_FILE="$0.keys"
 NETWORK_KEYS_FILE=",nns-dapp-metrics-$DFX_NETWORK.keys"
 NETWORK_METRICS_FILE=",nns-dapp-metrics-$DFX_NETWORK.txt"
 curl "$METRICS_URL" >"$NETWORK_METRICS_FILE"
-sed -nE '/^([a-z_]+).*/{s//\1/g;p}' "$NETWORK_METRICS_FILE" | sort >"$NETWORK_KEYS_FILE"
+# Output just the metric names, filtering out values and comments.
+grep -oE '^[a-z_]+' "$NETWORK_METRICS_FILE" | sort >"$NETWORK_KEYS_FILE"
 diff "$REFERENCE_KEYS_FILE" "$NETWORK_KEYS_FILE" || {
   echo "ERROR: The list of metrics in  does not match the reference set."
   echo "Expected metrics are in: $REFERENCE_KEYS_FILE"


### PR DESCRIPTION
# Motivation

`sed` works slightly different on Mac than on Linux.
One difference is that it does not support the `p` command.
`scripts/nns-dapp/e2e-test-metrics-present` uses `sed` to output the metric names without comments or values.
This can actually more easily be done with `grep`.
The `-o` flag on `grep` makes it output just the matches rather than the full line.

# Changes

Change `scripts/nns-dapp/e2e-test-metrics-present` to use `grep` instead of `sed` so that it works on Mac as well.

# Tests

1. Tested manually on Mac.
2. CI runs on Linux and [still passes](https://github.com/dfinity/nns-dapp/actions/runs/11629035979/job/32385359427?pr=5712).

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary