### PR TITLE
FOLLOW-244: Add notifyTopUpIfNeeded to canisters service

### DIFF
--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -181,9 +181,9 @@ export const topUpCanister = async ({
   }
 };
 
-// Returns the blockheight of the transaction, if it was a canister topup, or
+// Returns the blockheight of the transaction, if it was a canister top-up, or
 // undefined otherwise.
-const getBlockHeightFromCanisterTopup = ({
+const getBlockHeightFromCanisterTopUp = ({
   id: blockHeight,
   transaction: { memo, operation },
 }: TransactionWithId): bigint | undefined => {
@@ -219,7 +219,7 @@ export const notifyTopUpIfNeeded = async ({
     return false;
   }
 
-  const blockHeight = getBlockHeightFromCanisterTopup(transaction);
+  const blockHeight = getBlockHeightFromCanisterTopUp(transaction);
 
   if (isNullish(blockHeight)) {
     // This should be very rare but it might be useful to know if it happens.

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -623,7 +623,7 @@ describe("canisters-services", () => {
     it("should notify if there is a non-zero balance from an unburned top-up", async () => {
       const blockHeight = 34n;
       const memo = 0x50555054n; // TPUP
-      const topupTransaction = createTransactionWithId({
+      const topUpTransaction = createTransactionWithId({
         id: blockHeight,
         memo,
       });
@@ -631,7 +631,7 @@ describe("canisters-services", () => {
       const spyGetTransactions = vi.spyOn(icpIndexApi, "getTransactions");
       spyGetTransactions.mockResolvedValue({
         balance: 100_000_000n,
-        transactions: [topupTransaction],
+        transactions: [topUpTransaction],
       });
 
       const result = await notifyTopUpIfNeeded({
@@ -673,10 +673,10 @@ describe("canisters-services", () => {
       expect(spyNotifyTopUpCanister).toBeCalledTimes(0);
     });
 
-    it("should not notify if there is a non-zero balance from a non-topup transaction", async () => {
+    it("should not notify if there is a non-zero balance from a non-top-up transaction", async () => {
       const blockHeight = 34n;
       const memo = 0n;
-      const nonTopupTransaction = createTransactionWithId({
+      const nonTopUpTransaction = createTransactionWithId({
         id: blockHeight,
         memo,
       });
@@ -687,7 +687,7 @@ describe("canisters-services", () => {
       const spyGetTransactions = vi.spyOn(icpIndexApi, "getTransactions");
       spyGetTransactions.mockResolvedValue({
         balance,
-        transactions: [nonTopupTransaction],
+        transactions: [nonTopUpTransaction],
       });
 
       const result = await notifyTopUpIfNeeded({
@@ -705,7 +705,7 @@ describe("canisters-services", () => {
           balance,
           canisterId: canisterId.toText(),
           cmcAccountIdentifierHex,
-          transaction: nonTopupTransaction,
+          transaction: nonTopUpTransaction,
         }
       );
     });
@@ -713,7 +713,7 @@ describe("canisters-services", () => {
     it("should ignore errors on notifying", async () => {
       const blockHeight = 34n;
       const memo = 0x50555054n; // TPUP
-      const topupTransaction = createTransactionWithId({
+      const topUpTransaction = createTransactionWithId({
         id: blockHeight,
         memo,
       });
@@ -723,7 +723,7 @@ describe("canisters-services", () => {
       const spyGetTransactions = vi.spyOn(icpIndexApi, "getTransactions");
       spyGetTransactions.mockResolvedValue({
         balance: 100_000_000n,
-        transactions: [topupTransaction],
+        transactions: [topUpTransaction],
       });
 
       const error = new Error("Notify in progress");


### PR DESCRIPTION
# Motivation

Topping up a canister is a 2-step process:

1. Transfer ICP to a subaccount of the CMC
2. Notify the CMC of the transfer
Because the process might be interrupted between the 2 steps, the nns-dapp canister listens for all transactions to see if any might be a canister top-up transaction by an NNS dapp user.

We want the NNS dapp to stop listening for all transactions so we want to move this fallback mechanism to the frontend.

In this PR we add a service function that will be used to check if the CMC needs to be notified and to do so if needed.

It only checks the most recent transaction to see if it is a funding transaction. It's theoretically possible to have a funding transaction that is followed by another transaction that's not the corresponding burn transaction. This was discussed with the PM and decided that it's unlikely enough that it's not worth the extra complexity to take into account. If we decide later that we do want to take this into account we can still recover from those cases that were missed before.

# Changes

1. Add `notifyTopUpIfNeeded`. It checks the latest transaction on the CMC subaccount for a specific canister and notifies the CMC if the latest transaction is a top-up transaction.

# Tests

1. Added unit tests.
2. Tested manually in a branch with end-to-end changes.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet