### PR TITLE
NNS1-3435: New icon with color hints

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -281,10 +281,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-08.tgz",
-      "integrity": "sha512-IWEXYcbTkEjaAUvGIzFx7u8FMMo6zffSm9F9DgTMEv0BeMuTYLQwbDLdpUk9qiK0Wo6UvOE412FXghfIEIzwog==",
-      "license": "Apache-2.0",
+      "version": "4.8.0-next-2024-11-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.tgz",
+      "integrity": "sha512-YFHDr9yC0MGkum+NX9DfUkM+qNR2IrjeEHBRedn5O/cKFLFMA1ssuVmsJky3COFqIvzjq93Kzkd9ZwaHKHLq1Q==",
       "dependencies": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",
@@ -6115,9 +6114,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-08.tgz",
-      "integrity": "sha512-IWEXYcbTkEjaAUvGIzFx7u8FMMo6zffSm9F9DgTMEv0BeMuTYLQwbDLdpUk9qiK0Wo6UvOE412FXghfIEIzwog==",
+      "version": "4.8.0-next-2024-11-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.tgz",
+      "integrity": "sha512-YFHDr9yC0MGkum+NX9DfUkM+qNR2IrjeEHBRedn5O/cKFLFMA1ssuVmsJky3COFqIvzjq93Kzkd9ZwaHKHLq1Q==",
       "requires": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -325,9 +325,10 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-12.tgz",
-      "integrity": "sha512-sCCYFXUbZiAhQ/yI3Q25iR1/UxHFoZ/nRGfoCsGPoo8as5yfKDtqB3tAH31ap4xPm+1xrFyMYxHNivmrBBSEAA==",
+      "version": "4.8.0-next-2024-11-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-08.tgz",
+      "integrity": "sha512-IWEXYcbTkEjaAUvGIzFx7u8FMMo6zffSm9F9DgTMEv0BeMuTYLQwbDLdpUk9qiK0Wo6UvOE412FXghfIEIzwog==",
+      "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",
@@ -6696,9 +6697,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-12.tgz",
-      "integrity": "sha512-sCCYFXUbZiAhQ/yI3Q25iR1/UxHFoZ/nRGfoCsGPoo8as5yfKDtqB3tAH31ap4xPm+1xrFyMYxHNivmrBBSEAA==",
+      "version": "4.8.0-next-2024-11-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-08.tgz",
+      "integrity": "sha512-IWEXYcbTkEjaAUvGIzFx7u8FMMo6zffSm9F9DgTMEv0BeMuTYLQwbDLdpUk9qiK0Wo6UvOE412FXghfIEIzwog==",
       "requires": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.tgz",
-      "integrity": "sha512-YFHDr9yC0MGkum+NX9DfUkM+qNR2IrjeEHBRedn5O/cKFLFMA1ssuVmsJky3COFqIvzjq93Kzkd9ZwaHKHLq1Q==",
+      "version": "4.8.0-next-2024-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.1.tgz",
+      "integrity": "sha512-+jIQhLlgQh3NWHsiyj5B9Of25NKSXgaTDDMzC/4IxVa6Fy3gYA0uYeWtJ7WEBeVzoN1AUqnxctmaHEZHof1xgQ==",
       "dependencies": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",
@@ -6114,9 +6114,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.tgz",
-      "integrity": "sha512-YFHDr9yC0MGkum+NX9DfUkM+qNR2IrjeEHBRedn5O/cKFLFMA1ssuVmsJky3COFqIvzjq93Kzkd9ZwaHKHLq1Q==",
+      "version": "4.8.0-next-2024-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.1.tgz",
+      "integrity": "sha512-+jIQhLlgQh3NWHsiyj5B9Of25NKSXgaTDDMzC/4IxVa6Fy3gYA0uYeWtJ7WEBeVzoN1AUqnxctmaHEZHof1xgQ==",
       "requires": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.1.tgz",
-      "integrity": "sha512-+jIQhLlgQh3NWHsiyj5B9Of25NKSXgaTDDMzC/4IxVa6Fy3gYA0uYeWtJ7WEBeVzoN1AUqnxctmaHEZHof1xgQ==",
+      "version": "4.8.0-next-2024-11-12",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-12.tgz",
+      "integrity": "sha512-sCCYFXUbZiAhQ/yI3Q25iR1/UxHFoZ/nRGfoCsGPoo8as5yfKDtqB3tAH31ap4xPm+1xrFyMYxHNivmrBBSEAA==",
       "dependencies": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",
@@ -6114,9 +6114,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-11.1.tgz",
-      "integrity": "sha512-+jIQhLlgQh3NWHsiyj5B9Of25NKSXgaTDDMzC/4IxVa6Fy3gYA0uYeWtJ7WEBeVzoN1AUqnxctmaHEZHof1xgQ==",
+      "version": "4.8.0-next-2024-11-12",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-12.tgz",
+      "integrity": "sha512-sCCYFXUbZiAhQ/yI3Q25iR1/UxHFoZ/nRGfoCsGPoo8as5yfKDtqB3tAH31ap4xPm+1xrFyMYxHNivmrBBSEAA==",
       "requires": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -53,7 +53,6 @@
       margin-bottom: var(--padding);
 
       border-radius: 50%;
-      aspect-ratio: 1;
 
       display: flex;
       align-items: center;

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -45,12 +45,12 @@
     :global(svg) {
       width: var(--padding-4x);
       height: var(--padding-4x);
-      margin-bottom: var(--padding);
     }
 
     .icon-wrapper {
       width: var(--padding-6x);
       height: var(--padding-6x);
+      margin-bottom: var(--padding);
 
       border-radius: 50%;
       aspect-ratio: 1;

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -13,7 +13,9 @@
 <ConfirmationModal on:nnsClose on:nnsConfirm>
   <div class="wrapper">
     {#if voteType === Vote.Yes}
-      <IconThumbUp />
+      <span class="icon-wrapper yes" aria-hidden="true">
+        <IconThumbUp />
+      </span>
       <h4>{$i18n.proposal_detail__vote.confirm_adopt_headline}</h4>
       <p>
         {replacePlaceholders($i18n.proposal_detail__vote.confirm_adopt_text, {
@@ -21,7 +23,9 @@
         })}
       </p>
     {:else}
-      <IconThumbDown />
+      <span class="icon-wrapper no" aria-hidden="true">
+        <IconThumbDown />
+      </span>
       <h4>{$i18n.proposal_detail__vote.confirm_reject_headline}</h4>
       <p>
         {replacePlaceholders($i18n.proposal_detail__vote.confirm_reject_text, {
@@ -39,9 +43,29 @@
     @include confirmation-modal.wrapper;
 
     :global(svg) {
+      width: var(--padding-4x);
+      height: var(--padding-4x);
+    }
+
+    .icon-wrapper {
       width: var(--padding-6x);
       height: var(--padding-6x);
-      margin-bottom: var(--padding);
+
+      border-radius: 50%;
+      aspect-ratio: 1;
+
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .yes {
+      color: var(--green);
+      background-color: rgb(from var(--green) r g b / 0.2);
+    }
+
+    .no {
+      color: var(--pink);
+      background-color: rgb(from var(--pink) r g b / 0.2);
     }
   }
 

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -59,13 +59,13 @@
       justify-content: center;
     }
     .yes {
-      color: var(--green-200);
-      background-color: var(--green-200-a25);
+      color: var(--positive-emphasis);
+      background-color: var(--positive-emphasis-light);
     }
 
     .no {
-      color: var(--pink-200);
-      background-color: var(--pink-200-a25);
+      color: var(--negative-emphasis);
+      background-color: var(--negative-emphasis-light);
     }
   }
 

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -60,7 +60,7 @@
     }
     .yes {
       color: var(--green);
-      background-color: rgb(from var(--green) r g b / 0.2);
+      background-color: rgb(from var(--green) r g b / 0.25);
     }
 
     .no {

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -59,13 +59,13 @@
       justify-content: center;
     }
     .yes {
-      color: var(--green);
-      background-color: rgb(from var(--green) r g b / 0.25);
+      color: var(--green-200);
+      background-color: var(--green-200-a25);
     }
 
     .no {
-      color: var(--pink);
-      background-color: rgb(from var(--pink) r g b / 0.2);
+      color: var(--pink-200);
+      background-color: var(--pink-200-a25);
     }
   }
 

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -45,6 +45,7 @@
     :global(svg) {
       width: var(--padding-4x);
       height: var(--padding-4x);
+      margin-bottom: var(--padding);
     }
 
     .icon-wrapper {


### PR DESCRIPTION
# Motivation

We have a new design for the `VoteConfirmationModal`.

# Changes

-  Update the gix dependency to include new icons.
-  Add a wrapper around the icons in the `VoteConfirmationModal`.

# Tests

[Design reference](https://www.figma.com/design/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?node-id=5486-51881&t=mmR64uy0BVpSlsyi-4)
[Testable version]()


Before:
<img width="783" alt="Screenshot 2024-11-11 at 11 09 28" src="https://github.com/user-attachments/assets/6b6424b0-694f-498f-9d3b-4a46bac562e4">

After:
<img width="793" alt="Screenshot 2024-11-11 at 11 10 07" src="https://github.com/user-attachments/assets/16e1ae10-d24f-4887-82ed-55bce6c3461b">

Before:
<img width="821" alt="Screenshot 2024-11-11 at 11 15 37" src="https://github.com/user-attachments/assets/51e2bb4e-7cac-404e-993b-bc5841b0ad75">

After:
<img width="506" alt="Screenshot 2024-11-11 at 11 19 14" src="https://github.com/user-attachments/assets/4d873980-4fac-4eb8-a58d-860730b2aa86">

Before:
<img width="649" alt="Screenshot 2024-11-11 at 11 15 57" src="https://github.com/user-attachments/assets/ccdc11ec-6d9d-4b05-9148-82f89084fdad">

After:
<img width="598" alt="Screenshot 2024-11-11 at 11 18 35" src="https://github.com/user-attachments/assets/3a662022-fe6b-4172-b4dc-a9cc0e05c1f0">


Before:
<img width="626" alt="Screenshot 2024-11-11 at 11 16 15" src="https://github.com/user-attachments/assets/dd21c4df-efc7-44dc-aa98-1dd1ada1eb26">

After:
<img width="617" alt="Screenshot 2024-11-11 at 11 18 44" src="https://github.com/user-attachments/assets/915b987e-5f3c-423b-85f4-8b6cac0ee682">



# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.