### PR TITLE
FOLLOW-244: Stop storing neuron accounts in stable memory

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Stop storing neuron accounts in the nns-dapp canister.
+
 #### Fixed
 
 #### Security

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1049,7 +1049,9 @@ impl StableState for AccountsStore {
             // Transactions are unused but we need to encode them for backwards
             // compatibility.
             VecDeque::<candid::Empty>::new(),
-            &self.neuron_accounts,
+            // Neuron accounts are unused but we need to encode them for
+            // backwards compatibility.
+            HashMap::<AccountIdentifier, candid::Empty>::new(),
             &self.block_height_synced_up_to,
             &self.multi_part_transactions_processor,
             &self.last_ledger_sync_timestamp_nanos,
@@ -1071,7 +1073,7 @@ impl StableState for AccountsStore {
             // Transactions are unused but we need to decode something for backwards
             // compatibility.
             _transactions,
-            neuron_accounts,
+            _neuron_accounts,
             block_height_synced_up_to,
             multi_part_transactions_processor,
             last_ledger_sync_timestamp_nanos,
@@ -1082,7 +1084,7 @@ impl StableState for AccountsStore {
             HashMap<AccountIdentifier, AccountWrapper>,
             HashMap<(AccountIdentifier, AccountIdentifier), (TransactionType, u64)>,
             candid::Reserved,
-            HashMap<AccountIdentifier, NeuronDetails>,
+            candid::Reserved,
             Option<BlockIndex>,
             MultiPartTransactionsProcessor,
             u64,
@@ -1110,7 +1112,7 @@ impl StableState for AccountsStore {
             accounts_db: AccountsDbAsProxy::default(),
             hardware_wallets_and_sub_accounts,
             pending_transactions,
-            neuron_accounts,
+            neuron_accounts: HashMap::new(),
             block_height_synced_up_to,
             multi_part_transactions_processor,
             accounts_db_stats,

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -32,7 +32,7 @@ get_transactions_count() {
 
 # Gets stats that should be invariant across upgrades
 get_upgrade_invariant_stats() {
-  dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count, neurons_created_count, neurons_topped_up_count, sub_accounts_count}'
+  dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count,  neurons_topped_up_count, sub_accounts_count}'
 }
 
 # Verifies that accounts were not recomputed on upgrade.


### PR DESCRIPTION
# Motivation

The nns-dapp backend canister stores neuron accounts to be able to detect neuron top-up transactions.
The canister no longer does the neuron top-ups so the neuron accounts aren't used anymore.
So we can stop storing them in stable memory during upgrades.
We can't change the structure of the stable memory so now we just store an empty map in pre-upgrade, and read nothing (of type `Reserved`) in post-upgrade. This is forward and backward compatible.

I originally thought changing the encoding will require multiple steps, but this way it can be done in one step.

There will be additional PRs to remove the `neuron_accounts` field completely.

# Changes

1. When encoding `AccountsStore`, write and empty `HashMap<AccountIdentifier, candid::Empty>` instead of `neuron_accounts`.
2. When decoding `AccountsStore`, ignore whats read in the position of the `neuron_accounts`. Declaring it as type `candid::Reserved` allows any data to be read there without error.

# Tests

1. I manually installed a wasm without these changes, created a neuron, upgraded to a wasm with these changes, created another neuron, and downgraded again. The neurons were still there and neither the upgrade nor downgrade caused any errors.
2. Remove `neurons_created_count` as an invariant preserved during upgrade because it no longer is.

# Todos

- [x] Add entry to changelog (if necessary).
