### PR TITLE
Sort utils

### DIFF
--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -1,8 +1,8 @@
 import type {
-  Comparator,
   ResponsiveTableColumn,
   ResponsiveTableOrder,
 } from "$lib/types/responsive-table";
+import type { Comparator } from "$lib/utils/sort.utils";
 import type { NeuronState } from "@dfinity/nns";
 import type { TokenAmountV2 } from "@dfinity/utils";
 

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -1,3 +1,4 @@
+import type { Comparator } from "$lib/utils/sort.utils";
 import type { ComponentType, SvelteComponent } from "svelte";
 
 export interface ResponsiveTableRowData {
@@ -25,11 +26,6 @@ export interface ResponsiveTableColumn<
   templateColumns: TemplateItem[];
   comparator?: Comparator<RowDataType>;
 }
-
-export type Comparator<RowDataType> = (
-  a: RowDataType,
-  b: RowDataType
-) => number;
 
 export type ResponsiveTableOrder<ColumnIdType = string> = Array<{
   columnId: ColumnIdType;

--- a/frontend/src/lib/utils/neurons-table-order-sorted-neuron-ids-store.utils.ts
+++ b/frontend/src/lib/utils/neurons-table-order-sorted-neuron-ids-store.utils.ts
@@ -1,6 +1,6 @@
 import type { NeuronsTableOrder, TableNeuron } from "$lib/types/neurons-table";
 import { comparatorsByColumnId } from "$lib/utils/neurons-table.utils";
-import { mergeComparators, negate } from "$lib/utils/responsive-table.utils";
+import { mergeComparators, negate } from "$lib/utils/sort.utils";
 
 export const getSortedNeuronIds = (
   order: NeuronsTableOrder,

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -16,11 +16,6 @@ import {
   neuronStakedMaturity,
 } from "$lib/utils/neuron.utils";
 import {
-  createAscendingComparator,
-  createDescendingComparator,
-  mergeComparators,
-} from "$lib/utils/responsive-table.utils";
-import {
   getSnsDissolveDelaySeconds,
   getSnsNeuronAvailableMaturity,
   getSnsNeuronIdAsHexString,
@@ -29,6 +24,11 @@ import {
   getSnsNeuronState,
   getSnsNeuronTags,
 } from "$lib/utils/sns-neuron.utils";
+import {
+  createAscendingComparator,
+  createDescendingComparator,
+  mergeComparators,
+} from "$lib/utils/sort.utils";
 import type { Identity } from "@dfinity/agent";
 import type { NeuronInfo } from "@dfinity/nns";
 import { NeuronState } from "@dfinity/nns";

--- a/frontend/src/lib/utils/responsive-table.utils.ts
+++ b/frontend/src/lib/utils/responsive-table.utils.ts
@@ -1,52 +1,11 @@
 import type {
-  Comparator,
   ResponsiveTableColumn,
   ResponsiveTableOrder,
   ResponsiveTableRowData,
 } from "$lib/types/responsive-table";
+import { mergeComparators, negate } from "$lib/utils/sort.utils";
 
 export const getCellGridAreaName = (index: number) => `cell-${index}`;
-
-// Takes a list of comparators and returns a single comparator by first applying
-// the first comparator and using subsequent comparators to break ties.
-export const mergeComparators = <RowDataType>(
-  comparators: Comparator<RowDataType>[]
-): Comparator<RowDataType> => {
-  return (a, b) => {
-    for (const comparator of comparators) {
-      const result = comparator(a, b);
-      if (result !== 0) {
-        return result;
-      }
-    }
-    return 0;
-  };
-};
-
-// Creates a comparator for sorting in descending order based on the value
-// returned by the getter function.
-export const createDescendingComparator = <RowDataType, Comparable>(
-  getter: (rowData: RowDataType) => Comparable
-): Comparator<RowDataType> => {
-  return (a, b) => {
-    const valueA = getter(a);
-    const valueB = getter(b);
-    if (valueA < valueB) return 1;
-    if (valueA > valueB) return -1;
-    return 0;
-  };
-};
-
-export const negate = <T>(comparator: Comparator<T>): Comparator<T> => {
-  // `|| 0` is to avoid the value `-0`.
-  return (a, b) => -comparator(a, b) || 0;
-};
-
-// Same as createDescendingComparator but returns a comparator for sorting in
-// ascending order.
-export const createAscendingComparator = <RowDataType, Comparable>(
-  getter: (rowData: RowDataType) => Comparable
-): Comparator<RowDataType> => negate(createDescendingComparator(getter));
 
 // Creates the new table order resulting from clicking on a column header.  This
 // means reversing the order if the selected column is already the primary

--- a/frontend/src/lib/utils/sort.utils.ts
+++ b/frontend/src/lib/utils/sort.utils.ts
@@ -1,0 +1,44 @@
+export type Comparator<DataType> = (a: DataType, b: DataType) => number;
+
+// Takes a list of comparators and returns a single comparator by first applying
+// the first comparator and using subsequent comparators to break ties.
+export const mergeComparators = <DataType>(
+  comparators: Comparator<DataType>[]
+): Comparator<DataType> => {
+  return (a, b) => {
+    for (const comparator of comparators) {
+      const result = comparator(a, b);
+      if (result !== 0) {
+        return result;
+      }
+    }
+    return 0;
+  };
+};
+
+export const negate = <DataType>(
+  comparator: Comparator<DataType>
+): Comparator<DataType> => {
+  // `|| 0` is to avoid the value `-0`.
+  return (a, b) => -comparator(a, b) || 0;
+};
+
+// Creates a comparator for sorting in descending order based on the value
+// returned by the getter function.
+export const createDescendingComparator = <DataType, Comparable>(
+  getter: (rowData: DataType) => Comparable
+): Comparator<DataType> => {
+  return (a, b) => {
+    const valueA = getter(a);
+    const valueB = getter(b);
+    if (valueA < valueB) return 1;
+    if (valueA > valueB) return -1;
+    return 0;
+  };
+};
+
+// Same as createDescendingComparator but returns a comparator for sorting in
+// ascending order.
+export const createAscendingComparator = <DataType, Comparable>(
+  getter: (rowData: DataType) => Comparable
+): Comparator<DataType> => negate(createDescendingComparator(getter));

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -9,16 +9,16 @@ import {
   hasValidStake as nnsHasValidStake,
 } from "$lib/utils/neuron.utils";
 import {
-  createAscendingComparator,
-  createDescendingComparator,
-  mergeComparators,
-} from "$lib/utils/responsive-table.utils";
-import {
   getSnsNeuronAvailableMaturity,
   getSnsNeuronStake,
   getSnsNeuronStakedMaturity,
   hasValidStake as snsHasValidStake,
 } from "$lib/utils/sns-neuron.utils";
+import {
+  createAscendingComparator,
+  createDescendingComparator,
+  mergeComparators,
+} from "$lib/utils/sort.utils";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -5,7 +5,7 @@ import {
   createAscendingComparator,
   createDescendingComparator,
   mergeComparators,
-} from "$lib/utils/responsive-table.utils";
+} from "$lib/utils/sort.utils";
 import { isUserTokenFailed } from "$lib/utils/user-token.utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -1,6 +1,6 @@
 import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
 import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
-import { createAscendingComparator } from "$lib/utils/responsive-table.utils";
+import { createAscendingComparator } from "$lib/utils/sort.utils";
 import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
 import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
 import { ResponsiveTablePo } from "$tests/page-objects/ResponsiveTable.page-object";

--- a/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
@@ -3,7 +3,7 @@ import type {
   ResponsiveTableColumn,
   ResponsiveTableOrder,
 } from "$lib/types/responsive-table";
-import { createAscendingComparator } from "$lib/utils/responsive-table.utils";
+import { createAscendingComparator } from "$lib/utils/sort.utils";
 import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
 import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
 import { ResponsiveTableSortModalPo } from "$tests/page-objects/ResponsiveTableSortModal.page-object";

--- a/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
@@ -1,13 +1,10 @@
 import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
 import {
-  createAscendingComparator,
-  createDescendingComparator,
   getCellGridAreaName,
-  mergeComparators,
-  negate,
   selectPrimaryOrder,
   sortTableData,
 } from "$lib/utils/responsive-table.utils";
+import { createAscendingComparator } from "$lib/utils/sort.utils";
 
 describe("responsive-table.utils", () => {
   describe("getCellGridAreaName", () => {
@@ -15,46 +12,6 @@ describe("responsive-table.utils", () => {
       expect(getCellGridAreaName(0)).toBe("cell-0");
       expect(getCellGridAreaName(1)).toBe("cell-1");
       expect(getCellGridAreaName(7)).toBe("cell-7");
-    });
-  });
-
-  describe("createDescendingComparator", () => {
-    it("should return a comparator that sorts in descending order", () => {
-      const item1 = { value: 10 };
-      const item2 = { value: 20 };
-      const comparator = createDescendingComparator(({ value }) => value);
-      expect(comparator(item1, item2)).toBe(1);
-      expect(comparator(item2, item1)).toBe(-1);
-      expect(comparator(item1, item1)).toBe(0);
-    });
-  });
-
-  describe("createAscendingComparator", () => {
-    it("should return a comparator that sorts in ascending order", () => {
-      const item1 = { value: 10 };
-      const item2 = { value: 20 };
-      const comparator = createAscendingComparator(({ value }) => value);
-      expect(comparator(item1, item2)).toBe(-1);
-      expect(comparator(item2, item1)).toBe(1);
-      expect(comparator(item1, item1)).toBe(0);
-    });
-  });
-
-  describe("mergeComparators", () => {
-    it("should create a lexicographic comparator", () => {
-      const item1 = { a: 10, b: 10 };
-      const item2 = { a: 10, b: 20 };
-      const item3 = { a: 20, b: 10 };
-      const item4 = { a: 20, b: 20 };
-      const comparatorA = createAscendingComparator(({ a }) => a);
-      const comparatorB = createAscendingComparator(({ b }) => b);
-      const comparator = mergeComparators([comparatorA, comparatorB]);
-      expect(comparator(item1, item2)).toBe(-1);
-      expect(comparator(item2, item1)).toBe(1);
-      expect(comparator(item2, item3)).toBe(-1);
-      expect(comparator(item3, item2)).toBe(1);
-      expect(comparator(item3, item4)).toBe(-1);
-      expect(comparator(item4, item3)).toBe(1);
     });
   });
 
@@ -189,30 +146,6 @@ describe("responsive-table.utils", () => {
           columns,
         })
       ).toEqual([item2, item1, item4, item3]);
-    });
-  });
-
-  describe("negate", () => {
-    it("should negate the result of a comparator", () => {
-      const ascendingComparator = (a: number, b: number) => a - b;
-      const negatedComparator = negate(ascendingComparator);
-
-      expect(ascendingComparator(1, 2)).toBe(-1);
-      expect(negatedComparator(1, 2)).toBe(1);
-
-      expect(ascendingComparator(2, 1)).toBe(1);
-      expect(negatedComparator(2, 1)).toBe(-1);
-
-      expect(ascendingComparator(1, 1)).toBe(0);
-      expect(negatedComparator(1, 1)).toBe(0);
-    });
-
-    it("should avoid returning -0", () => {
-      const alwaysZeroComparator = () => 0;
-      const negatedComparator = negate(alwaysZeroComparator);
-
-      expect(Object.is(negatedComparator(1, 2), -0)).toBe(false);
-      expect(negatedComparator(1, 2)).toBe(0);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/sort.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sort.utils.spec.ts
@@ -1,0 +1,72 @@
+import {
+  createAscendingComparator,
+  createDescendingComparator,
+  mergeComparators,
+  negate,
+} from "$lib/utils/sort.utils";
+
+describe("sort.utils", () => {
+  describe("createDescendingComparator", () => {
+    it("should return a comparator that sorts in descending order", () => {
+      const item1 = { value: 10 };
+      const item2 = { value: 20 };
+      const comparator = createDescendingComparator(({ value }) => value);
+      expect(comparator(item1, item2)).toBe(1);
+      expect(comparator(item2, item1)).toBe(-1);
+      expect(comparator(item1, item1)).toBe(0);
+    });
+  });
+
+  describe("createAscendingComparator", () => {
+    it("should return a comparator that sorts in ascending order", () => {
+      const item1 = { value: 10 };
+      const item2 = { value: 20 };
+      const comparator = createAscendingComparator(({ value }) => value);
+      expect(comparator(item1, item2)).toBe(-1);
+      expect(comparator(item2, item1)).toBe(1);
+      expect(comparator(item1, item1)).toBe(0);
+    });
+  });
+
+  describe("mergeComparators", () => {
+    it("should create a lexicographic comparator", () => {
+      const item1 = { a: 10, b: 10 };
+      const item2 = { a: 10, b: 20 };
+      const item3 = { a: 20, b: 10 };
+      const item4 = { a: 20, b: 20 };
+      const comparatorA = createAscendingComparator(({ a }) => a);
+      const comparatorB = createAscendingComparator(({ b }) => b);
+      const comparator = mergeComparators([comparatorA, comparatorB]);
+      expect(comparator(item1, item2)).toBe(-1);
+      expect(comparator(item2, item1)).toBe(1);
+      expect(comparator(item2, item3)).toBe(-1);
+      expect(comparator(item3, item2)).toBe(1);
+      expect(comparator(item3, item4)).toBe(-1);
+      expect(comparator(item4, item3)).toBe(1);
+    });
+  });
+
+  describe("negate", () => {
+    it("should negate the result of a comparator", () => {
+      const ascendingComparator = (a: number, b: number) => a - b;
+      const negatedComparator = negate(ascendingComparator);
+
+      expect(ascendingComparator(1, 2)).toBe(-1);
+      expect(negatedComparator(1, 2)).toBe(1);
+
+      expect(ascendingComparator(2, 1)).toBe(1);
+      expect(negatedComparator(2, 1)).toBe(-1);
+
+      expect(ascendingComparator(1, 1)).toBe(0);
+      expect(negatedComparator(1, 1)).toBe(0);
+    });
+
+    it("should avoid returning -0", () => {
+      const alwaysZeroComparator = () => 0;
+      const negatedComparator = negate(alwaysZeroComparator);
+
+      expect(Object.is(negatedComparator(1, 2), -0)).toBe(false);
+      expect(negatedComparator(1, 2)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Move sorting utility functions from `responsive-table.utils` to `sort.utils` to reuse them outside of the tables.

Note: the changes should be easy to review by commit.

# Changes

1. Moved `type Comparator`, `createAscendingComparator`, `createDescendingComparator`, `mergeComparators` and `negate` into sort.utils.ts.
2. Renamed generic type `RowDataType` to `DataType`.
3. Updated imports.

# Tests

- Related tests moved to `sort.utils.spec`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.