### PR TITLE
Sync the SNS rewards status logic calculation with the backend

### DIFF
--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -155,6 +155,17 @@ describe("sns-proposals utils", () => {
       );
     });
 
+    it("should return SETTLED based on reward event end timestamp", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        reward_event_round: 0n,
+        reward_event_end_timestamp_seconds: [0n],
+      };
+      expect(snsRewardStatus(proposal)).toBe(
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED
+      );
+    });
+
     it("should return ACCEPT_VOTES", () => {
       const now = BigInt(nowInSeconds());
       const proposal: SnsProposalData = {
@@ -165,6 +176,20 @@ describe("sns-proposals utils", () => {
             current_deadline_timestamp_seconds: now + 100n,
           },
         ],
+      };
+      expect(snsRewardStatus(proposal)).toBe(
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES
+      );
+    });
+
+    it("should return ACCEPT_VOTES w/o current_deadline_timestamp_seconds ", () => {
+      const now = BigInt(nowInSeconds());
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        reward_event_round: 0n,
+        wait_for_quiet_state: [],
+        proposal_creation_timestamp_seconds: now,
+        initial_voting_period_seconds: 100n,
       };
       expect(snsRewardStatus(proposal)).toBe(
         SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES


### PR DESCRIPTION
# Motivation

The logic for SNS reward status calculation is outdated on the front end. Although we haven’t received error reports recently, after discussing with a backend developer, it was suggested to sync the logic.


Presumably, the backend fixes led to the related code changes:

**1. SNS list_proposals reward status filtering does not exclude old SNS-1 proposals.**

There is a new field is reward_event_end_timestamp_seconds. Older proposals do not populate this field, since they predate it.
Currently, the correct way to determine whether a proposal is associated with a reward event is to look at both the new field, as well as the old one, to wit reward_event_round.

[Added here.](https://github.com/dfinity/nns-dapp/pull/5766/files#diff-bc794365fb0826c7ec5cc7d9ab15121c6bc9630e990e7bd8751b8b84273601b6R304-R305)

See more in [NNS1-2588](https://dfinity.atlassian.net/browse/NNS1-2588).

**2. NNS proposal votes should not be able to be registered after the proposal deadline.**
https://github.com/dfinity/ic/commit/9587cc9e118b8a9f38a3acccea5da26c9baf06f5#diff-0da5ccadff83a3bb673833b806280c8032311d143120522fa59b6e202d7216f9R902

A voter can still cast a ballot in the time between which a proposal’s deadline is over and the time where the proposal is settled.
This is not expected. It should be checked whether a proposal still accepts votes (with the method accepts_vote) before a neuron’s vote is cast.

And the logic from the `accepts_vote` function was added [here](https://github.com/dfinity/nns-dapp/pull/5766/files#diff-bc794365fb0826c7ec5cc7d9ab15121c6bc9630e990e7bd8751b8b84273601b6R312-R313).

See more in [NNS1-959](https://dfinity.atlassian.net/browse/NNS1-959).

# Changes

- Update the logic and the reference url to the backend code.

# Tests

- Unit test updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-2588]: https://dfinity.atlassian.net/browse/NNS1-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NNS1-959]: https://dfinity.atlassian.net/browse/NNS1-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ