### PR TITLE
NNS1-3450: New utility function to generate a user-friendly date string after a delay.

### DIFF
--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -122,3 +122,12 @@ export const daysToSeconds = (days: number): number =>
 export const nowInSeconds = (): number => Math.round(Date.now() / 1000);
 export const nowInBigIntNanoSeconds = (): bigint =>
   BigInt(Date.now()) * BigInt(1e6);
+
+export const getFutureDateFromDelayInSeconds = (seconds: bigint): string => {
+  if (seconds < 0n) {
+    throw new Error("Delay cannot be negative");
+  }
+
+  const todayPlusDelayedSeconds = nowInSeconds() + Number(seconds);
+  return secondsToDate(todayPlusDelayedSeconds);
+};

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -211,7 +211,7 @@ describe("daysToSeconds", () => {
     });
 
     it("should return correct future date for zero delay", () => {
-      const result = getFutureDateFromDelayInSeconds(BigInt(-0));
+      const result = getFutureDateFromDelayInSeconds(BigInt(0));
       expect(result).toBe("Nov 14, 2023");
     });
 

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -2,6 +2,7 @@ import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
 import {
   daysToDuration,
   daysToSeconds,
+  getFutureDateFromDelayInSeconds,
   nanoSecondsToDateTime,
   secondsToDate,
   secondsToDateTime,
@@ -201,5 +202,40 @@ describe("daysToSeconds", () => {
   it("returns integers only", () => {
     expect(daysToSeconds(1.123456)).not.toBe(SECONDS_IN_DAY * 1.123456);
     expect(daysToSeconds(1.123456)).toBe(97067);
+  });
+
+  describe("getDateInTheFutureFromDelayedSeconds", () => {
+    beforeEach(() => {
+      const mockNow = 1700000000000; // Nov 14, 2023
+      vi.spyOn(Date, "now").mockImplementation(() => mockNow);
+    });
+
+    it("should return correct future date for zero delay", () => {
+      const result = getFutureDateFromDelayInSeconds(BigInt(0));
+      expect(result).toBe("Nov 14, 2023");
+    });
+
+    it("should return correct future date for zero delay", () => {
+      const result = getFutureDateFromDelayInSeconds(BigInt(-0));
+      expect(result).toBe("Nov 14, 2023");
+    });
+
+    it("should return correct future date for one day delay", () => {
+      const oneDayInSeconds = BigInt(24 * 60 * 60);
+      const result = getFutureDateFromDelayInSeconds(oneDayInSeconds);
+      expect(result).toBe("Nov 15, 2023"); // One day after mockNow
+    });
+
+    it("should return correct future date for large delay", () => {
+      const oneYearInSeconds = BigInt(365 * 24 * 60 * 60);
+      const result = getFutureDateFromDelayInSeconds(oneYearInSeconds);
+      expect(result).toBe("Nov 13, 2024"); // One year after mockNow
+    });
+
+    it("should throw error for negative delay", () => {
+      expect(() => getFutureDateFromDelayInSeconds(-60n)).toThrow(
+        "Delay cannot be negative"
+      );
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -206,7 +206,7 @@ describe("daysToSeconds", () => {
 
   describe("getDateInTheFutureFromDelayedSeconds", () => {
     beforeEach(() => {
-      const mockNow = 1700000000000; // Nov 14, 2023
+      const mockNow = new Date(2023, 10, 14).getTime();
       vi.spyOn(Date, "now").mockImplementation(() => mockNow);
     });
 

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -211,11 +211,6 @@ describe("daysToSeconds", () => {
     });
 
     it("should return correct future date for zero delay", () => {
-      const result = getFutureDateFromDelayInSeconds(BigInt(0));
-      expect(result).toBe("Nov 14, 2023");
-    });
-
-    it("should return correct future date for zero delay", () => {
       const result = getFutureDateFromDelayInSeconds(BigInt(-0));
       expect(result).toBe("Nov 14, 2023");
     });


### PR DESCRIPTION
# Motivation

NNS1-3450 will download a csv where show the users the date at which their neuron will dissolve. Eg:

| Neuron Id  |  Dissolve Delay | Dissolve Date |
| ------------- | ------------- |-------------|
| 12345  | 1day, 1hours  | Nov 22, 2024 |

# Changes

- Adds new date utility function `getFutureDateFromDelayInSeconds`

# Tests

- Unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev PR: #5812 | Next PR: #5836 