### PR TITLE
bot: Update snsdemo to release-2024-11-06

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -402,7 +402,7 @@
         "DIDC_VERSION": "didc 0.4.0",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-10-30",
+        "SNSDEMO_RELEASE": "release-2024-11-06",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-10-31_03-09-ubuntu20.04",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-10-31_03-09-ubuntu20.04"
       },


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.
* Ensured that the `dfx` version in `dfx.json` matches `snsdemo`.

# Tests
CI should pass.