### PR TITLE
Fix test order dependency in SnsWallet.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -486,26 +486,26 @@ describe("SnsWallet", () => {
         await po.getWalletPageHeaderPo().getUniverseSummaryPo().getLogoUrl()
       ).not.toBe(tokenLogo);
     });
-  });
 
-  it('should have canister links in "more" popup', async () => {
-    const po = await renderComponent({});
-    const morePopoverPo = po.getWalletMorePopoverPo();
+    it('should have canister links in "more" popup', async () => {
+      const po = await renderComponent({});
+      const morePopoverPo = po.getWalletMorePopoverPo();
 
-    await po.getMoreButton().click();
-    await runResolvedPromises();
+      await po.getMoreButton().click();
+      await runResolvedPromises();
 
-    expect(await morePopoverPo.getLinkToLedgerCanisterPo().isPresent()).toBe(
-      true
-    );
-    expect(await morePopoverPo.getLinkToLedgerCanisterPo().getHref()).toBe(
-      `https://dashboard.internetcomputer.org/canister/${ledgerCanisterId.toText()}`
-    );
-    expect(await morePopoverPo.getLinkToIndexCanisterPo().isPresent()).toBe(
-      true
-    );
-    expect(await morePopoverPo.getLinkToIndexCanisterPo().getHref()).toBe(
-      `https://dashboard.internetcomputer.org/canister/${indexCanisterId.toText()}`
-    );
+      expect(await morePopoverPo.getLinkToLedgerCanisterPo().isPresent()).toBe(
+        true
+      );
+      expect(await morePopoverPo.getLinkToLedgerCanisterPo().getHref()).toBe(
+        `https://dashboard.internetcomputer.org/canister/${ledgerCanisterId.toText()}`
+      );
+      expect(await morePopoverPo.getLinkToIndexCanisterPo().isPresent()).toBe(
+        true
+      );
+      expect(await morePopoverPo.getLinkToIndexCanisterPo().getHref()).toBe(
+        `https://dashboard.internetcomputer.org/canister/${indexCanisterId.toText()}`
+      );
+    });
   });
 });


### PR DESCRIPTION
# Motivation

The `'should have canister links in "more" popup'` test in `SnsWallet.spec.ts` relies on `icrcLedgerApi.queryIcrcBalance` being mocked. But this happens in the `beforeEach` of a `describe` block which the test is not a part of.

So the test fails when run separately with `it.only()`.

# Changes

1. Put the test inside the `describe("loading accounts"` block.

# Tests

The test passes when run separately with `it.only`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary