### PR TITLE
Generic banner component

### DIFF
--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -6,9 +6,9 @@
   export let testId: string = "banner-component";
 
   /** Dispatches `nnsClose` event */
-  export let isClosable: boolean = false;
+  export let isClosable = false;
   /** Displayed in a high-contrast */
-  export let isCritical: boolean = false;
+  export let isCritical = false;
 
   export let title: string | undefined = undefined;
   export let text: string | undefined = undefined;

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { Html, IconClose } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let testId: string = "banner-component";
 

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -50,6 +50,18 @@
     border-radius: var(--border-radius);
     background: var(--input-background);
   }
+
+  .banner.isCritical {
+    background: var(--tooltip-background);
+
+    .title {
+      color: var(--tooltip-text-color);
+    }
+    .text {
+      color: var(--tooltip-description-color);
+    }
+  }
+
   .icon {
     grid-area: icon;
   }
@@ -65,6 +77,7 @@
     display: flex;
     gap: var(--padding-1_5x);
   }
+
   .title {
     margin: 0;
     @include fonts.standard(true);

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -5,8 +5,8 @@
   export let isCritical: boolean | undefined = undefined;
 </script>
 
-<article class="banner" class:isCritical data-tid={testId}>
-  <div class="icon">
+<article data-tid={testId} class="banner" class:isCritical>
+  <div class="icon" aria-hidden="true">
     <slot name="icon"></slot>
   </div>
   <div class="content-wrapper">
@@ -31,18 +31,22 @@
 
   .banner {
     display: grid;
-    grid-template-columns: 32px 1fr;
-    grid-template-rows: auto auto;
     grid-template-areas:
-      "icon content"
-      "actions actions";
-    align-items: start;
+      "icon"
+      "content"
+      "actions";
     grid-gap: var(--padding-1_5x);
 
+    @include media.min-width(small) {
+      grid-template-areas:
+        "icon content"
+        "actions actions";
+      grid-template-columns: auto 1fr;
+    }
+
     @include media.min-width(medium) {
-      grid-template-columns: 32px 1fr auto;
-      grid-template-rows: auto;
       grid-template-areas: "icon content actions";
+      grid-template-columns: auto 1fr auto;
       align-items: center;
     }
 

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -1,14 +1,36 @@
 <script lang="ts">
+  import { Html, IconClose } from "@dfinity/gix-components";
+  import { createEventDispatcher } from "svelte";
+
   export let testId: string = "banner-component";
+
+  /** Dispatches `nnsClose` event */
+  export let isClosable: boolean = false;
+  /** Displayed in a high-contrast */
+  export let isCritical: boolean = false;
+
   export let title: string | undefined = undefined;
   export let text: string | undefined = undefined;
-  export let isCritical: boolean | undefined = undefined;
+  export let htmlText: string | undefined = undefined;
+
+  const dispatcher = createEventDispatcher();
 </script>
 
 <article data-tid={testId} class="banner" class:isCritical>
   <div class="icon" aria-hidden="true">
     <slot name="icon"></slot>
   </div>
+  {#if isClosable}
+    <div class="close">
+      <button
+        class="icon-only"
+        on:click={() => dispatcher("nnsClose")}
+        aria-label="Close"
+      >
+        <IconClose />
+      </button>
+    </div>
+  {/if}
   <div class="content-wrapper">
     {#if title}
       <h2 class="title">{title}</h2>
@@ -16,9 +38,9 @@
     {#if text}
       <p class="text">{text}</p>
     {/if}
-    <div class="content">
-      <slot name="content"></slot>
-    </div>
+    {#if htmlText}
+      <Html text={htmlText} />
+    {/if}
   </div>
   <div class="actions">
     <slot name="actions"></slot>
@@ -32,25 +54,22 @@
   .banner {
     display: grid;
     grid-template-areas:
-      "icon"
-      "content"
-      "actions";
-    grid-gap: var(--padding-1_5x);
-
-    @include media.min-width(small) {
-      grid-template-areas:
-        "icon content"
-        "actions actions";
-      grid-template-columns: auto 1fr;
-    }
-
+      "icon close"
+      ". ."
+      "content content"
+      ". ."
+      "actions actions";
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto var(--padding-1_5x) auto var(--padding-3x) auto;
     @include media.min-width(medium) {
-      grid-template-areas: "icon content actions";
-      grid-template-columns: auto 1fr auto;
+      grid-template-areas: "icon content actions close";
+      grid-template-columns: auto 1fr auto auto;
+      grid-template-rows: auto;
+      grid-gap: var(--padding-1_5x);
       align-items: center;
     }
 
-    padding: var(--padding-1_5x);
+    padding: var(--padding-2x);
     border-radius: var(--border-radius);
     background: var(--input-background);
   }
@@ -64,17 +83,23 @@
     .text {
       color: var(--tooltip-description-color);
     }
+    .close {
+      color: var(--tooltip-description-color);
+    }
   }
 
   .icon {
     grid-area: icon;
   }
+  .close {
+    grid-area: close;
+  }
   .content-wrapper {
     grid-area: content;
+
     display: flex;
     flex-direction: column;
-    flex: 1 1 auto;
-    overflow: hidden;
+    gap: var(--padding);
   }
   .actions {
     grid-area: actions;

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  export let testId: string;
+  export let title: string | undefined = undefined;
+  export let text: string | undefined = undefined;
+  export let isCritical: boolean | undefined = undefined;
+</script>
+
+<article class="banner" class:isCritical data-tid={testId}>
+  <div class="icon">
+    <slot name="icon"></slot>
+  </div>
+  <div class="content-wrapper">
+    {#if title}
+      <h2 class="title">{title}</h2>
+    {/if}
+    {#if text}
+      <p class="text">{text}</p>
+    {/if}
+    <div class="content">
+      <slot name="content"></slot>
+    </div>
+  </div>
+  <div class="actions">
+    <slot name="actions"></slot>
+  </div>
+</article>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .banner {
+    display: grid;
+    grid-template-columns: 32px 1fr;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+      "icon content"
+      "actions actions";
+    align-items: start;
+    grid-gap: var(--padding-1_5x);
+
+    @include media.min-width(medium) {
+      grid-template-columns: 32px 1fr auto;
+      grid-template-rows: auto;
+      grid-template-areas: "icon content actions";
+      align-items: center;
+    }
+
+    padding: var(--padding-1_5x);
+    border-radius: var(--border-radius);
+    background: var(--input-background);
+  }
+  .icon {
+    grid-area: icon;
+  }
+  .content-wrapper {
+    grid-area: content;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
+  .actions {
+    grid-area: actions;
+    display: flex;
+    gap: var(--padding-1_5x);
+  }
+  .title {
+    margin: 0;
+    @include fonts.standard(true);
+  }
+  .text {
+    margin: 0;
+    @include fonts.standard(false);
+    color: var(--description-color);
+  }
+</style>

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let testId: string;
+  export let testId: string = "banner-component";
   export let title: string | undefined = undefined;
   export let text: string | undefined = undefined;
   export let isCritical: boolean | undefined = undefined;

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Html, IconClose } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let testId: string = "banner-component";
 
@@ -26,6 +27,7 @@
         class="icon-only"
         on:click={() => dispatcher("nnsClose")}
         aria-label="Close"
+        data-tid="close-button"
       >
         <IconClose />
       </button>
@@ -33,13 +35,15 @@
   {/if}
   <div class="content-wrapper">
     {#if title}
-      <h2 class="title">{title}</h2>
+      <h2 class="title" data-tid="title">{title}</h2>
     {/if}
     {#if text}
-      <p class="text">{text}</p>
+      <p class="text" data-tid="text">{text}</p>
     {/if}
     {#if htmlText}
-      <Html text={htmlText} />
+      <TestIdWrapper testId="html-text">
+        <Html text={htmlText} />
+      </TestIdWrapper>
     {/if}
   </div>
   <div class="actions">

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -41,12 +41,12 @@
       <p class="text" data-tid="text">{text}</p>
     {/if}
     {#if htmlText}
-      <TestIdWrapper testId="html-text">
+      <div data-tid="html-text">
         <Html text={htmlText} />
-      </TestIdWrapper>
+      </div>
     {/if}
   </div>
-  <div class="actions">
+  <div class="actions" data-tid="actions">
     <slot name="actions"></slot>
   </div>
 </article>

--- a/frontend/src/lib/components/ui/BannerIcon.svelte
+++ b/frontend/src/lib/components/ui/BannerIcon.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  export let status: undefined | "error" | "success" = undefined;
+</script>
+
+<div
+  data-tid="banner-icon-component"
+  class="icon-wrapper"
+  class:error={status === "error"}
+  class:success={status === "success"}
+  aria-hidden="true"
+>
+  <slot />
+</div>
+
+<style lang="scss">
+  .icon-wrapper {
+    padding: var(--padding);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    // Avoid the icon from stretching
+    width: max-content;
+
+    border-radius: 50%;
+    // TODO(mstr): Replace with semantically correct colors
+    color: var(--blue-accent);
+    background-color: var(--blue-accent-tint);
+
+    &.error {
+      color: var(--negative-emphasis);
+      background-color: var(--negative-emphasis-light);
+    }
+
+    &.success {
+      color: var(--positive-emphasis);
+      background-color: var(--positive-emphasis-light);
+    }
+  }
+</style>

--- a/frontend/src/tests/lib/components/ui/Banner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Banner.spec.ts
@@ -48,9 +48,14 @@ describe("Banner", () => {
   });
 
   it("should display actions slot content", async () => {
-    const po = renderComponent();
+    const testAction = "test-action";
+    const po = renderComponent({
+      props: {
+        testAction,
+      },
+    });
 
-    expect(await po.getActions().getText()).toContain("test-action");
+    expect(await po.getActions().getText()).toContain(testAction);
   });
 
   it("should not have close button by default", async () => {

--- a/frontend/src/tests/lib/components/ui/Banner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Banner.spec.ts
@@ -1,6 +1,6 @@
 import { BannerPo } from "$tests/page-objects/Banner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 import BannerTest from "./BannerTest.svelte";
 
 describe("Banner", () => {
@@ -41,17 +41,22 @@ describe("Banner", () => {
     expect(await po.getHtmlText()).toContain("Test HTML Text");
   });
 
-  it("should display slots", async () => {
+  it("should display icon slot content", async () => {
     const po = renderComponent();
 
-    expect(await po.getText()).toContain("test-icon");
-    expect(await po.getText()).toContain("test-action");
+    expect(await po.getBannerIcon().isPresent()).toBe(true);
+  });
+
+  it("should display actions slot content", async () => {
+    const po = renderComponent();
+
+    expect(await po.getActions().getText()).toContain("test-action");
   });
 
   it("should not have close button by default", async () => {
     const po = renderComponent();
 
-    expect(await po.isClosable()).toBe(false);
+    expect(await po.getCloseButton().isPresent()).toBe(false);
   });
 
   it("should have close button", async () => {
@@ -63,7 +68,7 @@ describe("Banner", () => {
       onClose,
     });
 
-    expect(await po.isClosable()).toBe(true);
+    expect(await po.getCloseButton().isPresent()).toBe(true);
     expect(onClose).toHaveBeenCalledTimes(0);
     await po.clickClose();
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/frontend/src/tests/lib/components/ui/Banner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Banner.spec.ts
@@ -1,0 +1,87 @@
+import { BannerPo } from "$tests/page-objects/Banner.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+import BannerTest from "./BannerTest.svelte";
+
+describe("Banner", () => {
+  const renderComponent = ({
+    props = {},
+    onClose,
+  }: { props?: unknown; onClose?: () => void } = {}) => {
+    const { container, component } = render(BannerTest, {
+      props,
+    });
+
+    if (onClose) {
+      component.$on("nnsClose", onClose);
+    }
+
+    return BannerPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render text and title", async () => {
+    const po = renderComponent({
+      props: {
+        title: "Test Title",
+        text: "Test Text",
+      },
+    });
+
+    expect(await po.getTitle()).toEqual("Test Title");
+    expect(await po.getText()).toEqual("Test Text");
+  });
+
+  it("should render HTML content", async () => {
+    const po = renderComponent({
+      props: {
+        htmlText: "<p>Test HTML Text</p>",
+      },
+    });
+
+    expect(await po.getHtmlText()).toContain("Test HTML Text");
+  });
+
+  it("should display slots", async () => {
+    const po = renderComponent();
+
+    expect(await po.getText()).toContain("test-icon");
+    expect(await po.getText()).toContain("test-action");
+  });
+
+  it("should not have close button by default", async () => {
+    const po = renderComponent();
+
+    expect(await po.isClosable()).toBe(false);
+  });
+
+  it("should have close button", async () => {
+    const onClose = vi.fn();
+    const po = renderComponent({
+      props: {
+        isClosable: true,
+      },
+      onClose,
+    });
+
+    expect(await po.isClosable()).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(0);
+    await po.clickClose();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not be critical by default", async () => {
+    const po = renderComponent();
+
+    expect(await po.isCritical()).toBe(false);
+  });
+
+  it("should be critical", async () => {
+    const po = renderComponent({
+      props: {
+        isCritical: true,
+      },
+    });
+
+    expect(await po.isCritical()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/ui/BannerIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/BannerIcon.spec.ts
@@ -1,0 +1,46 @@
+import { BannerIconPo } from "$tests/page-objects/BannerIcon.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import BannerIconTest from "./BannerIconTest.svelte";
+
+describe("BannerIcon", () => {
+  const renderComponent = (props?: unknown) => {
+    const { container } = render(BannerIconTest, {
+      props,
+    });
+
+    return BannerIconPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render slot", async () => {
+    const slotContent = "Test slot content";
+    const po = renderComponent({
+      slotContent,
+    });
+
+    expect(await po.root.getText()).toEqual(slotContent);
+  });
+
+  it("should not have a specified status by default", async () => {
+    const po = renderComponent();
+
+    expect(await po.isStatusError()).toBe(false);
+    expect(await po.isStatusSuccess()).toBe(false);
+  });
+
+  it("should display error status", async () => {
+    const po = renderComponent({
+      status: "error",
+    });
+
+    expect(await po.isStatusError()).toBe(true);
+  });
+
+  it("should display success status", async () => {
+    const po = renderComponent({
+      status: "success",
+    });
+
+    expect(await po.isStatusSuccess()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/ui/BannerIconTest.svelte
+++ b/frontend/src/tests/lib/components/ui/BannerIconTest.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import BannerIcon from "$lib/components/ui/BannerIcon.svelte";
+
+  export let status: undefined | "error" | "success" = undefined;
+  export let slotContent: string | undefined = undefined;
+</script>
+
+<BannerIcon {status}>{slotContent}</BannerIcon>

--- a/frontend/src/tests/lib/components/ui/BannerTest.svelte
+++ b/frontend/src/tests/lib/components/ui/BannerTest.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Banner from "$lib/components/ui/Banner.svelte";
+  import BannerIcon from "$lib/components/ui/BannerIcon.svelte";
+  import { IconErrorOutline } from "@dfinity/gix-components";
 
   export let isClosable: boolean = false;
   export let isCritical: boolean = false;
@@ -8,10 +10,10 @@
   export let htmlText: string | undefined = undefined;
 </script>
 
-<Banner {isClosable} {isCritical} {title} {text} {htmlText}>
-  <div slot="icon">
-    <div>test-icon</div>
-  </div>
+<Banner {isClosable} {isCritical} {title} {text} {htmlText} on:nnsClose>
+  <BannerIcon slot="icon" status="success">
+    <IconErrorOutline />
+  </BannerIcon>
   <div slot="actions">
     <button>test-action</button>
   </div>

--- a/frontend/src/tests/lib/components/ui/BannerTest.svelte
+++ b/frontend/src/tests/lib/components/ui/BannerTest.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Banner from "$lib/components/ui/Banner.svelte";
+
+  export let isClosable: boolean = false;
+  export let isCritical: boolean = false;
+  export let title: string | undefined = undefined;
+  export let text: string | undefined = undefined;
+  export let htmlText: string | undefined = undefined;
+</script>
+
+<Banner {isClosable} {isCritical} {title} {text} {htmlText}>
+  <div slot="icon">
+    <div>test-icon</div>
+  </div>
+  <div slot="actions">
+    <button>test-action</button>
+  </div>
+</Banner>

--- a/frontend/src/tests/lib/components/ui/BannerTest.svelte
+++ b/frontend/src/tests/lib/components/ui/BannerTest.svelte
@@ -8,6 +8,7 @@
   export let title: string | undefined = undefined;
   export let text: string | undefined = undefined;
   export let htmlText: string | undefined = undefined;
+  export let testAction: string | undefined = undefined;
 </script>
 
 <Banner {isClosable} {isCritical} {title} {text} {htmlText} on:nnsClose>
@@ -15,6 +16,6 @@
     <IconErrorOutline />
   </BannerIcon>
   <div slot="actions">
-    <button>test-action</button>
+    {testAction}
   </div>
 </Banner>

--- a/frontend/src/tests/page-objects/Banner.page-object.ts
+++ b/frontend/src/tests/page-objects/Banner.page-object.ts
@@ -1,11 +1,25 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BannerIconPo } from "./BannerIcon.page-object";
+import type { ButtonPo } from "./Button.page-object";
 
 export class BannerPo extends BasePageObject {
   private static readonly TID = "banner-component";
 
   static under(element: PageObjectElement): BannerPo {
     return new BannerPo(element.byTestId(BannerPo.TID));
+  }
+
+  getBannerIcon(): BannerIconPo {
+    return BannerIconPo.under(this.root);
+  }
+
+  getActions(): PageObjectElement {
+    return this.root.byTestId("actions");
+  }
+
+  getCloseButton(): ButtonPo {
+    return this.getButton("close-button");
   }
 
   async getTitle(): Promise<string> {
@@ -20,16 +34,8 @@ export class BannerPo extends BasePageObject {
     return this.root.byTestId("html-text").getText();
   }
 
-  private getCloseButton(): PageObjectElement {
-    return this.root.byTestId("close-button");
-  }
-
   async clickClose(): Promise<void> {
     await this.getCloseButton().click();
-  }
-
-  async isClosable(): Promise<boolean> {
-    return this.getCloseButton().isPresent();
   }
 
   async isCritical(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/Banner.page-object.ts
+++ b/frontend/src/tests/page-objects/Banner.page-object.ts
@@ -1,0 +1,38 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class BannerPo extends BasePageObject {
+  private static readonly TID = "banner-component";
+
+  static under(element: PageObjectElement): BannerPo {
+    return new BannerPo(element.byTestId(BannerPo.TID));
+  }
+
+  async getTitle(): Promise<string> {
+    return this.root.byTestId("title").getText();
+  }
+
+  async getText(): Promise<string> {
+    return this.root.byTestId("text").getText();
+  }
+
+  async getHtmlText(): Promise<string> {
+    return this.root.byTestId("html-text").getText();
+  }
+
+  private getCloseButton(): PageObjectElement {
+    return this.root.byTestId("close-button");
+  }
+
+  async clickClose(): Promise<void> {
+    await this.getCloseButton().click();
+  }
+
+  async isClosable(): Promise<boolean> {
+    return this.getCloseButton().isPresent();
+  }
+
+  async isCritical(): Promise<boolean> {
+    return (await this.root.getClasses()).includes("isCritical");
+  }
+}

--- a/frontend/src/tests/page-objects/BannerIcon.page-object.ts
+++ b/frontend/src/tests/page-objects/BannerIcon.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class BannerIconPo extends BasePageObject {
+  private static readonly TID = "banner-icon-component";
+
+  static under(element: PageObjectElement): BannerIconPo {
+    return new BannerIconPo(element.byTestId(BannerIconPo.TID));
+  }
+
+  async isStatusError(): Promise<boolean> {
+    return (await this.root.getClasses()).includes("error");
+  }
+
+  async isStatusSuccess(): Promise<boolean> {
+    return (await this.root.getClasses()).includes("success");
+  }
+}


### PR DESCRIPTION
# Motivation

Currently, there are already a couple of custom banner implementations done in the nns-dapp. All of them look almost the same. Since several banners are planned for the upcoming periodic confirmation feature, it’s a good opportunity to introduce a banner as a component ([here](https://www.figma.com/design/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?node-id=4127-45761) is the design for it). For the first iteration, it is planned to include it in the nns-dapp codebase to test whether it meets all the needs for periodic confirmation and to replace the currently presented banners. Afterward, it can be moved to the gix-components.

# Changes

- New components: Banner and BannerIcon. Since they need to be used together, both are included in the same PR.

# Tests

- POs and unit tests added.

# Screenshots

### Mobile

<img width="285" alt="image" src="https://github.com/user-attachments/assets/68b9d9ab-0efb-4a7d-b82e-a1b2ccf7e8a4">

<img width="276" alt="image" src="https://github.com/user-attachments/assets/22cc8008-9c59-4b43-9742-855cf7c9c4d0">

### Desktop

<img width="789" alt="image" src="https://github.com/user-attachments/assets/36ec1471-be69-4eff-b939-0fb9b996d54c">

<img width="785" alt="image" src="https://github.com/user-attachments/assets/9dd147de-bb12-4677-87c6-45a80f1e1e9f">

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary