### PR TITLE
Enforces an exact match of replica processes

### DIFF
--- a/scripts/deploy-devenv
+++ b/scripts/deploy-devenv
@@ -30,7 +30,7 @@ else
   exit 1
 fi
 
-if ! pgrep replica; then
+if ! pgrep -x replica; then
   echo "A local replica must be running to deploy to." >&2
   exit 1
 fi

--- a/scripts/dfx-snapshot-install
+++ b/scripts/dfx-snapshot-install
@@ -215,7 +215,7 @@ install_state() {
 
 output_restore_backup_script() {
   cat <<-EOF
-	if pgrep replica; then
+	if pgrep -x replica; then
 	  echo "A replica is still running. State should be restored automatically when the replica is stopped." >&2
 	  exit 1
 	fi

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -33,7 +33,7 @@ source "$(clap.build)"
 # shellcheck disable=SC2009
 SCRIPT_COUNT="$(ps -A -o command | grep -c "^bash .*$(basename "$0")")"
 
-if pgrep replica || [ "$SCRIPT_COUNT" -gt 2 ]; then
+if pgrep -x replica || [ "$SCRIPT_COUNT" -gt 2 ]; then
   echo "ERROR: There is already a replica running. Please stop it first."
   exit 1
 fi

--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -331,7 +331,7 @@ sha256() {
 }
 
 get_dfx_identity() {
-  if pgrep replica; then
+  if pgrep -x replica; then
     (
       echo
       echo "A replica is running."

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -17,7 +17,7 @@ clap.define short=i long=identity desc="Identity to use to create proposals" var
 source "$(clap.build)"
 
 # Check if a replica is running:
-if ! pgrep replica; then
+if ! pgrep -x replica; then
   echo "A replica must be running to submit proposals to." >&2
   exit 1
 fi

--- a/scripts/nns-dapp/upgrade-downgrade-test
+++ b/scripts/nns-dapp/upgrade-downgrade-test
@@ -35,7 +35,7 @@ if ! [ -f "$ARGS_FILE" ]; then
 fi
 
 # Check if a replica is running:
-if pgrep replica; then
+if pgrep -x replica; then
   echo "A replica is already running. Shut it down first." >&2
   exit 1
 fi


### PR DESCRIPTION
# Motivation

A script runs `pgrep -l replica` to check for replica processes, but it can't receive false positives from a process called `replicatord`.

```sh
$ pgrep -l replica
781 replicatord
95113 replica
```

# Changes

- The script checks for exact matches with the keyword `replica`.

# Tests

I couldn't run the script that starts the snapshot without this change because it was complaining about a process (`replicatord`) matching the pattern. This change allowed me to run it without issues. I also tried to start a second snapshot, and it correctly informed me that a replica was already running.

# Todos

- [ ] Add entry to changelog (if necessary) - Not necessary
