### PR TITLE
Reset overrideFeatureFlagsStore in routes/app/tokens/page.spec.ts

### DIFF
--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -136,6 +136,7 @@ describe("Tokens route", () => {
   describe("when feature flag enabled", () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      overrideFeatureFlagsStore.reset();
       icrcAccountsStore.reset();
       tokensStore.reset();
       defaultIcrcCanistersStore.reset();
@@ -535,6 +536,7 @@ describe("Tokens route", () => {
       describe("when logged in", () => {
         beforeEach(() => {
           resetIdentity();
+          overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
         });
 
         it("should display tokens in specific order", async () => {
@@ -676,6 +678,7 @@ describe("Tokens route", () => {
       );
       beforeEach(() => {
         resetIdentity();
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
 
         vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockImplementation(
           async ({ canisterId }) => {


### PR DESCRIPTION
# Motivation

Some tests in `routes/app/tokens/page.spec.ts` depend on the `ENABLE_CKTESTBTC` feature flag being disabled.
But they do not disable the feature flag.
They only pass because other tests disable the feature flag and the `overrideFeatureFlagsStore` isn't properly reset between tests.

# Changes

1. Reset `overrideFeatureFlagsStore` in `beforeEach`.
2. `overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);` in the `beforeEach` of those `describe` blocks that were implicitly relying on this.

# Tests

1. Test failed after adding the `reset` and passed again after adding the `setFlag`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary