### PR TITLE
Remove neuron_accounts field from AccountsStore

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -52,11 +52,6 @@ pub struct AccountsStore {
     // pending_transactions: HashMap<(from, to), (TransactionType, timestamp_ms_since_epoch)>
     pending_transactions: HashMap<(AccountIdentifier, AccountIdentifier), (TransactionType, u64)>,
 
-    // TODO: Remove neuron_accounts once not topping up neurons has been
-    //       released for some time. Removing this field will have to be done in
-    //       multiple steps because it is stored in stable memory during
-    //       upgrades.
-    neuron_accounts: HashMap<AccountIdentifier, NeuronDetails>,
     block_height_synced_up_to: Option<BlockIndex>,
     multi_part_transactions_processor: MultiPartTransactionsProcessor,
     accounts_db_stats: AccountsDbStats,
@@ -85,11 +80,10 @@ impl fmt::Debug for AccountsStore {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "AccountsStore{{accounts_db: {:?}, hardware_wallets_and_sub_accounts: HashMap[{:?}], pending_transactions: HashMap[{:?}], neuron_accounts: HashMap[{:?}], block_height_synced_up_to: {:?}, multi_part_transactions_processor: {:?}, accounts_db_stats: {:?}, last_ledger_sync_timestamp_nanos: {:?}, neurons_topped_up_count: {:?}}}",
+            "AccountsStore{{accounts_db: {:?}, hardware_wallets_and_sub_accounts: HashMap[{:?}], pending_transactions: HashMap[{:?}], block_height_synced_up_to: {:?}, multi_part_transactions_processor: {:?}, accounts_db_stats: {:?}, last_ledger_sync_timestamp_nanos: {:?}, neurons_topped_up_count: {:?}}}",
             self.accounts_db,
             self.hardware_wallets_and_sub_accounts.len(),
             self.pending_transactions.len(),
-            self.neuron_accounts.len(),
             self.block_height_synced_up_to,
             self.multi_part_transactions_processor,
             self.accounts_db_stats,
@@ -826,7 +820,6 @@ impl AccountsStore {
         stats.hardware_wallet_accounts_count = self.accounts_db_stats.hardware_wallet_accounts_count;
         stats.block_height_synced_up_to = self.block_height_synced_up_to;
         stats.seconds_since_last_ledger_sync = duration_since_last_sync.as_secs();
-        stats.neurons_created_count = self.neuron_accounts.len() as u64;
         stats.neurons_topped_up_count = self.neurons_topped_up_count;
         stats.transactions_to_process_queue_length = self.multi_part_transactions_processor.get_queue_length();
         stats.migration_countdown = Some(self.accounts_db.migration_countdown());
@@ -1080,7 +1073,6 @@ impl StableState for AccountsStore {
             accounts_db: AccountsDbAsProxy::default(),
             hardware_wallets_and_sub_accounts,
             pending_transactions,
-            neuron_accounts: HashMap::new(),
             block_height_synced_up_to,
             multi_part_transactions_processor,
             accounts_db_stats,

--- a/rs/backend/src/accounts_store/toy_data.rs
+++ b/rs/backend/src/accounts_store/toy_data.rs
@@ -1,9 +1,12 @@
 //! Test data for unit tests and test networks.
 
 use crate::accounts_store::{
-    schema::AccountsDbTrait, Account, AccountIdentifier, AccountsStore, AttachCanisterRequest, CanisterId, Memo,
-    NeuronDetails, NeuronId, PrincipalId, RegisterHardwareWalletRequest,
+    schema::AccountsDbTrait, Account, AccountsStore, AttachCanisterRequest, CanisterId, PrincipalId,
+    RegisterHardwareWalletRequest,
 };
+
+#[cfg(test)]
+use crate::accounts_store::AccountIdentifier;
 
 #[cfg(test)]
 use std::collections::HashMap;
@@ -14,7 +17,6 @@ use crate::accounts_store::{convert_byte_to_sub_account, NamedCanister, NamedHar
 const MAX_SUB_ACCOUNTS_PER_ACCOUNT: u64 = 3; // Toy accounts have between 0 and this many subaccounts.
 const MAX_HARDWARE_WALLETS_PER_ACCOUNT: u64 = 1; // Toy accounts have between 0 and this many hardware wallets.
 const MAX_CANISTERS_PER_ACCOUNT: u64 = 2; // Toy accounts have between 0 and this many canisters.
-const NEURONS_PER_ACCOUNT: f32 = 0.3;
 
 /// A specification for how large a toy account should be.
 ///
@@ -123,8 +125,6 @@ impl AccountsStore {
         // If we call this function twice, we don't want to create the same accounts again, so we index from the number of existing accounts.
         let num_existing_accounts = self.accounts_db.db_accounts_len();
         let (index_range_start, index_range_end) = (num_existing_accounts, (num_existing_accounts + num_accounts));
-        let mut neurons_needed: f32 = 0.0;
-        let mut neurons_created: f32 = 0.0;
         // Creates accounts:
         for toy_account_index in index_range_start..index_range_end {
             let account = PrincipalId::new_user_test_id(toy_account_index);
@@ -154,22 +154,6 @@ impl AccountsStore {
                     canister_id,
                 };
                 self.attach_canister(account, attach_canister_request);
-            }
-            // Creates neurons
-            neurons_needed += NEURONS_PER_ACCOUNT;
-            while neurons_created < neurons_needed {
-                // Warning: This is in no way a realistic neuron.
-                neurons_created += 1.0;
-                let neuron = NeuronDetails {
-                    account_identifier: AccountIdentifier::from(PrincipalId::new_user_test_id(9)),
-                    principal: PrincipalId::new_user_test_id(10),
-                    memo: Memo(11),
-                    neuron_id: Some(NeuronId(12)),
-                };
-                self.neuron_accounts.insert(
-                    AccountIdentifier::from(PrincipalId::new_user_test_id(toy_account_index)),
-                    neuron,
-                );
             }
         }
         index_range_start


### PR DESCRIPTION
# Motivation

The nns-dapp canister used to have a list of all the users' neuron accounts.
This was used to detect neuron top-up transactions as a fallback when neuron top-up failed in the frontend.
The fallback mechanism has now been moved to the frontend so we stopped populating the `neuron_accounts` field in the `AccountsStore` in the nns-dapp canister.

This PR removes the unused `neuron_accounts` field.

A future PR will remove the `neurons_created_count` field from the stats, as it will now always be 0 because the data from which it was derived is gone.

# Changes

1. Remove the unused `neuron_accounts` field from `AccountsStore`.

# Tests

1. Stop populating the `neuron_accounts` field in `toy_data.rs`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary