### PR TITLE
FOLLOW-244: Remove MultiPartTransactionToBeProcessed::TopUpNeuron

### DIFF
--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -13,9 +13,6 @@ pub struct MultiPartTransactionsProcessor {
 #[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub enum MultiPartTransactionToBeProcessed {
     StakeNeuron(PrincipalId, Memo),
-    // TODO: Remove TopUpNeuron after a version has been released that does not
-    //       add TopUpNeuron to the multi-part transaction queue anymore.
-    TopUpNeuron(PrincipalId, Memo),
     CreateCanisterV2(PrincipalId),
     TopUpCanisterV2(PrincipalId, CanisterId),
     // ParticipateSwap(buyer_id, from, to, swap_canister_id)

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -26,10 +26,6 @@ pub async fn run_periodic_tasks() {
             MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo) => {
                 handle_stake_neuron(principal, memo).await;
             }
-            // TODO: Remove TopUpNeuron after a version has been released that
-            //       does not add TopUpNeuron to the multi-part transaction
-            //       queue anymore.
-            MultiPartTransactionToBeProcessed::TopUpNeuron(_principal, _memo) => {}
             MultiPartTransactionToBeProcessed::CreateCanisterV2(controller) => {
                 handle_create_canister_v2(block_height, controller).await;
             }


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/5706 removed the functionality to top up neurons from the nns-dapp canister.
Because `TopUpNeuron` transactions could be on the queue when the canister is upgraded, I didn't remove the `MultiPartTransactionToBeProcessed::TopUpNeuron` enum value yet.
Now that the current version on mainnet no longer adds `TopUpNeuron` to the queue, it should be safe to remove this value from the enum type.

# Changes

1. Remove `TopUpNeuron` from `MultiPartTransactionToBeProcessed`.

# Tests

CI passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary