### PR TITLE
Decode neuron_accounts into original type instead of Reserved

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Stop trying to get swap commitments from aborted SNSes.
 * Stop making unnecessary calls to SNS-W and SNS root canisters.
 * User gets the wrong identity when connecting different hardware wallets devices in a certain order.
+* Fix candid decoding error of stable memory.
 
 #### Security
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1045,7 +1045,7 @@ impl StableState for AccountsStore {
             HashMap<AccountIdentifier, AccountWrapper>,
             HashMap<(AccountIdentifier, AccountIdentifier), (TransactionType, u64)>,
             candid::Reserved,
-            candid::Reserved,
+            HashMap<AccountIdentifier, NeuronDetails>,
             Option<BlockIndex>,
             MultiPartTransactionsProcessor,
             u64,


### PR DESCRIPTION
# Motivation

The latest nns-dapp upgrade failed because the stable memory couldn't be decoded.

```
Decoding stable memory failed. Error: "Fail to decode argument 4 from table14 to reserved"
```

In my understanding, anything should be able to be decoded to type `candid::Reserved` and with local testing this is the case but apparently there are edge cases where this is not true.

It's still not clear to me why it failed but I was able to reproduce the failure against golden test data and the changes in this PR fixed it.

I'll try to continue to look into this more to understand what really happened but meanwhile it's good to have a releasable repo again.

# Changes

Decode unused `neuron_accounts` as its original type `HashMap<AccountIdentifier, NeuronDetails>` instead of `candid::Reserve`.

# Tests

1. I tried upgrading nns-dapp with the failed release candidate from https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=134171 against the golden NNS state and was able to reproduce the decoding error.
2. Then I built a wasm with the type change from this PR and was able to upgrade NNS dapp without errors.

I made the following changes to the golden state test to be able to test with nns-dapp:
https://github.com/dfinity/ic/pull/2657

# Todos

- [x] Add entry to changelog (if necessary).
