### PR TITLE
Mock updateBalance in ckbtc-minter.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -37,6 +37,7 @@ describe("ckbtc-minter-services", () => {
     resetIdentity();
     toastsStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
+    vi.spyOn(minterApi, "updateBalance").mockResolvedValue(mockUpdateBalanceOk);
   });
 
   describe("loadBtcAddress", () => {


### PR DESCRIPTION
# Motivation

These tests in `ckbtc-minter.services.spec.ts` relied on `"should update balance"` to mock `minterApi.updateBalance` and failed when run individually (with `it.only`):
1. `should reload after update balance`
2. `should start and stop busy`
3. `should not start and stop busy`

# Changes

1. Mock `minterApi.updateBalance` in top-level `beforeEach`.

# Tests

The 3 tests now all pass when run with `it.only`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary