### PR TITLE
bot: Update sns_aggregator candid bindings

### DIFF
--- a/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
+++ b/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/sns/governance/canister/governance.did>
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -10,6 +10,7 @@ type Action = variant {
   ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
+  AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
@@ -25,6 +26,7 @@ type Action = variant {
 type ActionAuxiliary = variant {
   TransferSnsTreasuryFunds : MintSnsTokensActionAuxiliary;
   MintSnsTokens : MintSnsTokensActionAuxiliary;
+  AdvanceSnsTargetVersion : AdvanceSnsTargetVersionActionAuxiliary;
 };
 
 type AddNeuronPermissions = record {
@@ -258,7 +260,12 @@ type GetProposalResponse = record {
 
 type GetRunningSnsVersionResponse = record {
   deployed_version : opt Version;
-  pending_version : opt UpgradeInProgress;
+  pending_version : opt record {
+    mark_failed_at_seconds : nat64;
+    checking_upgrade_lock : nat64;
+    proposal_id : nat64;
+    target_version : opt Version;
+  };
 };
 
 type GetSnsInitializationParametersResponse = record {
@@ -371,6 +378,19 @@ type ManageDappCanisterSettings = record {
   compute_allocation : opt nat64;
 };
 
+type SnsVersion = record {
+  governance_wasm_hash : opt blob;
+  swap_wasm_hash : opt blob;
+  root_wasm_hash : opt blob;
+  index_wasm_hash : opt blob;
+  ledger_wasm_hash : opt blob;
+  archive_wasm_hash : opt blob;
+};
+
+type AdvanceSnsTargetVersion = record {
+  new_target : opt SnsVersion;
+};
+
 type ManageLedgerParameters = record {
   token_symbol : opt text;
   transfer_fee : opt nat64;
@@ -422,6 +442,10 @@ type MintSnsTokens = record {
 
 type MintSnsTokensActionAuxiliary = record {
   valuation : opt Valuation;
+};
+
+type AdvanceSnsTargetVersionActionAuxiliary = record {
+  target_version : opt SnsVersion;
 };
 
 type Motion = record {
@@ -675,14 +699,14 @@ type TransferSnsTreasuryFunds = record {
 type UpgradeInProgress = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
-  proposal_id : nat64;
+  proposal_id : opt nat64;
   target_version : opt Version;
 };
 
 type PendingVersion = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
-  proposal_id : nat64;
+  proposal_id : opt nat64;
   target_version : opt Version;
 };
 
@@ -757,6 +781,7 @@ type TargetVersionSet = record {
 type TargetVersionReset = record {
   new_target_version : opt Version;
   old_target_version : opt Version;
+  human_readable : opt text;
 };
 
 type UpgradeStarted = record {
@@ -788,6 +813,7 @@ type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
+  deployed_version : opt Version;
   upgrade_journal : opt UpgradeJournal;
 };
 

--- a/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
+++ b/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/ledger_suite/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/ledger_suite/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/used_by_sns_aggregator/sns_root/sns_root.did
+++ b/declarations/used_by_sns_aggregator/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/sns/root/canister/root.did>
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
+++ b/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/dfx.json
+++ b/dfx.json
@@ -434,7 +434,7 @@
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-11-20",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-11-21_03-11-24.04-base-kernel",
-        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-11-14_03-07-base"
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-11-21_03-11-24.04-base-kernel"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -126,6 +126,7 @@ pub struct UpgradeStepsRefreshed {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TargetVersionReset {
+    pub human_readable: Option<String>,
     pub old_target_version: Option<Version>,
     pub new_target_version: Option<Version>,
 }
@@ -207,7 +208,7 @@ pub struct RewardEvent {
 pub struct PendingVersion {
     pub mark_failed_at_seconds: u64,
     pub checking_upgrade_lock: u64,
-    pub proposal_id: u64,
+    pub proposal_id: Option<u64>,
     pub target_version: Option<Version>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -250,9 +251,23 @@ pub struct MintSnsTokensActionAuxiliary {
     pub valuation: Option<Valuation>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct SnsVersion {
+    pub archive_wasm_hash: Option<serde_bytes::ByteBuf>,
+    pub root_wasm_hash: Option<serde_bytes::ByteBuf>,
+    pub swap_wasm_hash: Option<serde_bytes::ByteBuf>,
+    pub ledger_wasm_hash: Option<serde_bytes::ByteBuf>,
+    pub governance_wasm_hash: Option<serde_bytes::ByteBuf>,
+    pub index_wasm_hash: Option<serde_bytes::ByteBuf>,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct AdvanceSnsTargetVersionActionAuxiliary {
+    pub target_version: Option<SnsVersion>,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum ActionAuxiliary {
     TransferSnsTreasuryFunds(MintSnsTokensActionAuxiliary),
     MintSnsTokens(MintSnsTokensActionAuxiliary),
+    AdvanceSnsTargetVersion(AdvanceSnsTargetVersionActionAuxiliary),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ballot {
@@ -313,6 +328,10 @@ pub struct MintSnsTokens {
     pub amount_e8s: Option<u64>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct AdvanceSnsTargetVersion {
+    pub new_target: Option<SnsVersion>,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageSnsMetadata {
     pub url: Option<String>,
     pub logo: Option<String>,
@@ -347,6 +366,7 @@ pub enum Action {
     UpgradeSnsControlledCanister(UpgradeSnsControlledCanister),
     DeregisterDappCanisters(DeregisterDappCanisters),
     MintSnsTokens(MintSnsTokens),
+    AdvanceSnsTargetVersion(AdvanceSnsTargetVersion),
     Unspecified(EmptyRecord),
     ManageSnsMetadata(ManageSnsMetadata),
     ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
@@ -690,7 +710,7 @@ pub struct CanisterStatusResultV2 {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetRunningSnsVersionArg {}
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct UpgradeInProgress {
+pub struct GetRunningSnsVersionResponsePendingVersionInner {
     pub mark_failed_at_seconds: u64,
     pub checking_upgrade_lock: u64,
     pub proposal_id: u64,
@@ -699,7 +719,7 @@ pub struct UpgradeInProgress {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetRunningSnsVersionResponse {
     pub deployed_version: Option<Version>,
-    pub pending_version: Option<UpgradeInProgress>,
+    pub pending_version: Option<GetRunningSnsVersionResponsePendingVersionInner>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsInitializationParametersArg {}
@@ -720,6 +740,7 @@ pub struct GetUpgradeJournalResponse {
     pub upgrade_journal: Option<UpgradeJournal>,
     pub upgrade_steps: Option<Versions>,
     pub response_timestamp_seconds: Option<u64>,
+    pub deployed_version: Option<Version>,
     pub target_version: Option<Version>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/ledger_suite/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/ledger_suite/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-14_03-07-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-11-21_03-11-24.04-base-kernel/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We would like to parse all the latest SNS data. To do so, we update the candid interfaces for the SNS aggregator.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_SNS_AGGREGATOR` specified in `dfx.json`.
* Updated the `sns_aggregator` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the aggregator.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  Breaking changes are:
    * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants