### PR TITLE
Reset accounts store in CkBTCWallet.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -121,6 +121,7 @@ describe("CkBTCWallet", () => {
     bitcoinAddressStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
     resetIdentity();
+    icrcAccountsStore.reset();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],
@@ -504,24 +505,24 @@ describe("CkBTCWallet", () => {
         [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: [statusWithId],
       });
     });
-  });
 
-  it('should have canister links in "more" popup', async () => {
-    const po = await renderWallet();
-    const morePopoverPo = po.getWalletMorePopoverPo();
+    it('should have canister links in "more" popup', async () => {
+      const po = await renderWallet();
+      const morePopoverPo = po.getWalletMorePopoverPo();
 
-    await po.getMoreButton().click();
-    await runResolvedPromises();
+      await po.getMoreButton().click();
+      await runResolvedPromises();
 
-    expect(await morePopoverPo.isPresent()).toBe(true);
-    expect(await morePopoverPo.getLinkToLedgerCanisterPo().getHref()).toBe(
-      `https://dashboard.internetcomputer.org/canister/${CKTESTBTC_LEDGER_CANISTER_ID.toText()}`
-    );
-    expect(await morePopoverPo.getLinkToIndexCanisterPo().isPresent()).toBe(
-      true
-    );
-    expect(await morePopoverPo.getLinkToIndexCanisterPo().getHref()).toBe(
-      `https://dashboard.internetcomputer.org/canister/${CKTESTBTC_INDEX_CANISTER_ID.toText()}`
-    );
+      expect(await morePopoverPo.isPresent()).toBe(true);
+      expect(await morePopoverPo.getLinkToLedgerCanisterPo().getHref()).toBe(
+        `https://dashboard.internetcomputer.org/canister/${CKTESTBTC_LEDGER_CANISTER_ID.toText()}`
+      );
+      expect(await morePopoverPo.getLinkToIndexCanisterPo().isPresent()).toBe(
+        true
+      );
+      expect(await morePopoverPo.getLinkToIndexCanisterPo().getHref()).toBe(
+        `https://dashboard.internetcomputer.org/canister/${CKTESTBTC_INDEX_CANISTER_ID.toText()}`
+      );
+    });
   });
 });


### PR DESCRIPTION
# Motivation

A test added in https://github.com/dfinity/nns-dapp/pull/5394 relies on accounts being present but is no placed inside the `describe("accounts loaded", () => {` which does the required accounts setup.
It doesn't fail because the `icrcAccountsStore` isn't properly reset between tests.

# Changes

1. Reset `icrcAccountsStore` in top-level `beforeEach` in `frontend/src/tests/lib/pages/CkBTCWallet.spec.ts`.
2. Place `it('should have canister links in "more" popup'` inside `describe("accounts loaded"`.

# Tests

1. The test failed after adding the `icrcAccountsStore.reset()` and passed again after moving the test inside the `describe`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary