### PR TITLE
Stop calling toastsStore.reset() in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -49,7 +49,6 @@ describe("ImportTokenModal", () => {
     importedTokensStore.reset();
     resetIdentity();
     resetSnsProjects();
-    toastsStore.reset();
     busyStore.resetForTesting();
 
     queryIcrcTokenSpy = vi

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -11,7 +11,6 @@ import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
 describe("NnsAutoStakeMaturity", () => {
   beforeEach(() => {
-    toastsStore.reset();
     resetIdentity();
     vi.spyOn(neuronsServices, "toggleAutoStakeMaturity").mockResolvedValue({
       success: true,

--- a/frontend/src/tests/lib/components/project-detail/ProjectProposal.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectProposal.spec.ts
@@ -16,7 +16,6 @@ describe("ProjectProposal", () => {
   blockAllCallsTo(blockedApiPaths);
 
   beforeEach(() => {
-    toastsStore.reset();
     setNoIdentity();
     vi.spyOn(proposalsApi, "queryProposal").mockResolvedValue(mockProposalInfo);
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -14,7 +14,6 @@ import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsAutoStakeMaturity", () => {
   beforeEach(() => {
-    toastsStore.reset();
     resetIdentity();
     vi.spyOn(snsNeuronsServices, "toggleAutoStakeMaturity").mockResolvedValue({
       success: true,

--- a/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
+++ b/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
@@ -4,7 +4,6 @@ import { metricsStore } from "$lib/stores/metrics.store";
 import type { DashboardMessageExecutionRateResponse } from "$lib/types/dashboard";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
-import { toastsStore } from "@dfinity/gix-components";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
@@ -42,7 +41,6 @@ describe("Warnings", () => {
   describe("TransactionRateWarning", () => {
     beforeEach(() => {
       metricsStore.set(undefined);
-      toastsStore.reset();
     });
 
     const transactionRateHighLoad: DashboardMessageExecutionRateResponse = {

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -24,8 +24,6 @@ describe("AddCyclesModal", () => {
   const reloadDetails = vi.fn();
   const props = { reloadDetails };
   beforeEach(() => {
-    toastsStore.reset();
-
     vi.spyOn(canistersServices, "getIcpToCyclesExchangeRate").mockResolvedValue(
       100_000n
     );

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -27,8 +27,6 @@ import { get } from "svelte/store";
 
 describe("CreateCanisterModal", () => {
   beforeEach(() => {
-    toastsStore.reset();
-
     vi.spyOn(canistersServices, "getIcpToCyclesExchangeRate").mockResolvedValue(
       10_000n
     );

--- a/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
@@ -55,7 +55,6 @@ describe("ChangeNeuronVisibilityModal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    toastsStore.reset();
     spyConsoleError?.mockRestore();
     changeNeuronVisibilitySpy?.mockRestore();
     queryNeuronSpy?.mockRestore();

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -49,7 +49,6 @@ describe("MergeNeuronsModal", () => {
     vi.clearAllMocks();
     resetAccountsForTesting();
     resetNeuronsApiService();
-    toastsStore.reset();
   });
 
   const selectAndTestTwoNeurons = async ({ po, neurons }) => {

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -117,7 +117,6 @@ describe("IcrcWallet", () => {
     vi.clearAllTimers();
     vi.useRealTimers();
     tokensStore.reset();
-    toastsStore.reset();
     resetIdentity();
     defaultIcrcCanistersStore.reset();
     busyStore.resetForTesting();

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -56,7 +56,6 @@ describe("NnsProposalDetail", () => {
   beforeEach(() => {
     resetIdentity();
     resetNeuronsApiService();
-    toastsStore.reset();
     vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue(testNeurons);
 
     actionableProposalsSegmentStore.set("all");

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -89,7 +89,6 @@ describe("NnsWallet", () => {
     resetAccountsForTesting();
     resetNeuronsApiService();
     icpTransactionsStore.reset();
-    toastsStore.reset();
     resetIdentity();
 
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -79,7 +79,6 @@ describe("SnsProposalDetail", () => {
     actionableProposalsSegmentStore.resetForTesting();
     snsProposalsStore.reset();
     snsNeuronsStore.reset();
-    toastsStore.reset();
   });
 
   describe("not logged in", () => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -79,7 +79,6 @@ describe("SnsWallet", () => {
     icrcAccountsStore.reset();
     tokensStore.reset();
     resetSnsProjects();
-    toastsStore.reset();
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],
     });

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -25,7 +25,6 @@ describe("app-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    toastsStore.reset();
     vi.clearAllMocks();
     clearSnsAggregatorCache();
     // resetSnsProjects();

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -60,7 +60,6 @@ describe("canisters-services", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
 
-    toastsStore.reset();
     canistersStore.setCanisters({ canisters: [], certified: true });
 
     spyQueryCanisters = vi

--- a/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
@@ -20,7 +20,6 @@ import { get } from "svelte/store";
 describe("ckbtc-info-services", () => {
   beforeEach(() => {
     ckBTCInfoStore.reset();
-    toastsStore.reset();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -35,7 +35,6 @@ describe("ckbtc-minter-services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-    toastsStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
     vi.spyOn(minterApi, "updateBalance").mockResolvedValue(mockUpdateBalanceOk);
   });

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -81,7 +81,6 @@ describe("icp-accounts.services", () => {
 
   beforeEach(() => {
     vi.spyOn(console, "error").mockReturnValue();
-    toastsStore.reset();
     resetAccountsForTesting();
     overrideFeatureFlagsStore.reset();
     resetIdentity();

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -47,7 +47,6 @@ describe("icp-ledger.services", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    toastsStore.reset();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -23,7 +23,6 @@ describe("icp-transactions services", () => {
     vi.clearAllMocks();
     resetIdentity();
     icpTransactionsStore.reset();
-    toastsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -52,7 +52,6 @@ describe("icrc-accounts-services", () => {
     icrcAccountsStore.reset();
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();
-    toastsStore.reset();
     resetSnsProjects();
 
     vi.spyOn(ledgerApi, "queryIcrcToken").mockResolvedValue(mockToken);

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -14,7 +14,6 @@ describe("icrc-index.services", () => {
     beforeEach(() => {
       vi.clearAllMocks();
       resetIdentity();
-      toastsStore.reset();
     });
 
     it("should return true when the ledger canister IDs match", async () => {

--- a/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
@@ -25,7 +25,6 @@ describe("icrc-transactions services", () => {
     vi.clearAllMocks();
     resetIdentity();
     icrcTransactionsStore.reset();
-    toastsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -46,7 +46,6 @@ describe("imported-tokens-services", () => {
     resetIdentity();
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();
-    toastsStore.reset();
     busyStore.resetForTesting();
     vi.spyOn(console, "error").mockReturnValue();
     vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -156,7 +156,6 @@ describe("neurons-services", () => {
     spyConsoleError = vi.spyOn(console, "error");
     resetAccountsForTesting();
     resetAccountIdentity();
-    toastsStore.reset();
     resetNeuronsApiService();
     overrideFeatureFlagsStore.reset();
     checkedNeuronSubaccountsStore.reset();

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -23,7 +23,6 @@ import { get } from "svelte/store";
 
 describe("proposals-services", () => {
   beforeEach(() => {
-    toastsStore.reset();
     proposalsStore.setProposalsForTesting({ proposals: [], certified: true });
     proposalPayloadsStore.reset();
     vi.spyOn(console, "error").mockRestore();

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -37,7 +37,6 @@ describe("sns-proposals services", () => {
   beforeEach(() => {
     snsFiltersStore.reset();
     snsProposalsStore.reset();
-    toastsStore.reset();
     vi.spyOn(console, "error").mockRestore();
   });
   const proposal1: SnsProposalData = {

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -20,7 +20,6 @@ describe("sns-accounts-balance.services", () => {
     vi.clearAllMocks();
     icrcAccountsStore.reset();
     tokensStore.reset();
-    toastsStore.reset();
     resetSnsProjects();
 
     setSnsProjects([

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -92,7 +92,6 @@ describe("sns-neurons-services", () => {
   };
 
   beforeEach(() => {
-    toastsStore.reset();
     resetIdentity();
     resetMockedConstants();
     resetSnsProjects();

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -133,7 +133,6 @@ describe("sns-api", () => {
 
     vi.useFakeTimers();
 
-    toastsStore.reset();
     snsTicketsStore.reset();
     resetAccountsForTesting();
     tokensStore.reset();

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -101,7 +101,6 @@ describe("sns-vote-registration-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    toastsStore.reset();
 
     spyQuerySnsProposals = vi
       .spyOn(api, "queryProposals")

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -49,7 +49,6 @@ describe("sns-services", () => {
     snsSwapCommitmentsStore.reset();
     resetSnsProjects();
     snsDerivedStateStore.reset();
-    toastsStore.reset();
   });
 
   describe("getSwapAccount", () => {

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -75,7 +75,6 @@ describe("vote-registration-services", () => {
   beforeEach(() => {
     // Cleanup:
     voteRegistrationStore.reset();
-    toastsStore.reset();
     proposalsStore.resetForTesting();
     resetIdentity();
 

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -33,7 +33,6 @@ describe("utils", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllTimers();
-    toastsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `toastsStore`.

# Changes

1. Remove resetting of `toastsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary