### PR TITLE
Stop calling defaultIcrcCanistersStore.reset() in beforeEach

### DIFF
--- a/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
@@ -14,7 +14,6 @@ describe("icrcCanistersStore", () => {
   const ledgerCanisterId3 = principal(3);
 
   beforeEach(() => {
-    defaultIcrcCanistersStore.reset();
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();
   });

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -20,10 +20,6 @@ import {
 import { get } from "svelte/store";
 
 describe("icrcTokensUniversesStore", () => {
-  beforeEach(() => {
-    defaultIcrcCanistersStore.reset();
-  });
-
   it("returns empty array if no tokens are present", () => {
     defaultIcrcCanistersStore.setCanisters({
       ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -105,10 +105,6 @@ describe("selected universe derived stores", () => {
   describe("isIcrcTokenUniverseStore", () => {
     const ledgerCanisterId = principal(0);
 
-    beforeEach(() => {
-      defaultIcrcCanistersStore.reset();
-    });
-
     it("should be ICRC Token inside ICRC Token universe", () => {
       page.mock({
         data: { universe: ledgerCanisterId.toText() },
@@ -431,7 +427,6 @@ describe("selected universe derived stores", () => {
     const ledgerCanisterId = principal(0);
 
     beforeEach(() => {
-      defaultIcrcCanistersStore.reset();
       defaultIcrcCanistersStore.setCanisters({
         ledgerCanisterId,
         indexCanisterId: principal(1),

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -4,7 +4,6 @@ import {
   snsOnlyProjectStore,
   snsProjectSelectedStore,
 } from "$lib/derived/sns/sns-selected-project.derived";
-import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
 import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import {
@@ -32,7 +31,6 @@ describe("selected sns project derived stores", () => {
           lifecycle: SnsSwapLifecycle.Committed,
         },
       ]);
-      defaultIcrcCanistersStore.reset();
     });
 
     it("should be set to undefined if NNS Universe", () => {

--- a/frontend/src/tests/lib/derived/universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes.derived.spec.ts
@@ -30,7 +30,6 @@ import { get } from "svelte/store";
 describe("universes derived stores", () => {
   beforeEach(() => {
     resetSnsProjects();
-    defaultIcrcCanistersStore.reset();
   });
 
   describe("ckTESTBTC enabled", () => {

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -116,7 +116,6 @@ describe("IcrcWallet", () => {
     vi.clearAllTimers();
     vi.useRealTimers();
     resetIdentity();
-    defaultIcrcCanistersStore.reset();
     busyStore.resetForTesting();
     importedTokensStore.reset();
 

--- a/frontend/src/tests/lib/services/icrc-canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-canisters.services.spec.ts
@@ -19,7 +19,6 @@ describe("icrc-canisters.services", () => {
   describe("loadIcrcCanisters", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
-      defaultIcrcCanistersStore.reset();
     });
 
     describe("if ckethtest is enabled", () => {

--- a/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
@@ -17,7 +17,6 @@ describe("icrc-tokens.services", () => {
     const token2 = { ...mockToken, name: "Token 2" };
 
     beforeEach(() => {
-      defaultIcrcCanistersStore.reset();
       vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockImplementation(
         async ({ canisterId }) => {
           if (canisterId.toText() === ledgerCanisterId1.toText()) {

--- a/frontend/src/tests/lib/services/public/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/app.services.spec.ts
@@ -25,7 +25,6 @@ vi.mock("$lib/services/public/sns.services", () => {
 
 describe("public/app-services", () => {
   beforeEach(() => {
-    defaultIcrcCanistersStore.reset();
     vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockCkETHToken);
     overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
   });

--- a/frontend/src/tests/lib/stores/icrc-canisters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-canisters.store.spec.ts
@@ -3,10 +3,6 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("icrc canisters store", () => {
-  beforeEach(() => {
-    defaultIcrcCanistersStore.reset();
-  });
-
   const ledgerCanisterId = principal(0);
   const indexCanisterId = principal(1);
 

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -159,10 +159,6 @@ describe("universes-utils", () => {
   });
 
   describe("isIcrcTokenUniverse", () => {
-    beforeEach(() => {
-      defaultIcrcCanistersStore.reset();
-    });
-
     it("should return true if universe is in ICRC Canisters store", () => {
       const universeId = principal(0);
       defaultIcrcCanistersStore.setCanisters({

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -134,7 +134,6 @@ describe("Tokens route", () => {
 
   describe("when feature flag enabled", () => {
     beforeEach(() => {
-      defaultIcrcCanistersStore.reset();
       importedTokensStore.reset();
       failedImportedTokenLedgerIdsStore.reset();
       ckBTCBalanceE8s = ckBTCDefaultBalanceE8s;


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `defaultIcrcCanistersStore`.

# Changes

1. Remove resetting of `defaultIcrcCanistersStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary