### PR TITLE
Remove subscribe from sns.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -26,7 +26,6 @@ import {
 } from "$tests/mocks/sns.api.mock";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
-import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { mock } from "vitest-mock-extended";
 
@@ -95,52 +94,36 @@ describe("SNS public services", () => {
       expect(functionsStore[rootCanisterId]).not.toBeUndefined();
     });
 
-    it("SNS certified calls after aggregator store is filled don't trigger a call to list_sns_canisters", () => {
+    it("SNS certified calls after aggregator store is filled don't trigger a call to list_sns_canisters", async () => {
       vi.spyOn(aggregatorApi, "querySnsProjects").mockImplementation(() =>
         Promise.resolve([aggregatorSnsMockDto, aggregatorSnsMockDto])
       );
 
-      return new Promise<void>((done) => {
-        snsAggregatorStore.subscribe(async ({ data }) => {
-          // There is an initial call to subscribe with undefined data
-          if (nonNullish(data)) {
-            await wrapper({
-              identity: mockIdentity,
-              rootCanisterId:
-                aggregatorSnsMockDto.canister_ids.root_canister_id,
-              certified: true,
-            });
-            expect(listSnsesSpy).not.toBeCalled();
-            done();
-          }
-        });
+      await loadSnsProjects();
 
-        loadSnsProjects();
+      await wrapper({
+        identity: mockIdentity,
+        rootCanisterId: aggregatorSnsMockDto.canister_ids.root_canister_id,
+        certified: true,
       });
+
+      expect(listSnsesSpy).not.toBeCalled();
     });
 
-    it("SNS uncertified calls after aggregator store is filled don't trigger a call to list_sns_canisters", () => {
+    it("SNS uncertified calls after aggregator store is filled don't trigger a call to list_sns_canisters", async () => {
       vi.spyOn(aggregatorApi, "querySnsProjects").mockImplementation(() =>
         Promise.resolve([aggregatorSnsMockDto, aggregatorSnsMockDto])
       );
 
-      return new Promise<void>((done) => {
-        snsAggregatorStore.subscribe(async ({ data }) => {
-          // There is an initial call to subscribe with undefined data
-          if (nonNullish(data)) {
-            await wrapper({
-              identity: mockIdentity,
-              rootCanisterId:
-                aggregatorSnsMockDto.canister_ids.root_canister_id,
-              certified: false,
-            });
-            expect(listSnsesSpy).not.toBeCalled();
-            done();
-          }
-        });
+      await loadSnsProjects();
 
-        loadSnsProjects();
+      await wrapper({
+        identity: mockIdentity,
+        rootCanisterId: aggregatorSnsMockDto.canister_ids.root_canister_id,
+        certified: false,
       });
+
+      expect(listSnsesSpy).not.toBeCalled();
     });
 
     it("should load sns aggregator store", async () => {


### PR DESCRIPTION
# Motivation

Some tests in `sns.services.spec.ts` subscribe to `snsAggregatorStore` and try to get/create a wrapper inside the listener function. But because the test never unsubscribe, the listeners continue being called during other tests.
If another test adds different data that the subscribing test doesn't expect, it looks like one test fails while another test is running.

Tests that subscribe to a store should also unsubscribe. But in this case, subscribing it totally unnecessary and just makes the test more complicated.

# Changes

1. Rewrite the tests to not use subscribe.

# Tests

1. The 2 changed tests still pass and fail if the call to `loadSnsProjects()` is removed.
2. In another branch a new test I tried to add was failing because of this, and unsubscribing fixed it.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary