### PR TITLE
FOLLOW-244: Add API to claim a neuron

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -3,6 +3,7 @@ import {
   autoStakeMaturity,
   changeNeuronVisibility,
   claimOrRefreshNeuron,
+  claimOrRefreshNeuronByMemo,
   disburse,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -24,6 +25,7 @@ import {
   stopDissolving,
   type ApiAutoStakeMaturityParams,
   type ApiChangeNeuronVisibilityParams,
+  type ApiClaimNeuronParams,
   type ApiDisburseParams,
   type ApiIncreaseDissolveDelayParams,
   type ApiManageHotkeyParams,
@@ -152,6 +154,9 @@ export const governanceApiService = {
   },
   autoStakeMaturity(params: ApiAutoStakeMaturityParams) {
     return clearCacheAfter(autoStakeMaturity(params));
+  },
+  claimOrRefreshNeuronByMemo(params: ApiClaimNeuronParams) {
+    return clearCacheAfter(claimOrRefreshNeuronByMemo(params));
   },
   claimOrRefreshNeuron(params: ApiManageNeuronParams) {
     return clearCacheAfter(claimOrRefreshNeuron(params));

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -42,6 +42,11 @@ export type ApiManageNeuronParams = ApiCallParams & {
   neuronId: NeuronId;
 };
 
+export type ApiClaimNeuronParams = ApiCallParams & {
+  memo: bigint;
+  controller: Principal;
+};
+
 /**
  * API FUNCTIONS
  */
@@ -462,6 +467,22 @@ export const claimOrRefreshNeuron = async ({
   logWithTimestamp(
     `ClaimingOrRefreshing Neurons (${hashCode(neuronId)}) complete.`
   );
+  return response;
+};
+
+export const claimOrRefreshNeuronByMemo = async ({
+  memo,
+  controller,
+  identity,
+}: ApiClaimNeuronParams): Promise<NeuronId | undefined> => {
+  logWithTimestamp(`claimOrRefreshNeuronByMemo call...`);
+  const { canister } = await governanceCanister({ identity });
+
+  const response = await canister.claimOrRefreshNeuronFromAccount({
+    memo,
+    controller,
+  });
+  logWithTimestamp(`claimOrRefreshNeuronByMemo complete.`);
   return response;
 };
 

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -594,6 +594,41 @@ describe("neurons api-service", () => {
     });
   });
 
+  describe("claimOrRefreshNeuronByMemo", () => {
+    const params = {
+      memo: 321n,
+      controller: mockPrincipal,
+      identity: mockIdentity,
+    };
+
+    it("should call claimOrRefreshNeuronByMemo api", async () => {
+      vi.spyOn(api, "claimOrRefreshNeuronByMemo").mockResolvedValueOnce(
+        neuronId
+      );
+      expect(
+        await governanceApiService.claimOrRefreshNeuronByMemo(params)
+      ).toEqual(neuronId);
+      expect(api.claimOrRefreshNeuronByMemo).toHaveBeenCalledWith(params);
+      expect(api.claimOrRefreshNeuronByMemo).toHaveBeenCalledTimes(1);
+    });
+
+    it("should invalidate the cache", async () => {
+      await shouldInvalidateCache({
+        apiFunc: api.claimOrRefreshNeuronByMemo,
+        apiServiceFunc: governanceApiService.claimOrRefreshNeuronByMemo,
+        params,
+      });
+    });
+
+    it("should invalidate the cache on failure", async () => {
+      await shouldInvalidateCacheOnFailure({
+        apiFunc: api.claimOrRefreshNeuronByMemo,
+        apiServiceFunc: governanceApiService.claimOrRefreshNeuronByMemo,
+        params,
+      });
+    });
+  });
+
   describe("disburse", () => {
     const params = {
       neuronId,

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -602,9 +602,7 @@ describe("neurons api-service", () => {
     };
 
     it("should call claimOrRefreshNeuronByMemo api", async () => {
-      vi.spyOn(api, "claimOrRefreshNeuronByMemo").mockResolvedValueOnce(
-        neuronId
-      );
+      vi.spyOn(api, "claimOrRefreshNeuronByMemo").mockResolvedValue(neuronId);
       expect(
         await governanceApiService.claimOrRefreshNeuronByMemo(params)
       ).toEqual(neuronId);


### PR DESCRIPTION
# Motivation

Staking a neuron requires 2 steps: transferring the stake and claiming the neuron.
Both steps are done in the canister code in ic-js.
But it's possible that the process get interrupted in between.
In this case the nns-dapp canister finishes the process.
We want to move this fallback mechanism to the frontend.
So the frontend should be able to claim a neuron as a separate step.
The governance API already has a `claimOrRefreshNeuron` function but it requires a `neuronId` as parameter so it can really only be used for neurons that already exist.

# Changes

1. Add `claimOrRefreshNeuronByMemo` which allows claiming a neuron for which we do not know the neuron ID yet.
2. Add `claimOrRefreshNeuronByMemo` to api-service as well.

# Tests

1. Unit tests added.
2. Tested end to end in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary