### PR TITLE
Fix test order dependency in sns-finalization.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -81,6 +81,7 @@ describe("sns-finalization-services", () => {
       });
 
       it("should call not load finalization status in store nor call api", async () => {
+        vi.spyOn(saleApi, "queryFinalizationStatus");
         await loadSnsFinalizationStatus({ rootCanisterId });
 
         const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
@@ -117,6 +118,7 @@ describe("sns-finalization-services", () => {
       });
 
       it("should call not load finalization status in store nor call api", async () => {
+        vi.spyOn(saleApi, "queryFinalizationStatus");
         await loadSnsFinalizationStatus({ rootCanisterId });
 
         const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);


### PR DESCRIPTION
# Motivation

The tests in `sns-finalization.services.spec.ts` that do not expect calls to `queryFinalizationStatus` still need `queryFinalizationStatus` to be spied on. Currently they rely on other tests to set up the spy, which means these tests fail when run individually.

# Changes

1. Spy on `queryFinalizationStatus` in 2 tests that require it but didn't do so.

# Tests

The tests failed before when run individually and now pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary