### PR TITLE
NNS1-3435: Applies new styles to ConfirmationModal's content

### DIFF
--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -41,6 +41,7 @@
     :global(svg) {
       width: var(--padding-6x);
       height: var(--padding-6x);
+      margin-bottom: var(--padding);
     }
   }
 

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -1,10 +1,9 @@
 @mixin wrapper {
-  padding-bottom: var(--padding-2x);
+  padding-bottom: var(--padding);
 
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: var(--padding);
 
   color: var(--background-contrast);
 }
@@ -12,8 +11,14 @@
 @mixin title {
   margin: 0;
   font-size: var(--font-size-h4);
+  padding-bottom: var(--padding-2x);
 }
 
 @mixin text {
   margin: 0;
+  padding-bottom: var(--padding);
+  
+  &:last-child {
+    padding-bottom: 0;
+  }
 }

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -11,10 +11,9 @@
 
 @mixin title {
   margin: 0;
-  font-size: var(--font-size-h3);
+  font-size: var(--font-size-h4);
 }
 
 @mixin text {
   margin: 0;
-  font-size: var(--font-size-h4);
 }

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: var(--padding);
 
   color: var(--background-contrast);
 }
@@ -11,14 +12,9 @@
 @mixin title {
   margin: 0;
   font-size: var(--font-size-h4);
-  padding-bottom: var(--padding-2x);
+  padding-bottom: var(--padding);
 }
 
 @mixin text {
   margin: 0;
-  padding-bottom: var(--padding);
-
-  &:last-child {
-    padding-bottom: 0;
-  }
 }

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -17,7 +17,7 @@
 @mixin text {
   margin: 0;
   padding-bottom: var(--padding);
-  
+
   &:last-child {
     padding-bottom: 0;
   }

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -12,7 +12,6 @@
 @mixin title {
   margin: 0;
   font-size: var(--font-size-h4);
-  padding-bottom: var(--padding);
 }
 
 @mixin text {

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
   gap: var(--padding-1_5x);
 
   color: var(--background-contrast);
@@ -17,6 +16,5 @@
 
 @mixin text {
   margin: 0;
-  align-self: stretch;
   font-size: var(--font-size-h4);
 }

--- a/frontend/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/src/lib/themes/mixins/_confirmation-modal.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: var(--padding-1_5x);
+  gap: var(--padding);
 
   color: var(--background-contrast);
 }


### PR DESCRIPTION
# Motivation

The content of the Dialog component (ConfirmationModal) has been updated in the designs.

# Changes
- Align the modal content to the left.  
-  Update the text size.  
-  Adjust the gap between the icon and title

# Tests

[Design reference](https://www.figma.com/design/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?node-id=5486-51881&t=VtiplDFURAt0K5JU-4)

[Testable version](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

Before:
<img width="544" alt="Screenshot 2024-11-11 at 09 02 30" src="https://github.com/user-attachments/assets/5681f54e-a041-49d0-b324-9c02f7dde810">

After:
<img width="619" alt="Screenshot 2024-11-11 at 09 26 40" src="https://github.com/user-attachments/assets/ea30766a-de28-499a-8892-8a8051b7912c">


Before:
<img width="545" alt="Screenshot 2024-11-11 at 09 03 17" src="https://github.com/user-attachments/assets/d923b761-663d-4b69-81be-96caecf37762">

After:
<img width="631" alt="Screenshot 2024-11-11 at 09 26 59" src="https://github.com/user-attachments/assets/d3f71ac3-1af5-4007-9b43-e2a9a0959069">


**Thumbs-up/down Icons will be replaced with the new ones in a follow up PR.**

Before:
<img width="584" alt="Screenshot 2024-11-11 at 08 59 58" src="https://github.com/user-attachments/assets/c1e34673-76a4-4bab-8f91-54cb2eaafb22">

After:
<img width="556" alt="Screenshot 2024-11-11 at 09 32 14" src="https://github.com/user-attachments/assets/e4ab8d5b-20e3-47e1-befc-f6edcdf70728">

Before:
<img width="536" alt="Screenshot 2024-11-11 at 09 01 06" src="https://github.com/user-attachments/assets/de55a219-79a5-416b-a583-e0f302bedde9">

After:
<img width="543" alt="Screenshot 2024-11-11 at 09 32 26" src="https://github.com/user-attachments/assets/06c80898-f36c-4bba-915a-24091b289975">


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
