### PR TITLE
Always vi.restoreAllMocks() before each test

### DIFF
--- a/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
@@ -1,16 +1,13 @@
+import * as canistersServices from "$lib/services/canisters.services";
 import { detachCanister } from "$lib/services/canisters.services";
 import { fireEvent, render } from "@testing-library/svelte";
 import UnlinkActionButtonTest from "./UnlinkActionButtonTest.svelte";
 
-vitest.mock("$lib/services/canisters.services", () => {
-  return {
-    detachCanister: vitest.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("DissolveActionButton", () => {
   beforeEach(() => {
-    vitest.clearAllMocks();
+    vi.spyOn(canistersServices, "detachCanister").mockResolvedValue({
+      success: true,
+    });
   });
 
   it("renders button", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
@@ -1,4 +1,5 @@
 import FollowSnsTopicSection from "$lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { removeFollowee } from "$lib/services/sns-neurons.services";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
@@ -13,10 +14,6 @@ import type { SnsNeuron } from "@dfinity/sns";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-vi.mock("$lib/services/sns-neurons.services", () => ({
-  removeFollowee: vi.fn().mockReturnValue({ success: true }),
-}));
-
 describe("FollowSnsTopicSection", () => {
   const reload = vi.fn();
   const followee1 = createMockSnsNeuron({ id: [1, 2, 3] });
@@ -26,6 +23,12 @@ describe("FollowSnsTopicSection", () => {
     ...mockSnsNeuron,
     followees: [[nervousSystemFunctionMock.id, { followees }]],
   };
+
+  beforeEach(() => {
+    vi.spyOn(snsNeuronsServices, "removeFollowee").mockResolvedValue({
+      success: true,
+    });
+  });
 
   const renderComponent = (): RenderResult<SvelteComponent> =>
     renderSelectedSnsNeuronContext({

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -1,5 +1,6 @@
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
+import * as icpAccountsServices from "$lib/services/icp-accounts.services";
 import { transferICP } from "$lib/services/icp-accounts.services";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -11,12 +12,6 @@ import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.p
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
 import { fireEvent, waitFor } from "@testing-library/svelte";
-
-vi.mock("$lib/services/icp-accounts.services", () => {
-  return {
-    transferICP: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
 
 describe("IcpTransactionModal", () => {
   const renderTransactionModal = () =>
@@ -34,6 +29,9 @@ describe("IcpTransactionModal", () => {
   beforeEach(() => {
     resetIdentity();
 
+    vi.spyOn(icpAccountsServices, "transferICP").mockResolvedValue({
+      success: true,
+    });
     vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
       mockAccountsStoreSubscribe([mockSubAccount])
     );

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -1,6 +1,7 @@
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import IncreaseNeuronStakeModal from "$lib/modals/neurons/IncreaseNeuronStakeModal.svelte";
+import * as neuronsServices from "$lib/services/neurons.services";
 import { topUpNeuron } from "$lib/services/neurons.services";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -16,14 +17,6 @@ import {
 import { fireEvent } from "@testing-library/dom";
 import { waitFor } from "@testing-library/svelte";
 
-vi.mock("$lib/api/nns-dapp.api");
-vi.mock("$lib/api/icp-ledger.api");
-vi.mock("$lib/services/neurons.services", () => {
-  return {
-    topUpNeuron: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("IncreaseNeuronStakeModal", () => {
   const renderTransactionModal = () =>
     renderModal({
@@ -35,6 +28,10 @@ describe("IncreaseNeuronStakeModal", () => {
 
   beforeEach(() => {
     resetIdentity();
+
+    vi.spyOn(neuronsServices, "topUpNeuron").mockResolvedValue({
+      success: true,
+    });
   });
 
   describe("when accounts store is empty", () => {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
@@ -1,5 +1,7 @@
 import { AppPath } from "$lib/constants/routes.constants";
 import SnsIncreaseStakeNeuronModal from "$lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte";
+import * as snsAccountsServices from "$lib/services/sns-accounts.services";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { increaseStakeNeuron } from "$lib/services/sns-neurons.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { page } from "$mocks/$app/stores";
@@ -21,25 +23,6 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { ICPToken } from "@dfinity/utils";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
-
-vi.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    increaseStakeNeuron: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
-vi.mock("$lib/services/sns-accounts.services", () => {
-  return {
-    loadSnsAccounts: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
-vi.mock("$lib/stores/busy.store", () => {
-  return {
-    startBusy: vi.fn(),
-    stopBusy: vi.fn(),
-  };
-});
 
 describe("SnsIncreaseStakeNeuronModal", () => {
   const reloadNeuron = vi.fn();
@@ -77,6 +60,13 @@ describe("SnsIncreaseStakeNeuronModal", () => {
       data: { universe: rootCanisterId.toText() },
     });
     setSnsProjects([snsProjectParams]);
+
+    vi.spyOn(snsNeuronsServices, "increaseStakeNeuron").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(snsAccountsServices, "loadSnsAccounts").mockResolvedValue(
+      undefined
+    );
   });
 
   describe("accounts and params are loaded", () => {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsStakeMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsStakeMaturityModal.spec.ts
@@ -1,4 +1,5 @@
 import SnsStakeMaturityModal from "$lib/modals/sns/neurons/SnsStakeMaturityModal.svelte";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { stakeMaturity } from "$lib/services/sns-neurons.services";
 import { formattedMaturity } from "$lib/utils/sns-neuron.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -8,14 +9,14 @@ import { selectPercentage } from "$tests/utils/neurons-modal.test-utils";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-vi.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    stakeMaturity: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
-
 describe("SnsStakeMaturityModal", () => {
   const reloadNeuron = vi.fn();
+
+  beforeEach(() => {
+    vi.spyOn(snsNeuronsServices, "stakeMaturity").mockResolvedValue({
+      success: true,
+    });
+  });
 
   const renderSnsStakeMaturityModal = async (): Promise<
     RenderResult<SvelteComponent>

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
@@ -1,6 +1,7 @@
 import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
+import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { stakeNeuron } from "$lib/services/sns-neurons.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { page } from "$mocks/$app/stores";
@@ -16,12 +17,6 @@ import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { Principal } from "@dfinity/principal";
 import { TokenAmount } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
-
-vi.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    stakeNeuron: vi.fn().mockResolvedValue({ success: true }),
-  };
-});
 
 describe("SnsStakeNeuronModal", () => {
   const ledgerCanisterId = principal(3);
@@ -59,6 +54,9 @@ describe("SnsStakeNeuronModal", () => {
       },
     });
 
+    vi.spyOn(snsNeuronsServices, "stakeNeuron").mockResolvedValue({
+      success: true,
+    });
     vi.spyOn(snsSelectedTransactionFeeStore, "subscribe").mockImplementation(
       mockSnsSelectedTransactionFeeStoreSubscribe()
     );

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -22,9 +22,10 @@ import {
 
 // Restore all mocks original behvior before each test.
 //
-// NOTE: This only affects mocks created with vi.spyOn but will leave module
-// functions of modules mocked with vi.mock as mocked. Regardless, it will make
-// sure that each test starts with the same behavior for all mocks.
+// NOTE: This restores mocks created with vi.spyOn() to their production
+// behavior, but returns mocks created on modules with vi.mock() to mocks that
+// return undefined. Regardless, it will make sure that each test starts with
+// the same behavior for all mocks.
 beforeEach(() => {
   vi.restoreAllMocks();
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -20,6 +20,15 @@ import {
   setDefaultTestConstants,
 } from "./src/tests/utils/mockable-constants.test-utils";
 
+// Restore all mocks original behvior before each test.
+//
+// NOTE: This only affects mocks created with vi.spyOn but will leave module
+// functions of modules mocked with vi.mock as mocked. Regardless, it will make
+// sure that each test starts with the same behavior for all mocks.
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
 // Reset every store before each test.
 const resetStoreFunctions = vi.hoisted(() => {
   return [];


### PR DESCRIPTION
# Motivation

To avoid unpredictable behavior, each test should start with a clean slate.
One component of that is restoring all mocks before each test.

This PR makes sure all mocks are restored before each test.
I thought all tests were already prepared in earlier PRs but some were apparently missed on my first pass.
This PR fixes all the remaining tests as well.

A follow-up PR will remove now unnecessary calls to `vi.restroreAllMock()` from individual tests.

# Changes

1. Call `vi.restoreAllMocks()` in `beforeEach` in `vitest.setup.ts`.
2. Fix all remaining tests that were missed before.

# Tests

All tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary