### PR TITLE
Stop calling overrideFeatureFlagsStore.reset() in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -3,7 +3,6 @@ import {
   SECONDS_IN_FOUR_YEARS,
   SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
@@ -46,7 +45,6 @@ describe("NnsNeuronAdvancedSection", () => {
 
   beforeEach(() => {
     nnsLatestRewardEventStore.reset();
-    overrideFeatureFlagsStore.reset();
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
     resetIdentity();

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -4,7 +4,6 @@ import {
   DEPRECATED_TOPICS,
 } from "$lib/constants/proposals.constants";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { proposalsFiltersStore } from "$lib/stores/proposals.store";
 import { PROPOSAL_FILTER_UNSPECIFIED_VALUE } from "$lib/types/proposals";
 import { enumSize } from "$lib/utils/enum.utils";
@@ -112,7 +111,6 @@ describe("NnsProposalsFilters", () => {
     };
 
     beforeEach(() => {
-      overrideFeatureFlagsStore.reset();
       proposalsFiltersStore.reset();
     });
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -3,7 +3,6 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import type { Universe } from "$lib/types/universe";
 import { createUniverse } from "$lib/utils/universe.utils";
 import { page } from "$mocks/$app/stores";
@@ -42,7 +41,6 @@ describe("SelectUniverseCard", () => {
   };
 
   beforeEach(() => {
-    overrideFeatureFlagsStore.reset();
     actionableNnsProposalsStore.reset();
     actionableSnsProposalsStore.resetForTesting();
     resetAccountsForTesting();

--- a/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
@@ -4,7 +4,6 @@ import type {
   SubAccountDetails,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
 import { icpAccountDetailsStore } from "$lib/stores/icp-account-details.store";
 import { principal } from "$tests/mocks/sns-projects.mock";
@@ -61,7 +60,6 @@ describe("icpAccountsStore", () => {
   };
 
   beforeEach(() => {
-    overrideFeatureFlagsStore.reset();
     icpAccountDetailsStore.resetForTesting();
     icpAccountBalancesStore.resetForTesting();
   });

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -6,17 +6,12 @@ import {
   neuronsPathStore,
   proposalsPathStore,
 } from "$lib/derived/paths.derived";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import { mockSnsCanisterIdText } from "$tests/mocks/sns.api.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { get } from "svelte/store";
 
 describe("paths derived stores", () => {
-  beforeEach(() => {
-    overrideFeatureFlagsStore.reset();
-  });
-
   describe("accountsPathStore", () => {
     it("should return NNS accounts path as default", () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -39,7 +39,6 @@ import { get } from "svelte/store";
 
 describe("selected universe derived stores", () => {
   beforeEach(() => {
-    overrideFeatureFlagsStore.reset();
     setSnsProjects([
       {
         rootCanisterId: mockSnsCanisterId,

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -14,7 +14,6 @@ import {
   stakeNeuron,
   updateDelay,
 } from "$lib/services/neurons.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -61,7 +60,6 @@ describe("NnsStakeNeuronModal", () => {
   beforeEach(() => {
     resetIdentity();
     cancelPollAccounts();
-    overrideFeatureFlagsStore.reset();
 
     vi.spyOn(neuronsServices, "stakeNeuron").mockResolvedValue(
       newNeuron.neuronId

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -2,7 +2,6 @@ import { resetNeuronsApiService } from "$lib/api-services/governance.api-service
 import * as api from "$lib/api/governance.api";
 import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
 import * as authServices from "$lib/services/auth.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
@@ -31,7 +30,6 @@ describe("NnsNeurons", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     resetNeuronsApiService();
-    overrideFeatureFlagsStore.reset();
   });
 
   const renderComponent = async () => {

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -2,7 +2,6 @@ import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
 import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { enumValues } from "$lib/utils/enum.utils";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -52,7 +51,6 @@ describe("SnsNeurons", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     checkedNeuronSubaccountsStore.reset();
-    overrideFeatureFlagsStore.reset();
     page.mock({ data: { universe: rootCanisterId.toText() } });
     resetIdentity();
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -4,7 +4,6 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Neurons from "$lib/routes/Neurons.svelte";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
@@ -46,7 +45,6 @@ describe("Neurons", () => {
 
   beforeEach(async () => {
     resetIdentity();
-    overrideFeatureFlagsStore.reset();
 
     fakeGovernanceApi.addNeuronWith({ neuronId: testNnsNeuronId });
     testCommittedSnsNeuron = fakeSnsGovernanceApi.addNeuronWith({

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -24,7 +24,6 @@ import {
   syncAccounts,
   transferICP,
 } from "$lib/services/icp-accounts.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
 import { icpAccountDetailsStore } from "$lib/stores/icp-account-details.store";
 import type { Account } from "$lib/types/account";
@@ -82,7 +81,6 @@ describe("icp-accounts.services", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockReturnValue();
     resetAccountsForTesting();
-    overrideFeatureFlagsStore.reset();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -16,7 +16,6 @@ import * as services from "$lib/services/neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
 import * as busyStore from "$lib/stores/busy.store";
 import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -157,7 +156,6 @@ describe("neurons-services", () => {
     resetAccountsForTesting();
     resetAccountIdentity();
     resetNeuronsApiService();
-    overrideFeatureFlagsStore.reset();
     checkedNeuronSubaccountsStore.reset();
 
     vi.spyOn(icpAccountsServices, "loadBalance").mockReturnValue(undefined);

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -12,9 +12,6 @@ describe("featureFlags store", () => {
   const notEditable: FeatureKey = "TEST_FLAG_NOT_EDITABLE";
   const notEditableError = `Feature flag is not editable: ${notEditable}`;
   const editableFlag: FeatureKey = "TEST_FLAG_EDITABLE";
-  beforeEach(() => {
-    overrideFeatureFlagsStore.reset();
-  });
 
   it("should export all feature flags on the module with default values", () => {
     let feature: FeatureKey;

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -136,7 +136,6 @@ describe("Tokens route", () => {
   describe("when feature flag enabled", () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      overrideFeatureFlagsStore.reset();
       icrcAccountsStore.reset();
       tokensStore.reset();
       defaultIcrcCanistersStore.reset();


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `overrideFeatureFlagsStore`.

# Changes

1. Remove resetting of `overrideFeatureFlagsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary