### PR TITLE
FOLLOW-244: Do not try to claim the same neuron multiple times in a session

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1129,6 +1129,20 @@ export const claimNeuronsIfNeeded = async ({
     transactions,
   });
   for (const { memo, accountIdentifier } of memos) {
+    // We only check neurons to recover from interrupted staking.
+    // Doing this once per neuron per session is often enough.
+    if (
+      !checkedNeuronSubaccountsStore.addSubaccount({
+        universeId: OWN_CANISTER_ID_TEXT,
+        // It's not actually the subaccount but rather the full account
+        // identifier. But ic-js doesn't expose the neuron's subaccount and it
+        // really just needs to be a unique consistent identifier to avoid
+        // checking too often.
+        subaccountHex: accountIdentifier,
+      })
+    ) {
+      return;
+    }
     if (neuronAccounts.has(accountIdentifier)) {
       // Neuron already exists.
       continue;

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -2335,6 +2335,33 @@ describe("neurons-services", () => {
 
       expect(get(toastsStore)).toEqual([]);
     });
+
+    it("should not try to claim a neuron more than once per session", async () => {
+      spyClaimOrRefreshByMemo.mockRejectedValue(new Error("Test error"));
+
+      expect(spyClaimOrRefreshByMemo).toBeCalledTimes(0);
+      expect(spyGetNeuron).toBeCalledTimes(0);
+
+      await claimNeuronsIfNeeded({
+        controller: neuronController,
+        transactions: [stakingTransaction],
+        neuronAccounts: new Set(),
+      });
+
+      expect(spyClaimOrRefreshByMemo).toBeCalledTimes(1);
+      expect(spyGetNeuron).toBeCalledTimes(0);
+
+      await claimNeuronsIfNeeded({
+        controller: neuronController,
+        transactions: [stakingTransaction],
+        neuronAccounts: new Set(),
+      });
+
+      expect(spyClaimOrRefreshByMemo).toBeCalledTimes(1);
+      expect(spyGetNeuron).toBeCalledTimes(0);
+
+      expect(get(toastsStore)).toEqual([]);
+    });
   });
 
   describe("changeNeuronVisibility", () => {


### PR DESCRIPTION
# Motivation

When the frontend sees a staking transaction without a corresponding neuron, it tries to claim the neuron in case claiming it was interrupted.
We don't need to do this more than once so we store the account identifier to at least not do it more than once per session.

# Changes

1. If we find a staking transaction, add the neuron account identifier to `checkedNeuronSubaccountsStore` and if it was already there, don't try to claim the neuron.

# Tests

1. Unit test added. Tested that the test fails without the new code.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary