### PR TITLE
Remove order dependence from AccountDetails.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/header/AccountDetails.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountDetails.spec.ts
@@ -7,18 +7,23 @@ import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("AccountDetails", () => {
-  const renderComponent = () => {
-    const { container } = render(AccountDetails);
-    return AccountDetailsPo.under(new JestPageObjectElement(container));
-  };
-  it("should display main ICP account ID if available", async () => {
-    const accountIdForTesting = "82376428374628347628347263847263847623";
+  const accountIdForTesting = "82376428374628347628347263847263847623";
+
+  beforeEach(() => {
     setAccountsForTesting({
       main: {
         ...mockMainAccount,
         identifier: accountIdForTesting,
       },
     });
+  });
+
+  const renderComponent = () => {
+    const { container } = render(AccountDetails);
+    return AccountDetailsPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should display main ICP account ID if available", async () => {
     const accountDetailsPo = renderComponent();
 
     const mainAccountId = await accountDetailsPo.getMainIcpAccountId();


### PR DESCRIPTION
# Motivation

The first test in `AccountDetails.spec.ts` sets a value on accounts stores and the other tests rely on this value being set.
This means that if test are run individually or in a different order, they fail.

# Changes

Move the setup from the one test to `beforeEach`.

# Tests

The last test was failing before when run as the `.only` test and now it passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary