### PR TITLE
Remove calls to vi.restoreAllMocks()

### DIFF
--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -33,7 +33,6 @@ describe("agent-api", () => {
   let utilsCreateAgentSpy;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     agentApi.resetAgents();
 
     utilsCreateAgentSpy = vi

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -14,7 +14,6 @@ import { mock } from "vitest-mock-extended";
 
 describe("icp-ledger.api", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.clearAllTimers();
 
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());

--- a/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
+++ b/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
@@ -8,8 +8,6 @@ import { mock } from "vitest-mock-extended";
 
 describe("nns-dapp api", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -23,8 +23,6 @@ describe("proposals-api", () => {
   let spyListProposals;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(GovernanceCanister, "create").mockImplementation(
       (): GovernanceCanister => mockGovernanceCanister
     );

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -87,8 +87,6 @@ describe("sns-api", () => {
   const getFunctionsSpy = vi.fn();
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     queryNeuronsSpy.mockResolvedValue([mockSnsNeuron]);
     getNeuronSpy.mockResolvedValue(mockSnsNeuron);
     queryNeuronSpy.mockResolvedValue(mockSnsNeuron);

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -44,8 +44,6 @@ describe("sns-sale.api", () => {
   const notifyParticipationSpy = vi.fn();
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     getOpenTicketSpy.mockResolvedValue(ticket.ticket);
     newSaleTicketSpy.mockResolvedValue(ticket.ticket);
     notifyPaymentFailureSpy.mockResolvedValue(ticket.ticket);

--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -10,7 +10,6 @@ import { mock } from "vitest-mock-extended";
 describe("sns-wrapper api", () => {
   beforeEach(() => {
     clearWrapperCache();
-    vi.restoreAllMocks();
     resetSnsProjects();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -73,8 +73,6 @@ describe("sns-api", () => {
   const increaseStakeNeuronSpy = vi.fn();
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     notifyParticipationSpy.mockResolvedValue(undefined);
     getUserCommitmentSpy.mockResolvedValue(mockUserCommitment);
     getDerivedStateSpy.mockResolvedValue(derivedState);

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -60,7 +60,6 @@ describe("CkBTCTransactionList", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     ckbtcPendingUtxosStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
     vi.useFakeTimers().setSystemTime(new Date());

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletConnectAction.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletConnectAction.spec.ts
@@ -11,9 +11,7 @@ import type { Mock } from "vitest";
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 
 describe("HardwareWalletConnectAction", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
+  beforeEach(() => {});
 
   it("should render a small explanation text", () => {
     const { queryByText } = render(HardwareWalletConnectAction);

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletConnectAction.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletConnectAction.spec.ts
@@ -11,8 +11,6 @@ import type { Mock } from "vitest";
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 
 describe("HardwareWalletConnectAction", () => {
-  beforeEach(() => {});
-
   it("should render a small explanation text", () => {
     const { queryByText } = render(HardwareWalletConnectAction);
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletShowActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletShowActionButton.spec.ts
@@ -10,8 +10,6 @@ describe("HardwareWalletShowActionButton", () => {
   let spy;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     spy = (
       showAddressAndPubKeyOnHardwareWalletProxy as Mock
     ).mockImplementation(async () => {

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
@@ -84,7 +84,6 @@ describe("IcrcWalletTransactionList", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.useFakeTimers().setSystemTime(new Date());
   });
 

--- a/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
@@ -33,10 +33,6 @@ describe("ImportTokenForm", () => {
     };
   };
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("should render ledger canister id", async () => {
     const { po } = renderComponent({
       ledgerCanisterId: principal(0),

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -46,7 +46,6 @@ describe("ImportTokenModal", () => {
   let queryIcrcTokenSpy: MockInstance;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     importedTokensStore.reset();
     resetIdentity();
     resetSnsProjects();

--- a/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
@@ -38,10 +38,6 @@ describe("ImportTokenRemoveConfirmation", () => {
     );
   };
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("should render token logo", async () => {
     const po = renderComponent({
       tokenToRemove: { universe: mockUniverse },

--- a/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
@@ -33,10 +33,6 @@ describe("ImportTokenReview", () => {
     };
   };
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("should render token meta information", async () => {
     const { po } = renderComponent({
       ledgerCanisterId: principal(0),

--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -27,8 +27,6 @@ describe("NnsDestinationAddress", () => {
   let onAccountSelectedSpy: Mock;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount1, mockSubAccount2],

--- a/frontend/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
@@ -13,8 +13,6 @@ describe("RenameSubAccountAction", () => {
   let spy;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     spy = (renameSubAccount as Mock).mockImplementation(async () => {
       // Do nothing test
     });

--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -15,7 +15,6 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SelectDestinationAddress", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetSnsProjects();
     icrcAccountsStore.reset();
   });

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
@@ -11,8 +11,6 @@ describe("RemoveCanisterControllerButton", () => {
   const props = { controller, reloadDetails: reloadDetailsMock };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(canisterServices, "removeController").mockResolvedValue({
       success: true,
     });

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -21,10 +21,6 @@ describe("AmountDisplay", () => {
     return AmountDisplayPo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("should render an token amount", async () => {
     const po = renderComponent(props);
     expect(await po.getAmount()).toEqual("1'234'567.89");

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -16,7 +16,6 @@ describe("Proposals", () => {
   let queryProposalsSpy;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     snsProposalsStore.reset();
 
     queryProposalsSpy = vi

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
@@ -34,7 +34,6 @@ describe("NnsNeuronHotkeysCard", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.restoreAllMocks();
     vi.spyOn(neuronsServices, "removeHotkey").mockResolvedValue(10n);
     vi.spyOn(neuronsServices, "getNeuronFromStore").mockReturnValue(undefined);
   });

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -11,7 +11,6 @@ import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
 describe("NnsAutoStakeMaturity", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     toastsStore.reset();
     resetIdentity();
     vi.spyOn(neuronsServices, "toggleAutoStakeMaturity").mockResolvedValue({

--- a/frontend/src/tests/lib/components/project-detail/ProjectProposal.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectProposal.spec.ts
@@ -16,7 +16,6 @@ describe("ProjectProposal", () => {
   blockAllCallsTo(blockedApiPaths);
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     toastsStore.reset();
     setNoIdentity();
     vi.spyOn(proposalsApi, "queryProposal").mockResolvedValue(mockProposalInfo);

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
@@ -22,7 +22,6 @@ describe("NnsProposalProposerPayloadEntry", () => {
   const payload = { b: "c" };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     proposalPayloadsStore.reset();
     vi.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -72,7 +72,6 @@ describe("VotingCard", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     voteRegistrationStore.reset();
 
     neuronsStore.setNeurons({ neurons: [], certified: true });

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -107,7 +107,6 @@ describe("SnsVotingCard", () => {
     });
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.useFakeTimers().setSystemTime(nowInSeconds * 1000);
     snsNeuronsStore.reset();
     resetIdentity();

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -61,7 +61,6 @@ describe("SnsNeuronHotkeysCard", () => {
     });
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     vi.spyOn(snsNeuronsServices, "removeHotkey").mockResolvedValue({
       success: true,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -14,7 +14,6 @@ import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsAutoStakeMaturity", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     toastsStore.reset();
     resetIdentity();
     vi.spyOn(snsNeuronsServices, "toggleAutoStakeMaturity").mockResolvedValue({

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -70,8 +70,6 @@ describe("ResponsiveTable", () => {
   ];
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     // Clicking on the rows that are links causes JSDOM to output an error about
     // navigation not being implemented. But the error is not logged immediately
     // and can happen during a different test. So we dissable error logging for

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -42,7 +42,6 @@ describe("SelectUniverseCard", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     overrideFeatureFlagsStore.reset();
     actionableNnsProposalsStore.reset();
     actionableSnsProposalsStore.resetForTesting();

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -23,7 +23,6 @@ import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseDropdown", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     icrcAccountsStore.reset();
     resetSnsProjects();
     resetIdentity();

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -35,8 +35,6 @@ describe("SelectUniverseList", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     page.mock({
       routeId: AppPath.Accounts,
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
@@ -12,8 +12,6 @@ import { get } from "svelte/store";
 
 describe("SelectUniverseNavList", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     page.mock({
       routeId: AppPath.Accounts,
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -41,7 +41,6 @@ import { render } from "@testing-library/svelte";
 
 describe("UniverseAccountsBalance", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetSnsProjects();
     icrcAccountsStore.reset();
 

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -47,7 +47,6 @@ describe("actionable proposals derived stores", () => {
   const principal2 = principal(2);
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetSnsProjects();
     actionableNnsProposalsStore.reset();
     actionableSnsProposalsStore.resetForTesting();

--- a/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
@@ -17,7 +17,6 @@ import { get } from "svelte/store";
 
 describe("selectable universes derived stores", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetCkETHCanisters();
 
     page.mock({

--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -16,8 +16,6 @@ describe("universes-accounts-balance.derived", () => {
   const ledgerCanisterId = mockSnsFullProject.summary.ledgerCanisterId;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
       mockAccountsStoreSubscribe([], [])
     );

--- a/frontend/src/tests/lib/derived/universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes.derived.spec.ts
@@ -30,7 +30,6 @@ import { get } from "svelte/store";
 
 describe("universes derived stores", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetSnsProjects();
     defaultIcrcCanistersStore.reset();
     tokensStore.reset();

--- a/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -14,8 +14,6 @@ describe("AddAccountModal", () => {
   const mockLedgerIdentity = new MockLedgerIdentity();
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(icpAccountsServices, "addSubAccount").mockResolvedValue(undefined);
     vi.spyOn(
       icpLedgerServicesProxy,

--- a/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
@@ -37,7 +37,6 @@ describe("BtcCkBTCReceiveModal", () => {
   const reloadSpy = vi.fn();
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     bitcoinAddressStore.reset();
     ckBTCInfoStore.reset();

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -83,7 +83,6 @@ describe("CkBTCTransactionModal", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.useFakeTimers();
     ckBTCInfoStore.reset();
 

--- a/frontend/src/tests/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.spec.ts
@@ -27,7 +27,6 @@ describe("HardwareWalletNeuronAddHotkeyModal", () => {
   const mockIdentity2 = createMockIdentity(0);
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     (getLedgerIdentityProxy as Mock).mockImplementation(() =>
       Promise.resolve(mockIdentity2)

--- a/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -18,8 +18,6 @@ describe("AddControllerModal", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(canistersServices, "addController").mockResolvedValue({
       success: true,
     });

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -24,7 +24,6 @@ describe("AddCyclesModal", () => {
   const reloadDetails = vi.fn();
   const props = { reloadDetails };
   beforeEach(() => {
-    vi.restoreAllMocks();
     toastsStore.reset();
 
     vi.spyOn(canistersServices, "getIcpToCyclesExchangeRate").mockResolvedValue(

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -27,7 +27,6 @@ import { get } from "svelte/store";
 
 describe("CreateCanisterModal", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     toastsStore.reset();
 
     vi.spyOn(canistersServices, "getIcpToCyclesExchangeRate").mockResolvedValue(

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -11,8 +11,6 @@ import { render, waitFor } from "@testing-library/svelte";
 
 describe("LinkCanisterModal", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(canistersServices, "attachCanister").mockResolvedValue({
       success: true,
     });

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -109,7 +109,6 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.restoreAllMocks();
     setAccountsForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
@@ -54,7 +54,6 @@ describe("ChangeNeuronVisibilityModal", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     neuronsStore.reset();
     toastsStore.reset();

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -35,7 +35,6 @@ import type { MockInstance } from "vitest";
 
 describe("DisburseNnsNeuronModal", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     cancelPollAccounts();
 

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
@@ -15,8 +15,6 @@ import type { SvelteComponent } from "svelte";
 
 describe("NnsStakeMaturityModal", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(neuronsServices, "stakeMaturity").mockResolvedValue({
       success: true,
     });

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -61,7 +61,6 @@ describe("NnsStakeNeuronModal", () => {
   beforeEach(() => {
     resetIdentity();
     cancelPollAccounts();
-    vi.restoreAllMocks();
     overrideFeatureFlagsStore.reset();
 
     vi.spyOn(neuronsServices, "stakeNeuron").mockResolvedValue(

--- a/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
@@ -26,8 +26,6 @@ describe("SplitNeuronModal", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(neuronsServices, "splitNeuron").mockResolvedValue(undefined);
     startBusySpy = vi.spyOn(busyServices, "startBusy");
   });

--- a/frontend/src/tests/lib/modals/sns/neurons/AddSnsHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/AddSnsHotkeyModal.spec.ts
@@ -11,7 +11,6 @@ describe("AddSnsHotkeyModal", () => {
   const reload = vi.fn();
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.spyOn(snsNeuronsServices, "addHotkey").mockResolvedValue({
       success: true,
     });

--- a/frontend/src/tests/lib/modals/sns/neurons/NewSnsFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/NewSnsFolloweeModal.spec.ts
@@ -14,7 +14,6 @@ describe("NewSnsFolloweeModal", () => {
   const functionId = 4n;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.spyOn(snsNeuronsServices, "addFollowee").mockResolvedValue({
       success: true,
     });

--- a/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
@@ -52,7 +52,6 @@ type SwapModalParams = {
 describe("ParticipateSwapModal", () => {
   beforeEach(() => {
     cancelPollAccounts();
-    vi.restoreAllMocks();
     resetIdentity();
     resetAccountsForTesting();
     snsTicketsStore.setNoTicket(rootCanisterIdMock);

--- a/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
+++ b/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
@@ -14,8 +14,6 @@ import { get } from "svelte/store";
 
 describe("SelectUniverseModal", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
       mockProjectSubscribe([mockSnsFullProject])
     );

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -58,7 +58,6 @@ describe("ActionableProposals", () => {
   const snsProposal2 = createProposal(33n);
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     resetSnsProjects();
     actionableNnsProposalsStore.reset();

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -116,7 +116,6 @@ describe("IcrcWallet", () => {
     vi.clearAllMocks();
     vi.clearAllTimers();
     vi.useRealTimers();
-    vi.restoreAllMocks();
     tokensStore.reset();
     toastsStore.reset();
     resetIdentity();

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -17,12 +17,6 @@ import { render } from "@testing-library/svelte";
 vi.mock("$lib/api/governance.api");
 
 describe("NeuronDetail", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  // fakeGovernanceApi needs to be installed after restoreAllMocks, otherwise
-  // its mocks will be restored.
   fakeGovernanceApi.install();
 
   const neuronId = 314n;

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -56,7 +56,6 @@ describe("NnsProposalDetail", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.restoreAllMocks();
     resetNeuronsApiService();
     toastsStore.reset();
     neuronsStore.reset();

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -49,7 +49,6 @@ describe("NnsProposals", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     proposalsStore.resetForTesting();
     resetNeuronsApiService();
     neuronsStore.reset();

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -76,7 +76,6 @@ describe("SnsWallet", () => {
   beforeEach(() => {
     vi.useRealTimers();
     resetIdentity();
-    vi.restoreAllMocks();
     icrcAccountsStore.reset();
     tokensStore.reset();
     resetSnsProjects();

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -18,10 +18,6 @@ import {
 import { get } from "svelte/store";
 
 describe("actionable-proposals.services", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   describe("updateActionableProposals", () => {
     const expectedQueryManageNeuronProposalsParams = {
       identity: mockIdentity,

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -33,7 +33,6 @@ import { get } from "svelte/store";
 
 describe("actionable-sns-proposals.services", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     failedActionableSnsesStore.resetForTesting();
     snsNeuronsStore.reset();
   });

--- a/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -18,7 +18,6 @@ describe("auth-services", () => {
   const originalLocation = window.location;
 
   beforeEach(async () => {
-    vi.restoreAllMocks();
     await authStore.signOut();
   });
 

--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -12,7 +12,6 @@ describe("busy-services", () => {
   let startBusySpy;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     startBusySpy = vi.spyOn(busyStore, "startBusy").mockImplementation(vi.fn());
   });
 

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -58,7 +58,6 @@ describe("canisters-services", () => {
   let spyGetExchangeRate: MockInstance;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     toastsStore.reset();

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -59,7 +59,6 @@ describe("ckbtc-convert-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.restoreAllMocks();
     vi.clearAllTimers();
 
     vi.spyOn(CkBTCMinterCanister, "create").mockImplementation(

--- a/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
@@ -19,7 +19,6 @@ import { get } from "svelte/store";
 
 describe("ckbtc-info-services", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     ckBTCInfoStore.reset();
     toastsStore.reset();
     resetIdentity();

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -77,12 +77,6 @@ const blockedApiPaths = ["$lib/api/nns-dapp.api", "$lib/api/icp-ledger.api"];
 describe("icp-accounts.services", () => {
   const mockLedgerIdentity = new MockLedgerIdentity();
 
-  beforeEach(() => {
-    // We need to do this before blockAllCallsTo otherwise it the effect of
-    // blockAllCallsTo is removed again.
-    vi.restoreAllMocks();
-  });
-
   blockAllCallsTo(blockedApiPaths);
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/services/known-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/known-neurons.services.spec.ts
@@ -15,7 +15,6 @@ describe("knownNeurons-services", () => {
   let spyQueryKnownNeurons;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -153,8 +153,6 @@ describe("neurons-services", () => {
   let spyConsoleError;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     spyConsoleError = vi.spyOn(console, "error");
     neuronsStore.reset();
     resetAccountsForTesting();

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -23,7 +23,6 @@ import { get } from "svelte/store";
 
 describe("proposals-services", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     toastsStore.reset();
     proposalsStore.setProposalsForTesting({ proposals: [], certified: true });
     proposalPayloadsStore.reset();

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -38,7 +38,6 @@ describe("sns-proposals services", () => {
     snsFiltersStore.reset();
     snsProposalsStore.reset();
     toastsStore.reset();
-    vi.restoreAllMocks();
     vi.spyOn(console, "error").mockRestore();
   });
   const proposal1: SnsProposalData = {

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -61,7 +61,6 @@ describe("sns-neurons-check-balances-services", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     resetIdentity();
     snsNeuronsStore.reset();
     checkedNeuronSubaccountsStore.reset();

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -92,7 +92,6 @@ describe("sns-neurons-services", () => {
   };
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     toastsStore.reset();
     resetIdentity();
     resetMockedConstants();

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -128,8 +128,6 @@ describe("sns-api", () => {
     get(snsTicketsStore)[rootCanisterId.toText()];
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     // Make sure there are no open polling timers
     cancelPollGetOpenTicket();
 

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -101,7 +101,6 @@ describe("sns-vote-registration-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.restoreAllMocks();
     toastsStore.reset();
 
     spyQuerySnsProposals = vi

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -46,7 +46,6 @@ describe("sns-services", () => {
     resetIdentity();
     vi.useFakeTimers();
     vi.clearAllTimers();
-    vi.restoreAllMocks();
     snsSwapCommitmentsStore.reset();
     resetSnsProjects();
     snsDerivedStateStore.reset();

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -74,7 +74,6 @@ describe("vote-registration-services", () => {
 
   beforeEach(() => {
     // Cleanup:
-    vi.restoreAllMocks();
     voteRegistrationStore.reset();
     toastsStore.reset();
     proposalsStore.resetForTesting();

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -20,8 +20,6 @@ import { get } from "svelte/store";
 describe("wallet-uncertified-accounts.services", () => {
   beforeEach(() => {
     resetIdentity();
-    vi.restoreAllMocks();
-
     icrcAccountsStore.reset();
     tokensStore.reset();
     vi.spyOn(toastsStore, "toastsError");

--- a/frontend/src/tests/lib/utils/auth.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/auth.utils.spec.ts
@@ -13,8 +13,6 @@ describe("auth-utils", () => {
   beforeEach(() => {
     // restore original host
     window.location.host = originalWindowLocationHost;
-
-    vi.restoreAllMocks();
   });
 
   describe("isSignedIn", () => {

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -102,14 +102,6 @@ describe("icrc-transaction utils", () => {
     },
   };
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   describe("getSortedTransactionsFromStore", () => {
     it("should return transactions sorted by date", () => {
       const transactions = [secondTx, oldestTx, recentTx];

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -31,7 +31,6 @@ import { get } from "svelte/store";
 
 describe("utils", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     vi.useFakeTimers();
     vi.clearAllTimers();
     toastsStore.reset();

--- a/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
+++ b/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
@@ -12,8 +12,6 @@ describe("timer.worker-utils", () => {
   let spyPostMessage;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     silentConsoleErrors();
 
     vi.clearAllTimers();

--- a/frontend/src/tests/routes/app/layout.spec.ts
+++ b/frontend/src/tests/routes/app/layout.spec.ts
@@ -13,7 +13,6 @@ vi.mock("$lib/services/public/app.services", () => ({
 describe("Layout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.restoreAllMocks();
   });
 
   it("should init the auth on mount", async () => {

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -25,8 +25,6 @@ vi.mock("$lib/proxy/app.services.proxy");
 
 describe("Layout", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-
     actionableNnsProposalsStore.reset();
 
     setNoIdentity();

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -46,7 +46,6 @@ let resolveUncertifiedPromise;
 
 describe("Proposal detail page when not logged in user", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     neuronsStore.reset();
     resetNeuronsApiService();
     resolveCertifiedPromise = undefined;

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -29,7 +29,6 @@ describe('NnsProposals when "all proposals" selected', () => {
     DEFAULT_PROPOSALS_FILTERS;
 
   beforeEach(() => {
-    vi.restoreAllMocks();
     neuronsStore.reset();
     resetNeuronsApiService();
 


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5788, `vi.restoreAllMocks()` is automatically called before each test.

# Changes

1. Remove redundant calls to `vi.restoreAllMocks()` from individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary