### PR TITLE
Remove call to allowLoggingInOneTestForDebugging

### DIFF
--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -6,7 +6,6 @@ import {
 import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
-import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
 import { render } from "@testing-library/svelte";
 import type { Mock } from "vitest";
 
@@ -28,7 +27,6 @@ describe("NnsDestinationAddress", () => {
   let onAccountSelectedSpy: Mock;
 
   beforeEach(() => {
-    allowLoggingInOneTestForDebugging();
     vi.restoreAllMocks();
 
     setAccountsForTesting({


### PR DESCRIPTION
# Motivation

`allowLoggingInOneTestForDebugging`, as the name says, is only for debugging.
Uses of it should not be merged.
But this accidentally happened in https://github.com/dfinity/nns-dapp/pull/3268

# Changes

Remove use of `allowLoggingInOneTestForDebugging` from `frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts`.

# Tests

Still passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary