### PR TITLE
Allow dfx-canister-url to make raw local URLs

### DIFF
--- a/scripts/dfx-canister-url
+++ b/scripts/dfx-canister-url
@@ -112,7 +112,6 @@ inject_canister_id() {
     # Raw may be inserted, except on localhost.
     local RAW_PART
     RAW_PART="${DFX_RAW:+.raw}"
-    [[ "$DFX_NETWORK" != "local" ]] || RAW_PART=""
     printf "%s\n" "$root_url" | sed -E "s,^(https?://)?,&${CANISTER_ID}${RAW_PART:-}.,g"
     ;;
   *) printf "%s\n" "$root_url" ;;

--- a/scripts/nns-dapp/e2e-test-metrics-present
+++ b/scripts/nns-dapp/e2e-test-metrics-present
@@ -23,7 +23,8 @@ REFERENCE_KEYS_FILE="$0.keys"
 NETWORK_KEYS_FILE=",nns-dapp-metrics-$DFX_NETWORK.keys"
 NETWORK_METRICS_FILE=",nns-dapp-metrics-$DFX_NETWORK.txt"
 curl "$METRICS_URL" >"$NETWORK_METRICS_FILE"
-sed -nE '/^([a-z_]+).*/{s//\1/g;p}' "$NETWORK_METRICS_FILE" | sort >"$NETWORK_KEYS_FILE"
+# Output just the metric names, filtering out values and comments.
+grep -oE '^[a-z_]+' "$NETWORK_METRICS_FILE" | sort >"$NETWORK_KEYS_FILE"
 diff "$REFERENCE_KEYS_FILE" "$NETWORK_KEYS_FILE" || {
   echo "ERROR: The list of metrics in  does not match the reference set."
   echo "Expected metrics are in: $REFERENCE_KEYS_FILE"


### PR DESCRIPTION
# Motivation

`dfx` 0.24.1 uses ic-http-certification instead of icx-proxy which means that metrics now need to be requested via a `.raw` URL locally just like on mainnet.

This breaks [e2e-test-metrics-present](https://github.com/dfinity/nns-dapp/blob/main/scripts/nns-dapp/e2e-test-metrics-present).
`e2e-test-metrics-present` actually already tries to use a raw URL by passing `--raw` to `dfx-canister-url` [here](https://github.com/dfinity/nns-dapp/blob/8e2701a57ed725f30e23aa5277fb179f1deacd99/scripts/nns-dapp/e2e-test-metrics-present#L21).

But `dfx-canister-url` ignore this flag on local.
Since raw URLs are now required on local, we should stop ignoring the flag.

# Changes

Remove the code that sets `RAW_PART` to the empty string for the local network.

# Tests

1. Manually ran `scripts/dfx-canister-url  --raw nns-dapp` to see that it now has a `.raw` URL.
2. Ran `scripts/nns-dapp/e2e-test-metrics-present`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary