### PR TITLE
housekeeping: removes targetBlankLinkRenderer utility

### DIFF
--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -93,17 +93,6 @@ export const uniqueObjects = <T>(list: T[]): T[] => {
 export const isDefined = <T>(argument: T | undefined): argument is T =>
   argument !== undefined;
 
-export const targetBlankLinkRenderer = (
-  href: string | null,
-  title: string | null,
-  text: string
-): string =>
-  `<a${
-    href === null
-      ? ""
-      : ` target="_blank" rel="noopener noreferrer" href="${href}"`
-  }${title === null ? "" : ` title="${title}"`}>${text}</a>`;
-
 /**
  * Returns an array of arrays of size <= `chunkSize`
  */


### PR DESCRIPTION
# Motivation

Removes an unused utility function that was introduced in #594 and later removed in #5446. The markdown component has been moved to GIX, making this function unnecessary.

# Changes

- Removes targetBlankLinkRenderer utility function

# Tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary