### PR TITLE
FOLLOW-244: Stop claiming neurons in the nns-dapp canister

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -56,3 +56,4 @@ M2
 protobuf
 se
 TVL
+backend

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,7 +19,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Updated the dark theme and page icons.
-* Claim unclaimed neurons from the frontend.
+* Claim unclaimed neurons from the frontend instead of the backend.
 
 #### Deprecated
 

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1,7 +1,6 @@
 use super::histogram::AccountsStoreHistogram;
 use super::*;
 use crate::accounts_store::toy_data::{toy_account, ToyAccountSize};
-use crate::multi_part_transactions_processor::MultiPartTransactionToBeProcessed;
 use icp_ledger::Tokens;
 use pretty_assertions::assert_eq;
 use std::str::FromStr;
@@ -133,37 +132,6 @@ fn register_hardware_wallet_hardware_wallet_already_registered() {
         AccountIdentifier::from(hw1),
         account.hardware_wallet_accounts[0].account_identifier
     );
-}
-
-#[test]
-fn maybe_process_transaction_detects_neuron_transactions() {
-    let mut store = setup_test_store();
-
-    let block_height = store.get_block_height_synced_up_to().unwrap_or(0) + 1;
-
-    let neuron_principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
-    let neuron_memo = Memo(16656605094239839590);
-    let neuron_account = AccountsStore::generate_stake_neuron_address(&neuron_principal, neuron_memo);
-
-    let transfer = Transfer {
-        from: AccountIdentifier::new(neuron_principal, None),
-        to: neuron_account,
-        spender: None,
-        amount: Tokens::from_tokens(1).unwrap(),
-        fee: Tokens::from_e8s(10000),
-    };
-    store
-        .maybe_process_transaction(&transfer, neuron_memo, block_height)
-        .unwrap();
-
-    if let Some((_, MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo))) =
-        store.multi_part_transactions_processor.take_next()
-    {
-        assert_eq!(principal, neuron_principal);
-        assert_eq!(memo, neuron_memo);
-    } else {
-        panic!();
-    }
 }
 
 #[test]

--- a/rs/backend/src/canisters/governance.rs
+++ b/rs/backend/src/canisters/governance.rs
@@ -1,22 +1,4 @@
-use dfn_candid::candid;
-use ic_nns_constants::GOVERNANCE_CANISTER_ID;
-pub use ic_nns_governance::pb::v1::{
-    governance::GovernanceCachedMetrics, ClaimOrRefreshNeuronFromAccount, ClaimOrRefreshNeuronFromAccountResponse,
-    GovernanceError,
-};
-
-pub async fn claim_or_refresh_neuron_from_account(
-    request: ClaimOrRefreshNeuronFromAccount,
-) -> Result<ClaimOrRefreshNeuronFromAccountResponse, String> {
-    dfn_core::call(
-        GOVERNANCE_CANISTER_ID,
-        "claim_or_refresh_neuron_from_account",
-        candid,
-        (request,),
-    )
-    .await
-    .map_err(|e| e.1)
-}
+pub use ic_nns_governance::pb::v1::{governance::GovernanceCachedMetrics, GovernanceError};
 
 #[cfg(not(test))]
 pub use prod::get_metrics;
@@ -28,7 +10,9 @@ type GetMetricsCallResult = Result<Result<GovernanceCachedMetrics, GovernanceErr
 
 #[cfg(not(test))]
 mod prod {
-    use super::{candid, GetMetricsCallResult, GOVERNANCE_CANISTER_ID};
+    use super::GetMetricsCallResult;
+    use dfn_candid::candid;
+    use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 
     pub async fn get_metrics() -> GetMetricsCallResult {
         dfn_core::call(GOVERNANCE_CANISTER_ID, "get_metrics", candid, ())

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -12,6 +12,8 @@ pub struct MultiPartTransactionsProcessor {
 
 #[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub enum MultiPartTransactionToBeProcessed {
+    // TODO: Remove StakeNeuron after a version has been released that does not
+    //       add StakeNeuron to the multi-part transaction queue anymore.
     StakeNeuron(PrincipalId, Memo),
     CreateCanisterV2(PrincipalId),
     TopUpCanisterV2(PrincipalId, CanisterId),


### PR DESCRIPTION
# Motivation

Staking a neuron requires 2 steps: transferring the stake and claiming the neuron.
Both steps are done in ic-js.
But it's possible that the process gets interrupted in between.
In this case the process needs to be finished later.
This is now done in the frontend so it no longer needs to be done in the backend.

# Changes

1. Remove logic to detect stake neuron transaction and claim neurons from the nns-dapp canister code.

# Tests

1. Unit test removed.

# Todos

- [x] Add entry to changelog (if necessary).
existing entry updated