### PR TITLE
Make icpAccountDetailsStore a queued store

### DIFF
--- a/frontend/src/lib/stores/icp-account-details.store.ts
+++ b/frontend/src/lib/stores/icp-account-details.store.ts
@@ -1,28 +1,15 @@
 import type { AccountDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { writable, type Readable } from "svelte/store";
+import { queuedStore, type QueuedStore } from "$lib/stores/queued-store";
 
 export interface IcpAccountDetailsStoreData {
   accountDetails: AccountDetails;
   certified: boolean;
 }
 
-export interface IcpAccountDetailsStore
-  extends Readable<IcpAccountDetailsStoreData | undefined> {
-  set: (accountDetails: IcpAccountDetailsStoreData | undefined) => void;
-  reset: () => void;
-}
+export type IcpAccountDetailsStore = QueuedStore<
+  IcpAccountDetailsStoreData | undefined
+>;
 
-const initIpcAccountDetailsStore = (): IcpAccountDetailsStore => {
-  const initialStoreData = undefined;
-  const { subscribe, set } = writable<IcpAccountDetailsStoreData | undefined>(
-    initialStoreData
-  );
-
-  return {
-    subscribe,
-    set,
-    reset: () => set(initialStoreData),
-  };
-};
-
-export const icpAccountDetailsStore = initIpcAccountDetailsStore();
+export const icpAccountDetailsStore = queuedStore<
+  IcpAccountDetailsStoreData | undefined
+>(undefined);

--- a/frontend/src/lib/stores/queued-store.ts
+++ b/frontend/src/lib/stores/queued-store.ts
@@ -50,11 +50,12 @@ export interface SingleMutationStore<StoreData> {
   cancel: () => void;
 }
 
-interface QueuedStore<StoreData> extends Readable<StoreData> {
+export interface QueuedStore<StoreData> extends Readable<StoreData> {
   getSingleMutationStore: (
     strategy?: QueryAndUpdateStrategy | undefined
   ) => SingleMutationStore<StoreData>;
   resetForTesting: () => void;
+  setForTesting: (data: StoreData) => void;
 }
 
 export const queuedStore = <StoreData>(
@@ -196,6 +197,12 @@ export const queuedStore = <StoreData>(
       certifiedData = initialData;
       mutationQueue = [];
       set(initialData);
+    },
+
+    setForTesting(data: StoreData) {
+      certifiedData = data;
+      mutationQueue = [];
+      set(data);
     },
   };
 };

--- a/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
@@ -62,7 +62,7 @@ describe("icpAccountsStore", () => {
 
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
-    icpAccountDetailsStore.reset();
+    icpAccountDetailsStore.resetForTesting();
     icpAccountBalancesStore.resetForTesting();
   });
 
@@ -75,7 +75,7 @@ describe("icpAccountsStore", () => {
   });
 
   it("should derive main account and balance", () => {
-    icpAccountDetailsStore.set({
+    icpAccountDetailsStore.setForTesting({
       accountDetails: {
         ...accountDetails,
         sub_accounts: [],
@@ -103,7 +103,7 @@ describe("icpAccountsStore", () => {
   });
 
   it("should derive all accounts and balances", () => {
-    icpAccountDetailsStore.set(accountDetailsData);
+    icpAccountDetailsStore.setForTesting(accountDetailsData);
 
     setBalance({
       accountIdentifier: mainAccountIdentifier,

--- a/frontend/src/tests/utils/accounts.test-utils.ts
+++ b/frontend/src/tests/utils/accounts.test-utils.ts
@@ -41,7 +41,7 @@ export const setAccountsForTesting = ({
 }: IcpAccountsStoreData & {
   certified?: boolean;
 }) => {
-  icpAccountDetailsStore.set({
+  icpAccountDetailsStore.setForTesting({
     accountDetails: {
       principal: main.principal,
       account_identifier: main.identifier,
@@ -112,6 +112,6 @@ export const setAccountBalanceForTesting = ({
 };
 
 export const resetAccountsForTesting = () => {
-  icpAccountDetailsStore.reset();
+  icpAccountDetailsStore.resetForTesting();
   icpAccountBalancesStore.resetForTesting();
 };


### PR DESCRIPTION
# Motivation

We've been seeing test flakiness in `e2e/accounts.spec.ts` since query+update has been rolled out for 10%.
The problem is that a subaccount is created before the original `queryAccount` update response comes back.
So when it finally comes back with a response from before the subaccount was created, it's as if the new subaccount suddenly disappears.

We've had similar issues before. The solution is to use `queuedStore` which is specifically made to make sure old update responses don't overwrite newer query responses.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
