### PR TITLE
housekeeping: removes unnecessary `vi` imports

### DIFF
--- a/frontend/src/tests/lib/components/header/LinkToCanisters.spec.ts
+++ b/frontend/src/tests/lib/components/header/LinkToCanisters.spec.ts
@@ -6,7 +6,6 @@ import {
 import { LinkToCanistersPo } from "$tests/page-objects/LinkToCanisters.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
-import { vi } from "vitest";
 
 describe("LinkToCanisters", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -13,7 +13,6 @@ import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { NeuronType, NeuronVisibility, type NeuronInfo } from "@dfinity/nns";
 import { nonNullish } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
-import { vi } from "vitest";
 
 describe("ChangeBulkNeuronVisibilityForm", () => {
   const createMockNeuron = ({

--- a/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
@@ -4,7 +4,6 @@ import { NeuronVisibilityRowPo } from "$tests/page-objects/NeuronVisibilityRow.p
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
-import { vi } from "vitest";
 
 describe("NeuronVisibilityRow", () => {
   const renderComponent = ({


### PR DESCRIPTION
# Motivation

Importing `vi` is no longer required as it is global.

# Changes

- Removes the `vi` import

# Tests


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary