### PR TITLE
Restore all mocks in NnsProposalDetail.spec.ts

### DIFF
--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -23,6 +23,7 @@ import {
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
+import * as proposalsApi from "$lib/api/proposals.api";
 
 vi.mock("$lib/api/governance.api");
 
@@ -40,28 +41,20 @@ const proposal = {
   ],
 };
 
-vi.mock("$lib/api/proposals.api", () => {
-  return {
-    queryProposal: vi.fn().mockImplementation(() => Promise.resolve(proposal)),
-  };
-});
-
-vi.mock("$lib/utils/html.utils", () => ({
-  markdownToHTML: (value) => Promise.resolve(value),
-}));
-
 let resolveCertifiedPromise;
 let resolveUncertifiedPromise;
 
 describe("Proposal detail page when not logged in user", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     neuronsStore.reset();
     resetNeuronsApiService();
     resolveCertifiedPromise = undefined;
     resolveUncertifiedPromise = undefined;
     // we don't display actionable proposals for non-logged in users
     actionableProposalsSegmentStore.set("all");
+
+    vi.spyOn(proposalsApi, "queryProposal").mockResolvedValue(proposal);
   });
 
   describe("when logged in user", () => {

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -1,5 +1,6 @@
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
+import * as proposalsApi from "$lib/api/proposals.api";
 import { queryProposal } from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import NnsProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
@@ -23,7 +24,6 @@ import {
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
-import * as proposalsApi from "$lib/api/proposals.api";
 
 vi.mock("$lib/api/governance.api");
 


### PR DESCRIPTION
# Motivation

To avoid unpredictable behavior, each test should start with a clean slate.
One component of that is restoring all mocks before each test.
To be able to do this, mock behavior needs to be defined in `beforeEach` rather than the top-level scope.

This PR does that for `NnsProposalDetail.spec.ts`.

# Changes

1. Mock `proposalsApi.queryProposal` in `beforeEach`.
2. Remove mocking of `markdownToHTML` as it seems to be unnecessary.
3. Add `vi.restoreAllMocks();` in `beforeEach`.

# Tests

Still passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary