### PR TITLE
FOLLOW-244: Remove neurons_created_count from metrics

### DIFF
--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
@@ -70,7 +70,6 @@ export const idlFactory = ({ IDL }) => {
     sub_accounts_count: IDL.Nat64,
     neurons_topped_up_count: IDL.Nat64,
     transactions_to_process_queue_length: IDL.Nat32,
-    neurons_created_count: IDL.Nat64,
     hardware_wallet_accounts_count: IDL.Nat64,
     accounts_count: IDL.Nat64,
     block_height_synced_up_to: IDL.Opt(IDL.Nat64),

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
@@ -130,7 +130,6 @@ type Stats =
         hardware_wallet_accounts_count: nat64;
         block_height_synced_up_to: opt nat64;
         seconds_since_last_ledger_sync: nat64;
-        neurons_created_count: nat64;
         neurons_topped_up_count: nat64;
         transactions_to_process_queue_length: nat32;
     };

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -70,7 +70,6 @@ export const idlFactory = ({ IDL }) => {
     sub_accounts_count: IDL.Nat64,
     neurons_topped_up_count: IDL.Nat64,
     transactions_to_process_queue_length: IDL.Nat32,
-    neurons_created_count: IDL.Nat64,
     hardware_wallet_accounts_count: IDL.Nat64,
     accounts_count: IDL.Nat64,
     block_height_synced_up_to: IDL.Opt(IDL.Nat64),

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -102,7 +102,6 @@ export interface Stats {
   sub_accounts_count: bigint;
   neurons_topped_up_count: bigint;
   transactions_to_process_queue_length: number;
-  neurons_created_count: bigint;
   hardware_wallet_accounts_count: bigint;
   accounts_count: bigint;
   block_height_synced_up_to: [] | [bigint];

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -132,7 +132,6 @@ type Stats =
         hardware_wallet_accounts_count: nat64;
         block_height_synced_up_to: opt nat64;
         seconds_since_last_ledger_sync: nat64;
-        neurons_created_count: nat64;
         neurons_topped_up_count: nat64;
         transactions_to_process_queue_length: nat32;
         performance_counts: vec PerformanceCount;

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -33,7 +33,6 @@ pub struct Stats {
     pub hardware_wallet_accounts_count: u64,
     pub block_height_synced_up_to: Option<u64>,
     pub seconds_since_last_ledger_sync: u64,
-    pub neurons_created_count: u64,
     pub neurons_topped_up_count: u64,
     pub transactions_to_process_queue_length: u32,
     pub performance_counts: Vec<PerformanceCount>,
@@ -57,11 +56,6 @@ pub struct Stats {
 #[allow(clippy::cast_precision_loss)] // We are converting u64 to f64
 pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     let stats = with_state(get_stats);
-    w.encode_gauge(
-        "neurons_created_count",
-        stats.neurons_created_count as f64,
-        "Number of neurons created.",
-    )?;
     w.encode_gauge(
         "neurons_topped_up_count",
         stats.neurons_topped_up_count as f64,

--- a/scripts/nns-dapp/e2e-test-metrics-present.keys
+++ b/scripts/nns-dapp/e2e-test-metrics-present.keys
@@ -1,7 +1,6 @@
 accounts_count
 exceptional_transactions_count
 hardware_wallet_accounts_count
-neurons_created_count
 neurons_topped_up_count
 nns_dapp_migration_countdown
 nns_dapp_stable_memory_size_gib

--- a/scripts/nns-dapp/estimate-upgrade-cycles
+++ b/scripts/nns-dapp/estimate-upgrade-cycles
@@ -52,7 +52,7 @@ export post_upgrade_instruction_count mainnet_state_recovery_instruction_count
   echo "The test state size should be similar to production."
   echo "| Data type                             | Num in Production | Num in test | % test/production |"
   echo "|---------------------------------------|-------------------|-------------|-------------------|"
-  for metric in accounts_count sub_accounts_count hardware_wallet_accounts_count neurons_created_count transactions_count; do
+  for metric in accounts_count sub_accounts_count hardware_wallet_accounts_count transactions_count; do
     mainnet_metric="$(jq -r ".$metric // 0" ,counts-mainnet.json)"
     mainnet_metric_str="$(humreadable mainnet_metric)"
     local_metric="$(jq -r ".$metric // 0" ,counts-local.json)"


### PR DESCRIPTION
# Motivation

The `neurons_created_count` metric was derived from the `neuron_accounts` field that was removed in https://github.com/dfinity/nns-dapp/pull/5767 so it will now always be zero.

So we should just remove it.

# Changes

Remove `neurons_created_count` from the exported metrics.

# Tests

Not tested. Relying on CI.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary