### PR TITLE
Make remaining tests work with vi.restoreAllMock()

### DIFF
--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -12,14 +12,16 @@ import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
 
 describe("universes-accounts-balance.derived", () => {
-  vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
-    mockAccountsStoreSubscribe([], [])
-  );
-
   const rootCanisterId = mockSnsFullProject.rootCanisterId;
   const ledgerCanisterId = mockSnsFullProject.summary.ledgerCanisterId;
 
   beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
+      mockAccountsStoreSubscribe([], [])
+    );
+
     setSnsProjects([
       {
         rootCanisterId,

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -5,7 +5,9 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import SnsWallet from "$lib/pages/SnsWallet.svelte";
 import * as workerBalances from "$lib/services/worker-balances.services";
+import * as workerBalancesServices from "$lib/services/worker-balances.services";
 import * as workerTransactions from "$lib/services/worker-transactions.services";
+import * as workerTransactionsServices from "$lib/services/worker-transactions.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { aggregatorCanisterLogoPath } from "$lib/utils/sns-aggregator-converters.utils";
@@ -39,32 +41,6 @@ import { get } from "svelte/store";
 vi.mock("$lib/api/icrc-index.api");
 
 let balancesObserverCallback;
-
-vi.mock("$lib/services/worker-transactions.services", () => ({
-  initTransactionsWorker: vi.fn(() =>
-    Promise.resolve({
-      startTransactionsTimer: () => {
-        // Do nothing
-      },
-      stopTransactionsTimer: () => {
-        // Do nothing
-      },
-    })
-  ),
-}));
-
-vi.mock("$lib/services/worker-balances.services", () => ({
-  initBalancesWorker: vi.fn(() =>
-    Promise.resolve({
-      startBalancesTimer: ({ callback }) => {
-        balancesObserverCallback = callback;
-      },
-      stopBalancesTimer: () => {
-        // Do nothing
-      },
-    })
-  ),
-}));
 
 describe("SnsWallet", () => {
   const testTokenSymbol = "OOO";
@@ -100,7 +76,7 @@ describe("SnsWallet", () => {
   beforeEach(() => {
     vi.useRealTimers();
     resetIdentity();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     icrcAccountsStore.reset();
     tokensStore.reset();
     resetSnsProjects();
@@ -109,6 +85,25 @@ describe("SnsWallet", () => {
       transactions: [],
     });
     vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(10n);
+    vi.spyOn(
+      workerTransactionsServices,
+      "initTransactionsWorker"
+    ).mockResolvedValue({
+      startTransactionsTimer: () => {
+        // Do nothing
+      },
+      stopTransactionsTimer: () => {
+        // Do nothing
+      },
+    });
+    vi.spyOn(workerBalancesServices, "initBalancesWorker").mockResolvedValue({
+      startBalancesTimer: ({ callback }) => {
+        balancesObserverCallback = callback;
+      },
+      stopBalancesTimer: () => {
+        // Do nothing
+      },
+    });
 
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -23,10 +23,10 @@ import { get } from "svelte/store";
 
 describe("proposals-services", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     toastsStore.reset();
     proposalsStore.setProposalsForTesting({ proposals: [], certified: true });
     proposalPayloadsStore.reset();
-    vi.clearAllMocks();
     vi.spyOn(console, "error").mockRestore();
   });
 
@@ -187,10 +187,12 @@ describe("proposals-services", () => {
     });
 
     describe("load", () => {
-      const spyQueryProposal = vi.spyOn(api, "queryProposal");
+      let spyQueryProposal;
 
       beforeEach(() => {
-        spyQueryProposal.mockResolvedValue({ ...mockProposals[0], id: 666n });
+        spyQueryProposal = vi
+          .spyOn(api, "queryProposal")
+          .mockResolvedValue({ ...mockProposals[0], id: 666n });
         proposalsStore.setProposalsForTesting({
           proposals: mockProposals,
           certified: true,
@@ -366,10 +368,11 @@ describe("proposals-services", () => {
   });
 
   describe("getProposalPayload", () => {
-    const spyQueryProposalPayload = vi.spyOn(api, "queryProposalPayload");
+    let spyQueryProposalPayload;
     const mockProposalPayload = { data: "test" };
 
     beforeEach(() => {
+      spyQueryProposalPayload = vi.spyOn(api, "queryProposalPayload");
       vi.spyOn(console, "error").mockReturnValue();
       spyQueryProposalPayload.mockResolvedValue(mockProposalPayload);
     });

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -38,7 +38,7 @@ describe("sns-proposals services", () => {
     snsFiltersStore.reset();
     snsProposalsStore.reset();
     toastsStore.reset();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.spyOn(console, "error").mockRestore();
   });
   const proposal1: SnsProposalData = {
@@ -55,9 +55,13 @@ describe("sns-proposals services", () => {
   };
   const proposals = [proposal1, proposal2, proposal3];
   describe("loadSnsProposals", () => {
-    const queryProposalsSpy = vi
-      .spyOn(api, "queryProposals")
-      .mockResolvedValue({ proposals, include_ballots_by_caller: [true] });
+    let queryProposalsSpy;
+
+    beforeEach(() => {
+      queryProposalsSpy = vi
+        .spyOn(api, "queryProposals")
+        .mockResolvedValue({ proposals, include_ballots_by_caller: [true] });
+    });
 
     describe("not logged in", () => {
       beforeEach(() => {

--- a/frontend/src/tests/lib/utils/auth.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/auth.utils.spec.ts
@@ -13,6 +13,8 @@ describe("auth-utils", () => {
   beforeEach(() => {
     // restore original host
     window.location.host = originalWindowLocationHost;
+
+    vi.restoreAllMocks();
   });
 
   describe("isSignedIn", () => {
@@ -44,10 +46,11 @@ describe("auth-utils", () => {
 
     describe("with identity", () => {
       const mockAuthClient = mock<AuthClient>();
-      mockAuthClient.isAuthenticated.mockResolvedValue(true);
-      mockAuthClient.getIdentity.mockResolvedValue(mockIdentity as never);
 
       beforeEach(() => {
+        mockAuthClient.isAuthenticated.mockResolvedValue(true);
+        mockAuthClient.getIdentity.mockResolvedValue(mockIdentity as never);
+
         vi.spyOn(AuthClient, "create").mockImplementation(
           async (): Promise<AuthClient> => mockAuthClient
         );

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -31,7 +31,8 @@ import { get } from "svelte/store";
 
 describe("utils", () => {
   beforeEach(() => {
-    vi.resetAllMocks();
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
     vi.clearAllTimers();
     toastsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -364,10 +365,6 @@ describe("utils", () => {
           text: `${en.error.high_load_retrying}`,
         },
       ];
-
-      beforeEach(() => {
-        vi.useFakeTimers();
-      });
 
       const getTimestamps = async ({
         maxAttempts,

--- a/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
+++ b/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
@@ -12,6 +12,8 @@ describe("timer.worker-utils", () => {
   let spyPostMessage;
 
   beforeEach(() => {
+    vi.restoreAllMocks();
+
     silentConsoleErrors();
 
     vi.clearAllTimers();
@@ -23,9 +25,9 @@ describe("timer.worker-utils", () => {
 
   describe("without identity", () => {
     const mockAuthClient = mock<AuthClient>();
-    mockAuthClient.isAuthenticated.mockResolvedValue(false);
 
     beforeEach(() => {
+      mockAuthClient.isAuthenticated.mockResolvedValue(false);
       vi.spyOn(AuthClient, "create").mockImplementation(
         async (): Promise<AuthClient> => mockAuthClient
       );
@@ -48,10 +50,10 @@ describe("timer.worker-utils", () => {
 
   describe("with identity", () => {
     const mockAuthClient = mock<AuthClient>();
-    mockAuthClient.isAuthenticated.mockResolvedValue(true);
-    mockAuthClient.getIdentity.mockResolvedValue(mockIdentity as never);
 
     beforeEach(() => {
+      mockAuthClient.isAuthenticated.mockResolvedValue(true);
+      mockAuthClient.getIdentity.mockResolvedValue(mockIdentity as never);
       vi.spyOn(AuthClient, "create").mockImplementation(
         async (): Promise<AuthClient> => mockAuthClient
       );

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -1,5 +1,6 @@
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
+import * as proposalsApi from "$lib/api/proposals.api";
 import { queryProposals } from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
@@ -23,26 +24,18 @@ const proposal = {
   status: ProposalStatus.Open,
 };
 
-vi.mock("$lib/api/proposals.api", () => {
-  return {
-    queryProposals: vi
-      .fn()
-      .mockImplementation(() => Promise.resolve([proposal])),
-  };
-});
-
-vi.mock("$lib/api/governance.api");
-
 describe('NnsProposals when "all proposals" selected', () => {
   const { topics: defaultIncludeTopcis, status: defaultIncludeStatus } =
     DEFAULT_PROPOSALS_FILTERS;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     neuronsStore.reset();
     resetNeuronsApiService();
 
     actionableProposalsSegmentStore.set("all");
+
+    vi.spyOn(proposalsApi, "queryProposals").mockResolvedValue([proposal]);
   });
 
   describe("when signed in user", () => {


### PR DESCRIPTION
# Motivation

To avoid unpredictable behavior, each test should start with a clean slate.
One component of that is restoring all mocks before each test.

I tried running all tests with `vi.restoreAllMocks()` in `beforeEach` in `vitests.setup.ts` and found a number of tests that failed as a result.

Several PRs have been merged to fix such failing test. This PR fixes the remaining ones.

A follow-up PR will enforce `vi.restoreAllMocks()` in `vitest.setup.ts` and after that all other calls to `vi.restoreAllMocks()` can be removed again.

# Changes

1. Replace top-level calls to `vi.mock` that define mock behavior with `vi.spyOn` in `beforeEach`.
2. Move calls to `vi.spyOn` in `describe` scope into `beforeEach`.
3. Move calls to `mockResolvedValue` and `mockImplementation` on mocks from `describe` scope to `beforeEach`.
4. Call `vi.restoreAllMocks()` in top-level `beforeEach`.
5. Remove `vi.clearAllMocks` as its behavior is a subset of `vi.restoreAllMocks`.
6. In `frontend/src/tests/lib/utils/utils.spec.ts`, move `vi.useFakeTimers` to the top level. Adding `restoreAllMocks()` caused `should throw PollingCancelledError when canceled during the last attempt` to fail because of some interaction with the mocking of `setTimeout` in `describe("without timers"` which resulted in `advanceTime` no longer working. I couldn't figure out completely why but moving `useFakeTimers()` to the top fixed it.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary