### PR TITLE
Mock queryIcrcToken in wallet-uncertified-accounts test

### DIFF
--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -82,6 +82,7 @@ describe("wallet-uncertified-accounts.services", () => {
 
   it("should toast error", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(icrcLegerApi, "queryIcrcToken").mockResolvedValue(mockCkBTCToken);
     vi.spyOn(icrcLegerApi, "queryIcrcBalance").mockRejectedValue(new Error());
 
     await services.uncertifiedLoadAccountsBalance(params);


### PR DESCRIPTION
# Motivation

Test `"should toast error"` fails when run individually because it relies on other tests mocking `queryIcrcToken`.

# Changes

Mock `queryIcrcToken` in  `"should toast error"`.

# Tests

The test now passes when run individually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary