### PR TITLE
Stop calling snsNeuronsStore.reset() in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -107,7 +107,6 @@ describe("SnsVotingCard", () => {
 
   beforeEach(() => {
     vi.useFakeTimers().setSystemTime(nowInSeconds * 1000);
-    snsNeuronsStore.reset();
     resetIdentity();
 
     spyRegisterVote = vi

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
@@ -58,7 +58,6 @@ describe("SnsNeuronPageHeader", () => {
 
   beforeEach(() => {
     resetSnsProjects();
-    snsNeuronsStore.reset();
     neuronsTableOrderStore.reset();
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -31,7 +31,6 @@ describe("ProjectsTable", () => {
   };
 
   beforeEach(() => {
-    snsNeuronsStore.reset();
     resetSnsProjects();
     resetIdentity();
 

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -19,7 +19,6 @@ describe("definedSnsNeuronStore", () => {
   const principal2 = Principal.fromText("aaaaa-aa");
 
   beforeEach(() => {
-    snsNeuronsStore.reset();
     setSnsProjects([
       {
         rootCanisterId: mockPrincipal,
@@ -151,7 +150,6 @@ describe("sortedSnsNeuronStore", () => {
   const principal2 = Principal.fromText("aaaaa-aa");
 
   beforeEach(() => {
-    snsNeuronsStore.reset();
     setSnsProjects([
       {
         rootCanisterId: mockPrincipal,
@@ -318,7 +316,6 @@ describe("sortedSnsNeuronStore", () => {
 });
 
 describe("sortedSnsUserNeuronsStore", () => {
-  beforeEach(() => snsNeuronsStore.reset());
   it("should not return CF neurons", async () => {
     const cfNeuron: SnsNeuron = {
       ...createMockSnsNeuron({
@@ -357,7 +354,6 @@ describe("sortedSnsUserNeuronsStore", () => {
 });
 
 describe("sortedSnsCFNeuronsStore", () => {
-  beforeEach(() => snsNeuronsStore.reset());
   it("should not return CF neurons", async () => {
     const cfNeuron1: SnsNeuron = {
       ...createMockSnsNeuron({

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -9,7 +9,6 @@ import {
 import { pageStore } from "$lib/derived/page.derived";
 import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
 import * as checkNeuronsService from "$lib/services/sns-neurons-check-balances.services";
-import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import {
   getSnsNeuronIdAsHexString,
   subaccountToHexString,
@@ -56,7 +55,6 @@ describe("SnsNeuronDetail", () => {
   };
 
   beforeEach(() => {
-    snsNeuronsStore.reset();
     setSnsProjects([
       {
         projectName,

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -8,7 +8,6 @@ import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposal
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
-import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
@@ -77,7 +76,6 @@ describe("SnsProposalDetail", () => {
     actionableSnsProposalsStore.resetForTesting();
     actionableProposalsSegmentStore.resetForTesting();
     snsProposalsStore.reset();
-    snsNeuronsStore.reset();
   });
 
   describe("not logged in", () => {

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -37,7 +37,6 @@ describe("Staking", () => {
   const snsCanisterId = principal(1112);
 
   beforeEach(() => {
-    snsNeuronsStore.reset();
     resetSnsProjects();
     resetIdentity();
     resetAccountsForTesting();

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -34,7 +34,6 @@ import { get } from "svelte/store";
 describe("actionable-sns-proposals.services", () => {
   beforeEach(() => {
     failedActionableSnsesStore.resetForTesting();
-    snsNeuronsStore.reset();
   });
 
   describe("loadActionableProposalsForSns", () => {

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -62,7 +62,6 @@ describe("sns-neurons-check-balances-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    snsNeuronsStore.reset();
     checkedNeuronSubaccountsStore.reset();
     resetSnsProjects();
 

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -100,8 +100,6 @@ describe("sns-neurons-services", () => {
 
   describe("syncSnsNeurons", () => {
     beforeEach(() => {
-      snsNeuronsStore.reset();
-
       setSnsProjects([
         {
           rootCanisterId: mockPrincipal,
@@ -170,7 +168,6 @@ describe("sns-neurons-services", () => {
 
   describe("loadSnsNeurons", () => {
     beforeEach(() => {
-      snsNeuronsStore.reset();
       vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
 
@@ -189,7 +186,6 @@ describe("sns-neurons-services", () => {
 
   describe("getSnsNeuron", () => {
     beforeEach(() => {
-      snsNeuronsStore.reset();
       vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
     it("should call api.querySnsNeuron and call load neuron when neuron not in store", () =>

--- a/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
@@ -38,7 +38,6 @@ describe("snsNeuronsTableOrderSortedNeuronIdsStore", () => {
 
   beforeEach(() => {
     neuronsTableOrderStore.reset();
-    snsNeuronsStore.reset();
     resetSnsProjects();
     snsNeuronsStore.setNeurons({
       rootCanisterId: mockRootCanisterId,

--- a/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
@@ -7,7 +7,6 @@ import { get } from "svelte/store";
 
 describe("SNS Neurons stores", () => {
   describe("snsNeurons store", () => {
-    beforeEach(() => snsNeuronsStore.reset());
     it("should set neurons for a project", () => {
       const neurons: SnsNeuron[] = [
         createMockSnsNeuron({


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `snsNeuronsStore`.

# Changes

1. Remove resetting of `snsNeuronsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary