### PR TITLE
Add scripts/ic-admin-propose

### DIFF
--- a/scripts/ic-admin-propose
+++ b/scripts/ic-admin-propose
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Wrapper around ic-admin to set some flags automatically.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define long=summary desc="Passed to ic-admin with --summary" variable=SUMMARY default="Proposal made via $0"
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="snsdemo8"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+export DFX_IDENTITY
+
+TOP_DIR="$(git rev-parse --show-toplevel)"
+
+IDENTITY_PATH="$HOME/.config/dfx/identity/$DFX_IDENTITY"
+PEM="${IDENTITY_PATH}/identity.pem"
+
+if [[ "$DFX_NETWORK" == "local" ]]; then
+  NNS_URL="http://localhost:$(
+    cd ~
+    dfx info webserver-port
+  )"
+else
+  NNS_URL="$(jq -er '.networks | .[env.DFX_NETWORK].providers[0] | select (.!=null)' "$TOP_DIR/dfx.json")"
+fi
+
+PROPOSER_NEURON_ID="$("$SOURCE_DIR/get-neurons" --identity "$DFX_IDENTITY" --network "$DFX_NETWORK" --can-propose | head -n 1)"
+
+if [[ -z "${PROPOSER_NEURON_ID:-}" ]]; then
+  echo "Couldn't find a neuron, for identity ${DFX_IDENTITY}, that can propose."
+  exit 1
+fi
+
+subcommand="$1"
+shift
+
+set ic-admin \
+  --secret-key-pem "$PEM" \
+  --nns-url "$NNS_URL" \
+  "$subcommand" \
+  --summary "$SUMMARY" \
+  --proposer "$PROPOSER_NEURON_ID" \
+  "$@"
+
+echo
+printf "%q " "$@"
+echo
+echo "Do you want to execute this command? [y/N]"
+read -r response
+if [[ "$response" =~ ^[yY] ]]; then
+  "$@"
+fi

--- a/scripts/propose-install-canister
+++ b/scripts/propose-install-canister
@@ -35,30 +35,9 @@ if [[ -z "${WASM:-}" ]]; then
   exit 1
 fi
 
-TOP_DIR="$(git rev-parse --show-toplevel)"
-
-IDENTITY_PATH="$HOME/.config/dfx/identity/$DFX_IDENTITY"
-PEM="${IDENTITY_PATH}/identity.pem"
-
 CANISTER_ID="$(dfx canister id "$CANISTER" --network "$DFX_NETWORK")"
 WASM_HASH="$(sha256sum "$WASM" | cut -d ' ' -f 1)"
 SUMMARY="Upgrade canister $CANISTER with module hash $WASM_HASH"
-
-if [[ "$DFX_NETWORK" == "local" ]]; then
-  NNS_URL="http://localhost:$(
-    cd ~
-    dfx info replica-port
-  )"
-else
-  NNS_URL="$(jq -er '.networks | .[env.DFX_NETWORK].providers[0] | select (.!=null)' "$TOP_DIR/dfx.json")"
-fi
-
-PROPOSER_NEURON_ID="$("$SOURCE_DIR/get-neurons" --identity "$DFX_IDENTITY" --network "$DFX_NETWORK" --can-propose | head -n 1)"
-
-if [[ -z "${PROPOSER_NEURON_ID:-}" ]]; then
-  echo "Couldn't find a neuron, for identity ${DFX_IDENTITY}, that can propose."
-  exit 1
-fi
 
 ARG_ARGS=()
 if [[ -n "${ARG_DID_FILE:-}" ]]; then
@@ -68,22 +47,13 @@ if [[ -n "${ARG_DID_FILE:-}" ]]; then
   ARG_ARGS=(--arg "$ARG_BIN_FILE")
 fi
 
-set ic-admin \
-  --secret-key-pem "$PEM" \
-  --nns-url "$NNS_URL" \
-  propose-to-change-nns-canister \
+"$SOURCE_DIR/ic-admin-propose" \
+  --identity "$DFX_IDENTITY" \
+  --network "$DFX_NETWORK" \
   --summary "$SUMMARY" \
-  --proposer "$PROPOSER_NEURON_ID" \
+  propose-to-change-nns-canister \
   --mode "$MODE" \
   --canister-id "$CANISTER_ID" \
   --wasm-module-path "$WASM" \
   --wasm-module-sha256 "$WASM_HASH" \
   "${ARG_ARGS[@]}"
-
-printf "%q " "$@"
-echo
-echo "Do you want to execute this command? [y/N]"
-read -r response
-if [[ "$response" =~ ^[yY] ]]; then
-  "$@"
-fi


### PR DESCRIPTION
# Motivation

Creating a proposal via `ic-admin` is always tedious because you need to construct arguments for `--nns-url`, `--secret-key-pem` and `--proposal`.

For the sake of upgrading a canister, `scripts/propose-install-canister` does this for you, but for other types of proposals it's still a hassle.

# Changes

1. Extract `scripts/ic-admin-propose` from `scripts/propose-install-canister` to create the necessary arguments for arbitrary proposals.
2. Use `scripts/ic-admin-propose` in `scripts/propose-install-canister`.
3. Use `webserver-port` instead of `replica-port`. It does not seem to make a difference but when switching to PocketIC, `webserver-port` gives the correct port to use and `replica-port` no longer works.

# Tests 

1. Used `scripts/propose-install-canister` to upgrade nns-dapp locally with
```
scripts/propose-install-canister --canister nns-dapp --wasm nns-dapp.wasm.gz -a nns-dapp-arg-local.did
```

2. Used `scripts/ic-admin-propose` to create an "Update SNS-W Subnet Ids" proposal locally with
```
scripts/ic-admin-propose propose-to-update-sns-subnet-ids-in-sns-wasm --sns-subnet-ids-to-add wz6mc-fcmtc-vbptg-sltyl-iljh5-sgwbf-uzlrl-uihqb-huk5d-l476q-gae  --sns-subnet-ids-to-remove ewlco-wjy6h-oafn4-sjmhf-litbm-aout5-atu3t-ygdsc-mqpmz-vpx73-sae
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary