### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-23_03-07-ubuntu20.04/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-31_03-09-ubuntu20.04/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -578,6 +578,7 @@ type Neuron = record {
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -629,6 +630,7 @@ type NeuronInfo = record {
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronStakeTransfer = record {

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-23_03-07-ubuntu20.04/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-31_03-09-ubuntu20.04/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -133,11 +133,15 @@ type KeyConfig = record {
   max_queue_size : opt nat32;
 };
 
-type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId };
+type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId; VetKd : VetKdKeyId };
 
 type SchnorrKeyId = record { algorithm : SchnorrAlgorithm; name : text };
 
 type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
+
+type VetKdKeyId = record { curve: VetKdCurve; name: text };
+
+type VetKdCurve = variant { bls12_381_g2 };
 
 type EcdsaConfig = record {
   quadruples_to_create_in_advance : nat32;

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-23_03-07-ubuntu20.04/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-31_03-09-ubuntu20.04/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/dfx.json
+++ b/dfx.json
@@ -404,7 +404,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-10-23",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-10-23_03-07-ubuntu20.04",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-10-31_03-09-ubuntu20.04",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-10-23_03-07-ubuntu20.04"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-23_03-07-ubuntu20.04/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-31_03-09-ubuntu20.04/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -741,6 +741,7 @@ pub struct Neuron {
     pub staked_maturity_e8s_equivalent: Option<u64>,
     pub controller: Option<Principal>,
     pub recent_ballots: Vec<BallotInfo>,
+    pub voting_power_refreshed_timestamp_seconds: Option<u64>,
     pub kyc_verified: bool,
     pub neuron_type: Option<i32>,
     pub not_for_profit: bool,
@@ -818,6 +819,7 @@ pub enum Result4 {
 pub struct NeuronInfo {
     pub dissolve_delay_seconds: u64,
     pub recent_ballots: Vec<BallotInfo>,
+    pub voting_power_refreshed_timestamp_seconds: Option<u64>,
     pub neuron_type: Option<i32>,
     pub created_timestamp_seconds: u64,
     pub state: i32,

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-23_03-07-ubuntu20.04/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-31_03-09-ubuntu20.04/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -158,8 +158,19 @@ pub struct SchnorrKeyId {
     pub name: String,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub enum VetKdCurve {
+    #[serde(rename = "bls12_381_g2")]
+    Bls12381G2,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct VetKdKeyId {
+    pub name: String,
+    pub curve: VetKdCurve,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub enum MasterPublicKeyId {
     Schnorr(SchnorrKeyId),
+    VetKd(VetKdKeyId),
     Ecdsa(EcdsaKeyId),
 }
 #[derive(Serialize, CandidType, Deserialize)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-23_03-07-ubuntu20.04/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-31_03-09-ubuntu20.04/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants