### PR TITLE
Support other networks for get-sns script

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -287,6 +287,8 @@ jobs:
             # moreutils is needed for sponge, used by network-config.test
             brew install bash coreutils moreutils
           fi
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
       - name: Install didc
         run: |
           scripts/install-didc

--- a/scripts/dfx-server-origin
+++ b/scripts/dfx-server-origin
@@ -4,21 +4,28 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
+clap.define short=c long=canister desc="To add canister ID subdomain prefix" variable="CANISTER" default=""
 clap.define short=n long=network desc="dfx network to use" variable="DFX_NETWORK" default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 export DFX_NETWORK
 
+CANISTER_SUBDOMAIN="${CANISTER:+$(dfx canister id "$CANISTER" --network "$DFX_NETWORK").}"
+
 if [[ "$DFX_NETWORK" == "local" ]]; then
   PORT="$(
     cd ~
     dfx info webserver-port
   )"
-  echo "http://localhost:$PORT"
+  echo "http://${CANISTER_SUBDOMAIN}localhost:$PORT"
   exit
 else
   TOP_DIR="$(git rev-parse --show-toplevel)"
   ORIGIN="$(jq -er '.networks | .[env.DFX_NETWORK].providers[0] | select (.!=null)' "$TOP_DIR/dfx.json")"
+  if [[ -n "$CANISTER_SUBDOMAIN" ]]; then
+    # Replace '://' with '://<canister-id>.'
+    ORIGIN="${ORIGIN//:\/\//:\/\/$CANISTER_SUBDOMAIN}"
+  fi
   echo "$ORIGIN"
 fi

--- a/scripts/sns/aggregator/get-sns
+++ b/scripts/sns/aggregator/get-sns
@@ -20,7 +20,7 @@ get_aggregator_page() {
   local page="$1"
   local aggregator_url
   aggregator_url="$("$SOURCE_DIR/../../dfx-server-origin" --canister sns_aggregator --network "$DFX_NETWORK")/v1/sns/list/page/$page/slow.json"
-  curl -Lsf "$aggregator_url" > "$(get_local_page_filename "$page")"
+  curl -Lsf "$aggregator_url" >"$(get_local_page_filename "$page")"
 }
 
 if [[ "$DFX_NETWORK" = "mainnet" ]]; then
@@ -33,7 +33,7 @@ else
   AGGREGATOR_PAGES=()
   while get_aggregator_page "$page"; do
     AGGREGATOR_PAGES+=("$(get_local_page_filename "$page")")
-    page=$(( page + 1 ))
+    page=$((page + 1))
   done
   rm "$(get_local_page_filename "$page")"
 fi

--- a/scripts/sns/aggregator/get-sns
+++ b/scripts/sns/aggregator/get-sns
@@ -5,19 +5,42 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../../clap.bash"
 clap.define long=json desc="Output as json" variable="ENABLE_JSON" nargs=0
+clap.define long=network desc="dfx network to use" variable="DFX_NETWORK" default="mainnet"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 SEARCH_PATTERN="$1"
 
-# These exist for a frontend test but they are kept up-to-date weekly so they
-# are useful to have quick access to the list of SNSes. We only use them to
-# find which SNS to query but then get the actual data from the aggregator.
-AGGREGATOR_PAGES=("$SOURCE_DIR"/../../../frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json)
+get_local_page_filename() {
+  local page="$1"
+  echo "sns-agg-page-$page.json"
+}
+
+get_aggregator_page() {
+  local page="$1"
+  local aggregator_url
+  aggregator_url="$("$SOURCE_DIR/../../dfx-server-origin" --canister sns_aggregator --network "$DFX_NETWORK")/v1/sns/list/page/$page/slow.json"
+  curl -Lsf "$aggregator_url" > "$(get_local_page_filename "$page")"
+}
+
+if [[ "$DFX_NETWORK" = "mainnet" ]]; then
+  # These exist for a frontend test but they are kept up-to-date weekly so they
+  # are useful to have quick access to the list of SNSes. We only use them to
+  # find which SNS to query but then get the actual data from the aggregator.
+  AGGREGATOR_PAGES=("$SOURCE_DIR"/../../../frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json)
+else
+  page=0
+  AGGREGATOR_PAGES=()
+  while get_aggregator_page "$page"; do
+    AGGREGATOR_PAGES+=("$(get_local_page_filename "$page")")
+    page=$(( page + 1 ))
+  done
+  rm "$(get_local_page_filename "$page")"
+fi
 
 ROOT_CANISTER_ID="$(jq -c '.[] | select(.lifecycle.lifecycle != 4) | .canister_ids * {name: .meta.name, symbol: (.icrc1_metadata | .[] | select(.[0] == "icrc1:symbol") | .[1].Text) }' "${AGGREGATOR_PAGES[@]}" | grep -i "$SEARCH_PATTERN" | head -n 1 | jq -r .root_canister_id)"
 
-AGGREGATOR_URL="https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/$ROOT_CANISTER_ID/slow.json"
+AGGREGATOR_URL="$("$SOURCE_DIR/../../dfx-server-origin" --canister sns_aggregator --network "$DFX_NETWORK")/v1/sns/root/$ROOT_CANISTER_ID/slow.json"
 
 get_sns_data() {
   curl -LsSf "$AGGREGATOR_URL"


### PR DESCRIPTION
# Motivation

`scripts/sns/aggregator/get-sns` is a script to conveniently get some information about any SNS based on the name or any of its canister IDs.

Currently it only works with mainnet SNSes but while trying to reproduce out-of-cycles SNSes locally, I found it useful to be able to use this locally.

# Changes

1. Add `--canister` flag to `scripts/dfx-server-origin` to support adding a canister as the subdomain in the origin. This is useful to create an SNS aggregator URL.
2. Add `--network` flag to `scripts/sns/aggregator/get-sns`.
3. Download aggregator pages if the network is not `mainnet` (if it is `mainnet`, then we use the pages present in the repo).
4. Connect to the aggregator based on the `--network` flag to get the current data.

# Tests

1. I used the script manually to get data from `mainnet`, `local` and `devenv_dskloet`.
2. Install `dfx` on CI because it's used by `scripts/dfx-server-origin`.
3. The [CI test](https://github.com/dfinity/nns-dapp/blob/c6e4e8f3aa470282d5e6a32b30a79758385457cc/.github/workflows/checks.yml#L318) still passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary