### PR TITLE
Remove unused stakeNeuronIcrc1 code

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -20,7 +20,6 @@ import {
   splitNeuron,
   stakeMaturity,
   stakeNeuron,
-  stakeNeuronIcrc1,
   startDissolving,
   stopDissolving,
   type ApiAutoStakeMaturityParams,
@@ -37,7 +36,6 @@ import {
   type ApiSpawnNeuronParams,
   type ApiSplitNeuronParams,
   type ApiStakeMaturityParams,
-  type ApiStakeNeuronIcrc1Params,
   type ApiStakeNeuronParams,
   type RegisterVoteParams,
 } from "$lib/api/governance.api";
@@ -196,9 +194,6 @@ export const governanceApiService = {
   },
   stakeNeuron(params: ApiStakeNeuronParams) {
     return clearCacheAfter(stakeNeuron(params));
-  },
-  stakeNeuronIcrc1(params: ApiStakeNeuronIcrc1Params) {
-    return clearCacheAfter(stakeNeuronIcrc1(params));
   },
   startDissolving(params: ApiManageNeuronParams) {
     return clearCacheAfter(startDissolving(params));

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -425,39 +425,6 @@ export type ApiStakeNeuronIcrc1Params = ApiCallParams & {
   fromSubAccount?: Uint8Array;
 };
 
-/**
- * Uses governance and ledger canisters to create a neuron
- */
-export const stakeNeuronIcrc1 = async ({
-  stake,
-  controller,
-  ledgerCanisterIdentity,
-  identity,
-  fromSubAccount,
-}: ApiStakeNeuronIcrc1Params): Promise<NeuronId> => {
-  // Ledger HW app currently (2023-09-21) doesn't support staking with ICRC-1
-  // but it should be supported in the future so we keep the code similar to the
-  // non-ICRC-1 flow above.
-  logWithTimestamp(`Staking Neuron ICRC-1 call...`);
-  const { canister } = await governanceCanister({ identity });
-
-  // The use case of staking from Hardware wallet uses a different agent for governance and ledger canister.
-  const { canister: ledgerCanister } = await getLedgerCanister({
-    identity: ledgerCanisterIdentity,
-  });
-
-  const createdAt = nowInBigIntNanoSeconds();
-  const response = await canister.stakeNeuronIcrc1({
-    stake,
-    principal: controller,
-    fromSubAccount,
-    ledgerCanister,
-    createdAt,
-  });
-  logWithTimestamp(`Staking Neuron ICRC-1 complete.`);
-  return response;
-};
-
 export const queryKnownNeurons = async ({
   identity,
   certified,

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -959,41 +959,6 @@ describe("neurons api-service", () => {
     });
   });
 
-  describe("stakeNeuronIcrc1", () => {
-    const params = {
-      identity: mockIdentity,
-      stake: 10_000_000n,
-      controller: mockPrincipal,
-      ledgerCanisterIdentity: mockIdentity,
-      fromSubaccount: new Uint8Array(),
-    };
-
-    it("should call stakeNeuronIcrc1 api", async () => {
-      vi.spyOn(api, "stakeNeuronIcrc1").mockResolvedValueOnce(neuronId);
-      expect(await governanceApiService.stakeNeuronIcrc1(params)).toEqual(
-        neuronId
-      );
-      expect(api.stakeNeuronIcrc1).toHaveBeenCalledWith(params);
-      expect(api.stakeNeuronIcrc1).toHaveBeenCalledTimes(1);
-    });
-
-    it("should invalidate the cache", async () => {
-      await shouldInvalidateCache({
-        apiFunc: api.stakeNeuronIcrc1,
-        apiServiceFunc: governanceApiService.stakeNeuronIcrc1,
-        params,
-      });
-    });
-
-    it("should invalidate the cache on failure", async () => {
-      await shouldInvalidateCacheOnFailure({
-        apiFunc: api.stakeNeuronIcrc1,
-        apiServiceFunc: governanceApiService.stakeNeuronIcrc1,
-        params,
-      });
-    });
-  });
-
   describe("startDissolving", () => {
     const params = {
       neuronId,

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -19,7 +19,6 @@ import {
   splitNeuron,
   stakeMaturity,
   stakeNeuron,
-  stakeNeuronIcrc1,
   startDissolving,
   stopDissolving,
 } from "$lib/api/governance.api";
@@ -94,37 +93,6 @@ describe("neurons-api", () => {
         fee,
       })
     );
-  });
-
-  it("stakeNeuronIcrc1 creates a new neuron", async () => {
-    vi.spyOn(LedgerCanister, "create").mockImplementation(() =>
-      mock<LedgerCanister>()
-    );
-
-    expect(mockGovernanceCanister.stakeNeuronIcrc1).not.toBeCalled();
-
-    const stake = 20_000_000n;
-    const controller = mockIdentity.getPrincipal();
-    const fromSubAccount = new Uint8Array([5, 6, 7]);
-
-    await stakeNeuronIcrc1({
-      stake,
-      controller,
-      ledgerCanisterIdentity: mockIdentity,
-      identity: mockIdentity,
-      fromSubAccount,
-    });
-
-    expect(mockGovernanceCanister.stakeNeuronIcrc1).toBeCalledTimes(1);
-    expect(mockGovernanceCanister.stakeNeuronIcrc1).toBeCalledWith(
-      expect.objectContaining({
-        stake,
-        principal: controller,
-        fromSubAccount,
-      })
-    );
-
-    expect(mockGovernanceCanister.stakeNeuron).not.toBeCalled();
   });
 
   it("queryNeurons fetches neurons", async () => {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -145,7 +145,6 @@ describe("neurons-services", () => {
   const neurons = [sameControlledNeuron, controlledNeuron];
 
   const spyStakeNeuron = vi.spyOn(api, "stakeNeuron");
-  const spyStakeNeuronIcrc1 = vi.spyOn(api, "stakeNeuronIcrc1");
   const spyGetNeuron = vi.spyOn(api, "queryNeuron");
   const spyIncreaseDissolveDelay = vi.spyOn(api, "increaseDissolveDelay");
   const spyJoinCommunityFund = vi.spyOn(api, "joinCommunityFund");
@@ -181,9 +180,6 @@ describe("neurons-services", () => {
     checkedNeuronSubaccountsStore.reset();
 
     spyStakeNeuron.mockImplementation(() =>
-      Promise.resolve(mockNeuron.neuronId)
-    );
-    spyStakeNeuronIcrc1.mockImplementation(() =>
       Promise.resolve(mockNeuron.neuronId)
     );
     spyGetNeuron.mockResolvedValue(mockNeuron);
@@ -232,7 +228,6 @@ describe("neurons-services", () => {
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
-      expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
     it("should stake and load a neuron from subaccount", async () => {
@@ -252,7 +247,6 @@ describe("neurons-services", () => {
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
-      expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
     it("should stake neuron from hardware wallet", async () => {
@@ -278,7 +272,6 @@ describe("neurons-services", () => {
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
-      expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
     it("stakeNeuron return undefined if amount less than 1 ICP", async () => {
@@ -294,7 +287,6 @@ describe("neurons-services", () => {
       expect(response).toBeUndefined();
       expectToastError(en.error.amount_not_enough_stake_neuron);
       expect(spyStakeNeuron).not.toBeCalled();
-      expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
     it("stake neuron should return undefined if amount not valid", async () => {
@@ -310,7 +302,6 @@ describe("neurons-services", () => {
       expect(response).toBeUndefined();
       expectToastError("Invalid number NaN");
       expect(spyStakeNeuron).not.toBeCalled();
-      expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
     it("stake neuron should return undefined if not enough funds in account", async () => {
@@ -331,7 +322,6 @@ describe("neurons-services", () => {
       expect(response).toBeUndefined();
       expectToastError(en.error.insufficient_funds);
       expect(spyStakeNeuron).not.toBeCalled();
-      expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
     it("should not stake neuron if no identity", async () => {
@@ -345,7 +335,6 @@ describe("neurons-services", () => {
       expect(response).toBeUndefined();
       expectToastError("Cannot read properties of null");
       expect(spyStakeNeuron).not.toBeCalled();
-      expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
     it("should create a public neuron when asPublicNeuron is true", async () => {


### PR DESCRIPTION
# Motivation

This code should have been removed in https://github.com/dfinity/nns-dapp/pull/3946

# Changes

Remove `stakeNeuronIcrc1` from API.

# Tests

The code was unused. Tests have been removed.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary