### PR TITLE
FOLLOW-244: Add notifyTopUpCanister to CMC API

### DIFF
--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -351,6 +351,33 @@ export const topUpCanister = async ({
   logWithTimestamp(`Topping up canister ${canisterId.toText()} complete.`);
 };
 
+// Returns the number of cycles that were topped up. But if called again, it
+// will return the same number. So this can't be used to tell if the top-up
+// wasn't done before.
+export const notifyTopUpCanister = async ({
+  identity,
+  blockHeight,
+  canisterId,
+}: {
+  identity: Identity;
+  blockHeight: bigint;
+  canisterId: Principal;
+}): Promise<bigint> => {
+  logWithTimestamp(`Notifying canister topup ${canisterId.toText()} call...`);
+
+  const { cmc } = await canisters(identity);
+  try {
+    return cmc.notifyTopUp({
+      canister_id: canisterId,
+      block_index: blockHeight,
+    });
+  } finally {
+    logWithTimestamp(
+      `Notifying canister topup ${canisterId.toText()} complete.`
+    );
+  }
+};
+
 const canisters = async (
   identity: Identity
 ): Promise<{


### PR DESCRIPTION
# Motivation

Topping up a canister is a 2-step process:
1. Transfer ICP to a subaccount of the CMC
2. Notify the CMC of the transfer

Because the process might be interrupted between the 2 steps, the nns-dapp canister listens for all transactions to see if any might be a canister top-up transaction by an NNS dapp user.

We want the NNS dapp to stop listening for all transactions so we want to move this fallback mechanism to the frontend.

In this PR we add just an API function that will be needed to notify the CMC from the frontend.

# Changes

1. Add `notifyTopUpCanister` to CMC API.

# Tests

1. Unit tests added.
2. Tested manually in another branch with more changes.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet