### PR TITLE
Add vi.restoreAllMocks to components tests

### DIFF
--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -15,6 +15,7 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SelectDestinationAddress", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     resetSnsProjects();
     icrcAccountsStore.reset();
   });
@@ -27,9 +28,11 @@ describe("SelectDestinationAddress", () => {
     const subaccounts = [mockSubAccount, mockSubAccount2];
     const hardwareWallets = [mockHardwareWalletAccount];
 
-    vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
-      mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
-    );
+    beforeEach(() => {
+      vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
+        mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
+      );
+    });
 
     it("should render address input as default", () => {
       const { container } = render(SelectDestinationAddress, {

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
@@ -1,14 +1,9 @@
+import * as canisterServices from "$lib/services/canisters.services";
 import { removeController } from "$lib/services/canisters.services";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import RemoveCanisterControllerButton from "./RemoveCanisterControllerButtonTest.svelte";
-
-vi.mock("$lib/services/canisters.services", () => {
-  return {
-    removeController: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
 
 describe("RemoveCanisterControllerButton", () => {
   const controller = "ryjl3-tyaaa-aaaaa-aaaba-cai";
@@ -16,7 +11,11 @@ describe("RemoveCanisterControllerButton", () => {
   const props = { controller, reloadDetails: reloadDetailsMock };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    vi.spyOn(canisterServices, "removeController").mockResolvedValue({
+      success: true,
+    });
   });
 
   it("renders a button", () => {

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -13,13 +13,15 @@ describe("Proposals", () => {
       ? snsProposalsStore.reset()
       : snsProposalsStore.setProposals({ proposals, certified: true });
 
-  const queryProposalsSpy = vitest
-    .spyOn(api, "queryProposals")
-    .mockResolvedValue([mockProposalInfo]);
+  let queryProposalsSpy;
 
   beforeEach(() => {
-    vitest.clearAllMocks();
+    vi.restoreAllMocks();
     snsProposalsStore.reset();
+
+    queryProposalsSpy = vi
+      .spyOn(api, "queryProposals")
+      .mockResolvedValue([mockProposalInfo]);
   });
 
   it("should trigger call to query proposals", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
@@ -1,6 +1,7 @@
 import NnsNeuronHotkeysCard from "$lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
+import * as neuronsServices from "$lib/services/neurons.services";
 import { removeHotkey } from "$lib/services/neurons.services";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -8,13 +9,6 @@ import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
-
-vi.mock("$lib/services/neurons.services", () => {
-  return {
-    removeHotkey: vi.fn().mockResolvedValue(10n),
-    getNeuronFromStore: vi.fn(),
-  };
-});
 
 describe("NnsNeuronHotkeysCard", () => {
   const hotKeys = [
@@ -40,7 +34,9 @@ describe("NnsNeuronHotkeysCard", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.spyOn(neuronsServices, "removeHotkey").mockResolvedValue(10n);
+    vi.spyOn(neuronsServices, "getNeuronFromStore").mockReturnValue(undefined);
   });
 
   it("renders hotkeys title", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -1,4 +1,5 @@
 import NnsAutoStakeMaturity from "$lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte";
+import * as neuronsServices from "$lib/services/neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
 import { mockPrincipalText, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -8,17 +9,14 @@ import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
-vi.mock("$lib/services/neurons.services", () => {
-  return {
-    toggleAutoStakeMaturity: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("NnsAutoStakeMaturity", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     toastsStore.reset();
     resetIdentity();
+    vi.spyOn(neuronsServices, "toggleAutoStakeMaturity").mockResolvedValue({
+      success: true,
+    });
   });
 
   it("renders checkbox", () => {

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
@@ -18,13 +18,13 @@ import { mock } from "vitest-mock-extended";
 
 describe("NnsProposalProposerPayloadEntry", () => {
   const nnsDappMock = mock<NNSDappCanister>();
-  vi.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
 
   const payload = { b: "c" };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     proposalPayloadsStore.reset();
+    vi.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -1,5 +1,6 @@
 import SnsNeuronHotkeysCard from "$lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { removeHotkey } from "$lib/services/sns-neurons.services";
 import { enumValues } from "$lib/utils/enum.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -12,12 +13,6 @@ import {
 import { Principal } from "@dfinity/principal";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 import { fireEvent, waitFor } from "@testing-library/svelte";
-
-vi.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    removeHotkey: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
 
 describe("SnsNeuronHotkeysCard", () => {
   const addHotkeyPermissions = (key) => ({
@@ -66,8 +61,11 @@ describe("SnsNeuronHotkeysCard", () => {
     });
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     resetIdentity();
+    vi.spyOn(snsNeuronsServices, "removeHotkey").mockResolvedValue({
+      success: true,
+    });
   });
 
   it("renders hotkeys title", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -1,5 +1,6 @@
 import SnsAutoStakeMaturity from "$lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/sns-neurons.services";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -11,17 +12,14 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
-vi.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    toggleAutoStakeMaturity: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("SnsAutoStakeMaturity", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     toastsStore.reset();
     resetIdentity();
+    vi.spyOn(snsNeuronsServices, "toggleAutoStakeMaturity").mockResolvedValue({
+      success: true,
+    });
     vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(
       mockTokenStore
     );

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -22,16 +22,8 @@ import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseDropdown", () => {
-  vi.spyOn(snsProjectSelectedStore, "subscribe").mockImplementation(
-    mockStoreSubscribe(mockSnsFullProject)
-  );
-
-  vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
-    mockProjectSubscribe([mockSnsFullProject])
-  );
-
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     icrcAccountsStore.reset();
     resetSnsProjects();
     resetIdentity();
@@ -39,6 +31,14 @@ describe("SelectUniverseDropdown", () => {
     page.mock({
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
+
+    vi.spyOn(snsProjectSelectedStore, "subscribe").mockImplementation(
+      mockStoreSubscribe(mockSnsFullProject)
+    );
+
+    vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
+      mockProjectSubscribe([mockSnsFullProject])
+    );
   });
 
   const renderComponent = () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -34,17 +34,17 @@ describe("SelectUniverseList", () => {
     return SelectUniverseListPo.under(new JestPageObjectElement(container));
   };
 
-  vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
-    mockProjectSubscribe(projects)
-  );
-
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
 
     page.mock({
       routeId: AppPath.Accounts,
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
+
+    vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
+      mockProjectSubscribe(projects)
+    );
   });
 
   it("should render universe cards", () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
@@ -11,15 +11,17 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SelectUniverseNavList", () => {
-  vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
-    mockProjectSubscribe([mockSnsFullProject])
-  );
-
   beforeEach(() => {
+    vi.restoreAllMocks();
+
     page.mock({
       routeId: AppPath.Accounts,
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
+
+    vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
+      mockProjectSubscribe([mockSnsFullProject])
+    );
   });
 
   it("should render universe cards as buttons", () => {

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -41,7 +41,7 @@ import { render } from "@testing-library/svelte";
 
 describe("UniverseAccountsBalance", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     resetSnsProjects();
     icrcAccountsStore.reset();
 
@@ -80,9 +80,14 @@ describe("UniverseAccountsBalance", () => {
   });
 
   describe("balance", () => {
-    vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
-      mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
-    );
+    beforeEach(() => {
+      vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
+        mockAccountsStoreSubscribe(
+          [mockSubAccount],
+          [mockHardwareWalletAccount]
+        )
+      );
+    });
 
     it("should render a total balance for Nns", () => {
       const { getByTestId } = render(ProjectAccountsBalance, {


### PR DESCRIPTION
# Motivation

To avoid unpredictable behavior, each test should start with a clean slate.
One component of that is restoring all mocks before each test.

I tried running all tests with `vi.restoreAllMocks()` in `beforeEach` in `vitests.setup.ts` and found a number of tests that failed as a result.

Of the failing tests, this PR fixes the ones under `frontend/src/tests/lib/components/`.

# Changes

1. Replace top-level calls to `vi.mock` that define mock behavior with `vi.spyOn` in `beforeEach`.
2. Move calls to `vi.spyOn` in `describe` scope into `beforeEach`.
3. Move calls to `mockResolvedValue` and `mockImplementation` on mocks from `describe` scope to `beforeEach`.
4. Call `vi.restoreAllMocks()` in top-level `beforeEach`.
5. Remove `vi.clearAllMocks` as its behavior is a subset of `vi.restoreAllMocks`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary