### PR TITLE
NNS1-3435: use & operator for combined class selectors

### DIFF
--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -57,15 +57,16 @@
       display: flex;
       align-items: center;
       justify-content: center;
-    }
-    .yes {
-      color: var(--positive-emphasis);
-      background-color: var(--positive-emphasis-light);
-    }
 
-    .no {
-      color: var(--negative-emphasis);
-      background-color: var(--negative-emphasis-light);
+      &.yes {
+        color: var(--positive-emphasis);
+        background-color: var(--positive-emphasis-light);
+      }
+
+      &.no {
+        color: var(--negative-emphasis);
+        background-color: var(--negative-emphasis-light);
+      }
     }
   }
 


### PR DESCRIPTION
# Motivation

Use `&` operator for combined class selectors

# Changes

- Prevent style leaking by scoping yes/no styles to icon-wrapper

# Tests

Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.