### PR TITLE
Add missing arg-sha256 parameter to release

### DIFF
--- a/scripts/nns-dapp/release
+++ b/scripts/nns-dapp/release
@@ -121,6 +121,7 @@ SHA="$(sha256sum <"$WASM" | awk '{print $1}')"
 # Gets the canister arguments
 ARG_DID="./release/nns-dapp-arg-${DFX_NETWORK}.did"
 ARG_PATH="./release/nns-dapp-arg-${DFX_NETWORK}.bin"
+ARG_PATH_HASH="$(sha256sum "$ARG_PATH" | cut -d ' ' -f 1)"
 test -e "$ARG_DID" || {
   echo "ERROR: Arguments need to be provided in $ARG_DID"
   exit 1
@@ -139,7 +140,8 @@ test -e "${SUMMARY_FILE:-}" || {
 } >&2
 
 # Prepares the command
-set ic-admin "${AUTH_ARGS[@]}" --nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$NNS_DAPP_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH"
+set ic-admin "${AUTH_ARGS[@]}" --nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$NNS_DAPP_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH" --arg-sha256 "$ARG_PATH_HASH"
+
 # ... just checking...
 echo
 echo PLEASE REVIEW THIS COMMAND:


### PR DESCRIPTION
# Motivation

When creating the upgrade proposal for nns-dapp, `ic-admin` requires a `--arg-sha256` parameter, which is currently missing in the release script. This omission results in the following error message:

```
thread 'main' panicked at rs/registry/admin/src/main.rs:5472:28:
Must provide a sha256 checksum for the upgrade arg
```

This requirement seems to have been added in https://github.com/dfinity/ic/pull/1640

# Changes

- Add missing parameter.

# Tests

- Created the latest release using these changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.