### PR TITLE
housekeeping: removes createChunks utility

### DIFF
--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -104,21 +104,6 @@ export const targetBlankLinkRenderer = (
       : ` target="_blank" rel="noopener noreferrer" href="${href}"`
   }${title === null ? "" : ` title="${title}"`}>${text}</a>`;
 
-/**
- * Returns an array of arrays of size <= `chunkSize`
- */
-export const createChunks = <T>(
-  elements: Array<T>,
-  chunkSize = 10
-): Array<Array<T>> => {
-  const chunks: Array<Array<T>> = [];
-  for (let i = 0; i < elements.length; i += chunkSize) {
-    const chunk = elements.slice(i, i + chunkSize);
-    chunks.push(chunk);
-  }
-  return chunks;
-};
-
 // e.g. payloads.did/state_hash
 export const isHash = (bytes: number[]): boolean =>
   bytes.length === 32 &&

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -3,7 +3,6 @@ import {
   PollingLimitExceededError,
   bytesToHexString,
   cancelPoll,
-  createChunks,
   expandObject,
   getObjMaxDepth,
   hexStringToBytes,
@@ -120,23 +119,6 @@ describe("utils", () => {
 
     it("should return false if undefined", () => {
       expect(isDefined(undefined)).toBe(false);
-    });
-  });
-
-  describe("createChunks", () => {
-    it("create chunks of elements", () => {
-      const twenty = new Array(20).fill(1);
-      expect(createChunks(twenty).length).toBe(2);
-      expect(createChunks(twenty)[0].length).toBe(10);
-      expect(createChunks(twenty, 7).length).toBe(3);
-      expect(createChunks(twenty, 7)[0].length).toBe(7);
-      expect(createChunks(twenty, 7)[1].length).toBe(7);
-      expect(createChunks(twenty, 7)[2].length).toBe(6);
-      expect(createChunks(twenty)[0].length).toBe(10);
-      expect(createChunks(twenty, 5).length).toBe(4);
-      expect(createChunks(twenty, 5)[0].length).toBe(5);
-      expect(createChunks(twenty, 1).length).toBe(twenty.length);
-      expect(createChunks(twenty, 1)[0].length).toBe(1);
     });
   });
 


### PR DESCRIPTION
# Motivation

Removes an unused utility function that was introduced in #610 and last used in #999. The function hasn't been used in two years, so it is safe to delete.

# Changes

- Removes createChunks utility function

# Tests

- Removed tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary