### PR TITLE
FOLLOW-244: Claim unclaimed neurons from the frontend

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,6 +19,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Updated the dark theme and page icons.
+* Claim unclaimed neurons from the frontend.
 
 #### Deprecated
 

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -49,10 +49,12 @@ export const createMockSendTransactionWithId = ({
   amount = 110_000_023n,
   fee = 10_000n,
   to = mockSubAccount.identifier,
+  memo = 0n,
 }: {
   amount?: bigint;
   fee?: bigint;
   to?: string;
+  memo?: bigint;
 }): TransactionWithId => {
   const transfer = {
     ...mockTransactionWithId.transaction["Transfer"],
@@ -66,6 +68,7 @@ export const createMockSendTransactionWithId = ({
   const transaction = {
     ...mockTransactionWithId.transaction,
     operation,
+    memo,
   };
   return {
     ...mockTransactionWithId,


### PR DESCRIPTION
# Motivation

Staking a neuron requires 2 steps: transferring the stake and claiming the neuron.
Both steps are done in ic-js.
But it's possible that the process gets interrupted in between.
In this case the nns-dapp canister finishes the process.
We want to move this fallback mechanism to the frontend.

The functionality was added in previous PRs. Here was call the service function from the wallet component to make it actually functional.

# Changes

1. Call `claimNeuronsIfNeeded` from `NnsWallet`.

# Tests

1. Tested manually after disabling the functionality in the canister, by reloading the page as soon as the staking process is started.
2. Unit tests added for main account, subaccount and hardware wallet account.

# Todos

- [x] Add entry to changelog (if necessary).
