### PR TITLE
Add vi.restoreAllMocks to API tests

### DIFF
--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -14,15 +14,6 @@ import * as utils from "@dfinity/utils";
 import type { Mocked } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-vi.mock("@dfinity/utils", async () => {
-  return {
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    ...(await vi.importActual<any>("@dfinity/utils")),
-    __esModule: true,
-    createAgent: vi.fn(),
-  };
-});
-
 const host = "http://localhost:8000";
 const testPrincipal1 = Principal.fromHex("123123123");
 const testPrincipal2 = Principal.fromHex("456456456");
@@ -39,13 +30,15 @@ const createAgent = (identity: Identity) =>
   });
 
 describe("agent-api", () => {
-  const utilsCreateAgentSpy = vi.spyOn(utils, "createAgent");
+  let utilsCreateAgentSpy;
 
   beforeEach(() => {
-    vi.resetAllMocks();
+    vi.restoreAllMocks();
     agentApi.resetAgents();
 
-    utilsCreateAgentSpy.mockResolvedValue(mock<HttpAgent>());
+    utilsCreateAgentSpy = vi
+      .spyOn(utils, "createAgent")
+      .mockResolvedValue(mock<HttpAgent>());
   });
 
   it("createAgent should create an agent", async () => {

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -14,7 +14,7 @@ import { mock } from "vitest-mock-extended";
 
 describe("icp-ledger.api", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.clearAllTimers();
 
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
@@ -260,9 +260,9 @@ describe("icp-ledger.api", () => {
   describe("transactionFee", () => {
     const fee = 10_000n;
     const ledgerMock = mock<LedgerCanister>();
-    ledgerMock.transactionFee.mockResolvedValue(fee);
 
     beforeEach(() => {
+      ledgerMock.transactionFee.mockResolvedValue(fee);
       vi.spyOn(LedgerCanister, "create").mockImplementation(
         (): LedgerCanister => ledgerMock
       );
@@ -278,9 +278,9 @@ describe("icp-ledger.api", () => {
   describe("queryAccountBalance", () => {
     const balance = 10_000_000n;
     const ledgerMock = mock<LedgerCanister>();
-    ledgerMock.accountBalance.mockResolvedValue(balance);
 
     beforeEach(() => {
+      ledgerMock.accountBalance.mockResolvedValue(balance);
       vi.spyOn(LedgerCanister, "create").mockImplementation(
         (): LedgerCanister => ledgerMock
       );

--- a/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
+++ b/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
@@ -8,16 +8,17 @@ import { mock } from "vitest-mock-extended";
 
 describe("nns-dapp api", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
+
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   describe("addAccount", () => {
     const nnsDappCanister = mock<NNSDappCanister>();
-    nnsDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
-    nnsDappCanister.addAccount.mockResolvedValue(undefined);
 
     beforeEach(() => {
-      vi.clearAllMocks();
+      nnsDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
+      nnsDappCanister.addAccount.mockResolvedValue(undefined);
       vi.spyOn(NNSDappCanister, "create").mockImplementation(
         (): NNSDappCanister => nnsDappCanister
       );

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -23,7 +23,7 @@ describe("proposals-api", () => {
   let spyListProposals;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
 
     vi.spyOn(GovernanceCanister, "create").mockImplementation(
       (): GovernanceCanister => mockGovernanceCanister
@@ -135,8 +135,11 @@ describe("proposals-api", () => {
 
   describe("queryProposalPayload", () => {
     const nnsDappMock = mock<NNSDappCanister>();
-    nnsDappMock.getProposalPayload.mockResolvedValue({});
-    vi.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
+
+    beforeEach(() => {
+      nnsDappMock.getProposalPayload.mockResolvedValue({});
+      vi.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
+    });
 
     it("should call the canister to get proposal payload", async () => {
       const spyGetProposalPayload = vi.spyOn(nnsDappMock, "getProposalPayload");

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -60,34 +60,56 @@ vi.mock("$lib/api/agent.api", () => {
 describe("sns-api", () => {
   const ledgerCanisterMock = mock<LedgerCanister>();
   const proposals = [mockSnsProposal];
-  const queryNeuronsSpy = vi.fn().mockResolvedValue([mockSnsNeuron]);
-  const getNeuronSpy = vi.fn().mockResolvedValue(mockSnsNeuron);
-  const queryNeuronSpy = vi.fn().mockResolvedValue(mockSnsNeuron);
-  const addNeuronPermissionsSpy = vi.fn().mockResolvedValue(undefined);
-  const removeNeuronPermissionsSpy = vi.fn().mockResolvedValue(undefined);
-  const disburseSpy = vi.fn().mockResolvedValue(undefined);
-  const splitNeuronSpy = vi.fn().mockResolvedValue(undefined);
-  const startDissolvingSpy = vi.fn().mockResolvedValue(undefined);
-  const stopDissolvingSpy = vi.fn().mockResolvedValue(undefined);
-  const increaseDissolveDelaySpy = vi.fn().mockResolvedValue(undefined);
-  const getNeuronBalanceSpy = vi.fn().mockResolvedValue(undefined);
-  const refreshNeuronSpy = vi.fn().mockResolvedValue(undefined);
-  const claimNeuronSpy = vi.fn().mockResolvedValue(undefined);
-  const setTopicFolloweesSpy = vi.fn().mockResolvedValue(undefined);
-  const stakeMaturitySpy = vi.fn().mockResolvedValue(undefined);
-  const registerVoteSpy = vi.fn().mockResolvedValue(undefined);
-  const autoStakeMaturitySpy = vi.fn().mockResolvedValue(undefined);
-  const listProposalsSpy = vi.fn().mockResolvedValue({ proposals });
-  const getProposalSpy = vi.fn().mockResolvedValue(mockSnsProposal);
-  const disburseMaturitySpy = vi.fn().mockResolvedValue(undefined);
+  const queryNeuronsSpy = vi.fn();
+  const getNeuronSpy = vi.fn();
+  const queryNeuronSpy = vi.fn();
+  const addNeuronPermissionsSpy = vi.fn();
+  const removeNeuronPermissionsSpy = vi.fn();
+  const disburseSpy = vi.fn();
+  const splitNeuronSpy = vi.fn();
+  const startDissolvingSpy = vi.fn();
+  const stopDissolvingSpy = vi.fn();
+  const increaseDissolveDelaySpy = vi.fn();
+  const getNeuronBalanceSpy = vi.fn();
+  const refreshNeuronSpy = vi.fn();
+  const claimNeuronSpy = vi.fn();
+  const setTopicFolloweesSpy = vi.fn();
+  const stakeMaturitySpy = vi.fn();
+  const registerVoteSpy = vi.fn();
+  const autoStakeMaturitySpy = vi.fn();
+  const listProposalsSpy = vi.fn();
+  const getProposalSpy = vi.fn();
+  const disburseMaturitySpy = vi.fn();
   const nervousSystemFunctionsMock: SnsListNervousSystemFunctionsResponse = {
     reserved_ids: new BigUint64Array(),
     functions: [nervousSystemFunctionMock],
   };
-  const getFunctionsSpy = vi.fn().mockResolvedValue(nervousSystemFunctionsMock);
+  const getFunctionsSpy = vi.fn();
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    queryNeuronsSpy.mockResolvedValue([mockSnsNeuron]);
+    getNeuronSpy.mockResolvedValue(mockSnsNeuron);
+    queryNeuronSpy.mockResolvedValue(mockSnsNeuron);
+    addNeuronPermissionsSpy.mockResolvedValue(undefined);
+    removeNeuronPermissionsSpy.mockResolvedValue(undefined);
+    disburseSpy.mockResolvedValue(undefined);
+    splitNeuronSpy.mockResolvedValue(undefined);
+    startDissolvingSpy.mockResolvedValue(undefined);
+    stopDissolvingSpy.mockResolvedValue(undefined);
+    increaseDissolveDelaySpy.mockResolvedValue(undefined);
+    getNeuronBalanceSpy.mockResolvedValue(undefined);
+    refreshNeuronSpy.mockResolvedValue(undefined);
+    claimNeuronSpy.mockResolvedValue(undefined);
+    setTopicFolloweesSpy.mockResolvedValue(undefined);
+    stakeMaturitySpy.mockResolvedValue(undefined);
+    registerVoteSpy.mockResolvedValue(undefined);
+    autoStakeMaturitySpy.mockResolvedValue(undefined);
+    listProposalsSpy.mockResolvedValue({ proposals });
+    getProposalSpy.mockResolvedValue(mockSnsProposal);
+    disburseMaturitySpy.mockResolvedValue(undefined);
+    getFunctionsSpy.mockResolvedValue(nervousSystemFunctionsMock);
 
     vi.spyOn(LedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -34,19 +34,22 @@ describe("sns-sale.api", () => {
     owner: mockPrincipal,
   });
 
-  const getOpenTicketSpy = vi.fn().mockResolvedValue(ticket.ticket);
-  const newSaleTicketSpy = vi.fn().mockResolvedValue(ticket.ticket);
-  const notifyPaymentFailureSpy = vi.fn().mockResolvedValue(ticket.ticket);
+  const getOpenTicketSpy = vi.fn();
+  const newSaleTicketSpy = vi.fn();
+  const notifyPaymentFailureSpy = vi.fn();
   const finalizationStatusSpy = vi.fn();
   const participationResponse = {
     icp_accepted_participation_e8s: 666n,
   };
-  const notifyParticipationSpy = vi
-    .fn()
-    .mockResolvedValue(participationResponse);
+  const notifyParticipationSpy = vi.fn();
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    getOpenTicketSpy.mockResolvedValue(ticket.ticket);
+    newSaleTicketSpy.mockResolvedValue(ticket.ticket);
+    notifyPaymentFailureSpy.mockResolvedValue(ticket.ticket);
+    notifyParticipationSpy.mockResolvedValue(participationResponse);
 
     const canisterIds = {
       rootCanisterId: rootCanisterIdMock,

--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -10,7 +10,7 @@ import { mock } from "vitest-mock-extended";
 describe("sns-wrapper api", () => {
   beforeEach(() => {
     clearWrapperCache();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     resetSnsProjects();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -63,16 +63,24 @@ describe("sns-api", () => {
     decentralization_sale_open_timestamp_seconds: [1n],
     decentralization_swap_termination_timestamp_seconds: [],
   };
-  const notifyParticipationSpy = vi.fn().mockResolvedValue(undefined);
+  const notifyParticipationSpy = vi.fn();
   const mockUserCommitment = createBuyersState(100_000_000n);
-  const getUserCommitmentSpy = vi.fn().mockResolvedValue(mockUserCommitment);
-  const getDerivedStateSpy = vi.fn().mockResolvedValue(derivedState);
-  const getLifecycleSpy = vi.fn().mockResolvedValue(lifecycleResponse);
+  const getUserCommitmentSpy = vi.fn();
+  const getDerivedStateSpy = vi.fn();
+  const getLifecycleSpy = vi.fn();
   const ledgerCanisterMock = mock<LedgerCanister>();
-  const stakeNeuronSpy = vi.fn().mockResolvedValue(mockSnsNeuron.id);
+  const stakeNeuronSpy = vi.fn();
   const increaseStakeNeuronSpy = vi.fn();
 
   beforeEach(() => {
+    vi.restoreAllMocks();
+
+    notifyParticipationSpy.mockResolvedValue(undefined);
+    getUserCommitmentSpy.mockResolvedValue(mockUserCommitment);
+    getDerivedStateSpy.mockResolvedValue(derivedState);
+    getLifecycleSpy.mockResolvedValue(lifecycleResponse);
+    stakeNeuronSpy.mockResolvedValue(mockSnsNeuron.id);
+
     vi.spyOn(LedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );


### PR DESCRIPTION
# Motivation

To avoid unpredictable behavior, each test should start with a clean slate.
One component of that is restoring all mocks before each test.

I tried running all tests with `vi.restoreAllMocks()` in `beforeEach` in `vitests.setup.ts` and found a number of tests that failed as we result.

Of the failing tests, this PR fixes the ones under `frontend/src/tests/lib/api/`.

# Changes

1. Replace top-level calls to `vi.mock` that define mock behavior with `vi.spyOn` in `beforeEach`.
2. Move calls to `vi.spyOn` in `describe` scope into `beforeEach`.
3. Move calls to `mockResolvedValue` and `mockImplementation` on mocks from `describe` scope to `beforeEach`.
4. Remove `vi.clearAllMocks` as its behavior is a subset of `vi.restoreAllMocks`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary