### PR TITLE
NNS1-3450: New utility date to generate a compact timestamp

### DIFF
--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -131,3 +131,18 @@ export const getFutureDateFromDelayInSeconds = (seconds: bigint): string => {
   const todayPlusDelayedSeconds = nowInSeconds() + Number(seconds);
   return secondsToDate(todayPlusDelayedSeconds);
 };
+
+/**
+ * Formats a date into YYYYMMDD string
+ * @param {Date} date - The date to format
+ * @returns {string} Date formatted as YYYYMMDD
+ * @example
+ * formatDateCompact(new Date('2024-11-22')) // Returns "20241122"
+ */
+export const formatDateCompact = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+
+  return `${year}${month}${day}`;
+};

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -2,6 +2,7 @@ import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
 import {
   daysToDuration,
   daysToSeconds,
+  formatDateCompact,
   getFutureDateFromDelayInSeconds,
   nanoSecondsToDateTime,
   secondsToDate,
@@ -231,6 +232,17 @@ describe("daysToSeconds", () => {
       expect(() => getFutureDateFromDelayInSeconds(-60n)).toThrow(
         "Delay cannot be negative"
       );
+    });
+  });
+  describe("formatDateCompact", () => {
+    it("should return the date formatted as YYYYMMDD", () => {
+      const date = new Date("2024-11-22");
+      expect(formatDateCompact(date)).toBe("20241122");
+    });
+
+    it("should pad single digit month and day", () => {
+      const date = new Date("2024-01-01");
+      expect(formatDateCompact(date)).toBe("20240101");
     });
   });
 });


### PR DESCRIPTION
# Motivation

Downloaded files should include a timestamp in their name indicating the day the file was generated. For example:
- `neurons_20241112.csv`
- `neurons_<accountId>_20241112.pdf`

# Changes

- Adds a new utility function to generate a timestamp from a provided date with the format `YYYYMMDD`

# Tests

- Unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary