### PR TITLE
FOLLOW-244: Notify for unfinished canister top-ups from the frontend

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Notify for unfinished canister top-ups from the frontend.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -8,6 +8,7 @@
   import {
     getCanisterDetails,
     listCanisters,
+    notifyTopUpIfNeeded,
   } from "$lib/services/canisters.services";
   import { canistersStore } from "$lib/stores/canisters.store";
   import { i18n } from "$lib/stores/i18n";
@@ -37,7 +38,7 @@
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
   import { getCanisterFromStore } from "$lib/utils/canisters.utils";
   import { emit } from "$lib/utils/events.utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
 
   // BEGIN: loading and navigation
 
@@ -176,6 +177,20 @@
 
   $: ({ details: canisterDetails, info: canisterInfo } =
     $selectedCanisterStore);
+
+  let notifyChecked = false;
+
+  const notifyIfNeeded = async (canisterId: Principal | undefined) => {
+    if (notifyChecked || isNullish(canisterId)) {
+      return;
+    }
+    notifyChecked = true;
+    if (await notifyTopUpIfNeeded({ canisterId })) {
+      reloadDetails(canisterId);
+    }
+  };
+
+  $: notifyIfNeeded(canisterInfo?.canister_id);
 
   // END: loading and navigation
 


### PR DESCRIPTION
# Motivation

# Motivation

Topping up a canister is a 2-step process:

1. Transfer ICP to a subaccount of the CMC
2. Notify the CMC of the transfer
Because the process might be interrupted between the 2 steps, the nns-dapp canister listens for all transactions to see if any might be a canister top-up transaction by an NNS dapp user.

We want the NNS dapp to stop listening for all transactions so we want to move this fallback mechanism to the frontend.

# Changes

1. Call the service function that was added in https://github.com/dfinity/nns-dapp/pull/5857 from `CanisterDetails` to actually do the notifying if needed.

# Tests

1. Unit tests added.
2. Tested manually by removing the top-up functionality from the backend canister and reloading the page in the middle of the top-up process.

# Todos

- [x] Add entry to changelog (if necessary).
