### PR TITLE
Aligns text to the left for confirmation modal

### DIFF
--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -19,5 +19,5 @@
   margin: 0;
 
   font-size: var(--font-size-h4);
-  text-align: center;
+  text-align: left;
 }

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -19,5 +19,4 @@
   margin: 0;
 
   font-size: var(--font-size-h4);
-  text-align: left;
 }


### PR DESCRIPTION
# Motivation

All modals show text left align but no the confirmation modal. This MR fixes this.

# Changes
- Confirmation modals text is now left aligned 

# Tests

It can be tested [here](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/neuron/?u=qsgjb-riaaa-aaaaa-aaaga-cai&neuron=11196078873928904437).

<img width="750" alt="Screenshot 2024-11-06 at 11 51 50" src="https://github.com/user-attachments/assets/1310c883-8b3d-4e05-9f1d-510d65acfa7d">

<img width="701" alt="Screenshot 2024-11-06 at 11 52 19" src="https://github.com/user-attachments/assets/b3d8e81f-b47b-46b2-82a9-f9f64236ad9c">




# Todos

- [ ] Add entry to changelog (if necessary).
