### PR TITLE
housekeeping: removes isLocalhost utility

### DIFF
--- a/frontend/src/lib/utils/env.utils.ts
+++ b/frontend/src/lib/utils/env.utils.ts
@@ -20,9 +20,6 @@ export const isNnsAlternativeOrigin = (): boolean => {
   return NNS_IC_ORG_ALTERNATIVE_ORIGINS.includes(origin);
 };
 
-export const isLocalhost = (hostname: string) =>
-  hostname.includes("localhost") || hostname.includes("127.0.0.1");
-
 // Given the used strategy and whether the current call is certified, returns
 // whether this is the last call.
 //

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -1,8 +1,4 @@
-import {
-  isLastCall,
-  isLocalhost,
-  isNnsAlternativeOrigin,
-} from "$lib/utils/env.utils";
+import { isLastCall, isNnsAlternativeOrigin } from "$lib/utils/env.utils";
 
 describe("env-utils", () => {
   describe("isNnsAlternativeOrigin", () => {
@@ -60,24 +56,6 @@ describe("env-utils", () => {
 
       setOrigin("https://beta.ic0.app");
       expect(isNnsAlternativeOrigin()).toBe(false);
-    });
-  });
-
-  describe("isLocalhost", () => {
-    it("return false when hostname is not localhost", () => {
-      expect(
-        isLocalhost(
-          "53zcu-tiaaa-aaaaa-qaaba-cai.medium09.testnet.dfinity.network"
-        )
-      ).toBe(false);
-      expect(isLocalhost("internetcomputer.org")).toBe(false);
-      expect(isLocalhost("nns.ic0.app")).toBe(false);
-    });
-
-    it("return true when hostname is localhost", () => {
-      expect(isLocalhost("localhost:3000")).toBe(true);
-      expect(isLocalhost("127.0.0.1:3000")).toBe(true);
-      expect(isLocalhost("xxxx.localhost")).toBe(true);
     });
   });
 


### PR DESCRIPTION
# Motivation

Removes an unused utility function that was introduced in #2377 and later removed in #5668. It doesn't contain any business logic.

# Changes

- Removes `isLocalhost` utility function

# Tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary