### PR TITLE
Stop calling icrcAccountsStore.reset() in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -19,7 +19,6 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 describe("SelectAccountDropdown", () => {
   beforeEach(() => {
     resetSnsProjects();
-    icrcAccountsStore.reset();
   });
 
   describe("no accounts", () => {

--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -16,7 +16,6 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 describe("SelectDestinationAddress", () => {
   beforeEach(() => {
     resetSnsProjects();
-    icrcAccountsStore.reset();
   });
 
   describe("nns accounts", () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -23,7 +23,6 @@ import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseDropdown", () => {
   beforeEach(() => {
-    icrcAccountsStore.reset();
     resetSnsProjects();
     resetIdentity();
 

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -42,7 +42,6 @@ import { render } from "@testing-library/svelte";
 describe("UniverseAccountsBalance", () => {
   beforeEach(() => {
     resetSnsProjects();
-    icrcAccountsStore.reset();
 
     page.mock({
       data: { universe: mockSnsCanisterId.toText() },

--- a/frontend/src/tests/lib/derived/sns/sns-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-accounts.derived.spec.ts
@@ -33,7 +33,6 @@ describe("sns-accounts.derived", () => {
 
   beforeEach(() => {
     resetSnsProjects();
-    icrcAccountsStore.reset();
 
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -211,7 +211,6 @@ describe("tokens-list-user.derived", () => {
   describe("tokensListUserStore", () => {
     beforeEach(() => {
       resetAccountsForTesting();
-      icrcAccountsStore.reset();
       authStore.setForTesting(mockIdentity);
       resetSnsProjects();
 

--- a/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
@@ -22,7 +22,6 @@ import { get } from "svelte/store";
 describe("universes-accounts", () => {
   beforeEach(() => {
     resetSnsProjects();
-    icrcAccountsStore.reset();
   });
 
   it("should derive Nns accounts", () => {

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -33,7 +33,6 @@ describe("IcrcTokenTransactionModal", () => {
       data: { universe: ledgerCanisterId.toText() },
       routeId: AppPath.Accounts,
     });
-    icrcAccountsStore.reset();
     vi.spyOn(ledgerApi, "icrcTransfer").mockResolvedValue(1234n);
   });
 

--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -47,7 +47,6 @@ describe("DisburseSnsNeuronModal", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     resetSnsProjects();
-    icrcAccountsStore.reset();
 
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
       testIdentity

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsDisburseMaturityModal.spec.ts
@@ -44,7 +44,6 @@ describe("SnsDisburseMaturityModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetSnsProjects();
-    icrcAccountsStore.reset();
 
     authStore.setForTesting(mockIdentity);
     setSnsProjects([

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
@@ -54,7 +54,6 @@ describe("SnsIncreaseStakeNeuronModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetSnsProjects();
-    icrcAccountsStore.reset();
     page.mock({
       routeId: AppPath.Neuron,
       data: { universe: rootCanisterId.toText() },

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
@@ -38,7 +38,6 @@ describe("SnsStakeNeuronModal", () => {
   beforeEach(() => {
     resetIdentity();
     resetSnsProjects();
-    icrcAccountsStore.reset();
 
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -73,7 +73,6 @@ describe("TransactionModal", () => {
   beforeEach(() => {
     resetIdentity();
     resetSnsProjects();
-    icrcAccountsStore.reset();
 
     setAccountsForTesting({
       main: mockMainAccount,

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -120,7 +120,6 @@ describe("CkBTCWallet", () => {
     bitcoinAddressStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
     resetIdentity();
-    icrcAccountsStore.reset();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],
@@ -214,8 +213,6 @@ describe("CkBTCWallet", () => {
     let resolveAccounts: (Account) => void;
 
     beforeEach(() => {
-      icrcAccountsStore.reset();
-
       page.mock({
         data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
         routeId: AppPath.Wallet,

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -195,8 +195,6 @@ describe("IcrcWallet", () => {
     let resolveAccounts: (bigint) => void;
 
     beforeEach(() => {
-      icrcAccountsStore.reset();
-
       page.mock({
         data: { universe: CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText() },
         routeId: AppPath.Wallet,

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -9,7 +9,6 @@ import {
 import { pageStore } from "$lib/derived/page.derived";
 import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
 import * as checkNeuronsService from "$lib/services/sns-neurons-check-balances.services";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import {
   getSnsNeuronIdAsHexString,
@@ -59,7 +58,6 @@ describe("SnsNeuronDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     snsNeuronsStore.reset();
-    icrcAccountsStore.reset();
     setSnsProjects([
       {
         projectName,

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -8,7 +8,6 @@ import * as workerBalances from "$lib/services/worker-balances.services";
 import * as workerBalancesServices from "$lib/services/worker-balances.services";
 import * as workerTransactions from "$lib/services/worker-transactions.services";
 import * as workerTransactionsServices from "$lib/services/worker-transactions.services";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { aggregatorCanisterLogoPath } from "$lib/utils/sns-aggregator-converters.utils";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
@@ -75,7 +74,6 @@ describe("SnsWallet", () => {
   beforeEach(() => {
     vi.useRealTimers();
     resetIdentity();
-    icrcAccountsStore.reset();
     resetSnsProjects();
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -7,7 +7,6 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import Staking from "$lib/routes/Staking.svelte";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { page } from "$mocks/$app/stores";
@@ -42,7 +41,6 @@ describe("Staking", () => {
     resetSnsProjects();
     resetIdentity();
     resetAccountsForTesting();
-    icrcAccountsStore.reset();
 
     page.mock({
       routeId: AppPath.Staking,

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -11,7 +11,6 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import Wallet from "$lib/routes/Wallet.svelte";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
@@ -108,7 +107,6 @@ describe("Wallet", () => {
       []
     );
 
-    icrcAccountsStore.reset();
     ckEthBalance = 1000000000000000000n;
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockImplementation(
       async ({ canisterId }) => {

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -48,7 +48,6 @@ describe("icrc-accounts-services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-    icrcAccountsStore.reset();
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();
     resetSnsProjects();
@@ -76,7 +75,6 @@ describe("icrc-accounts-services", () => {
   describe("loadAccounts", () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      icrcAccountsStore.reset();
       vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
 
@@ -332,7 +330,6 @@ describe("icrc-accounts-services", () => {
   describe("syncAccounts", () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      icrcAccountsStore.reset();
     });
 
     it("should call ckBTC accounts and token and load them in store", async () => {

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -1,7 +1,6 @@
 import * as ledgerApi from "$lib/api/icrc-ledger.api";
 import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
 import * as services from "$lib/services/sns-accounts-balance.services";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
@@ -17,7 +16,6 @@ describe("sns-accounts-balance.services", () => {
   beforeEach(() => {
     resetIdentity();
     vi.clearAllMocks();
-    icrcAccountsStore.reset();
     resetSnsProjects();
 
     setSnsProjects([

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -32,7 +32,6 @@ describe("sns-accounts-services", () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      icrcAccountsStore.reset();
 
       setSnsProjects([
         {

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -6,7 +6,6 @@ import {
 import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import * as services from "$lib/services/wallet-uncertified-accounts.services";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -19,7 +18,6 @@ import { get } from "svelte/store";
 describe("wallet-uncertified-accounts.services", () => {
   beforeEach(() => {
     resetIdentity();
-    icrcAccountsStore.reset();
     vi.spyOn(toastsStore, "toastsError");
   });
 

--- a/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
@@ -14,8 +14,6 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("icrc Accounts store", () => {
-  beforeEach(() => icrcAccountsStore.reset());
-
   const accounts: Account[] = [mockCkBTCMainAccount];
 
   it("should set accounts", () => {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -17,7 +17,6 @@ import {
 } from "$lib/constants/ckusdc-canister-ids.constants";
 import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import {
   failedImportedTokenLedgerIdsStore,
   importedTokensStore,
@@ -136,7 +135,6 @@ describe("Tokens route", () => {
   describe("when feature flag enabled", () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      icrcAccountsStore.reset();
       defaultIcrcCanistersStore.reset();
       importedTokensStore.reset();
       failedImportedTokenLedgerIdsStore.reset();


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `icrcAccountsStore`.

# Changes

1. Remove resetting of `icrcAccountsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary