### PR TITLE
Upgrade ic js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -296,10 +296,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.2-next-2024-11-01.tgz",
-      "integrity": "sha512-dUM7k4Q2JFMg7ITSXipNAyJKCSW76+CgcS/kFfcfkJTPa0kZ+8yrlYLkbrHZTX9kkMHGpa5CzKrSmXtr/EbxUA==",
-      "license": "Apache-2.0",
+      "version": "3.1.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.2-next-2024-11-14.tgz",
+      "integrity": "sha512-aV04iHoj+i/2WY95BMaRSR0Z3sQenEwvnUfyTerUWnNe0KbGSjP91uVC36FMvkriUJY+QYFq0UuYt6vbHBhcqg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -313,10 +312,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "4.0.0-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.0-next-2024-11-01.tgz",
-      "integrity": "sha512-TKrplNX+8CqPDbOkWMHnR1EsvoMK/GEiJ6iXbvgTfJq/zqO4Brj6gxHCBCzmMcuU6uxVMAK3zGu33mXw4TjJ7w==",
-      "license": "Apache-2.0",
+      "version": "4.0.0-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.0-next-2024-11-14.tgz",
+      "integrity": "sha512-NBvsWL320nLRzGk/WjInc1F4SW8RO9T4phQmAg5q4ooWFsSKcJLYZwByN3bUzWObPaxUqO8c4ozCOHPtlm/25w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,10 +339,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "5.2.3-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.2.3-next-2024-11-01.tgz",
-      "integrity": "sha512-Z9WO7Vf13pmqgMaYJf/NDSutGLkLPqIlg9ZsDFQKfu82+WqqB1gaBi9dsKrMqMOFa+tapTG4cR/ps/fINnamhw==",
-      "license": "Apache-2.0",
+      "version": "5.2.3-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.2.3-next-2024-11-14.tgz",
+      "integrity": "sha512-GICvT96NY6VyEDo/H6HMxLLfROgbKrhTMtlckgYL3+4U/+P567RKEe2d/zCug4XFDRoqk02VIIAo7ihI2sh6JA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -368,10 +365,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.6.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.2-next-2024-11-01.tgz",
-      "integrity": "sha512-omYwh762JwL57ocU4s2zGgAVMyH15olhTOP4IKo+F7O++gNVUyFIdafHl6OcQAn+dhquxv5WRIyYem7nvDARvA==",
-      "license": "Apache-2.0",
+      "version": "2.6.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.2-next-2024-11-14.tgz",
+      "integrity": "sha512-3k67M+OwuYSSd0HKRCVZoyrQVfVk3Sx5vkRTEH6QJbj3p6L3tu74PMZ5lVspW1bhsUQMl0TggwytgbejU+2loA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -380,10 +376,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.6.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.2-next-2024-11-01.tgz",
-      "integrity": "sha512-SrLGocNu08P5EJRB8IMCoqxDXzX7tNhuxT0EqbgUXUDu8MAAfzJMR7d3Zgoz8q5t/d4wxaE/eyaHJJz9piU3oA==",
-      "license": "Apache-2.0",
+      "version": "2.6.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.2-next-2024-11-14.tgz",
+      "integrity": "sha512-YWFRnU4r5vSSLmz2kyjWbHtHkXeb+Fojoa13W+e4E8FInPRk/GrhfQFQjJsMHgIg7GbN7Yl/zzE87PWn8tuJ/A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -392,10 +387,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "7.0.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-7.0.2-next-2024-11-01.tgz",
-      "integrity": "sha512-VdDg5p5gze8CEy2oyCcfjO+MK7Rhw/pgQeIIBzs86PeqRtw7stSZ/+5xnQeSrfl3Q7yo6L1fiUHQ/AK+s0Xu0w==",
-      "license": "Apache-2.0",
+      "version": "7.0.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-7.0.2-next-2024-11-14.tgz",
+      "integrity": "sha512-10lhKTA/WbWkAkGhqprCxz2618avklnDjI82r5J6oiVZabhlyFyDhXfAAqlZiRd4TmvOWjkfW0D8uIvjm7sH6w==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -417,10 +411,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.2.3-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.3-next-2024-11-01.tgz",
-      "integrity": "sha512-3BLp6+kyd6/ZGiG6y6cTfKLGEElCCfHd2T6OgZro5DPyfFpDWtBA8eSFwP5OgS2WDecxCHXlYV2Ni8KADrdE4w==",
-      "license": "Apache-2.0",
+      "version": "3.2.3-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.3-next-2024-11-14.tgz",
+      "integrity": "sha512-u7fFmMBxb7smgeKWCdOnLKnAdyi+s7sb/wXywDB8y8UZkvk++qFcnSepN5ONPIOrmYVvtCGnFfqZLbxMSQWlJw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -433,10 +426,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.6.0-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.6.0-next-2024-11-01.tgz",
-      "integrity": "sha512-RUfhqmA3YP0pj4iJ61SnQFbEIjQPVRS7NLuBSwhDjMoQ5Q8OwoPFmHjREZOToPy8Ajt315WXgWEVdMxBlgUxlw==",
-      "license": "Apache-2.0",
+      "version": "2.6.0-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.6.0-next-2024-11-14.tgz",
+      "integrity": "sha512-/ham6y3hBxA7KCI5VGAQdTouU97TrCJ66rnnIzzrwAdPmPZovRziWwdiDLFQUhH/sNAejIcUsJ8a7oW8Tl0nXw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -2246,7 +2238,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
       "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2281,8 +2272,7 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
@@ -4971,7 +4961,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -6681,9 +6670,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "3.1.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.2-next-2024-11-01.tgz",
-      "integrity": "sha512-dUM7k4Q2JFMg7ITSXipNAyJKCSW76+CgcS/kFfcfkJTPa0kZ+8yrlYLkbrHZTX9kkMHGpa5CzKrSmXtr/EbxUA==",
+      "version": "3.1.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.2-next-2024-11-14.tgz",
+      "integrity": "sha512-aV04iHoj+i/2WY95BMaRSR0Z3sQenEwvnUfyTerUWnNe0KbGSjP91uVC36FMvkriUJY+QYFq0UuYt6vbHBhcqg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -6691,9 +6680,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "4.0.0-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.0-next-2024-11-01.tgz",
-      "integrity": "sha512-TKrplNX+8CqPDbOkWMHnR1EsvoMK/GEiJ6iXbvgTfJq/zqO4Brj6gxHCBCzmMcuU6uxVMAK3zGu33mXw4TjJ7w==",
+      "version": "4.0.0-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.0-next-2024-11-14.tgz",
+      "integrity": "sha512-NBvsWL320nLRzGk/WjInc1F4SW8RO9T4phQmAg5q4ooWFsSKcJLYZwByN3bUzWObPaxUqO8c4ozCOHPtlm/25w==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -6708,9 +6697,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "5.2.3-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.2.3-next-2024-11-01.tgz",
-      "integrity": "sha512-Z9WO7Vf13pmqgMaYJf/NDSutGLkLPqIlg9ZsDFQKfu82+WqqB1gaBi9dsKrMqMOFa+tapTG4cR/ps/fINnamhw==",
+      "version": "5.2.3-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.2.3-next-2024-11-14.tgz",
+      "integrity": "sha512-GICvT96NY6VyEDo/H6HMxLLfROgbKrhTMtlckgYL3+4U/+P567RKEe2d/zCug4XFDRoqk02VIIAo7ihI2sh6JA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -6724,21 +6713,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.6.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.2-next-2024-11-01.tgz",
-      "integrity": "sha512-omYwh762JwL57ocU4s2zGgAVMyH15olhTOP4IKo+F7O++gNVUyFIdafHl6OcQAn+dhquxv5WRIyYem7nvDARvA==",
+      "version": "2.6.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.2-next-2024-11-14.tgz",
+      "integrity": "sha512-3k67M+OwuYSSd0HKRCVZoyrQVfVk3Sx5vkRTEH6QJbj3p6L3tu74PMZ5lVspW1bhsUQMl0TggwytgbejU+2loA==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.6.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.2-next-2024-11-01.tgz",
-      "integrity": "sha512-SrLGocNu08P5EJRB8IMCoqxDXzX7tNhuxT0EqbgUXUDu8MAAfzJMR7d3Zgoz8q5t/d4wxaE/eyaHJJz9piU3oA==",
+      "version": "2.6.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.2-next-2024-11-14.tgz",
+      "integrity": "sha512-YWFRnU4r5vSSLmz2kyjWbHtHkXeb+Fojoa13W+e4E8FInPRk/GrhfQFQjJsMHgIg7GbN7Yl/zzE87PWn8tuJ/A==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "7.0.2-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-7.0.2-next-2024-11-01.tgz",
-      "integrity": "sha512-VdDg5p5gze8CEy2oyCcfjO+MK7Rhw/pgQeIIBzs86PeqRtw7stSZ/+5xnQeSrfl3Q7yo6L1fiUHQ/AK+s0Xu0w==",
+      "version": "7.0.2-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-7.0.2-next-2024-11-14.tgz",
+      "integrity": "sha512-10lhKTA/WbWkAkGhqprCxz2618avklnDjI82r5J6oiVZabhlyFyDhXfAAqlZiRd4TmvOWjkfW0D8uIvjm7sH6w==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -6753,17 +6742,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.2.3-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.3-next-2024-11-01.tgz",
-      "integrity": "sha512-3BLp6+kyd6/ZGiG6y6cTfKLGEElCCfHd2T6OgZro5DPyfFpDWtBA8eSFwP5OgS2WDecxCHXlYV2Ni8KADrdE4w==",
+      "version": "3.2.3-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.3-next-2024-11-14.tgz",
+      "integrity": "sha512-u7fFmMBxb7smgeKWCdOnLKnAdyi+s7sb/wXywDB8y8UZkvk++qFcnSepN5ONPIOrmYVvtCGnFfqZLbxMSQWlJw==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.6.0-next-2024-11-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.6.0-next-2024-11-01.tgz",
-      "integrity": "sha512-RUfhqmA3YP0pj4iJ61SnQFbEIjQPVRS7NLuBSwhDjMoQ5Q8OwoPFmHjREZOToPy8Ajt315WXgWEVdMxBlgUxlw==",
+      "version": "2.6.0-next-2024-11-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.6.0-next-2024-11-14.tgz",
+      "integrity": "sha512-/ham6y3hBxA7KCI5VGAQdTouU97TrCJ66rnnIzzrwAdPmPZovRziWwdiDLFQUhH/sNAejIcUsJ8a7oW8Tl0nXw==",
       "requires": {}
     },
     "@esbuild/aix-ppc64": {

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -28,6 +28,7 @@ export const mockFullNeuron: Neuron = {
   dissolveState: undefined,
   followees: [],
   visibility: undefined,
+  votingPowerRefreshedTimestampSeconds: 0n,
 };
 
 export const createMockFullNeuron = (id: number | bigint) => {


### PR DESCRIPTION
# Motivation

Upgrade to the next version of ic-js to get the `votingPowerRefreshedTimestampSeconds` field of the neuron.

# Changes

- npm run upgrade:next;
- Add a new field to the mocked neuron.

# Tests

- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.