### PR TITLE
Mock console.error in icrc-accounts.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -485,9 +485,7 @@ describe("icrc-accounts-services", () => {
     it("displays a toast on error", async () => {
       const consoleSpy = vi.spyOn(console, "error").mockReturnValue(undefined);
       const error = new Error("test");
-      vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(
-        error
-      );
+      vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(error);
       expect(ledgerApi.queryIcrcToken).not.toBeCalled();
       expect(get(toastsStore)).toMatchObject([]);
       await loadIcrcToken({ ledgerCanisterId });

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -483,8 +483,10 @@ describe("icrc-accounts-services", () => {
     });
 
     it("displays a toast on error", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockReturnValue(undefined);
+      const error = new Error("test");
       vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(
-        new Error("test")
+        error
       );
       expect(ledgerApi.queryIcrcToken).not.toBeCalled();
       expect(get(toastsStore)).toMatchObject([]);
@@ -506,6 +508,7 @@ describe("icrc-accounts-services", () => {
           text: "Sorry, there was an error loading the token metadata information. test",
         },
       ]);
+      expect(consoleSpy).toBeCalledWith(error);
     });
 
     it("displays no toast on uncertified error", async () => {
@@ -535,10 +538,12 @@ describe("icrc-accounts-services", () => {
     });
 
     it("displays a toast on uncertified error for query call", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockReturnValue(undefined);
+      const error = new Error("test");
       vi.spyOn(ledgerApi, "queryIcrcToken").mockImplementation(
         async ({ certified }) => {
           if (!certified) {
-            throw new Error("test");
+            throw error;
           }
           return mockToken;
         }
@@ -558,6 +563,7 @@ describe("icrc-accounts-services", () => {
           text: "Sorry, there was an error loading the token metadata information. test",
         },
       ]);
+      expect(consoleSpy).toBeCalledWith(error);
     });
 
     it("displays no toast on uncertified error", async () => {


### PR DESCRIPTION
# Motivation

`icrc-accounts.services.spec.ts` has multiple tests that require `console.error` to be mocked.
So of these tests do not mock `console.error` and so they depend on another test doing it before them and can't be run individually.

# Changes

1. Mock `console.error` in 2 tests that depend on it but didn't mock it before.

# Tests

1. These tests can now be run individually while before they would fail when run individually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary