### PR TITLE
Stop calling neuronsStore.reset() in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/neuron-detail/NeuronNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronNavigation.spec.ts
@@ -35,7 +35,6 @@ const testNeurons = [
 describe("NeuronNavigation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    neuronsStore.reset();
     neuronsStore.setNeurons({ neurons: testNeurons, certified: true });
     page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
   });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
@@ -63,7 +63,6 @@ describe("NnsNeuronPageHeader", () => {
   };
 
   beforeEach(() => {
-    neuronsStore.reset();
     neuronsTableOrderStore.reset();
     neuronsStore.setNeurons({ neurons: testNeurons, certified: true });
   });

--- a/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
@@ -29,7 +29,6 @@ describe("EditFollowNeurons", () => {
     });
 
   beforeEach(() => {
-    neuronsStore.reset();
     resetIdentity();
     vi.spyOn(governanceApi, "queryKnownNeurons").mockResolvedValue([]);
     fillNeuronStore();

--- a/frontend/src/tests/lib/components/neurons/MakeNeuronsPublicBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/MakeNeuronsPublicBanner.spec.ts
@@ -35,7 +35,6 @@ describe("MakeNeuronsPublicBanner", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    neuronsStore.reset();
     localStorage.clear();
     setAccountsForTesting({
       main: mockMainAccount,

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -31,7 +31,6 @@ describe("ProjectsTable", () => {
   };
 
   beforeEach(() => {
-    neuronsStore.reset();
     snsNeuronsStore.reset();
     resetSnsProjects();
     resetIdentity();

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -113,7 +113,6 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     });
-    neuronsStore.reset();
   });
 
   const renderComponent = ({

--- a/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
@@ -55,7 +55,6 @@ describe("ChangeNeuronVisibilityModal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    neuronsStore.reset();
     toastsStore.reset();
     spyConsoleError?.mockRestore();
     changeNeuronVisibilitySpy?.mockRestore();

--- a/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
@@ -29,7 +29,6 @@ describe("FollowNeuronsModal", () => {
     });
 
   beforeEach(() => {
-    neuronsStore.reset();
     resetIdentity();
     vi.spyOn(governanceApi, "queryKnownNeurons").mockResolvedValue([]);
     fillNeuronStore();

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -49,7 +49,6 @@ describe("MergeNeuronsModal", () => {
     );
     vi.clearAllMocks();
     resetAccountsForTesting();
-    neuronsStore.reset();
     resetNeuronsApiService();
     toastsStore.reset();
   });

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -4,7 +4,6 @@ import { mergeNeurons } from "$lib/api/governance.api";
 import MergeNeuronsModal from "$lib/modals/neurons/MergeNeuronsModal.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { listNeurons } from "$lib/services/neurons.services";
-import { neuronsStore } from "$lib/stores/neurons.store";
 import type { Account } from "$lib/types/account";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
 import { createMockIdentity } from "$tests/mocks/auth.store.mock";

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -4,7 +4,6 @@ import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import NnsNeuronDetail from "$lib/pages/NnsNeuronDetail.svelte";
 import * as knownNeuronsServices from "$lib/services/known-neurons.services";
 import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
-import { neuronsStore } from "$lib/stores/neurons.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -41,7 +41,6 @@ describe("NeuronDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-    neuronsStore.reset();
     voteRegistrationStore.reset();
     checkedNeuronSubaccountsStore.reset();
     fakeGovernanceApi.addNeuronWith({ neuronId, stake: neuronStake });

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -3,7 +3,6 @@ import * as api from "$lib/api/governance.api";
 import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { neuronsStore } from "$lib/stores/neurons.store";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -32,7 +32,6 @@ describe("NnsNeurons", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     resetNeuronsApiService();
-    neuronsStore.reset();
     overrideFeatureFlagsStore.reset();
   });
 

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -5,7 +5,6 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import NnsProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
-import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import {
   mockIdentity,

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -58,7 +58,6 @@ describe("NnsProposalDetail", () => {
     resetIdentity();
     resetNeuronsApiService();
     toastsStore.reset();
-    neuronsStore.reset();
     vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue(testNeurons);
 
     actionableProposalsSegmentStore.set("all");

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -51,7 +51,6 @@ describe("NnsProposals", () => {
   beforeEach(() => {
     proposalsStore.resetForTesting();
     resetNeuronsApiService();
-    neuronsStore.reset();
     proposalsFiltersStore.reset();
     actionableNnsProposalsStore.reset();
     actionableProposalsSegmentStore.resetForTesting();

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -8,7 +8,6 @@ import NnsProposals from "$lib/pages/NnsProposals.svelte";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
-import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   proposalsFiltersStore,
   proposalsStore,

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -87,7 +87,6 @@ describe("NnsWallet", () => {
     vi.unstubAllGlobals();
     cancelPollAccounts();
     resetAccountsForTesting();
-    neuronsStore.reset();
     resetNeuronsApiService();
     icpTransactionsStore.reset();
     toastsStore.reset();

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -38,7 +38,6 @@ describe("Staking", () => {
   const snsCanisterId = principal(1112);
 
   beforeEach(() => {
-    neuronsStore.reset();
     snsNeuronsStore.reset();
     resetSnsProjects();
     resetIdentity();
@@ -64,7 +63,6 @@ describe("Staking", () => {
 
   it("should not render banner and login button when signed in but NNS neurons still loading", async () => {
     resetIdentity();
-    neuronsStore.reset();
     const po = renderComponent();
     expect(await po.getPageBannerPo().isPresent()).toBe(false);
     expect(await po.getSignInPo().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -98,7 +98,6 @@ describe("actionable-proposals.services", () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      neuronsStore.reset();
       actionableNnsProposalsStore.reset();
       resetIdentity();
       spyQueryProposals = vi

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -154,7 +154,6 @@ describe("neurons-services", () => {
 
   beforeEach(() => {
     spyConsoleError = vi.spyOn(console, "error");
-    neuronsStore.reset();
     resetAccountsForTesting();
     resetAccountIdentity();
     toastsStore.reset();

--- a/frontend/src/tests/lib/stores/neurons-table-order-sorted-neuron-ids-store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons-table-order-sorted-neuron-ids-store.spec.ts
@@ -62,7 +62,6 @@ describe("neuronsTableOrderSortedNeuronIdsStore", () => {
   ];
 
   beforeEach(() => {
-    neuronsStore.reset();
     neuronsTableOrderStore.reset();
     resetIdentity();
     setAccountsForTesting({ main: mockMainAccount });

--- a/frontend/src/tests/lib/stores/neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons.store.spec.ts
@@ -9,8 +9,6 @@ import type { NeuronInfo } from "@dfinity/nns";
 import { get } from "svelte/store";
 
 describe("neurons-store", () => {
-  beforeEach(() => neuronsStore.reset());
-
   describe("neuronsStore", () => {
     it("should set neurons", () => {
       const neurons: NeuronInfo[] = [

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -5,7 +5,6 @@ import { queryProposal } from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import NnsProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
-import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import {
   mockIdentity,

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -46,7 +46,6 @@ let resolveUncertifiedPromise;
 
 describe("Proposal detail page when not logged in user", () => {
   beforeEach(() => {
-    neuronsStore.reset();
     resetNeuronsApiService();
     resolveCertifiedPromise = undefined;
     resolveUncertifiedPromise = undefined;

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -29,7 +29,6 @@ describe('NnsProposals when "all proposals" selected', () => {
     DEFAULT_PROPOSALS_FILTERS;
 
   beforeEach(() => {
-    neuronsStore.reset();
     resetNeuronsApiService();
 
     actionableProposalsSegmentStore.set("all");

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -7,7 +7,6 @@ import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import NnsProposals from "$lib/pages/NnsProposals.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
-import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `neuronsStore`.

# Changes

1. Remove resetting of `neuronsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary