### PR TITLE
Add vi.restoreAllMocks to services tests

### DIFF
--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -9,12 +9,11 @@ import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 
 describe("busy-services", () => {
-  const startBusySpy = vi
-    .spyOn(busyStore, "startBusy")
-    .mockImplementation(vi.fn());
+  let startBusySpy;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    startBusySpy = vi.spyOn(busyStore, "startBusy").mockImplementation(vi.fn());
   });
 
   it("call start busy without message if neuron is not controlled by hardware wallet", async () => {

--- a/frontend/src/tests/lib/services/known-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/known-neurons.services.spec.ts
@@ -12,15 +12,17 @@ import { mockKnownNeuron } from "$tests/mocks/neurons.mock";
 import { get } from "svelte/store";
 
 describe("knownNeurons-services", () => {
-  const spyQueryKnownNeurons = vi
-    .spyOn(api, "queryKnownNeurons")
-    .mockResolvedValue([mockKnownNeuron]);
+  let spyQueryKnownNeurons;
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity
     );
+    spyQueryKnownNeurons = vi
+      .spyOn(api, "queryKnownNeurons")
+      .mockResolvedValue([mockKnownNeuron]);
   });
 
   it("should list known neurons", async () => {

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -82,14 +82,8 @@ describe("sns-vote-registration-services", () => {
     ballots: testBallots,
   };
   let resolveQuerySnsProposals;
-  const spyQuerySnsProposals = vi
-    .spyOn(api, "queryProposals")
-    .mockReturnValue(
-      new Promise((resolve) => (resolveQuerySnsProposals = resolve))
-    );
-  const spyQuerySnsNeurons = vi
-    .spyOn(api, "querySnsNeurons")
-    .mockResolvedValue([...neurons]);
+  let spyQuerySnsProposals;
+  let spyQuerySnsNeurons;
   const callRegisterVote = async ({
     vote,
     reloadProposalCallback,
@@ -107,8 +101,17 @@ describe("sns-vote-registration-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     toastsStore.reset();
+
+    spyQuerySnsProposals = vi
+      .spyOn(api, "queryProposals")
+      .mockReturnValue(
+        new Promise((resolve) => (resolveQuerySnsProposals = resolve))
+      );
+    spyQuerySnsNeurons = vi
+      .spyOn(api, "querySnsNeurons")
+      .mockResolvedValue([...neurons]);
 
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -54,8 +54,8 @@ describe("vote-registration-services", () => {
     ...mockNeuron,
     neuronId,
   }));
-  const spyRegisterVote = vi.spyOn(governanceApi, "registerVote");
-  const spyLoadProposal = vi.spyOn(proposalsServices, "loadProposal");
+  let spyRegisterVote;
+  let spyLoadProposal;
 
   const votableProposal: ProposalInfo = {
     ...mockProposalInfo,
@@ -67,20 +67,14 @@ describe("vote-registration-services", () => {
     ],
   };
   let resolveSpyQueryProposals;
-  const spyQueryProposals = vi
-    .spyOn(api, "queryProposals")
-    .mockReturnValue(
-      new Promise((resolve) => (resolveSpyQueryProposals = resolve))
-    );
-  const spyQueryNeurons = vi
-    .spyOn(governanceApi, "queryNeurons")
-    .mockResolvedValue([...neurons]);
+  let spyQueryProposals;
+  let spyQueryNeurons;
 
   let proposal: ProposalInfo = proposalInfo();
 
   beforeEach(() => {
     // Cleanup:
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     voteRegistrationStore.reset();
     toastsStore.reset();
     proposalsStore.resetForTesting();
@@ -102,10 +96,22 @@ describe("vote-registration-services", () => {
     vi.spyOn(neuronsServices, "listNeurons").mockImplementation(() =>
       Promise.resolve()
     );
-    spyRegisterVote.mockResolvedValue(undefined);
-    spyLoadProposal.mockImplementation(async ({ setProposal }) => {
-      setProposal(proposal);
-    });
+    spyRegisterVote = vi
+      .spyOn(governanceApi, "registerVote")
+      .mockResolvedValue(undefined);
+    spyLoadProposal = vi
+      .spyOn(proposalsServices, "loadProposal")
+      .mockImplementation(async ({ setProposal }) => {
+        setProposal(proposal);
+      });
+    spyQueryProposals = vi
+      .spyOn(api, "queryProposals")
+      .mockReturnValue(
+        new Promise((resolve) => (resolveSpyQueryProposals = resolve))
+      );
+    spyQueryNeurons = vi
+      .spyOn(governanceApi, "queryNeurons")
+      .mockResolvedValue([...neurons]);
   });
 
   describe("success voting", () => {

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -15,20 +15,16 @@ import {
   mockCkBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
 import { get } from "svelte/store";
-
-vi.mock("$lib/stores/toasts.store", () => {
-  return {
-    toastsError: vi.fn(),
-  };
-});
+import * as toastsStore from "$lib/stores/toasts.store";
 
 describe("wallet-uncertified-accounts.services", () => {
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
 
     icrcAccountsStore.reset();
     tokensStore.reset();
+    vi.spyOn(toastsStore, "toastsError");
   });
 
   const params = {
@@ -82,6 +78,7 @@ describe("wallet-uncertified-accounts.services", () => {
 
   it("should toast error", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(icrcLegerApi, "queryIcrcToken").mockResolvedValue(mockCkBTCToken);
     vi.spyOn(icrcLegerApi, "queryIcrcBalance").mockRejectedValue(new Error());
 
     await services.uncertifiedLoadAccountsBalance(params);


### PR DESCRIPTION
# Motivation

To avoid unpredictable behavior, each test should start with a clean slate.
One component of that is restoring all mocks before each test.

I tried running all tests with `vi.restoreAllMocks()` in `beforeEach` in `vitests.setup.ts` and found a number of tests that failed as a result.

Of the failing tests, this PR fixes the ones under `frontend/src/tests/lib/services/`.

# Changes

1. Replace top-level calls to `vi.mock` that define mock behavior with `vi.spyOn` in `beforeEach`.
2. Move calls to `vi.spyOn` in `describe` scope into `beforeEach`.
3. Move calls to `mockResolvedValue` and `mockImplementation` on mocks from `describe` scope to `beforeEach`.
4. Call `vi.restoreAllMocks()` in top-level `beforeEach`.
5. Remove `vi.clearAllMocks` as its behavior is a subset of `vi.restoreAllMocks`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary