### PR TITLE
Add getLoadedSnsAggregatorData

### DIFF
--- a/frontend/src/lib/services/public/sns.services.ts
+++ b/frontend/src/lib/services/public/sns.services.ts
@@ -3,15 +3,42 @@ import { queryProposals } from "$lib/api/proposals.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { queryAndUpdate } from "$lib/services/utils.services";
-import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
+import {
+  snsAggregatorIncludingAbortedProjectsStore,
+  snsAggregatorStore,
+} from "$lib/stores/sns-aggregator.store";
 import { snsProposalsStore } from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { isLastCall } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { ProposalStatus, Topic, type ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
 import { getCurrentIdentity } from "../auth.services";
+
+// Returns a promise that resolves once the snsAggregatorStore data is defined.
+export const getLoadedSnsAggregatorData = async (): Promise<CachedSnsDto[]> => {
+  let resolve: (aggregatorData: CachedSnsDto[]) => void;
+  const promise = new Promise<CachedSnsDto[]>((r) => {
+    resolve = r;
+  });
+
+  const unsubscribe = snsAggregatorStore.subscribe(({ data }) => {
+    if (nonNullish(data)) {
+      resolve(data);
+      // We can't unsubscribe here because the handler can be called before the
+      // unsubscribe function is returned.
+    }
+  });
+
+  try {
+    return await promise;
+  } finally {
+    unsubscribe();
+  }
+};
 
 export const loadSnsProjects = async (): Promise<void> => {
   try {

--- a/frontend/src/lib/services/public/sns.services.ts
+++ b/frontend/src/lib/services/public/sns.services.ts
@@ -28,8 +28,8 @@ export const getLoadedSnsAggregatorData = async (): Promise<CachedSnsDto[]> => {
   const unsubscribe = snsAggregatorStore.subscribe(({ data }) => {
     if (nonNullish(data)) {
       resolve(data);
-      // We can't unsubscribe here because the handler can be called before the
-      // unsubscribe function is returned.
+      // We can't unsubscribe here because the handler can be called
+      // synchronously before the unsubscribe function is returned.
     }
   });
 

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -8,12 +8,16 @@ import {
 } from "$lib/api/sns-wrapper.api";
 import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
 import { snsTotalTokenSupplyStore } from "$lib/derived/sns-total-token-supply.derived";
-import { loadSnsProjects } from "$lib/services/public/sns.services";
+import {
+  getLoadedSnsAggregatorData,
+  loadSnsProjects,
+} from "$lib/services/public/sns.services";
 import {
   snsAggregatorIncludingAbortedProjectsStore,
   snsAggregatorStore,
 } from "$lib/stores/sns-aggregator.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   aggregatorMockSnsesDataDto,
@@ -73,6 +77,31 @@ describe("SNS public services", () => {
     tokensStore.reset();
     clearSnsAggregatorCache();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
+
+  describe("getLoadedSnsAggregatorData", () => {
+    it("should return the aggregator store data", async () => {
+      const data = [aggregatorSnsMockDto];
+      snsAggregatorIncludingAbortedProjectsStore.setData(data);
+
+      expect(await getLoadedSnsAggregatorData()).toEqual(data);
+    });
+
+    it("should work if the data is loaded after the call", async () => {
+      let receivedData: CachedSnsDto[] | undefined;
+      const promise = getLoadedSnsAggregatorData().then((data) => {
+        receivedData = data;
+      });
+
+      expect(receivedData).toBeUndefined();
+
+      const data = [aggregatorSnsMockDto];
+      snsAggregatorIncludingAbortedProjectsStore.setData(data);
+
+      await promise;
+
+      expect(receivedData).toEqual(data);
+    });
   });
 
   describe("loadSnsProjects", () => {


### PR DESCRIPTION
# Motivation

We want to create SNS wrappers based on aggregator data to avoid unnecessary calls to SNS-W and root canisters.

To do this we need to be able to wait for the `snsAggregatorStore` to be loaded if wrappers are requested before the aggregator data is loaded.

In this PR we add just a function to get the data from the `snsAggregatorStore` after it is loaded.

# Changes

1. Add `getLoadedSnsAggregatorData` which waits for the `snsAggregatorStore` to have defined data and then returns that data.

# Tests

1. Unit tests added.
2. Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary