### PR TITLE
Soon losing rewards store

### DIFF
--- a/frontend/src/lib/stores/neurons.store.ts
+++ b/frontend/src/lib/stores/neurons.store.ts
@@ -1,4 +1,9 @@
-import { hasValidStake, sortNeuronsByStake } from "$lib/utils/neuron.utils";
+import {
+  hasValidStake,
+  shouldDisplayRewardLossNotification,
+  sortNeuronsByStake,
+  sortNeuronsByVotingPowerRefreshedTimeout,
+} from "$lib/utils/neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
@@ -92,6 +97,14 @@ export const definedNeuronsStore: Readable<NeuronInfo[]> = derived(
 export const sortedNeuronStore: Readable<NeuronInfo[]> = derived(
   definedNeuronsStore,
   (initializedNeuronsStore) => sortNeuronsByStake(initializedNeuronsStore)
+);
+
+export const soonLosingRewardNeuronsStore: Readable<NeuronInfo[]> = derived(
+  definedNeuronsStore,
+  ($definedNeuronsStore) =>
+    sortNeuronsByVotingPowerRefreshedTimeout(
+      $definedNeuronsStore.filter(shouldDisplayRewardLossNotification)
+    )
 );
 
 export const neuronAccountsStore: Readable<Set<string>> = derived(

--- a/frontend/src/tests/lib/stores/neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons.store.spec.ts
@@ -214,6 +214,14 @@ describe("neurons-store", () => {
       },
     };
 
+    it("should return empty list when no neurons", () => {
+      neuronsStore.setNeurons({
+        neurons: [],
+        certified: true,
+      });
+      expect(get(soonLosingRewardNeuronsStore)).toEqual([]);
+    });
+
     it("should include only neurons that will soon losing its rewards", () => {
       neuronsStore.setNeurons({
         neurons: [neuron3, freshNeuron, neuron2, neuron1],
@@ -225,6 +233,7 @@ describe("neurons-store", () => {
         neuron1,
       ]);
     });
+
     it("should sort neurons by votingPowerRefreshedTimestampSeconds", () => {
       neuronsStore.setNeurons({
         neurons: [neuron2, neuron1, neuron3],


### PR DESCRIPTION
# Motivation

After periodic confirmation is activated, we need to notify users about their neurons that could soon lose rewards, so they can take action to avoid it. To simplify this, it’s better to have a derived store containing all the affected neurons, sorted by the time they start losing rewards.

# Changes

- New `soonLosingRewardNeuronsStore` store.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.