### PR TITLE
Support snapshots created with PocketIC

### DIFF
--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -65,7 +65,23 @@ echo "*  starting the replica may just hang after a panic.                *"
 echo "*                                                                   *"
 echo "*********************************************************************"
 
+if [ "$(uname)" = "Darwin" ]; then
+  DFX_LOCAL_DATA_DIR="$HOME/Library/Application Support/org.dfinity.dfx/network/local"
+else
+  DFX_LOCAL_DATA_DIR="$HOME/.local/share/dfx/network/local"
+fi
+
+SNAPSHOT_TYPE="$(jq -r '.type' "$DFX_LOCAL_DATA_DIR/replica-effective-config.json")"
+
 DFX_ARGS=()
+
+if [ "$SNAPSHOT_TYPE" = "pocket_ic" ]; then
+  DFX_ARGS+=("--pocketic")
+# TODO: Add when --replica flag is supported.
+# else
+#   DFX_ARGS+=("--replica")
+#
+fi
 
 if [ "${DFX_HOST:-}" ]; then
   DFX_ARGS+=("--host" "$DFX_HOST")


### PR DESCRIPTION
# Motivation

When using `dfx start` you can pass `--pocketic` to run PocketIC instead of a replica.
Eventually this will be the default.
It also allows making calls from a controller that you do not control, which we need to take control of SNS canisters in order to freeze them to test NNS dapp behavior when SNS canisters are frozen.

If an snsdemo snapshot is made with `dfx start --pocketic` then we also need to pass `--pocketic` when starting the snapshot.

We can see if a snapshot was made with `--pocketic` by checking `.type` in `replica-effective-config.json`.

For a smooth transition when `--pocketic` becomes the default, we should also pass `--replica` if the snapshot wasn't made with PocketIC, but this will only work once we have a release including https://github.com/dfinity/sdk/pull/4014

# Changes

1. Check if the snapshot was made with PocketIC and if so, pass `--pocketic` when starting dfx.

# Tests

Tested manually on Mac and Linux with a snapshot made with and without PocketIC.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary