### PR TITLE
Mock queryNeurons in neurons.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -429,10 +429,12 @@ describe("neurons-services", () => {
   });
 
   describe("list neurons", () => {
-    const spyQueryNeurons = vi.spyOn(api, "queryNeurons");
+    let spyQueryNeurons;
 
     beforeEach(() => {
-      spyQueryNeurons.mockResolvedValue(neurons);
+      spyQueryNeurons = vi
+        .spyOn(api, "queryNeurons")
+        .mockResolvedValue(neurons);
     });
 
     it("should list neurons", async () => {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -213,6 +213,7 @@ describe("neurons-services", () => {
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity
     );
+    vi.spyOn(api, "queryNeurons").mockResolvedValue([]);
   });
 
   describe("stake new neuron", () => {


### PR DESCRIPTION
# Motivation

The following tests fail when `describe("list neurons"` is skipped:
```
 FAIL  src/tests/lib/services/neurons.services.spec.ts > neurons-services > disburse > should disburse neuron
 FAIL  src/tests/lib/services/neurons.services.spec.ts > neurons-services > disburse > should sync account balance
 FAIL  src/tests/lib/services/neurons.services.spec.ts > neurons-services > spawnNeuron > should spawn a neuron from maturity
 FAIL  src/tests/lib/services/neurons.services.spec.ts > neurons-services > mergeNeurons > should merge neurons
 FAIL  src/tests/lib/services/neurons.services.spec.ts > neurons-services > splitNeuron > should update neuron
 FAIL  src/tests/lib/services/neurons.services.spec.ts > neurons-services > splitNeuron > should add transaction fee to the amount
```
They fail with this error:
```
It looks like the agent is trying to make a request that should have been mocked at Error: 
    at Object.transformRequest (/Users/dskloet/dev/nns-dapp/tree3/frontend/src/tests/mocks/auth.store.mock.ts:15:5)
    at makeQuery (/Users/dskloet/dev/nns-dapp/tree3/frontend/node_modules/@dfinity/agent/src/agent/http/index.ts:849:52)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at HttpAgent.query (/Users/dskloet/dev/nns-dapp/tree3/frontend/node_modules/@dfinity/agent/src/agent/http/index.ts:967:6)
    at caller (/Users/dskloet/dev/nns-dapp/tree3/frontend/node_modules/@dfinity/agent/src/actor.ts:511:8)
    at e.listNeurons (/Users/dskloet/dev/nns-dapp/tree3/frontend/node_modules/@dfinity/nns/dist/esm/chunk-C4Y572FN.js:14:92396)
    at Module.queryNeurons (/Users/dskloet/dev/nns-dapp/tree3/frontend/src/lib/api/governance.api.ts:378:20)
```
because they depend on `queryNeurons` being mocked but they do not themselves mock `queryNeurons`.

# Changes

1. Mock `queryNeurons` in the top-level `beforeEach`.

# Tests

Now the tests pass even when `describe("list neurons"` is skipped.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary