### PR TITLE
Reset every store before each test

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -20,6 +20,29 @@ import {
   setDefaultTestConstants,
 } from "./src/tests/utils/mockable-constants.test-utils";
 
+// Reset every store before each test.
+const resetStoreFunctions = vi.hoisted(() => {
+  return [];
+});
+
+vi.mock("svelte/store", async (importOriginal) => {
+  const svelteStoreModule = await importOriginal();
+  return {
+    ...svelteStoreModule,
+    writable: <T>(initialValue, ...otherArgs) => {
+      const store = svelteStoreModule.writable<T>(initialValue, ...otherArgs);
+      resetStoreFunctions.push(() => store.set(initialValue));
+      return store;
+    },
+  }
+});
+
+beforeEach(() => {
+  for (const reset of resetStoreFunctions) {
+    reset();
+  }
+});
+
 // Mock SubtleCrypto to test @dfinity/auth-client
 const crypto = new SubtleCrypto();
 Object.defineProperty(global, "crypto", {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -34,7 +34,7 @@ vi.mock("svelte/store", async (importOriginal) => {
       resetStoreFunctions.push(() => store.set(initialValue));
       return store;
     },
-  }
+  };
 });
 
 beforeEach(() => {


### PR DESCRIPTION
# Motivation

Test can accidentally share state because we have a lot of global stores which keep their state between tests.
This can result in confusing and difficult to debug behavior from tests.
If we reset every store before each test we eliminate one source of dependencies of test on the order in which they are run.

# Changes

1. Spy on `writable` from `"svelte/store"` by wrapping the call to `writable` in a function that records a way to reset the created store.
2. Reset each of these stores in a global `beforeEach` functions.

# Tests

1. Resetting all stores caused some tests to fail. These tests have been fixed in other PRs such as https://github.com/dfinity/nns-dapp/pull/5716, https://github.com/dfinity/nns-dapp/pull/5722 and https://github.com/dfinity/nns-dapp/pull/5723.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary