### PR TITLE
Add vi.restoreAllMocks to modals tests

### DIFF
--- a/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -1,34 +1,37 @@
 import { LedgerConnectionState } from "$lib/constants/ledger.constants";
 import AddAccountModal from "$lib/modals/accounts/AddAccountModal.svelte";
+import * as icpLedgerServicesProxy from "$lib/proxy/icp-ledger.services.proxy";
+import * as icpAccountsServices from "$lib/services/icp-accounts.services";
 import { addSubAccount } from "$lib/services/icp-accounts.services";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { MockLedgerIdentity } from "$tests/mocks/ledger.identity.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-// This is the way to mock when we import in a destructured manner
-// and we want to mock the imported function
-vi.mock("$lib/services/icp-accounts.services", () => {
-  return {
-    addSubAccount: vi.fn().mockResolvedValue(undefined),
-  };
-});
+describe("AddAccountModal", () => {
+  const mockLedgerIdentity = new MockLedgerIdentity();
 
-vi.mock("$lib/proxy/icp-ledger.services.proxy", () => {
-  return {
-    connectToHardwareWalletProxy: vi.fn().mockImplementation(async (callback) =>
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(icpAccountsServices, "addSubAccount").mockResolvedValue(undefined);
+    vi.spyOn(
+      icpLedgerServicesProxy,
+      "connectToHardwareWalletProxy"
+    ).mockImplementation(async (callback) =>
       callback({
         connectionState: LedgerConnectionState.CONNECTED,
-        ledgerIdentity: mockIdentity,
+        ledgerIdentity: mockLedgerIdentity,
       })
-    ),
-    registerHardwareWalletProxy: vi.fn().mockResolvedValue(undefined),
-  };
-});
+    );
+    vi.spyOn(
+      icpLedgerServicesProxy,
+      "registerHardwareWalletProxy"
+    ).mockResolvedValue(undefined);
+  });
 
-describe("AddAccountModal", () => {
   it("should display modal", () => {
     const { container } = render(AddAccountModal);
 

--- a/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -1,14 +1,9 @@
+import * as canistersServices from "$lib/services/canisters.services";
 import { addController } from "$lib/services/canisters.services";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import AddControllerModal from "./AddControllerModalTest.svelte";
-
-vi.mock("$lib/services/canisters.services", () => {
-  return {
-    addController: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
 
 describe("AddControllerModal", () => {
   const reloadMock = vi.fn();
@@ -23,7 +18,11 @@ describe("AddControllerModal", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    vi.spyOn(canistersServices, "addController").mockResolvedValue({
+      success: true,
+    });
   });
 
   it("should display modal", async () => {

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -1,4 +1,5 @@
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+import * as canistersServices from "$lib/services/canisters.services";
 import {
   getIcpToCyclesExchangeRate,
   topUpCanister,
@@ -19,24 +20,24 @@ import { tick } from "svelte";
 import { get } from "svelte/store";
 import AddCyclesModalTest from "./AddCyclesModalTest.svelte";
 
-vi.mock("$lib/services/canisters.services", () => {
-  return {
-    getIcpToCyclesExchangeRate: vi.fn().mockResolvedValue(100_000n),
-    topUpCanister: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("AddCyclesModal", () => {
-  vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
-    mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
-  );
-
   const reloadDetails = vi.fn();
   const props = { reloadDetails };
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     toastsStore.reset();
+
+    vi.spyOn(canistersServices, "getIcpToCyclesExchangeRate").mockResolvedValue(
+      100_000n
+    );
+    vi.spyOn(canistersServices, "topUpCanister").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
+      mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
+    );
   });
+
   it("should display modal", () => {
     const { container } = render(AddCyclesModalTest, { props });
 

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "$lib/constants/canisters.constants";
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import CreateCanisterModal from "$lib/modals/canisters/CreateCanisterModal.svelte";
+import * as canistersServices from "$lib/services/canisters.services";
 import {
   createCanister,
   getIcpToCyclesExchangeRate,
@@ -24,23 +25,20 @@ import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/services/canisters.services", () => {
-  return {
-    getIcpToCyclesExchangeRate: vi.fn().mockResolvedValue(10_000n),
-    createCanister: vi
-      .fn()
-      .mockImplementation(() => Promise.resolve(mockCanister.canister_id)),
-  };
-});
-
 describe("CreateCanisterModal", () => {
-  vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
-    mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
-  );
-
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     toastsStore.reset();
+
+    vi.spyOn(canistersServices, "getIcpToCyclesExchangeRate").mockResolvedValue(
+      10_000n
+    );
+    vi.spyOn(canistersServices, "createCanister").mockImplementation(
+      async () => mockCanister.canister_id
+    );
+    vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
+      mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
+    );
   });
 
   it("should display modal", () => {

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -1,5 +1,6 @@
 import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import LinkCanisterModal from "$lib/modals/canisters/LinkCanisterModal.svelte";
+import * as canistersServices from "$lib/services/canisters.services";
 import { attachCanister } from "$lib/services/canisters.services";
 import en from "$tests/mocks/i18n.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
@@ -8,15 +9,13 @@ import { nonNullish } from "@dfinity/utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 
-vi.mock("$lib/services/canisters.services", () => {
-  return {
-    attachCanister: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("LinkCanisterModal", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    vi.spyOn(canistersServices, "attachCanister").mockResolvedValue({
+      success: true,
+    });
   });
 
   it("should display modal", () => {

--- a/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
@@ -54,6 +54,7 @@ describe("ChangeNeuronVisibilityModal", () => {
   };
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     resetIdentity();
     neuronsStore.reset();
     toastsStore.reset();
@@ -70,10 +71,13 @@ describe("ChangeNeuronVisibilityModal", () => {
       neurons: [publicNeuron, privateNeuron],
       certified: true,
     });
+
+    startBusySpy = vi.spyOn(busyServices, "startBusy");
+    stopBusySpy = vi.spyOn(busyServices, "stopBusy");
   });
 
-  const startBusySpy = vi.spyOn(busyServices, "startBusy");
-  const stopBusySpy = vi.spyOn(busyServices, "stopBusy");
+  let startBusySpy;
+  let stopBusySpy;
 
   const renderComponent = async (neuron = mockNeuron) => {
     const { container, component } = await renderModal({

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -6,6 +6,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import DisburseNnsNeuronModal from "$lib/modals/neurons/DisburseNnsNeuronModal.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
+import * as neuronsServices from "$lib/services/neurons.services";
 import { disburse } from "$lib/services/neurons.services";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -32,19 +33,14 @@ import type { SvelteComponent } from "svelte";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
 
-vi.mock("$lib/api/nns-dapp.api");
-vi.mock("$lib/api/icp-ledger.api");
-vi.mock("$lib/services/neurons.services", () => {
-  return {
-    disburse: vi.fn().mockResolvedValue({ success: true }),
-    getNeuronFromStore: vi.fn(),
-  };
-});
-
 describe("DisburseNnsNeuronModal", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     resetIdentity();
     cancelPollAccounts();
+
+    vi.spyOn(neuronsServices, "disburse").mockResolvedValue({ success: true });
+    vi.spyOn(neuronsServices, "getNeuronFromStore").mockReturnValue(undefined);
   });
 
   const renderDisburseModal = async (

--- a/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
@@ -1,4 +1,5 @@
 import SplitNeuronModal from "$lib/modals/neurons/SplitNnsNeuronModal.svelte";
+import * as neuronsServices from "$lib/services/neurons.services";
 import { splitNeuron } from "$lib/services/neurons.services";
 import * as busyServices from "$lib/stores/busy.store";
 import {
@@ -13,14 +14,8 @@ import { fireEvent } from "@testing-library/dom";
 import type { RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-vi.mock("$lib/services/neurons.services", () => {
-  return {
-    splitNeuron: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
 describe("SplitNeuronModal", () => {
-  const startBusySpy = vi.spyOn(busyServices, "startBusy");
+  let startBusySpy;
   const renderSplitNeuronModal = async (
     neuron: NeuronInfo
   ): Promise<RenderResult<SvelteComponent>> => {
@@ -31,7 +26,10 @@ describe("SplitNeuronModal", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    vi.spyOn(neuronsServices, "splitNeuron").mockResolvedValue(undefined);
+    startBusySpy = vi.spyOn(busyServices, "startBusy");
   });
 
   it("should display modal", async () => {

--- a/frontend/src/tests/lib/modals/sns/neurons/AddSnsHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/AddSnsHotkeyModal.spec.ts
@@ -1,4 +1,5 @@
 import AddSnsHotkeyModal from "$lib/modals/sns/neurons/AddSnsHotkeyModal.svelte";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { addHotkey } from "$lib/services/sns-neurons.services";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -6,14 +7,15 @@ import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-vi.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    addHotkey: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("AddSnsHotkeyModal", () => {
   const reload = vi.fn();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(snsNeuronsServices, "addHotkey").mockResolvedValue({
+      success: true,
+    });
+  });
 
   const renderAddSnsHotkeyModal = async (): Promise<
     RenderResult<SvelteComponent>

--- a/frontend/src/tests/lib/modals/sns/neurons/NewSnsFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/NewSnsFolloweeModal.spec.ts
@@ -1,4 +1,5 @@
 import NewSnsFolloweeModal from "$lib/modals/sns/neurons/NewSnsFolloweeModal.svelte";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { addFollowee } from "$lib/services/sns-neurons.services";
 import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
@@ -8,15 +9,16 @@ import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-vi.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    addFollowee: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("NewSnsFolloweeModal", () => {
   const reload = vi.fn();
   const functionId = 4n;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(snsNeuronsServices, "addFollowee").mockResolvedValue({
+      success: true,
+    });
+  });
 
   const renderNewSnsFolloweeModal = (): RenderResult<SvelteComponent> =>
     renderSelectedSnsNeuronContext({

--- a/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
+++ b/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
@@ -13,11 +13,13 @@ import { fireEvent } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SelectUniverseModal", () => {
-  vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
-    mockProjectSubscribe([mockSnsFullProject])
-  );
-
   beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
+      mockProjectSubscribe([mockSnsFullProject])
+    );
+
     page.mock({
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });


### PR DESCRIPTION
# Motivation

To avoid unpredictable behavior, each test should start with a clean slate.
One component of that is restoring all mocks before each test.

I tried running all tests with `vi.restoreAllMocks()` in `beforeEach` in `vitests.setup.ts` and found a number of tests that failed as a result.

Of the failing tests, this PR fixes the ones under `frontend/src/tests/lib/modals/`.

# Changes

1. Replace top-level calls to `vi.mock` that define mock behavior with `vi.spyOn` in `beforeEach`.
2. Move calls to `vi.spyOn` in `describe` scope into `beforeEach`.
3. Move calls to `mockResolvedValue` and `mockImplementation` on mocks from `describe` scope to `beforeEach`.
4. Call `vi.restoreAllMocks()` in top-level `beforeEach`.
5. Remove `vi.clearAllMocks` as its behavior is a subset of `vi.restoreAllMocks`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary