### PR TITLE
Fix caching of ledger identity

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Stop trying to get swap commitments from aborted SNSes.
+* User gets the wrong identity when connecting different HWs in a certain order.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,7 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Stop trying to get swap commitments from aborted SNSes.
-* User gets the wrong identity when connecting different HWs in a certain order.
+* User gets the wrong identity when connecting different hardware wallets devices in a certain order.
 
 #### Security
 

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -120,9 +120,7 @@ export const getLedgerIdentity = async (
     return identities[identifier];
   }
   const ledgerIdentity: LedgerIdentity = await createLedgerIdentity();
-
-  identities[identifier] = ledgerIdentity;
-
+  
   const ledgerIdentifier = principalToAccountIdentifier(
     ledgerIdentity.getPrincipal()
   );
@@ -137,6 +135,8 @@ export const getLedgerIdentity = async (
       })
     );
   }
+
+  identities[identifier] = ledgerIdentity;
 
   return ledgerIdentity;
 };

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -120,7 +120,7 @@ export const getLedgerIdentity = async (
     return identities[identifier];
   }
   const ledgerIdentity: LedgerIdentity = await createLedgerIdentity();
-  
+
   const ledgerIdentifier = principalToAccountIdentifier(
     ledgerIdentity.getPrincipal()
   );

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -99,16 +99,6 @@ export const registerHardwareWallet = async ({
 const createLedgerIdentity = (): Promise<LedgerIdentity> =>
   LedgerIdentity.create();
 
-// Used to cache the identities.
-// The identity is an instance of the class LedgerIdentity.
-// This identity is used in other layers and then cached. If this returns a new one it's not necessarily used.
-// For example, the `createAgent` cached the agents which has the identity inside.
-// We had the issue that the `neuronStakeFlag` was not being set because the agent was using a cached identity.
-let identities: Record<string, LedgerIdentity> = {};
-
-// For testing purposes
-export const resetIdentitiesCachedForTesting = () => (identities = {});
-
 /**
  * Unlike getIdentity(), getting the ledger identity does not automatically logout if no identity is found - i.e. if errors happen.
  * User might need several tries to attach properly the ledger to the computer.
@@ -116,9 +106,6 @@ export const resetIdentitiesCachedForTesting = () => (identities = {});
 export const getLedgerIdentity = async (
   identifier: string
 ): Promise<LedgerIdentity> => {
-  if (identities[identifier]) {
-    return identities[identifier];
-  }
   const ledgerIdentity: LedgerIdentity = await createLedgerIdentity();
 
   const ledgerIdentifier = principalToAccountIdentifier(
@@ -135,8 +122,6 @@ export const getLedgerIdentity = async (
       })
     );
   }
-
-  identities[identifier] = ledgerIdentity;
 
   return ledgerIdentity;
 };

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -11,7 +11,6 @@ import {
   getLedgerIdentity,
   listNeuronsHardwareWallet,
   registerHardwareWallet,
-  resetIdentitiesCachedForTesting,
   showAddressAndPubKeyOnHardwareWallet,
 } from "$lib/services/icp-ledger.services";
 import { LedgerErrorKey, LedgerErrorMessage } from "$lib/types/ledger.errors";
@@ -47,7 +46,6 @@ describe("icp-ledger.services", () => {
   });
 
   beforeEach(() => {
-    resetIdentitiesCachedForTesting();
     vi.clearAllMocks();
     toastsStore.reset();
     resetIdentity();
@@ -218,7 +216,7 @@ describe("icp-ledger.services", () => {
       );
     });
 
-    it("should cache ledger identity for same identifier", async () => {
+    it("should not cache ledger identity for same identifier", async () => {
       const identity1 = await getLedgerIdentity(mockLedgerIdentifier);
 
       expect(identity1).not.toBeNull();
@@ -226,8 +224,10 @@ describe("icp-ledger.services", () => {
 
       const identity2 = await getLedgerIdentity(mockLedgerIdentifier);
 
-      expect(identity2).toBe(identity1);
-      expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
+      expect(identity2.getPrincipal().toText()).toBe(
+        identity1.getPrincipal().toText()
+      );
+      expect(LedgerIdentity.create).toHaveBeenCalledTimes(2);
     });
 
     it("should not return cached ledger identity for different account", async () => {

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -276,7 +276,7 @@ describe("icp-ledger.services", () => {
 
       // Second call should return the correct identity because the correct HW is connected.
       const identity = await getLedgerIdentity(mockLedgerIdentifier);
-      
+
       expect(LedgerIdentity.create).toHaveBeenCalledTimes(2);
       expect(identity).not.toBeNull();
       expect(principalToAccountIdentifier(identity.getPrincipal())).toEqual(


### PR DESCRIPTION
# Motivation

There was a bug when the user followed the following sequence:

* I have two HWs, A and B.
* HW A controls the neuron
* I connect HW B and try to perform something for neuron A.
* The NNS dapp tells me it is the wrong HW
* I connect HW A to fix it.
* I get this error: `Sorry, none of your principals is the controller of the neuron.`.

The reason was because the wrong identity was cached in `getLedgerIdentity`.

# Changes

* Do not cache identities at all.

# Tests

* Add a test scenario that checks the bug and change the test that checks that identites are cached.

# Todos

- [x] Add entry to changelog (if necessary).
