### PR TITLE
FOLLOW-244: Stop inserting into AccountsStore.neuron_accounts

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1016,13 +1016,6 @@ impl AccountsStore {
                 );
             }
             TransactionType::StakeNeuron => {
-                let neuron_details = NeuronDetails {
-                    account_identifier: to,
-                    principal,
-                    memo,
-                    neuron_id: None,
-                };
-                self.neuron_accounts.insert(to, neuron_details);
                 self.multi_part_transactions_processor.push(
                     block_height,
                     MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo),

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -802,15 +802,6 @@ impl AccountsStore {
         self.multi_part_transactions_processor.take_next()
     }
 
-    /// Records that a neuron has been created for the given account.
-    ///
-    /// # Panics
-    /// - If the account does not exist.
-    pub fn mark_neuron_created(&mut self, principal: &PrincipalId, memo: Memo, neuron_id: NeuronId) {
-        let account_identifier = Self::generate_stake_neuron_address(principal, memo);
-        self.neuron_accounts.get_mut(&account_identifier).unwrap_or_else(|| panic!("Failed to mark neuron created for account {account_identifier} as the account has no neuron_accounts entry.")).neuron_id = Some(neuron_id);
-    }
-
     pub fn enqueue_multi_part_transaction(
         &mut self,
         block_height: BlockIndex,

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -42,9 +42,7 @@ pub async fn run_periodic_tasks() {
 
 async fn handle_stake_neuron(principal: PrincipalId, memo: Memo) {
     match claim_or_refresh_neuron(principal, memo).await {
-        Ok(neuron_id) => with_state_mut(|s| {
-            s.accounts_store.mark_neuron_created(&principal, memo, neuron_id);
-        }),
+        Ok(_neuron_id) => (),
         Err(_error) => (),
     }
 }


### PR DESCRIPTION
# Motivation

`AccountsStore.neuron_accounts` was only used to detect if a transaction is a neuron top-up transaction.
Now that the nns-dapp canister no longer does neuron refreshing for neuron top-ups, we no longer need to add new neurons to `neuron_accounts`.

This is one or multiple PRs to eventually remove the `neuron_accounts` field entirely.

# Changes

Remove the code that adds new entries to `AccountsStore.neuron_accounts`.

# Tests

Existing tests still pass so apparently this functionality wasn't tested.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary