### PR TITLE
housekeeping: removes mapPromises utility

### DIFF
--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -121,17 +121,6 @@ export const hexStringToBytes = (hexString: string): number[] => {
   return bytes;
 };
 
-export const mapPromises = async <T, R>(
-  items: Array<T> | undefined,
-  fun: (args: T) => Promise<R>
-): Promise<Array<R> | undefined> => {
-  if (items === undefined) {
-    return undefined;
-  }
-
-  return Promise.all(items.map(async (item) => await fun(item)));
-};
-
 export const isArrayEmpty = <T>({ length }: T[]): boolean => length === 0;
 
 const AMOUNT_VERSION_PARTS = 3;


### PR DESCRIPTION
# Motivation

Removes an unused utility function that was introduced in #882 and later removed in #5636. 

# Changes

- Removes `mapPromises` utility function

# Tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary