### PR TITLE
Stop calling tokensStore.reset() in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -29,7 +29,6 @@ describe("IncreaseSnsDissolveDelayButton", () => {
         certified: true,
       },
     ]);
-    tokensStore.reset();
     tokensStore.setToken({
       canisterId: rootCanisterId,
       certified: true,

--- a/frontend/src/tests/lib/derived/accounts-title.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-title.derived.spec.ts
@@ -13,7 +13,6 @@ describe("accountsTitleStore", () => {
       routeId: AppPath.Accounts,
       data: { universe: OWN_CANISTER_ID_TEXT },
     });
-    tokensStore.reset();
   });
 
   it("returns 'Tokens' if no token is found", () => {

--- a/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
@@ -14,10 +14,6 @@ describe("icp-tokens-list-visitors.derived", () => {
   });
 
   describe("icpTokensListVisitors", () => {
-    beforeEach(() => {
-      tokensStore.reset();
-    });
-
     it("should return ICP with unavailable balance", () => {
       expect(get(icpTokensListVisitors)).toEqual([expectedIcpTokenVisitor]);
     });

--- a/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
@@ -1,6 +1,5 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { icpTokensListVisitors } from "$lib/derived/icp-tokens-list-visitors.derived";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
 import { createIcpUserToken } from "$tests/mocks/tokens-page.mock";
 import { get } from "svelte/store";

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -21,7 +21,6 @@ import { get } from "svelte/store";
 
 describe("icrcTokensUniversesStore", () => {
   beforeEach(() => {
-    tokensStore.reset();
     defaultIcrcCanistersStore.reset();
   });
 

--- a/frontend/src/tests/lib/derived/main-transaction-fee.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/main-transaction-fee.derived.spec.ts
@@ -9,9 +9,6 @@ import { TokenAmount } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("mainTransactionFeeStoreAsToken", () => {
-  beforeEach(() => {
-    tokensStore.reset();
-  });
   it("should return transaction fee as token", () => {
     const value = get(mainTransactionFeeStoreAsToken);
     expect(value instanceof TokenAmount).toBeTruthy();

--- a/frontend/src/tests/lib/derived/selected-token.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-token.derived.spec.ts
@@ -14,7 +14,6 @@ describe("selectedTokenStore", () => {
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
     });
-    tokensStore.reset();
   });
 
   it("should return ICPToken for NNS universe", () => {

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -464,7 +464,6 @@ describe("selected universe derived stores", () => {
 
     beforeEach(() => {
       defaultIcrcCanistersStore.reset();
-      tokensStore.reset();
       defaultIcrcCanistersStore.setCanisters({
         ledgerCanisterId,
         indexCanisterId: principal(1),

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -20,7 +20,6 @@ describe("selected-project-new-transaction-data derived store", () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
       resetSnsProjects();
       snsSwapCommitmentsStore.reset();
-      tokensStore.reset();
     });
 
     it("returns undefined when nns", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -6,7 +6,6 @@ import {
 } from "$lib/derived/sns/sns-selected-project.derived";
 import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
 import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import {
   mockSnsSwapCommitment,

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -34,7 +34,6 @@ describe("selected sns project derived stores", () => {
         },
       ]);
       defaultIcrcCanistersStore.reset();
-      tokensStore.reset();
     });
 
     it("should be set to undefined if NNS Universe", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -19,7 +19,6 @@ describe("snsSelectedTransactionFeeStore", () => {
   };
   beforeEach(() => {
     resetSnsProjects();
-    tokensStore.reset();
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });
 

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -1,6 +1,5 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockToken } from "$tests/mocks/sns-projects.mock";

--- a/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
@@ -46,7 +46,6 @@ describe("tokens-list-base.derived", () => {
   describe("tokensListBaseStore", () => {
     beforeEach(() => {
       resetSnsProjects();
-      tokensStore.reset();
     });
 
     it("should return ICP, ckBTC and ckTESTBTC without any other data loaded", () => {

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -212,7 +212,6 @@ describe("tokens-list-user.derived", () => {
     beforeEach(() => {
       resetAccountsForTesting();
       icrcAccountsStore.reset();
-      tokensStore.reset();
       authStore.setForTesting(mockIdentity);
       resetSnsProjects();
 

--- a/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
@@ -160,7 +160,6 @@ describe("tokens-list-base.derived", () => {
   describe("tokensListVisitorsStore", () => {
     beforeEach(() => {
       resetSnsProjects();
-      tokensStore.reset();
       setCkETHCanisters();
     });
 

--- a/frontend/src/tests/lib/derived/tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens.derived.spec.ts
@@ -39,7 +39,6 @@ describe("tokens.derived", () => {
   };
 
   beforeEach(() => {
-    tokensStore.reset();
     resetSnsProjects();
 
     setSnsProjects([

--- a/frontend/src/tests/lib/derived/universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes.derived.spec.ts
@@ -32,7 +32,6 @@ describe("universes derived stores", () => {
   beforeEach(() => {
     resetSnsProjects();
     defaultIcrcCanistersStore.reset();
-    tokensStore.reset();
   });
 
   describe("ckBTC both enabled", () => {

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -116,7 +116,6 @@ describe("CkBTCWallet", () => {
     vi.clearAllMocks();
     vi.clearAllTimers();
     vi.useRealTimers();
-    tokensStore.reset();
     ckBTCInfoStore.reset();
     bitcoinAddressStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -116,7 +116,6 @@ describe("IcrcWallet", () => {
     vi.clearAllMocks();
     vi.clearAllTimers();
     vi.useRealTimers();
-    tokensStore.reset();
     resetIdentity();
     defaultIcrcCanistersStore.reset();
     busyStore.resetForTesting();

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -59,7 +59,6 @@ describe("SnsNeuronDetail", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    tokensStore.reset();
     snsNeuronsStore.reset();
     icrcAccountsStore.reset();
     setSnsProjects([

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -11,7 +11,6 @@ import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
 import * as checkNeuronsService from "$lib/services/sns-neurons-check-balances.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import {
   getSnsNeuronIdAsHexString,
   subaccountToHexString,

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -77,7 +77,6 @@ describe("SnsWallet", () => {
     vi.useRealTimers();
     resetIdentity();
     icrcAccountsStore.reset();
-    tokensStore.reset();
     resetSnsProjects();
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -9,7 +9,6 @@ import * as workerBalancesServices from "$lib/services/worker-balances.services"
 import * as workerTransactions from "$lib/services/worker-transactions.services";
 import * as workerTransactionsServices from "$lib/services/worker-transactions.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { aggregatorCanisterLogoPath } from "$lib/utils/sns-aggregator-converters.utils";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -24,7 +24,6 @@ describe("ckbtc-tokens-services", () => {
       symbol: "ckTESTBTC",
     };
     beforeEach(() => {
-      tokensStore.reset();
       vi.spyOn(ledgerApi, "queryIcrcToken").mockImplementation(
         async ({ canisterId }) => {
           if (canisterId.toText() === CKBTC_UNIVERSE_CANISTER_ID.toText()) {

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -48,7 +48,6 @@ describe("icrc-accounts-services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-    tokensStore.reset();
     icrcAccountsStore.reset();
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();

--- a/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
@@ -18,7 +18,6 @@ describe("icrc-tokens.services", () => {
 
     beforeEach(() => {
       defaultIcrcCanistersStore.reset();
-      tokensStore.reset();
       vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockImplementation(
         async ({ canisterId }) => {
           if (canisterId.toText() === ledgerCanisterId1.toText()) {

--- a/frontend/src/tests/lib/services/public/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/app.services.spec.ts
@@ -27,7 +27,6 @@ describe("public/app-services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     defaultIcrcCanistersStore.reset();
-    tokensStore.reset();
     vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockCkETHToken);
     overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
   });

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -74,7 +74,6 @@ describe("SNS public services", () => {
   blockAllCallsTo(blockedPaths);
 
   beforeEach(() => {
-    tokensStore.reset();
     clearSnsAggregatorCache();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -16,7 +16,6 @@ import {
   snsAggregatorIncludingAbortedProjectsStore,
   snsAggregatorStore,
 } from "$lib/stores/sns-aggregator.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -19,7 +19,6 @@ describe("sns-accounts-balance.services", () => {
     resetIdentity();
     vi.clearAllMocks();
     icrcAccountsStore.reset();
-    tokensStore.reset();
     resetSnsProjects();
 
     setSnsProjects([

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -2,7 +2,6 @@ import * as ledgerApi from "$lib/api/icrc-ledger.api";
 import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
 import * as services from "$lib/services/sns-accounts-balance.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -476,10 +476,6 @@ describe("sns-neurons-services", () => {
   });
 
   describe("stakeNeuron", () => {
-    beforeEach(() => {
-      tokensStore.reset();
-    });
-
     it("should call sns api stakeNeuron, query neurons again and load sns accounts", async () => {
       setSnsProjects([
         {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -135,7 +135,6 @@ describe("sns-api", () => {
 
     snsTicketsStore.reset();
     resetAccountsForTesting();
-    tokensStore.reset();
 
     vi.spyOn(agentApi, "createAgent").mockImplementation(async () =>
       mock<Agent>()

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -21,7 +21,6 @@ describe("wallet-uncertified-accounts.services", () => {
   beforeEach(() => {
     resetIdentity();
     icrcAccountsStore.reset();
-    tokensStore.reset();
     vi.spyOn(toastsStore, "toastsError");
   });
 

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -9,7 +9,6 @@ import * as services from "$lib/services/wallet-uncertified-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCMainAccount,

--- a/frontend/src/tests/lib/stores/tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/tokens.store.spec.ts
@@ -9,8 +9,6 @@ import { mockTokens, mockUniversesTokens } from "$tests/mocks/tokens.mock";
 import { get } from "svelte/store";
 
 describe("Tokens store", () => {
-  beforeEach(() => tokensStore.reset());
-
   const ckBtcData = {
     canisterId: CKBTC_UNIVERSE_CANISTER_ID,
     token: mockCkBTCToken,

--- a/frontend/src/tests/lib/utils/icrc-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-tokens.utils.spec.ts
@@ -27,10 +27,6 @@ import { IcrcMetadataResponseEntries } from "@dfinity/ledger-icrc";
 import { get } from "svelte/store";
 
 describe("ICRC tokens utils", () => {
-  beforeEach(() => {
-    tokensStore.reset();
-  });
-
   describe("mapOptionalToken", () => {
     it("should return token", () => {
       const token = mapOptionalToken(mockQueryTokenResponse);

--- a/frontend/src/tests/routes/app/accounts/layout.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/layout.spec.ts
@@ -13,7 +13,6 @@ import { get } from "svelte/store";
 describe("Accounts layout", () => {
   beforeEach(() => {
     layoutTitleStore.set({ title: "" });
-    tokensStore.reset();
     page.mock({
       routeId: AppPath.Accounts,
       data: {

--- a/frontend/src/tests/routes/app/home/layout.spec.ts
+++ b/frontend/src/tests/routes/app/home/layout.spec.ts
@@ -9,7 +9,6 @@ import { get } from "svelte/store";
 describe("Home layout", () => {
   beforeEach(() => {
     layoutTitleStore.set({ title: "" });
-    tokensStore.reset();
     page.mock({
       routeId: "/",
       data: {

--- a/frontend/src/tests/routes/app/home/layout.spec.ts
+++ b/frontend/src/tests/routes/app/home/layout.spec.ts
@@ -1,6 +1,5 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { layoutTitleStore } from "$lib/stores/layout.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import AccountsLayout from "$routes/(app)/(home)/+layout.svelte";
 import { render } from "@testing-library/svelte";

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -137,7 +137,6 @@ describe("Tokens route", () => {
     beforeEach(() => {
       vi.clearAllMocks();
       icrcAccountsStore.reset();
-      tokensStore.reset();
       defaultIcrcCanistersStore.reset();
       importedTokensStore.reset();
       failedImportedTokenLedgerIdsStore.reset();


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `tokensStore`.

# Changes

1. Remove resetting of `tokensStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary