### PR TITLE
Neuron action state utils

### DIFF
--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -37,8 +37,8 @@ export const TOPICS_TO_FOLLOW_NNS = [
   ...LAST_TOPICS,
 ];
 
-// If a neuron has not "refreshed" (manual voting or a following update) its voting power after this amount of time,
-// its deciding voting power starts decreasing linearly.
+// A neuron's voting power begins to decrease linearly if it remains inactive for this duration.
+// Inactivity means no manual votes cast and no updates to the list of followed neurons (followees).
 export const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
 // After how many seconds from the start of voting power decrease,
 // a neuron followings (all topics other than NeuronManagement) will be cleared.

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -39,9 +39,13 @@ export const TOPICS_TO_FOLLOW_NNS = [
 
 // A neuron's voting power begins to decrease linearly if it remains inactive for this duration.
 // Inactivity means no manual votes cast and no updates to the list of followed neurons (followees).
+// Draft ic pr: https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L582)
+// TODO(mstr): replace with the actual ic link.
 export const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
 // After how many seconds from the start of voting power decrease,
 // a neuron followings (all topics other than NeuronManagement) will be cleared.
+// Draft ic pr: https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L592
+// TODO(mstr): replace with the actual ic link.
 export const CLEAR_FOLLOWING_AFTER_SECONDS = SECONDS_IN_MONTH;
 
 // To notify users that their rewards will start decreasing in 30 days.

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -1,6 +1,7 @@
 import {
   SECONDS_IN_7_DAYS,
   SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
 import { enumValues } from "$lib/utils/enum.utils";
 import { Topic } from "@dfinity/nns";
@@ -35,3 +36,10 @@ export const TOPICS_TO_FOLLOW_NNS = [
   ),
   ...LAST_TOPICS,
 ];
+
+// If a neuron has not "refreshed" (manual voting or a following update) its voting power after this amount of time,
+// its deciding voting power starts decreasing linearly.
+const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
+// After how many seconds from the start of voting power decrease,
+// a neuron followings (all topics other than NeuronManagement) will be cleared.
+const CLEAR_FOLLOWING_AFTER_SECONDS = SECONDS_IN_MONTH;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -1,7 +1,6 @@
 import {
   SECONDS_IN_7_DAYS,
   SECONDS_IN_HALF_YEAR,
-  SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
 import { enumValues } from "$lib/utils/enum.utils";
 import { Topic } from "@dfinity/nns";
@@ -42,11 +41,6 @@ export const TOPICS_TO_FOLLOW_NNS = [
 // Draft ic pr: https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L582)
 // TODO(mstr): replace with the actual ic link.
 export const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
-// After how many seconds from the start of voting power decrease,
-// a neuron followings (all topics other than NeuronManagement) will be cleared.
-// Draft ic pr: https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L592
-// TODO(mstr): replace with the actual ic link.
-export const CLEAR_FOLLOWING_AFTER_SECONDS = SECONDS_IN_MONTH;
 
 // To notify users that their rewards will start decreasing in 30 days.
 export const NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS = 30;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -39,7 +39,10 @@ export const TOPICS_TO_FOLLOW_NNS = [
 
 // If a neuron has not "refreshed" (manual voting or a following update) its voting power after this amount of time,
 // its deciding voting power starts decreasing linearly.
-const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
+export const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
 // After how many seconds from the start of voting power decrease,
 // a neuron followings (all topics other than NeuronManagement) will be cleared.
-const CLEAR_FOLLOWING_AFTER_SECONDS = SECONDS_IN_MONTH;
+export const CLEAR_FOLLOWING_AFTER_SECONDS = SECONDS_IN_MONTH;
+
+// To notify users that their rewards will start decreasing in 30 days.
+export const NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS = 30;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -10,7 +10,6 @@ import {
   E8S_PER_ICP,
 } from "$lib/constants/icp.constants";
 import {
-  CLEAR_FOLLOWING_AFTER_SECONDS,
   MATURITY_MODULATION_VARIANCE_PERCENTAGE,
   MAX_AGE_BONUS,
   MAX_DISSOLVE_DELAY_BONUS,
@@ -1173,17 +1172,10 @@ const getVotingPowerRefreshedTimestampSeconds = ({
   // to avoid unnecessary notifications.
   fullNeuron?.votingPowerRefreshedTimestampSeconds ?? BigInt(nowInSeconds());
 
-export const hasNeuronLostAllRewards = (neuron: NeuronInfo): boolean =>
-  nowInSeconds() >=
-  getVotingPowerRefreshedTimestampSeconds(neuron) +
-    BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) +
-    BigInt(CLEAR_FOLLOWING_AFTER_SECONDS);
-
 export const isNeuronLosingRewards = (neuron: NeuronInfo): boolean =>
   nowInSeconds() >=
-    getVotingPowerRefreshedTimestampSeconds(neuron) +
-      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) &&
-  !hasNeuronLostAllRewards(neuron);
+  getVotingPowerRefreshedTimestampSeconds(neuron) +
+    BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS);
 
 // e.g. "Neuron will start losing rewards in 30 days"
 export const shouldDisplayRewardLossNotification = (

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1173,7 +1173,7 @@ const getVotingPowerRefreshedTimestampSeconds = ({
   // https://github.com/dfinity/ic/blob/f8c4eb15e8447f967e9b31edc305412c1741a6e6/rs/nns/governance/src/lib.rs#L186-L189
   fullNeuron.votingPowerRefreshedTimestampSeconds as bigint;
 
-export const neuronLostAllRewards = (
+export const hasNeuronLostAllRewards = (
   neuron: NeuronInfo & { fullNeuron: Neuron }
 ): boolean =>
   nowInSeconds() >=
@@ -1181,13 +1181,13 @@ export const neuronLostAllRewards = (
     BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) +
     BigInt(CLEAR_FOLLOWING_AFTER_SECONDS);
 
-export const neuronLosingRewards = (
+export const isNeuronLosingRewards = (
   neuron: NeuronInfo & { fullNeuron: Neuron }
 ): boolean =>
   nowInSeconds() >=
     getVotingPowerRefreshedTimestampSeconds(neuron) +
       BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) &&
-  !neuronLostAllRewards(neuron);
+  !hasNeuronLostAllRewards(neuron);
 
 // e.g. "Neuron will start losing rewards in 30 days"
 export const shouldDisplayRewardLossNotification = (

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1166,10 +1166,11 @@ export const isPublicNeuron = (neuronInfo: NeuronInfo): boolean => {
   return neuronInfo.visibility === NeuronVisibility.Public;
 };
 
-export const getVotingPowerRefreshedTimestampSeconds = ({
+const getVotingPowerRefreshedTimestampSeconds = ({
   fullNeuron,
 }: NeuronInfo & { fullNeuron: Neuron }): bigint =>
   // The timestamp is always defined.
+  // https://github.com/dfinity/ic/blob/f8c4eb15e8447f967e9b31edc305412c1741a6e6/rs/nns/governance/src/lib.rs#L186-L189
   fullNeuron.votingPowerRefreshedTimestampSeconds as bigint;
 
 export const neuronLostAllRewards = (
@@ -1183,21 +1184,16 @@ export const neuronLostAllRewards = (
 export const neuronLosingRewards = (
   neuron: NeuronInfo & { fullNeuron: Neuron }
 ): boolean =>
-  !neuronLostAllRewards(neuron) &&
   nowInSeconds() >=
     getVotingPowerRefreshedTimestampSeconds(neuron) +
-      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS);
+      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) &&
+  !neuronLostAllRewards(neuron);
 
-// Neuron will start losing rewards in 30 days.
-export const neuronWillLoseRewardsSoon = (
+// e.g. "Neuron will start losing rewards in 30 days"
+export const shouldDisplayRewardLossNotification = (
   neuron: NeuronInfo & { fullNeuron: Neuron }
 ): boolean =>
   nowInSeconds() >=
-    getVotingPowerRefreshedTimestampSeconds(neuron) +
-      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) -
-      BigInt(
-        daysToSeconds(NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS)
-      ) &&
-  nowInSeconds() <
-    getVotingPowerRefreshedTimestampSeconds(neuron) +
-      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS);
+  getVotingPowerRefreshedTimestampSeconds(neuron) +
+    BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) -
+    BigInt(daysToSeconds(NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS));

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1168,22 +1168,18 @@ export const isPublicNeuron = (neuronInfo: NeuronInfo): boolean => {
 
 const getVotingPowerRefreshedTimestampSeconds = ({
   fullNeuron,
-}: NeuronInfo & { fullNeuron: Neuron }): bigint =>
-  // The timestamp is always defined.
-  // https://github.com/dfinity/ic/blob/f8c4eb15e8447f967e9b31edc305412c1741a6e6/rs/nns/governance/src/lib.rs#L186-L189
-  fullNeuron.votingPowerRefreshedTimestampSeconds as bigint;
+}: NeuronInfo): bigint =>
+  // When the fullNeuron is not presented, we assume that the neuron is not losing rewards
+  // to avoid unnecessary notifications.
+  fullNeuron?.votingPowerRefreshedTimestampSeconds ?? BigInt(nowInSeconds());
 
-export const hasNeuronLostAllRewards = (
-  neuron: NeuronInfo & { fullNeuron: Neuron }
-): boolean =>
+export const hasNeuronLostAllRewards = (neuron: NeuronInfo): boolean =>
   nowInSeconds() >=
   getVotingPowerRefreshedTimestampSeconds(neuron) +
     BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) +
     BigInt(CLEAR_FOLLOWING_AFTER_SECONDS);
 
-export const isNeuronLosingRewards = (
-  neuron: NeuronInfo & { fullNeuron: Neuron }
-): boolean =>
+export const isNeuronLosingRewards = (neuron: NeuronInfo): boolean =>
   nowInSeconds() >=
     getVotingPowerRefreshedTimestampSeconds(neuron) +
       BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) &&
@@ -1191,7 +1187,7 @@ export const isNeuronLosingRewards = (
 
 // e.g. "Neuron will start losing rewards in 30 days"
 export const shouldDisplayRewardLossNotification = (
-  neuron: NeuronInfo & { fullNeuron: Neuron }
+  neuron: NeuronInfo
 ): boolean =>
   nowInSeconds() >=
   getVotingPowerRefreshedTimestampSeconds(neuron) +

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3197,15 +3197,15 @@ describe("neuron-utils", () => {
 
   describe("Neuron voting power refreshed utils", () => {
     const neuronWithRefreshedTimestamp = ({
-      secondsSinceLastRefresh,
+      votingPowerRefreshedTimestampAgeSecs,
     }: {
-      secondsSinceLastRefresh: number;
+      votingPowerRefreshedTimestampAgeSecs: number;
     }) => ({
       ...mockNeuron,
       fullNeuron: {
         ...mockFullNeuron,
         votingPowerRefreshedTimestampSeconds: BigInt(
-          nowInSeconds() - secondsSinceLastRefresh
+          nowInSeconds() - votingPowerRefreshedTimestampAgeSecs
         ),
       },
     });
@@ -3226,14 +3226,14 @@ describe("neuron-utils", () => {
         expect(
           isNeuronLosingRewards(
             neuronWithRefreshedTimestamp({
-              secondsSinceLastRefresh: losingRewardsPeriod,
+              votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod,
             })
           )
         ).toBe(true);
         expect(
           isNeuronLosingRewards(
             neuronWithRefreshedTimestamp({
-              secondsSinceLastRefresh: losingRewardsPeriod + 1,
+              votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod + 1,
             })
           )
         ).toBe(true);
@@ -3243,7 +3243,7 @@ describe("neuron-utils", () => {
         expect(
           isNeuronLosingRewards(
             neuronWithRefreshedTimestamp({
-              secondsSinceLastRefresh: losingRewardsPeriod - 1,
+              votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod - 1,
             })
           )
         ).toBe(false);
@@ -3264,14 +3264,15 @@ describe("neuron-utils", () => {
         expect(
           shouldDisplayRewardLossNotification(
             neuronWithRefreshedTimestamp({
-              secondsSinceLastRefresh: losingRewardsPeriod - notificationPeriod,
+              votingPowerRefreshedTimestampAgeSecs:
+                losingRewardsPeriod - notificationPeriod,
             })
           )
         ).toBe(true);
         expect(
           shouldDisplayRewardLossNotification(
             neuronWithRefreshedTimestamp({
-              secondsSinceLastRefresh:
+              votingPowerRefreshedTimestampAgeSecs:
                 losingRewardsPeriod - notificationPeriod + 1,
             })
           )
@@ -3282,7 +3283,7 @@ describe("neuron-utils", () => {
         expect(
           shouldDisplayRewardLossNotification(
             neuronWithRefreshedTimestamp({
-              secondsSinceLastRefresh:
+              votingPowerRefreshedTimestampAgeSecs:
                 losingRewardsPeriod - (notificationPeriod + 1),
             })
           )

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3196,7 +3196,11 @@ describe("neuron-utils", () => {
   });
 
   describe("Neuron voting power refreshed utils", () => {
-    const neuronWithRefreshedTimestamp = (secondsSinceLastRefresh: number) => ({
+    const neuronWithRefreshedTimestamp = ({
+      secondsSinceLastRefresh,
+    }: {
+      secondsSinceLastRefresh: number;
+    }) => ({
       ...mockNeuron,
       fullNeuron: {
         ...mockFullNeuron,
@@ -3205,7 +3209,7 @@ describe("neuron-utils", () => {
         ),
       },
     });
-    const loosingRewardsPeriod = SECONDS_IN_HALF_YEAR;
+    const losingRewardsPeriod = SECONDS_IN_HALF_YEAR;
     const notificationPeriod = 30 * SECONDS_IN_DAY;
 
     describe("isNeuronLosingRewards", () => {
@@ -3221,12 +3225,16 @@ describe("neuron-utils", () => {
       it("should return true after the reward loss has started", () => {
         expect(
           isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(loosingRewardsPeriod)
+            neuronWithRefreshedTimestamp({
+              secondsSinceLastRefresh: losingRewardsPeriod,
+            })
           )
         ).toBe(true);
         expect(
           isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(loosingRewardsPeriod + 1)
+            neuronWithRefreshedTimestamp({
+              secondsSinceLastRefresh: losingRewardsPeriod + 1,
+            })
           )
         ).toBe(true);
       });
@@ -3234,7 +3242,9 @@ describe("neuron-utils", () => {
       it("should return false", () => {
         expect(
           isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(loosingRewardsPeriod - 1)
+            neuronWithRefreshedTimestamp({
+              secondsSinceLastRefresh: losingRewardsPeriod - 1,
+            })
           )
         ).toBe(false);
       });
@@ -3253,16 +3263,17 @@ describe("neuron-utils", () => {
       it("should return true after notification period starts", () => {
         expect(
           shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(
-              loosingRewardsPeriod - notificationPeriod
-            )
+            neuronWithRefreshedTimestamp({
+              secondsSinceLastRefresh: losingRewardsPeriod - notificationPeriod,
+            })
           )
         ).toBe(true);
         expect(
           shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(
-              loosingRewardsPeriod - notificationPeriod + 1
-            )
+            neuronWithRefreshedTimestamp({
+              secondsSinceLastRefresh:
+                losingRewardsPeriod - notificationPeriod + 1,
+            })
           )
         ).toBe(true);
       });
@@ -3270,9 +3281,10 @@ describe("neuron-utils", () => {
       it("should return false before notification period", () => {
         expect(
           shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(
-              loosingRewardsPeriod - (notificationPeriod + 1)
-            )
+            neuronWithRefreshedTimestamp({
+              secondsSinceLastRefresh:
+                losingRewardsPeriod - (notificationPeriod + 1),
+            })
           )
         ).toBe(false);
       });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3215,6 +3215,15 @@ describe("neuron-utils", () => {
       startLosingRewardsTimestamp - SECONDS_IN_MONTH;
 
     describe("hasNeuronLostAllRewards", () => {
+      it("should return false by default", () => {
+        expect(
+          hasNeuronLostAllRewards({
+            ...mockNeuron,
+            fullNeuron: undefined,
+          })
+        ).toBe(false);
+      });
+
       it("should return true", () => {
         expect(
           hasNeuronLostAllRewards(
@@ -3248,6 +3257,15 @@ describe("neuron-utils", () => {
     });
 
     describe("isNeuronLosingRewards", () => {
+      it("should return false by default", () => {
+        expect(
+          isNeuronLosingRewards({
+            ...mockNeuron,
+            fullNeuron: undefined,
+          })
+        ).toBe(false);
+      });
+
       it("should return true", () => {
         expect(
           isNeuronLosingRewards(
@@ -3281,6 +3299,15 @@ describe("neuron-utils", () => {
     });
 
     describe("shouldDisplayRewardLossNotification", () => {
+      it("should return false by default", () => {
+        expect(
+          shouldDisplayRewardLossNotification({
+            ...mockNeuron,
+            fullNeuron: undefined,
+          })
+        ).toBe(false);
+      });
+
       it("should return true", () => {
         expect(
           shouldDisplayRewardLossNotification(

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -43,6 +43,7 @@ import {
   getTopicTitle,
   hasEnoughMaturityToStake,
   hasJoinedCommunityFund,
+  hasNeuronLostAllRewards,
   hasValidStake,
   isEnoughMaturityToSpawn,
   isEnoughToStakeNeuron,
@@ -51,6 +52,7 @@ import {
   isNeuronControllable,
   isNeuronControllableByUser,
   isNeuronControlledByHardwareWallet,
+  isNeuronLosingRewards,
   isPublicNeuron,
   isSpawning,
   isValidInputAmount,
@@ -61,8 +63,6 @@ import {
   neuronAge,
   neuronAvailableMaturity,
   neuronCanBeSplit,
-  neuronLosingRewards,
-  neuronLostAllRewards,
   neuronStake,
   neuronStakedMaturity,
   neuronVotingPower,
@@ -3205,19 +3205,19 @@ describe("neuron-utils", () => {
         votingPowerRefreshedTimestampSeconds: BigInt(timestamp),
       },
     });
-    const startLoosingRewardsTimestamp = nowInSeconds() - SECONDS_IN_HALF_YEAR;
+    const startLosingRewardsTimestamp = nowInSeconds() - SECONDS_IN_HALF_YEAR;
     const recentlyRefreshedTimestamp = nowInSeconds() - SECONDS_IN_DAY;
     const activeNeuronRefreshedTimestamp =
-      startLoosingRewardsTimestamp + 30 * SECONDS_IN_DAY + 1;
-    const notifiedNeuronRefreshedTimestamp = startLoosingRewardsTimestamp + 1;
-    const loosingRewardsRefreshedTimestamp = startLoosingRewardsTimestamp;
+      startLosingRewardsTimestamp + 30 * SECONDS_IN_DAY + 1;
+    const notifiedNeuronRefreshedTimestamp = startLosingRewardsTimestamp + 1;
+    const losingRewardsRefreshedTimestamp = startLosingRewardsTimestamp;
     const lostRewardsRefreshedTimestamp =
-      startLoosingRewardsTimestamp - SECONDS_IN_MONTH;
+      startLosingRewardsTimestamp - SECONDS_IN_MONTH;
 
-    describe("neuronLostAllRewards", () => {
+    describe("hasNeuronLostAllRewards", () => {
       it("should return true", () => {
         expect(
-          neuronLostAllRewards(
+          hasNeuronLostAllRewards(
             neuronWithRefreshedTimestamp(lostRewardsRefreshedTimestamp)
           )
         ).toBe(true);
@@ -3225,55 +3225,55 @@ describe("neuron-utils", () => {
 
       it("should return false", () => {
         expect(
-          neuronLostAllRewards(
+          hasNeuronLostAllRewards(
             neuronWithRefreshedTimestamp(recentlyRefreshedTimestamp)
           )
         ).toBe(false);
         expect(
-          neuronLostAllRewards(
+          hasNeuronLostAllRewards(
             neuronWithRefreshedTimestamp(activeNeuronRefreshedTimestamp)
           )
         ).toBe(false);
         expect(
-          neuronLostAllRewards(
+          hasNeuronLostAllRewards(
             neuronWithRefreshedTimestamp(notifiedNeuronRefreshedTimestamp)
           )
         ).toBe(false);
         expect(
-          neuronLostAllRewards(
-            neuronWithRefreshedTimestamp(loosingRewardsRefreshedTimestamp)
+          hasNeuronLostAllRewards(
+            neuronWithRefreshedTimestamp(losingRewardsRefreshedTimestamp)
           )
         ).toBe(false);
       });
     });
 
-    describe("neuronLosingRewards", () => {
+    describe("isNeuronLosingRewards", () => {
       it("should return true", () => {
         expect(
-          neuronLosingRewards(
-            neuronWithRefreshedTimestamp(loosingRewardsRefreshedTimestamp)
+          isNeuronLosingRewards(
+            neuronWithRefreshedTimestamp(losingRewardsRefreshedTimestamp)
           )
         ).toBe(true);
       });
 
       it("should return false", () => {
         expect(
-          neuronLosingRewards(
+          isNeuronLosingRewards(
             neuronWithRefreshedTimestamp(recentlyRefreshedTimestamp)
           )
         ).toBe(false);
         expect(
-          neuronLosingRewards(
+          isNeuronLosingRewards(
             neuronWithRefreshedTimestamp(activeNeuronRefreshedTimestamp)
           )
         ).toBe(false);
         expect(
-          neuronLosingRewards(
+          isNeuronLosingRewards(
             neuronWithRefreshedTimestamp(notifiedNeuronRefreshedTimestamp)
           )
         ).toBe(false);
         expect(
-          neuronLosingRewards(
+          isNeuronLosingRewards(
             neuronWithRefreshedTimestamp(lostRewardsRefreshedTimestamp)
           )
         ).toBe(false);
@@ -3289,7 +3289,7 @@ describe("neuron-utils", () => {
         ).toBe(true);
         expect(
           shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(loosingRewardsRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(losingRewardsRefreshedTimestamp)
           )
         ).toBe(true);
         expect(

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3209,7 +3209,10 @@ describe("neuron-utils", () => {
     const recentlyRefreshedTimestamp = nowInSeconds() - SECONDS_IN_DAY;
     const activeNeuronRefreshedTimestamp =
       startLosingRewardsTimestamp + 30 * SECONDS_IN_DAY + 1;
-    const notifiedNeuronRefreshedTimestamp = startLosingRewardsTimestamp + 1;
+    const notifiedNeuronRefreshedBeginningTimestamp =
+      startLosingRewardsTimestamp + 1;
+    const notifiedNeuronRefreshedEndTimestamp =
+      startLosingRewardsTimestamp + 30 * SECONDS_IN_DAY;
     const lostRewardsRefreshedTimestamp =
       startLosingRewardsTimestamp - SECONDS_IN_MONTH;
 
@@ -3244,7 +3247,14 @@ describe("neuron-utils", () => {
         ).toBe(false);
         expect(
           hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(notifiedNeuronRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(
+              notifiedNeuronRefreshedBeginningTimestamp
+            )
+          )
+        ).toBe(false);
+        expect(
+          hasNeuronLostAllRewards(
+            neuronWithRefreshedTimestamp(notifiedNeuronRefreshedEndTimestamp)
           )
         ).toBe(false);
         expect(
@@ -3286,7 +3296,14 @@ describe("neuron-utils", () => {
         ).toBe(false);
         expect(
           isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(notifiedNeuronRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(
+              notifiedNeuronRefreshedBeginningTimestamp
+            )
+          )
+        ).toBe(false);
+        expect(
+          isNeuronLosingRewards(
+            neuronWithRefreshedTimestamp(notifiedNeuronRefreshedEndTimestamp)
           )
         ).toBe(false);
         expect(
@@ -3310,7 +3327,14 @@ describe("neuron-utils", () => {
       it("should return true", () => {
         expect(
           shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(notifiedNeuronRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(
+              notifiedNeuronRefreshedBeginningTimestamp
+            )
+          )
+        ).toBe(true);
+        expect(
+          shouldDisplayRewardLossNotification(
+            neuronWithRefreshedTimestamp(notifiedNeuronRefreshedEndTimestamp)
           )
         ).toBe(true);
         expect(

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -4,7 +4,6 @@ import {
   SECONDS_IN_FOUR_YEARS,
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_HOUR,
-  SECONDS_IN_MONTH,
   SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
@@ -43,7 +42,6 @@ import {
   getTopicTitle,
   hasEnoughMaturityToStake,
   hasJoinedCommunityFund,
-  hasNeuronLostAllRewards,
   hasValidStake,
   isEnoughMaturityToSpawn,
   isEnoughToStakeNeuron,
@@ -3206,64 +3204,12 @@ describe("neuron-utils", () => {
       },
     });
     const startLosingRewardsTimestamp = nowInSeconds() - SECONDS_IN_HALF_YEAR;
-    const recentlyRefreshedTimestamp = nowInSeconds() - SECONDS_IN_DAY;
-    const activeNeuronRefreshedTimestamp =
+    const notNotifiedRefreshedTimestamp =
       startLosingRewardsTimestamp + 30 * SECONDS_IN_DAY + 1;
     const notifiedNeuronRefreshedBeginningTimestamp =
       startLosingRewardsTimestamp + 1;
     const notifiedNeuronRefreshedEndTimestamp =
       startLosingRewardsTimestamp + 30 * SECONDS_IN_DAY;
-    const lostRewardsRefreshedTimestamp =
-      startLosingRewardsTimestamp - SECONDS_IN_MONTH;
-
-    describe("hasNeuronLostAllRewards", () => {
-      it("should return false by default", () => {
-        expect(
-          hasNeuronLostAllRewards({
-            ...mockNeuron,
-            fullNeuron: undefined,
-          })
-        ).toBe(false);
-      });
-
-      it("should return true", () => {
-        expect(
-          hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(lostRewardsRefreshedTimestamp)
-          )
-        ).toBe(true);
-      });
-
-      it("should return false", () => {
-        expect(
-          hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(recentlyRefreshedTimestamp)
-          )
-        ).toBe(false);
-        expect(
-          hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(activeNeuronRefreshedTimestamp)
-          )
-        ).toBe(false);
-        expect(
-          hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(
-              notifiedNeuronRefreshedBeginningTimestamp
-            )
-          )
-        ).toBe(false);
-        expect(
-          hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(notifiedNeuronRefreshedEndTimestamp)
-          )
-        ).toBe(false);
-        expect(
-          hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(startLosingRewardsTimestamp)
-          )
-        ).toBe(false);
-      });
-    });
 
     describe("isNeuronLosingRewards", () => {
       it("should return false by default", () => {
@@ -3286,12 +3232,7 @@ describe("neuron-utils", () => {
       it("should return false", () => {
         expect(
           isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(recentlyRefreshedTimestamp)
-          )
-        ).toBe(false);
-        expect(
-          isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(activeNeuronRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(notNotifiedRefreshedTimestamp)
           )
         ).toBe(false);
         expect(
@@ -3304,11 +3245,6 @@ describe("neuron-utils", () => {
         expect(
           isNeuronLosingRewards(
             neuronWithRefreshedTimestamp(notifiedNeuronRefreshedEndTimestamp)
-          )
-        ).toBe(false);
-        expect(
-          isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(lostRewardsRefreshedTimestamp)
           )
         ).toBe(false);
       });
@@ -3342,22 +3278,12 @@ describe("neuron-utils", () => {
             neuronWithRefreshedTimestamp(startLosingRewardsTimestamp)
           )
         ).toBe(true);
-        expect(
-          shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(lostRewardsRefreshedTimestamp)
-          )
-        ).toBe(true);
       });
 
       it("should return false", () => {
         expect(
           shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(activeNeuronRefreshedTimestamp)
-          )
-        ).toBe(false);
-        expect(
-          shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(recentlyRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(notNotifiedRefreshedTimestamp)
           )
         ).toBe(false);
       });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3210,7 +3210,6 @@ describe("neuron-utils", () => {
     const activeNeuronRefreshedTimestamp =
       startLosingRewardsTimestamp + 30 * SECONDS_IN_DAY + 1;
     const notifiedNeuronRefreshedTimestamp = startLosingRewardsTimestamp + 1;
-    const losingRewardsRefreshedTimestamp = startLosingRewardsTimestamp;
     const lostRewardsRefreshedTimestamp =
       startLosingRewardsTimestamp - SECONDS_IN_MONTH;
 
@@ -3250,7 +3249,7 @@ describe("neuron-utils", () => {
         ).toBe(false);
         expect(
           hasNeuronLostAllRewards(
-            neuronWithRefreshedTimestamp(losingRewardsRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(startLosingRewardsTimestamp)
           )
         ).toBe(false);
       });
@@ -3269,7 +3268,7 @@ describe("neuron-utils", () => {
       it("should return true", () => {
         expect(
           isNeuronLosingRewards(
-            neuronWithRefreshedTimestamp(losingRewardsRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(startLosingRewardsTimestamp)
           )
         ).toBe(true);
       });
@@ -3316,7 +3315,7 @@ describe("neuron-utils", () => {
         ).toBe(true);
         expect(
           shouldDisplayRewardLossNotification(
-            neuronWithRefreshedTimestamp(losingRewardsRefreshedTimestamp)
+            neuronWithRefreshedTimestamp(startLosingRewardsTimestamp)
           )
         ).toBe(true);
         expect(


### PR DESCRIPTION
# Motivation

For the periodic following confirmation feature, some UI elements will rely on a neuron’s inactivity state. In this PR, a new utility function to calculate these states is introduced.

Inactivity states:
- Losing rewards.
- And an extra state when to notify user that the neuron will lose rewards soon.

# Changes

- New constants related to the activity state (from ic / VotingPowerEconomics).
- New util functions.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.