### PR TITLE
Filter out SNSes without lifecycle

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -32,6 +32,7 @@ proposal is successful, the changes it released will be moved from this file to
 * User gets the wrong identity when connecting different hardware wallets devices in a certain order.
 * Fix candid decoding error of stable memory.
 * Show successfully loaded swap commitments even if some fail to load.
+* Hide SNSes for which the aggregator doesn't have a lifecycle.
 
 #### Security
 

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -1,5 +1,6 @@
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { SnsSwapLifecycle } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
 
 /**
@@ -35,7 +36,9 @@ export const snsAggregatorStore: SnsAggregatorStore = derived(
   snsAggregatorIncludingAbortedProjectsStore,
   (store) => ({
     data: store.data?.filter(
-      (sns) => sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
+      (sns) =>
+        nonNullish(sns.lifecycle) &&
+        sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
     ),
   })
 );

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -229,5 +229,5 @@ export type CachedSnsDto = {
   derived_state: CachedSnsSwapDerivedDto;
   swap_params: CachedSwapParamsResponseDto;
   init: CachedInitResponseDto;
-  lifecycle: CachedLifecycleResponseDto;
+  lifecycle: CachedLifecycleResponseDto | null;
 };

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -467,27 +467,33 @@ const convertDtoToSnsSummarySwap = (
 };
 
 const convertDtoToLifecycle = (
-  data: CachedLifecycleResponseDto
-): SnsGetLifecycleResponse => ({
-  decentralization_sale_open_timestamp_seconds: toNullable(
-    convertOptionalNumToBigInt(
-      data.decentralization_sale_open_timestamp_seconds
-    )
-  ),
-  lifecycle: toNullable(data.lifecycle),
-  // TODO: Add support in SNS Aggregaro for these fields
-  decentralization_swap_termination_timestamp_seconds: [],
-});
+  data: CachedLifecycleResponseDto | null
+): SnsGetLifecycleResponse | undefined => {
+  if (isNullish(data)) {
+    return undefined;
+  }
+  return {
+    decentralization_sale_open_timestamp_seconds: toNullable(
+      convertOptionalNumToBigInt(
+        data.decentralization_sale_open_timestamp_seconds
+      )
+    ),
+    lifecycle: toNullable(data.lifecycle),
+    // TODO: Add support in SNS Aggregaro for these fields
+    decentralization_swap_termination_timestamp_seconds: [],
+  };
+};
 
 type PartialSummary = Omit<
   SnsSummary,
-  "metadata" | "token" | "swap" | "init" | "swapParams"
+  "metadata" | "token" | "swap" | "init" | "swapParams" | "lifecycle"
 > & {
   metadata?: SnsSummaryMetadata;
   token?: IcrcTokenMetadata;
   swap?: SnsSummarySwap;
   init?: SnsSwapInit;
   swapParams?: SnsParams;
+  lifecycle?: SnsGetLifecycleResponse;
 };
 
 const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
@@ -495,7 +501,8 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.token) &&
   nonNullish(entry.swap) &&
   nonNullish(entry.init) &&
-  nonNullish(entry.swapParams);
+  nonNullish(entry.swapParams) &&
+  nonNullish(entry.lifecycle);
 
 export const convertDtoToSnsSummary = ({
   canister_ids: {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -479,7 +479,7 @@ const convertDtoToLifecycle = (
       )
     ),
     lifecycle: toNullable(data.lifecycle),
-    // TODO: Add support in SNS Aggregaro for these fields
+    // TODO: Add support in SNS Aggregator for these fields
     decentralization_swap_termination_timestamp_seconds: [],
   };
 };

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -537,6 +537,16 @@ describe("sns aggregator converters utils", () => {
       ).toBeUndefined();
     });
 
+    it("returns undefined if a lifecycle required field is missing", () => {
+      const aggregatorMissingLifecycle: CachedSnsDto = {
+        ...mockData,
+        lifecycle: null,
+      };
+      expect(
+        convertDtoToSnsSummary(aggregatorMissingLifecycle)
+      ).toBeUndefined();
+    });
+
     it("converts fields related to NF participation enhancements", () => {
       const aggregatorNFAndDirectParticipationFields: CachedSnsDto = {
         ...mockData,


### PR DESCRIPTION
# Motivation

When an SNS swap canister runs out of cycles, the next time the SNS aggregator tries to fetch the data for this SNS, it will overwrite its existing data (at least the data that comes from the swap canister) with empty default data.
This means it will no longer have a value for the `lifecycle` field and this breaks the code that tries to filter out SNSes which are aborted.

We should probably fix the aggregator to not drop information when the canister runs out of cycles but this will take longer.
In the meantime it's better to hide one SNS than for the entire NNS dapp to break.

# Changes

1. Filter out SNSes without `lifecycle` in addition to SNSes with `lifecycle === SnsSwapLifecycle.Aborted` in the aggregator store.
2. Filter out SNSes without `lifecycle` when creating SNS summaries.

# Tests

1. Unit tests added.
2. Updated `snsWithLifecycle` which took 2 unnamed parameters to take named parameters.

# Todos

- [x] Add entry to changelog (if necessary).
