### PR TITLE
Add scripts/dfx-server-origin

### DIFF
--- a/scripts/dfx-server-origin
+++ b/scripts/dfx-server-origin
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+clap.define short=n long=network desc="dfx network to use" variable="DFX_NETWORK" default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+
+if [[ "$DFX_NETWORK" == "local" ]]; then
+  PORT="$(
+    cd ~
+    dfx info webserver-port
+  )"
+  echo "http://localhost:$PORT"
+  exit
+else
+  TOP_DIR="$(git rev-parse --show-toplevel)"
+  ORIGIN="$(jq -er '.networks | .[env.DFX_NETWORK].providers[0] | select (.!=null)' "$TOP_DIR/dfx.json")"
+  echo "$ORIGIN"
+fi

--- a/scripts/ic-admin-propose
+++ b/scripts/ic-admin-propose
@@ -22,19 +22,10 @@ source "$(clap.build)"
 export DFX_NETWORK
 export DFX_IDENTITY
 
-TOP_DIR="$(git rev-parse --show-toplevel)"
-
 IDENTITY_PATH="$HOME/.config/dfx/identity/$DFX_IDENTITY"
 PEM="${IDENTITY_PATH}/identity.pem"
 
-if [[ "$DFX_NETWORK" == "local" ]]; then
-  NNS_URL="http://localhost:$(
-    cd ~
-    dfx info webserver-port
-  )"
-else
-  NNS_URL="$(jq -er '.networks | .[env.DFX_NETWORK].providers[0] | select (.!=null)' "$TOP_DIR/dfx.json")"
-fi
+NNS_URL="$("$SOURCE_DIR/dfx-server-origin" --network "$DFX_NETWORK")"
 
 PROPOSER_NEURON_ID="$("$SOURCE_DIR/get-neurons" --identity "$DFX_IDENTITY" --network "$DFX_NETWORK" --can-propose | head -n 1)"
 


### PR DESCRIPTION
# Motivation

Some scripts require a URL to the replica that depends on the dfx network being used.
It's useful to have this in a separate script to be able to reuse it.
I want to use this later to make `scripts/sns/aggregator/get-sns` support networks other than mainnet.

# Changes

1. Extract the code to get the server URL from `scripts/ic-admin-propose` and create a new script `scripts/dfx-server-origin` with it.

# Tests

Manually tried using `propose-install-canister` (which uses `scripts/ic-admin-propose`) to install nns-dapp on `local` and on `devenv_dskloet`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary