### PR TITLE
NNS1-3240: Clean up unused feature flag

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { authStore } from "$lib/stores/auth.store";
-  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
   import { secondsToDate, secondsToDateTime } from "$lib/utils/date.utils";
@@ -49,11 +48,9 @@
 <Section testId="nns-neuron-advanced-section-component">
   <h3 slot="title">{$i18n.neuron_detail.advanced_settings_title}</h3>
   <div class="content">
-    {#if $ENABLE_NEURON_VISIBILITY}
-      <div class="visibility-action-container">
-        <NnsNeuronPublicVisibilityAction {neuron} />
-      </div>
-    {/if}
+    <div class="visibility-action-container">
+      <NnsNeuronPublicVisibilityAction {neuron} />
+    </div>
     <KeyValuePair>
       <span slot="key" class="label">{$i18n.neurons.neuron_id}</span>
       <span slot="value" class="value" data-tid="neuron-id"

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Hash from "$lib/components/ui/Hash.svelte";
-  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import { IconPublicBadge, Tag, Tooltip } from "@dfinity/gix-components";
@@ -16,7 +15,7 @@
     idPrefix="neuron-id-cell"
     showCopy
   />
-  {#if $ENABLE_NEURON_VISIBILITY && rowData.isPublic}
+  {#if rowData.isPublic}
     <span class="public-icon-container" data-tid="public-icon-container">
       <Tooltip
         top

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -12,7 +12,6 @@
   import { loadBalance } from "$lib/services/icp-accounts.services";
   import { stakeNeuron } from "$lib/services/neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
-  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
   import type { Account } from "$lib/types/account";
@@ -98,26 +97,24 @@
     >
   </TransactionFormFee>
 
-  {#if $ENABLE_NEURON_VISIBILITY}
-    <Separator spacing="small" />
+  <Separator spacing="small" />
 
-    <Checkbox
-      testId="as-public-neuron-checkbox"
-      inputId="as-public-neuron-checkbox"
-      checked={asPublicNeuron}
-      on:nnsChange={() => (asPublicNeuron = !asPublicNeuron)}
-      --checkbox-label-order="1"
-      --checkbox-padding="0"
-    >
-      <span data-tid="as-public-neuron-checkbox-label"
-        >{$i18n.neurons.create_as_public}
-      </span>
-      <TooltipIcon
-        text={$i18n.neurons.create_as_public_tooltip}
-        tooltipId="create_as_public_tooltip"
-      />
-    </Checkbox>
-  {/if}
+  <Checkbox
+    testId="as-public-neuron-checkbox"
+    inputId="as-public-neuron-checkbox"
+    checked={asPublicNeuron}
+    on:nnsChange={() => (asPublicNeuron = !asPublicNeuron)}
+    --checkbox-label-order="1"
+    --checkbox-padding="0"
+  >
+    <span data-tid="as-public-neuron-checkbox-label"
+      >{$i18n.neurons.create_as_public}
+    </span>
+    <TooltipIcon
+      text={$i18n.neurons.create_as_public_tooltip}
+      tooltipId="create_as_public_tooltip"
+    />
+  </Checkbox>
 
   <div class="toolbar">
     <button

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -6,7 +6,6 @@
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
-  import { ENABLE_NEURON_VISIBILITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
@@ -34,9 +33,7 @@
   {#if isLoading}
     <Spinner />
   {:else if tableNeurons.length > 0}
-    {#if $ENABLE_NEURON_VISIBILITY}
-      <MakeNeuronsPublicBanner />
-    {/if}
+    <MakeNeuronsPublicBanner />
     <NeuronsTable neurons={tableNeurons} />
   {:else}
     <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>

--- a/frontend/src/tests/e2e/neuron-details.spec.ts
+++ b/frontend/src/tests/e2e/neuron-details.spec.ts
@@ -3,7 +3,6 @@ import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
 import {
   replaceContent,
-  setFeatureFlag,
   signInWithNewUser,
   step,
 } from "$tests/utils/e2e.test-utils";
@@ -36,12 +35,6 @@ test("Test neuron details", async ({ page, context }) => {
   await appPo.goToNeuronDetails(neuronId);
 
   step("Make screenshots");
-
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURON_VISIBILITY",
-    value: true,
-  });
 
   // Replace neuron details with fixed values
   await replaceContent({

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -245,35 +245,4 @@ describe("NnsNeuronAdvancedSection", () => {
     expect(await po.dissolveDate()).toBeNull();
   });
 
-  it("should not display NnsNeuronPublicVisibilityAction when ENABLE_NEURON_VISIBILITY is false", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_VISIBILITY", false);
-
-    const po = renderComponent(mockNeuron);
-
-    expect(await po.getNnsNeuronPublicVisibilityActionPo().isPresent()).toBe(
-      false
-    );
-  });
-
-  it("should display NnsNeuronPublicVisibilityAction when ENABLE_NEURON_VISIBILITY is true", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_VISIBILITY", true);
-
-    const po = renderComponent(mockNeuron);
-
-    expect(await po.getNnsNeuronPublicVisibilityActionPo().isPresent()).toBe(
-      true
-    );
-  });
-
-  it("should pass the correct neuron to NnsNeuronPublicVisibilityAction", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_VISIBILITY", true);
-
-    const po = renderComponent(createMockNeuron(123));
-
-    expect(await po.getNnsNeuronPublicVisibilityActionPo().isPresent()).toBe(
-      true
-    );
-
-    expect(await po.getNeuronId()).toBe("123");
-  });
 });

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -328,103 +328,85 @@ describe("NnsStakeNeuronModal", () => {
     });
 
     describe("public neuron checkbox", () => {
-      it("should not display public neuron checkbox when feature flag is false", async () => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_VISIBILITY", false);
+      it("should create a private neuron when checkbox is unchecked", async () => {
+        const po = await renderComponent({});
+
+        await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(22);
+
+        await po.getNnsStakeNeuronPo().clickCreate();
+
+        expect(stakeNeuron).toBeCalledTimes(1);
+        expect(stakeNeuron).toBeCalledWith({
+          account: mockMainAccount,
+          amount: 22,
+          loadNeuron: true,
+          asPublicNeuron: false,
+        });
+      });
+
+      it("should have unchecked public neuron checkbox by default", async () => {
         const po = await renderComponent({});
 
         expect(
           await po
             .getNnsStakeNeuronPo()
             .getAsPublicNeuronCheckboxPo()
-            .isPresent()
+            .isChecked()
         ).toBe(false);
       });
 
-      describe("when feature flag is enabled", () => {
-        beforeEach(() => {
-          overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_VISIBILITY", true);
-        });
+      it("should be able to toggle public neuron checkbox", async () => {
+        const po = await renderComponent({});
 
-        it("should create a private neuron when checkbox is unchecked", async () => {
-          const po = await renderComponent({});
-
-          await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(22);
-
-          await po.getNnsStakeNeuronPo().clickCreate();
-
-          expect(stakeNeuron).toBeCalledTimes(1);
-          expect(stakeNeuron).toBeCalledWith({
-            account: mockMainAccount,
-            amount: 22,
-            loadNeuron: true,
-            asPublicNeuron: false,
-          });
-        });
-
-        it("should have unchecked public neuron checkbox by default", async () => {
-          const po = await renderComponent({});
-
-          expect(
-            await po
-              .getNnsStakeNeuronPo()
-              .getAsPublicNeuronCheckboxPo()
-              .isChecked()
-          ).toBe(false);
-        });
-
-        it("should be able to toggle public neuron checkbox", async () => {
-          const po = await renderComponent({});
-
-          await po.getNnsStakeNeuronPo().getAsPublicNeuronCheckboxPo().toggle();
-          expect(
-            await po
-              .getNnsStakeNeuronPo()
-              .getAsPublicNeuronCheckboxPo()
-              .isChecked()
-          ).toBe(true);
-
-          await po.getNnsStakeNeuronPo().getAsPublicNeuronCheckboxPo().toggle();
-          expect(
-            await po
-              .getNnsStakeNeuronPo()
-              .getAsPublicNeuronCheckboxPo()
-              .isChecked()
-          ).toBe(false);
-        });
-
-        it("should create a public neuron when checkbox is checked", async () => {
-          const po = await renderComponent({});
-
-          await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(22);
-          await po.getNnsStakeNeuronPo().getAsPublicNeuronCheckboxPo().toggle();
-
-          await po.getNnsStakeNeuronPo().clickCreate();
-
-          expect(stakeNeuron).toBeCalledTimes(1);
-          expect(stakeNeuron).toBeCalledWith({
-            account: mockMainAccount,
-            amount: 22,
-            loadNeuron: true,
-            asPublicNeuron: true,
-          });
-        });
-
-        it("should display correct text for checkbox and tooltip", async () => {
-          const po = await renderComponent({});
-
-          const checkboxLabel = await po
+        await po.getNnsStakeNeuronPo().getAsPublicNeuronCheckboxPo().toggle();
+        expect(
+          await po
             .getNnsStakeNeuronPo()
-            .getAsPublicNeuronCheckboxLabelText();
-          expect(checkboxLabel).toBe("Create as a public neuron");
+            .getAsPublicNeuronCheckboxPo()
+            .isChecked()
+        ).toBe(true);
 
-          const tooltipText = await po
+        await po.getNnsStakeNeuronPo().getAsPublicNeuronCheckboxPo().toggle();
+        expect(
+          await po
             .getNnsStakeNeuronPo()
-            .getAsPublicNeuronTooltipPo()
-            .getTooltipText();
-          expect(tooltipText).toBe(
-            "Public neurons reveal more information about themselves including how they vote on proposals."
-          );
+            .getAsPublicNeuronCheckboxPo()
+            .isChecked()
+        ).toBe(false);
+      });
+
+      it("should create a public neuron when checkbox is checked", async () => {
+        const po = await renderComponent({});
+
+        await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(22);
+        await po.getNnsStakeNeuronPo().getAsPublicNeuronCheckboxPo().toggle();
+
+        await po.getNnsStakeNeuronPo().clickCreate();
+
+        expect(stakeNeuron).toBeCalledTimes(1);
+        expect(stakeNeuron).toBeCalledWith({
+          account: mockMainAccount,
+          amount: 22,
+          loadNeuron: true,
+          asPublicNeuron: true,
         });
+      });
+
+      it("should display correct text for checkbox and tooltip", async () => {
+        const po = await renderComponent({});
+
+        const checkboxLabel = await po
+          .getNnsStakeNeuronPo()
+          .getAsPublicNeuronCheckboxLabelText();
+        expect(checkboxLabel).toBe("Create as a public neuron");
+
+        const tooltipText = await po
+          .getNnsStakeNeuronPo()
+          .getAsPublicNeuronTooltipPo()
+          .getTooltipText();
+        expect(tooltipText).toBe(
+          "Public neurons reveal more information about themselves including how they vote on proposals."
+        );
       });
     });
   });

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -131,18 +131,10 @@ describe("NnsNeurons", () => {
         privateControlledNeuron,
       ]);
     });
-    it("should render makeNeuronsPublicBanner when ENABLE_NEURON_VISIBILITY set to true", async () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_VISIBILITY", true);
+    it("should render makeNeuronsPublicBanner", async () => {
       const po = await renderComponent();
 
       expect(await po.getMakeNeuronsPublicBannerPo().isPresent()).toBe(true);
-    });
-
-    it("should render makeNeuronsPublicBanner when ENABLE_NEURON_VISIBILITY set to false", async () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_VISIBILITY", false);
-      const po = await renderComponent();
-
-      expect(await po.getMakeNeuronsPublicBannerPo().isPresent()).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Motivation
#5515 introduced a feature flag for its development. It is no longer needed since the feature has been released.

# Changes

- Removes `ENABLE_NEURON_VISIBILITY` and no longer necessary code.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
