### PR TITLE
NNS1-3450: Adds a metadata field to generate Csv

### DIFF
--- a/frontend/src/lib/utils/export-to-csv.utils.ts
+++ b/frontend/src/lib/utils/export-to-csv.utils.ts
@@ -68,9 +68,7 @@ export const convertToCsv = <T>({
     csvRows.push(metadataRow);
 
     // Add an empty row to separate metadata from data
-    const emptyRow = Array(headers.length + metadata.length)
-      .fill("")
-      .join(",");
+    const emptyRow = "";
     csvRows.push(emptyRow);
 
     padLeft = PAD_LEFT_WHEN_METADATA_PRESENT;

--- a/frontend/src/lib/utils/export-to-csv.utils.ts
+++ b/frontend/src/lib/utils/export-to-csv.utils.ts
@@ -51,7 +51,7 @@ export const convertToCsv = <T>({
   metadata = [],
 }: CsvBaseConfig<T>) => {
   if (headers.length === 0) return "";
-  
+
   const PAD_LEFT_WHEN_METADATA_PRESENT = 2;
   const csvRows: string[] = [];
   let padLeft = 0;
@@ -68,7 +68,9 @@ export const convertToCsv = <T>({
     csvRows.push(metadataRow);
 
     // Add an empty row to separate metadata from data
-    const emptyRow = Array(headers.length + metadata.length).fill("").join(",");
+    const emptyRow = Array(headers.length + metadata.length)
+      .fill("")
+      .join(",");
     csvRows.push(emptyRow);
 
     padLeft = PAD_LEFT_WHEN_METADATA_PRESENT;

--- a/frontend/src/lib/utils/export-to-csv.utils.ts
+++ b/frontend/src/lib/utils/export-to-csv.utils.ts
@@ -68,7 +68,8 @@ export const convertToCsv = <T>({
     csvRows.push(metadataRow);
 
     // Add an empty row to separate metadata from data
-    csvRows.push("");
+    const emptyRow = Array(headers.length + metadata.length).fill("").join(",");
+    csvRows.push(emptyRow);
 
     padLeft = PAD_LEFT_WHEN_METADATA_PRESENT;
   }
@@ -167,6 +168,7 @@ const saveFileWithAnchor = ({
  * @param options - Configuration object for the Csv download
  * @param options.data - Array of objects to be converted to Csv. Each object should have consistent keys. It uses first object to check for consistency
  * @param options.headers - Array of objects defining the headers and their order in the CSV. Each object should include an `id` key that corresponds to a key in the data objects.
+ * @param options.meatadata - Array of objects defining the metadata to be included in the CSV. Each object should include a `label` and `value` key. When present the main table will be shifted two columns to the left.
  * @param options.fileName - Name of the file without extension (defaults to "data")
  * @param options.description - File description for save dialog (defaults to " Csv file")
  *
@@ -192,11 +194,12 @@ const saveFileWithAnchor = ({
 export const generateCsvFileToSave = async <T>({
   data,
   headers,
+  metadata,
   fileName = "data",
   description = "Csv file",
 }: CsvFileConfig<T>): Promise<void> => {
   try {
-    const csvContent = convertToCsv<T>({ data, headers });
+    const csvContent = convertToCsv<T>({ data, headers, metadata });
 
     const blob = new Blob([csvContent], {
       type: "text/csv;charset=utf-8;",

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -135,10 +135,11 @@ describe("Export to Csv", () => {
         {
           label: "Title",
           value: "This is a test file",
-        },{
-          label: 'Export Date',
-          value: new Date('2021-10-10').toLocaleString()
-        }
+        },
+        {
+          label: "Export Date",
+          value: new Date("2021-10-10").toLocaleString(),
+        },
       ];
       const expected = `Title,This is a test file\nExport Date,"10/10/2021, 2:00:00 AM"\n,,,\n,,name,age\n,,John,30`;
 

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -141,7 +141,7 @@ describe("Export to Csv", () => {
           value: "10/10/2021, 2:00:00 AM",
         },
       ];
-      const expected = `Title,This is a test file\nExport Date,"10/10/2021, 2:00:00 AM"\n,,,\n,,name,age\n,,John,30`;
+      const expected = `Title,This is a test file\nExport Date,"10/10/2021, 2:00:00 AM"\n\n,,name,age\n,,John,30`;
 
       expect(convertToCsv({ data, headers, metadata })).toBe(expected);
     });

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -140,7 +140,7 @@ describe("Export to Csv", () => {
           value: new Date('2021-10-10').toLocaleString()
         }
       ];
-      const expected = `Title,This is a test file\nExport Date,"10/10/2021, 2:00:00 AM"\n\n,,name,age\n,,John,30`;
+      const expected = `Title,This is a test file\nExport Date,"10/10/2021, 2:00:00 AM"\n,,,\n,,name,age\n,,John,30`;
 
       expect(convertToCsv({ data, headers, metadata })).toBe(expected);
     });

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -138,7 +138,7 @@ describe("Export to Csv", () => {
         },
         {
           label: "Export Date",
-          value: new Date("2021-10-10").toLocaleString(),
+          value: "10/10/2021, 2:00:00 AM",
         },
       ];
       const expected = `Title,This is a test file\nExport Date,"10/10/2021, 2:00:00 AM"\n,,,\n,,name,age\n,,John,30`;

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -124,6 +124,26 @@ describe("Export to Csv", () => {
       const expected = 'Full Name,Age\n"Peter\nParker",24\nJane Doe,25';
       expect(convertToCsv({ data, headers })).toBe(expected);
     });
+
+    it("should add metadata to the CSV file", () => {
+      const data: TestPersonData[] = [{ name: "John", age: 30 }];
+      const headers: CsvHeader<TestPersonData>[] = [
+        { id: "name", label: "name" },
+        { id: "age", label: "age" },
+      ];
+      const metadata = [
+        {
+          label: "Title",
+          value: "This is a test file",
+        },{
+          label: 'Export Date',
+          value: new Date('2021-10-10').toLocaleString()
+        }
+      ];
+      const expected = `Title,This is a test file\nExport Date,"10/10/2021, 2:00:00 AM"\n\n,,name,age\n,,John,30`;
+
+      expect(convertToCsv({ data, headers, metadata })).toBe(expected);
+    });
   });
 
   describe("downloadCSV", () => {


### PR DESCRIPTION
# Motivation

CSV files can include metadata that appears before the table. For example:

<img width="1459" alt="Screenshot 2024-11-22 at 16 50 10" src="https://github.com/user-attachments/assets/441944c6-4484-4174-a2a8-7c19513dd566">

# Changes

- Adds a new parameter `metadata` that if present is render before the table. When present it shifts the table two columns to the right.

# Tests

- Unit test
- Manually tested in #5813

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev PR: #5812 | Next PR: #5813 