### PR TITLE
Stop using clearAllMocks and resetAllMocks

### DIFF
--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -156,7 +156,6 @@ describe("neurons api-service", () => {
   const neuronId = 12n;
 
   beforeEach(() => {
-    vi.resetAllMocks();
     resetNeuronsApiService();
   });
 

--- a/frontend/src/tests/lib/api/accounts.api.spec.ts
+++ b/frontend/src/tests/lib/api/accounts.api.spec.ts
@@ -8,7 +8,6 @@ import { mock } from "vitest-mock-extended";
 
 describe("accounts-api", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -43,7 +43,6 @@ describe("canisters-api", () => {
   const fee = 10_000n;
 
   beforeEach(() => {
-    vi.resetAllMocks();
     vi.clearAllTimers();
 
     // Prevent HttpAgent.create(), which is called by createAgent, from making a

--- a/frontend/src/tests/lib/api/dashboard.api.spec.ts
+++ b/frontend/src/tests/lib/api/dashboard.api.spec.ts
@@ -3,7 +3,6 @@ import type { DashboardMessageExecutionRateResponse } from "$lib/types/dashboard
 
 describe("Dashboard API", () => {
   beforeEach(() => {
-    vi.resetAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -46,8 +46,6 @@ vi.mock("$lib/api/agent.api", () => {
 describe("neurons-api", () => {
   const mockGovernanceCanister = mock<GovernanceCanister>();
   beforeEach(() => {
-    vi.resetAllMocks();
-
     mockGovernanceCanister.listNeurons.mockImplementation(
       vi.fn().mockResolvedValue([])
     );

--- a/frontend/src/tests/lib/api/icp-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-index.api.spec.ts
@@ -12,7 +12,6 @@ import { mock } from "vitest-mock-extended";
 
 describe("icp-index.api", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.clearAllTimers();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -26,7 +26,6 @@ describe("icrc-index api", () => {
   let spyOnIndexCanisterCreate;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     spyOnIndexCanisterCreate = vi
       .spyOn(IcrcIndexCanister, "create")
       .mockImplementation(() => indexCanisterMock);

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -22,7 +22,6 @@ describe("icrc-ledger api", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useFakeTimers();
     vi.spyOn(IcrcLedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock

--- a/frontend/src/tests/lib/api/imported-tokens.api.spec.ts
+++ b/frontend/src/tests/lib/api/imported-tokens.api.spec.ts
@@ -12,8 +12,6 @@ describe("imported-tokens-api", () => {
   const mockNNSDappCanister = mock<NNSDappCanister>();
 
   beforeEach(() => {
-    vi.resetAllMocks();
-
     vi.spyOn(NNSDappCanister, "create").mockImplementation(
       (): NNSDappCanister => mockNNSDappCanister
     );

--- a/frontend/src/tests/lib/api/location.api.spec.ts
+++ b/frontend/src/tests/lib/api/location.api.spec.ts
@@ -2,10 +2,6 @@ import { queryUserCountryLocation } from "$lib/api/location.api";
 
 describe("location api", () => {
   describe("queryUserCountryLocation", () => {
-    beforeEach(() => {
-      vi.resetAllMocks();
-    });
-
     describe("if GeoIP service works", () => {
       it("should return country code", async () => {
         const countryCode = "CH";

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -3,10 +3,6 @@ import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 
 describe("sns-aggregator api", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
   describe("querySnsProjects", () => {
     it("should fetch json once if less than 10 SNSes", async () => {
       const mockFetch = vi.fn();

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedFee.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedFee.spec.ts
@@ -14,7 +14,6 @@ describe("BitcoinEstimatedFee", () => {
   const result = { minter_fee: 123n, bitcoin_fee: 456n };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     spyEstimateFee = vi
       .spyOn(minterApi, "estimateFee")

--- a/frontend/src/tests/lib/components/accounts/CkBTCInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCInfoCard.spec.ts
@@ -37,7 +37,6 @@ describe("CkBTCInfoCard", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
     bitcoinAddressStore.reset();
     ckBTCInfoStore.reset();
 

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -23,7 +23,6 @@ describe("SelectAccountDropdown", () => {
 
   describe("no accounts", () => {
     beforeEach(() => {
-      vi.clearAllMocks();
       resetAccountsForTesting();
     });
 

--- a/frontend/src/tests/lib/components/accounts/UiTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/UiTransactionsList.spec.ts
@@ -27,10 +27,6 @@ describe("UiTransactionsList", () => {
     return UiTransactionsListPo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders skeleton when loading transactions", async () => {
     vi.spyOn(icrcTransactionsStore, "subscribe").mockImplementation(
       mockIcrcTransactionsStoreSubscribe({})

--- a/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
@@ -24,7 +24,6 @@ describe("CanisterHeadingTitle", () => {
   };
 
   beforeEach(() => {
-    vitest.clearAllMocks();
     window.removeEventListener("nnsCanisterDetailModal", eventListener);
   });
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -30,7 +30,6 @@ describe("ProjectCard", () => {
   const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useFakeTimers().setSystemTime(now);
     vi.spyOn(saleApi, "queryFinalizationStatus").mockResolvedValue(
       createFinalizationStatusMock(false)

--- a/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -6,7 +6,6 @@ import { render, waitFor } from "@testing-library/svelte";
 describe("Projects", () => {
   beforeEach(() => {
     resetSnsProjects();
-    vitest.clearAllMocks();
   });
 
   it("should render 'Open' projects", () => {

--- a/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
+++ b/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
@@ -10,7 +10,6 @@ let metricsCallback: MetricsCallback | undefined;
 
 describe("TotalValueLocked", () => {
   beforeEach(() => {
-    vi.resetAllMocks();
     metricsCallback = undefined;
     metricsStore.set(undefined);
 

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
@@ -29,7 +29,6 @@ describe("NeuronFollowingCard", () => {
     },
   };
   beforeEach(() => {
-    vi.resetAllMocks();
     resetIdentity();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronNavigation.spec.ts
@@ -7,7 +7,6 @@ import { NeuronNavigationPo } from "$tests/page-objects/NeuronNavigation.page-ob
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
-import { vi } from "vitest";
 const testNeurons = [
   {
     ...mockNeuron,

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronNavigation.spec.ts
@@ -34,7 +34,6 @@ const testNeurons = [
 
 describe("NeuronNavigation", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     neuronsStore.setNeurons({ neurons: testNeurons, certified: true });
     page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
   });

--- a/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
@@ -5,10 +5,6 @@ import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextTest from "../NeuronContextTest.svelte";
 
 describe("AddHotkeyButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders add hotkey message", () => {
     const { getByText } = render(NeuronContextTest, {
       props: {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -7,10 +7,6 @@ import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextTest from "../NeuronContextTest.svelte";
 
 describe("DisburseButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders title", () => {
     const { getByText } = render(NeuronContextTest, {
       props: {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseMaturityButton.spec.ts
@@ -13,10 +13,6 @@ describe("DisburseMaturityButton", () => {
     return DisburseMaturityButtonPo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders disburse maturity cta", async () => {
     const po = renderComponent(undefined);
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
@@ -17,10 +17,6 @@ vi.mock("$lib/services/neurons.services", () => {
 });
 
 describe("DissolveActionButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders start dissolve message when neuron is locked", () => {
     const { getByText } = render(DissolveActionButtonTest, {
       props: {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
@@ -7,10 +7,6 @@ import { render } from "@testing-library/svelte";
 import NeuronContextTest from "../NeuronContextTest.svelte";
 
 describe("IncreaseDissolveDelayButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   const renderComponent = (neuron: NeuronInfo) => {
     const { container } = render(NeuronContextTest, {
       props: {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
@@ -11,10 +11,6 @@ vi.mock("$lib/services/neurons.services", () => {
 });
 
 describe("JoinCommunityFundCheckbox", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders enabled checkbox", () => {
     const neuron = {
       ...mockNeuron,

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
@@ -5,10 +5,6 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
 describe("NnsStakeMaturityButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should open stake maturity modal", async () => {
     const { getByText, getByTestId } = render(NeuronContextActionsTest, {
       props: {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
@@ -5,10 +5,6 @@ import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
 describe("SplitNeuronButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders split neuron message", () => {
     const { getByText } = render(NeuronContextActionsTest, {
       props: {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/StakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/StakeMaturityButton.spec.ts
@@ -3,10 +3,6 @@ import en from "$tests/mocks/i18n.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("StakeMaturityButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders stake maturity cta", () => {
     const { getByText } = render(StakeMaturityButton, {
       props: {

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -34,7 +34,6 @@ describe("ParticipateButton", () => {
     beforeEach(() => {
       resetIdentity();
       snsTicketsStore.reset();
-      vi.clearAllMocks();
       userCountryStore.set(NOT_LOADED);
     });
 

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -27,10 +27,6 @@ describe("ProjectCommitment", () => {
     return ProjectCommitmentPo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should render min and max commitment", async () => {
     const summary = createSummary({
       maxTotalCommitment: 50000000000n,

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -16,7 +16,6 @@ import { waitFor } from "@testing-library/svelte";
 
 describe("ProjectStatusSection", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     snsTicketsStore.reset();
     resetIdentity();
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -18,7 +18,6 @@ import {
 
 describe("SnsNeuronFollowingCard", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     resetSnsProjects();
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
@@ -57,7 +57,6 @@ describe("SnsNeuronPageHeader", () => {
   };
 
   beforeEach(() => {
-    vi.resetAllMocks();
     resetSnsProjects();
     snsNeuronsStore.reset();
     neuronsTableOrderStore.reset();

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
@@ -6,10 +6,6 @@ import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("AddSnsHotkeyButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   const renderCard = () =>
     render(SnsNeuronContextTest, {
       props: {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
@@ -12,8 +12,6 @@ import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("DisburseSnsButton", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-
     vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(
       mockTokenStore
     );

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
@@ -19,10 +19,6 @@ vi.mock("$lib/services/sns-neurons.services", () => {
 });
 
 describe("DissolveSnsNeuronButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders start dissolve message when neuron is locked", () => {
     const { getByText } = render(DissolveSnsNeuronButtonTest, {
       props: {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
@@ -9,8 +9,6 @@ import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("FollowSnsNeuronsButton", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-
     vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(
       mockTokenStore
     );

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -21,7 +21,6 @@ vi.mock("$lib/services/sns-parameters.services");
 describe("IncreaseSnsDissolveDelayButton", () => {
   const rootCanisterId = mockPrincipal;
   beforeEach(() => {
-    vi.clearAllMocks();
     setSnsProjects([
       {
         rootCanisterId,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.spec.ts
@@ -18,10 +18,6 @@ describe("SnsDisburseMaturityButton", () => {
     return DisburseMaturityButtonPo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should be enabled if enough maturity is available", async () => {
     const po = renderComponent(
       {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -5,10 +5,6 @@ import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsStakeMaturityButton", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should open stake maturity modal", async () => {
     const { queryByTestId, getByTestId } = render(SnsNeuronContextTest, {
       props: {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
@@ -36,10 +36,6 @@ describe("SplitSnsNeuronButton", () => {
     token: mockToken,
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should display enabled button", async () => {
     const { getByTestId } = render(SplitSnsNeuronButton, {
       props,

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -42,7 +42,6 @@ describe("ProposalSystemInfoSection", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetSnsProjects();
     fakeSnsGovernanceApi.addNervousSystemFunctionWith({
       rootCanisterId,

--- a/frontend/src/tests/lib/components/summary/Summary.spec.ts
+++ b/frontend/src/tests/lib/components/summary/Summary.spec.ts
@@ -18,7 +18,6 @@ describe("Summary", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     page.reset();
     resetSnsProjects();
   });

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -41,10 +41,6 @@ describe("TokensTable", () => {
     return TokensTablePo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should render a row per token", async () => {
     const token1 = createUserToken({
       universeId: OWN_CANISTER_ID,

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -28,7 +28,6 @@ describe("SelectUniverseNav", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetSnsProjects();
     actionableNnsProposalsStore.reset();
     actionableSnsProposalsStore.resetForTesting();

--- a/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
+++ b/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
@@ -34,7 +34,6 @@ vi.mock("$lib/constants/environment.constants.ts", async () => {
 
 describe("Warnings", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     metricsCallback = undefined;
   });
 

--- a/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
@@ -19,10 +19,6 @@ import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("universes-tokens", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("complete data set", () => {
     beforeEach(() => {
       vi.spyOn(tokensStore, "subscribe").mockImplementation(

--- a/frontend/src/tests/lib/directives/intersection.directives.spec.ts
+++ b/frontend/src/tests/lib/directives/intersection.directives.spec.ts
@@ -11,8 +11,6 @@ describe("IntersectionDirectives", () => {
   let testIntersecting: boolean;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-
     spy = vi
       .spyOn(dispatchEvents, "dispatchIntersecting")
       .mockImplementation(

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -54,7 +54,6 @@ describe("LedgerIdentity", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mockLedgerApp.getAddressAndPubKey.mockResolvedValue({
       errorMessage: undefined,

--- a/frontend/src/tests/lib/modals/accounts/BuyIcpModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/BuyIcpModal.spec.ts
@@ -19,10 +19,6 @@ describe("BuyIcpModal", () => {
     return BuyICPModalPo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders the account's identifier", async () => {
     const po = renderModal(account);
 

--- a/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
@@ -10,10 +10,6 @@ describe("IcrcReceiveModal", () => {
   const reloadSpy = vi.fn();
   const tokenSymbol = "TST";
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   const renderComponent = async ({
     account = mockSnsMainAccount,
     tokenSymbol,

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -18,7 +18,6 @@ describe("ReceiveModal", () => {
   const reloadSpy = vi.fn();
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetAccountsForTesting();
   });
 

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -168,7 +168,6 @@ describe("DisburseNnsNeuronModal", () => {
     beforeEach(() => {
       resetAccountsForTesting();
       vi.clearAllTimers();
-      vi.clearAllMocks();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -45,7 +45,6 @@ describe("DisburseSnsNeuronModal", () => {
   };
 
   beforeEach(() => {
-    vi.resetAllMocks();
     resetSnsProjects();
 
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -46,7 +46,6 @@ describe("MergeNeuronsModal", () => {
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
       testIdentity
     );
-    vi.clearAllMocks();
     resetAccountsForTesting();
     resetNeuronsApiService();
   });

--- a/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
@@ -39,7 +39,6 @@ describe("NewFolloweeModal", () => {
     },
   };
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     knownNeuronsStore.setNeurons([]);
   });

--- a/frontend/src/tests/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.spec.ts
@@ -58,7 +58,6 @@ describe("IncreaseSnsDissolveDelayModal", () => {
     container.querySelector("progress").getAttribute("value");
 
   beforeEach(() => {
-    vi.resetAllMocks();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
       testIdentity
     );

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsDisburseMaturityModal.spec.ts
@@ -42,7 +42,6 @@ describe("SnsDisburseMaturityModal", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetSnsProjects();
 
     authStore.setForTesting(mockIdentity);

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
@@ -52,7 +52,6 @@ describe("SnsIncreaseStakeNeuronModal", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetSnsProjects();
     page.mock({
       routeId: AppPath.Neuron,

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -22,7 +22,6 @@ describe("CanisterDetail", () => {
   blockAllCallsTo(["$lib/api/canisters.api"]);
 
   beforeEach(() => {
-    vi.clearAllMocks();
     authStore.setForTesting(mockIdentity);
     canistersStore.setCanisters({ canisters: undefined, certified: true });
   });

--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -36,7 +36,6 @@ describe("Canisters", () => {
   let authStoreMock: MockInstance;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     authStoreMock = vi.spyOn(authStore, "subscribe");
     resetIdentity();
 

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -113,7 +113,6 @@ describe("CkBTCWallet", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.clearAllTimers();
     vi.useRealTimers();
     ckBTCInfoStore.reset();

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -113,7 +113,6 @@ describe("IcrcWallet", () => {
 
   beforeEach(() => {
     balancesObserverCallback = undefined;
-    vi.clearAllMocks();
     vi.clearAllTimers();
     vi.useRealTimers();
     resetIdentity();

--- a/frontend/src/tests/lib/pages/Launchpad.spec.ts
+++ b/frontend/src/tests/lib/pages/Launchpad.spec.ts
@@ -25,10 +25,6 @@ vi.mock("$lib/services/sns.services", () => {
 });
 
 describe("Launchpad", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("signed in", () => {
     beforeEach(() => {
       resetIdentity();

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -29,7 +29,6 @@ describe("NnsAccounts", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     resetAccountsForTesting();
     // TODO: Move the pollAccounts to Accounts route when universe selected is NNS instead of the child.
@@ -107,7 +106,6 @@ describe("NnsAccounts", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
       vi.clearAllTimers();
-      vi.clearAllMocks();
       cancelPollAccounts();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -38,7 +38,6 @@ describe("NeuronDetail", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     voteRegistrationStore.reset();
     checkedNeuronSubaccountsStore.reset();

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -28,7 +28,6 @@ describe("NnsNeurons", () => {
   };
 
   beforeEach(() => {
-    vi.resetAllMocks();
     resetNeuronsApiService();
   });
 

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -82,7 +82,6 @@ describe("NnsWallet", () => {
   const accountTransactions = [mockTransactionWithId];
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.clearAllTimers();
     vi.unstubAllGlobals();
     cancelPollAccounts();

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -84,7 +84,6 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
   const nowInSeconds = Math.floor(now / 1000);
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetSnsProjects();
     snsSwapCommitmentsStore.reset();
     snsSwapMetricsStore.reset();

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -56,7 +56,6 @@ describe("SnsNeuronDetail", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     snsNeuronsStore.reset();
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -49,7 +49,6 @@ describe("SnsNeurons", () => {
   const projectName = "Tetris";
 
   beforeEach(() => {
-    vi.clearAllMocks();
     checkedNeuronSubaccountsStore.reset();
     page.mock({ data: { universe: rootCanisterId.toText() } });
     resetIdentity();

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -71,7 +71,6 @@ describe("SnsProposalDetail", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     page.reset();
     resetSnsProjects();

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -46,7 +46,6 @@ describe("SnsProposals", () => {
   const projectName = "🪙";
 
   beforeEach(() => {
-    vi.clearAllMocks();
     snsProposalsStore.reset();
     snsFiltersStore.reset();
     // Reset to default value

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -58,7 +58,6 @@ describe("Accounts", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     resetAccountsForTesting();
 

--- a/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
@@ -12,8 +12,6 @@ vi.mock("$lib/api/governance.api");
 
 describe("ProposalDetail", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-
     // Reset to default value
     page.mock({
       data: {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -90,7 +90,6 @@ describe("Wallet", () => {
   const importedTokenId = principal(123);
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
     importedTokensStore.reset();
     setCkETHCanisters();
     setSnsProjects([

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -97,7 +97,6 @@ describe("actionable-proposals.services", () => {
     let spyConsoleError;
 
     beforeEach(() => {
-      vi.clearAllMocks();
       actionableNnsProposalsStore.reset();
       resetIdentity();
       spyQueryProposals = vi

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -128,7 +128,6 @@ describe("actionable-sns-proposals.services", () => {
     let spyConsoleError;
 
     beforeEach(() => {
-      vi.clearAllMocks();
       resetSnsProjects();
       actionableSnsProposalsStore.resetForTesting();
       resetIdentity();

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -25,7 +25,6 @@ describe("app-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
     clearSnsAggregatorCache();
     // resetSnsProjects();
     vi.spyOn(LedgerCanister, "create").mockImplementation(

--- a/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -57,8 +57,6 @@ describe("auth-services", () => {
     mockAuthClient.logout.mockResolvedValue(undefined);
 
     beforeEach(() => {
-      vi.clearAllMocks();
-
       vi.spyOn(AuthClient, "create").mockImplementation(
         async (): Promise<AuthClient> => mockAuthClient
       );

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -33,7 +33,6 @@ import { get } from "svelte/store";
 
 describe("ckbtc-minter-services", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     ckbtcRetrieveBtcStatusesStore.reset();
     vi.spyOn(minterApi, "updateBalance").mockResolvedValue(mockUpdateBalanceOk);

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -14,7 +14,6 @@ vi.mock("$lib/api/icrc-ledger.api");
 
 describe("ckbtc-tokens-services", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
   });
 

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -46,7 +46,6 @@ describe("icp-ledger.services", () => {
   });
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -20,7 +20,6 @@ describe("icp-transactions services", () => {
   const accountIdentifier2 = mockSnsMainAccount.identifier;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     icpTransactionsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -46,7 +46,6 @@ describe("icrc-accounts-services", () => {
   const balanceE8s2 = 222000000n;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();
@@ -74,7 +73,6 @@ describe("icrc-accounts-services", () => {
 
   describe("loadAccounts", () => {
     beforeEach(() => {
-      vi.clearAllMocks();
       vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
 
@@ -328,10 +326,6 @@ describe("icrc-accounts-services", () => {
   });
 
   describe("syncAccounts", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
     it("should call ckBTC accounts and token and load them in store", async () => {
       const spyAccountsQuery = vi
         .spyOn(ledgerApi, "queryIcrcBalance")

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -12,7 +12,6 @@ describe("icrc-index.services", () => {
     const differentLedgerCanisterId = principal(11);
 
     beforeEach(() => {
-      vi.clearAllMocks();
       resetIdentity();
     });
 

--- a/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
@@ -22,7 +22,6 @@ describe("icrc-transactions services", () => {
   const ledgerCanisterId = principal(1);
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     icrcTransactionsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -42,7 +42,6 @@ describe("imported-tokens-services", () => {
   const testError = new Error("test");
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();

--- a/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
+++ b/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
@@ -17,7 +17,6 @@ describe("nns-reward-event-services", () => {
 
   beforeEach(() => {
     nnsLatestRewardEventStore.reset();
-    vi.clearAllMocks();
     spyQueryLatestRewardEvent = vi
       .spyOn(api, "queryLastestRewardEvent")
       .mockResolvedValue(mockRewardEvent);

--- a/frontend/src/tests/lib/services/public/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/app.services.spec.ts
@@ -25,7 +25,6 @@ vi.mock("$lib/services/public/sns.services", () => {
 
 describe("public/app-services", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     defaultIcrcCanistersStore.reset();
     vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockCkETHToken);
     overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -65,7 +65,6 @@ describe("sns-proposals services", () => {
       beforeEach(() => {
         snsFiltersStore.reset();
         snsProposalsStore.reset();
-        vi.clearAllMocks();
         setNoIdentity();
       });
       it("should call queryProposals with the default params", async () => {
@@ -228,7 +227,6 @@ describe("sns-proposals services", () => {
     describe("logged in", () => {
       beforeEach(() => {
         snsProposalsStore.reset();
-        vi.clearAllMocks();
         resetIdentity();
       });
 
@@ -288,7 +286,6 @@ describe("sns-proposals services", () => {
     const vote = SnsVote.Yes;
 
     beforeEach(() => {
-      vi.clearAllMocks();
       resetIdentity();
     });
 

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -106,7 +106,6 @@ describe("SNS public services", () => {
     beforeEach(() => {
       snsAggregatorIncludingAbortedProjectsStore.reset();
       clearWrapperCache();
-      vi.clearAllMocks();
       resetIdentity();
     });
 

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -15,7 +15,6 @@ describe("sns-accounts-balance.services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
     resetSnsProjects();
 
     setSnsProjects([

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -31,8 +31,6 @@ describe("sns-accounts-services", () => {
     const snsLedgerCanisterId = principal(2);
 
     beforeEach(() => {
-      vi.clearAllMocks();
-
       setSnsProjects([
         {
           rootCanisterId,

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -17,7 +17,6 @@ describe("sns-finalization-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllMocks();
     resetSnsProjects();
     resetSnsFinalizationStatusStore();
 

--- a/frontend/src/tests/lib/services/sns-swap-metrics.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-swap-metrics.services.spec.ts
@@ -7,7 +7,6 @@ import { get } from "svelte/store";
 
 describe("sns-swap-metrics", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     snsSwapMetricsStore.reset();
   });
 

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -11,7 +11,6 @@ describe("location services", () => {
   blockAllCallsTo(["$lib/api/location.api"]);
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 

--- a/frontend/src/tests/lib/services/utils.services.spec.ts
+++ b/frontend/src/tests/lib/services/utils.services.spec.ts
@@ -12,7 +12,6 @@ describe("api-utils", () => {
   describe("queryAndUpdate", () => {
     describe("not logged in user", () => {
       beforeEach(() => {
-        vi.clearAllMocks();
         setNoIdentity();
       });
 
@@ -62,7 +61,6 @@ describe("api-utils", () => {
 
     describe("logged in user", () => {
       beforeEach(() => {
-        vi.clearAllMocks();
         resetIdentity();
       });
       it("should request twice", async () => {

--- a/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
+++ b/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
@@ -7,7 +7,6 @@ vi.mock("$lib/workers/cycles.worker?worker");
 describe("initCyclesWorker", () => {
   const postMessage = vi.fn();
   beforeEach(async () => {
-    vi.clearAllMocks();
     const module = await import("$lib/workers/cycles.worker?worker");
     module.default = vi.fn().mockReturnValue({
       postMessage,

--- a/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
@@ -37,7 +37,6 @@ describe("snsNeuronsTableOrderSortedNeuronIdsStore", () => {
   const mockRootCanisterId = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
 
   beforeEach(() => {
-    vi.resetAllMocks();
     neuronsTableOrderStore.reset();
     snsNeuronsStore.reset();
     resetSnsProjects();

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -32,7 +32,6 @@ import { get } from "svelte/store";
 
 describe("sns.store", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     snsAggregatorIncludingAbortedProjectsStore.reset();
     snsDerivedStateStore.reset();
     snsLifecycleStore.reset();

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -4,7 +4,6 @@ import { get } from "svelte/store";
 
 describe("writableStored", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     localStorage.clear();
   });
 

--- a/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
@@ -25,10 +25,6 @@ describe("imported tokens utils", () => {
     indexCanisterId: undefined,
   };
 
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
   describe("toImportedTokenData", () => {
     it("should convert imported token", () => {
       expect(toImportedTokenData(importedToken)).toEqual(importedTokenData);

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -107,7 +107,6 @@ import { get } from "svelte/store";
 
 describe("neuron-utils", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useFakeTimers().setSystemTime(Date.now());
     neuronsStore.setNeurons({ neurons: [], certified: true });
   });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -48,7 +48,6 @@ describe("project-utils", () => {
   });
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useRealTimers();
   });
 
@@ -288,10 +287,6 @@ describe("project-utils", () => {
   });
 
   describe("userCountryIsNeeded", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
     it("country not needed", () => {
       expect(
         userCountryIsNeeded({

--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -61,10 +61,6 @@ describe("tokens-table.utils", () => {
     domKey: "",
   } as UserTokenFailed;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("compareTokensIcpFirst", () => {
     it("should keep ICP first", () => {
       const icpToken = createIcpUserToken();

--- a/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
@@ -33,8 +33,6 @@ describe("canisters-worker-api", () => {
   };
 
   beforeEach(async () => {
-    vi.resetAllMocks();
-
     const mockICManagementCanister = mock<ICManagementCanister>();
     vi.spyOn(ICManagementCanister, "create").mockImplementation(
       () => mockICManagementCanister

--- a/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
@@ -10,8 +10,6 @@ describe("icrc-index.worker-api", () => {
   const indexCanisterMock = mock<IcrcIndexCanister>();
 
   beforeEach(() => {
-    vi.clearAllMocks();
-
     vi.spyOn(IcrcIndexCanister, "create").mockImplementation(
       () => indexCanisterMock
     );

--- a/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
@@ -10,8 +10,6 @@ describe("icrc-ledger.worker-api", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
 
   beforeEach(() => {
-    vi.clearAllMocks();
-
     vi.spyOn(IcrcLedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );

--- a/frontend/src/tests/lib/worker-api/tvl.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/tvl.worker-api.spec.ts
@@ -21,7 +21,6 @@ describe("tvl worker-api", () => {
   };
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     vi.spyOn(TVLCanister, "create").mockImplementation(() => tvlCanisterMock);
     // Prevent HttpAgent.create(), which is called by createAgent, from making a
     // real network request via agent.syncTime().

--- a/frontend/src/tests/lib/worker-services/icrc-balances.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-balances.worker-services.spec.ts
@@ -14,8 +14,6 @@ describe("balances.worker-services", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
 
   beforeEach(() => {
-    vi.clearAllMocks();
-
     vi.spyOn(IcrcLedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );

--- a/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
@@ -17,8 +17,6 @@ describe("transactions.worker-services", () => {
   const indexCanisterMock = mock<IcrcIndexCanister>();
 
   beforeEach(() => {
-    vi.clearAllMocks();
-
     vi.spyOn(IcrcIndexCanister, "create").mockImplementation(
       () => indexCanisterMock
     );

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -22,7 +22,6 @@ describe("Accounts page", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     resetAccountsForTesting();
     vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue(mockAccountDetails);
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(314000000n);

--- a/frontend/src/tests/routes/app/layout.spec.ts
+++ b/frontend/src/tests/routes/app/layout.spec.ts
@@ -11,10 +11,6 @@ vi.mock("$lib/services/public/app.services", () => ({
 }));
 
 describe("Layout", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should init the auth on mount", async () => {
     render(App);
 

--- a/frontend/src/tests/routes/app/settings/layout.spec.ts
+++ b/frontend/src/tests/routes/app/settings/layout.spec.ts
@@ -9,10 +9,6 @@ import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Layout", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
   const renderSettingsAndBack = () => {
     page.mock({
       data: {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -134,7 +134,6 @@ describe("Tokens route", () => {
 
   describe("when feature flag enabled", () => {
     beforeEach(() => {
-      vi.clearAllMocks();
       defaultIcrcCanistersStore.reset();
       importedTokensStore.reset();
       failedImportedTokenLedgerIdsStore.reset();

--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -36,7 +36,6 @@ describe("Accounts", () => {
     name: newSubaccountName,
   };
   beforeEach(() => {
-    vi.clearAllMocks();
     resetIdentity();
     vi.spyOn(console, "error").mockImplementation(vi.fn);
 

--- a/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
+++ b/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
@@ -19,7 +19,6 @@ vi.mock("$lib/api/sns-sale.api");
 
 describe("Launchpad", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     authStore.setForTesting(null);
 
     vi.spyOn(proposalsApi, "queryProposals").mockImplementation(() =>


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5788 we automatically always call `vi.restoreAllMocks` before every test.
`vi.clearAllMocks()` and `vi.resetAllMocks()` do strictly less so using them in `beforeEach` is redundant.

# Changes

Remove all calls to `vi.clearAllMocks()` and `vi.resetAllMocks()` from `beforeEach` in tests.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary