### PR TITLE
Stop resetting actionableNnsProposalsStore and actionableSnsProposals…

### DIFF
--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -206,8 +206,6 @@ describe("MenuItems", () => {
 
     beforeEach(() => {
       resetIdentity();
-      actionableNnsProposalsStore.reset();
-      actionableSnsProposalsStore.resetForTesting();
     });
 
     it("should display actionable proposal count", async () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -41,8 +41,6 @@ describe("SelectUniverseCard", () => {
   };
 
   beforeEach(() => {
-    actionableNnsProposalsStore.reset();
-    actionableSnsProposalsStore.resetForTesting();
     resetAccountsForTesting();
     resetIdentity();
   });
@@ -165,7 +163,6 @@ describe("SelectUniverseCard", () => {
     describe("when signed in", () => {
       beforeEach(() => {
         resetIdentity();
-        actionableSnsProposalsStore.resetForTesting();
       });
 
       it("should display balance if selected", async () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -29,9 +29,6 @@ describe("SelectUniverseNav", () => {
 
   beforeEach(() => {
     resetSnsProjects();
-    actionableNnsProposalsStore.reset();
-    actionableSnsProposalsStore.resetForTesting();
-
     resetIdentity();
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -48,8 +48,6 @@ describe("actionable proposals derived stores", () => {
 
   beforeEach(() => {
     resetSnsProjects();
-    actionableNnsProposalsStore.reset();
-    actionableSnsProposalsStore.resetForTesting();
     failedActionableSnsesStore.resetForTesting();
   });
 

--- a/frontend/src/tests/lib/derived/proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/proposals.derived.spec.ts
@@ -56,7 +56,6 @@ describe("proposals-derived", () => {
     beforeEach(() => {
       proposalsStore.resetForTesting();
       proposalsFiltersStore.reset();
-      actionableNnsProposalsStore.reset();
     });
 
     it("should append isActionable", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-filtered-actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-filtered-actionable-proposals.derived.spec.ts
@@ -26,7 +26,6 @@ describe("snsFilteredActionableProposalsStore", () => {
 
   beforeEach(() => {
     snsProposalsStore.reset();
-    actionableSnsProposalsStore.resetForTesting();
 
     const decisionStatus = [
       {

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -60,8 +60,6 @@ describe("ActionableProposals", () => {
   beforeEach(() => {
     resetIdentity();
     resetSnsProjects();
-    actionableNnsProposalsStore.reset();
-    actionableSnsProposalsStore.resetForTesting();
 
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -51,7 +51,6 @@ describe("NnsProposals", () => {
     proposalsStore.resetForTesting();
     resetNeuronsApiService();
     proposalsFiltersStore.reset();
-    actionableNnsProposalsStore.reset();
     actionableProposalsSegmentStore.resetForTesting();
 
     resetIdentity();

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -73,7 +73,6 @@ describe("SnsProposalDetail", () => {
     resetIdentity();
     page.reset();
     resetSnsProjects();
-    actionableSnsProposalsStore.resetForTesting();
     actionableProposalsSegmentStore.resetForTesting();
     snsProposalsStore.reset();
   });

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -65,7 +65,6 @@ describe("SnsProposals", () => {
       },
     ]);
     actionableProposalsSegmentStore.resetForTesting();
-    actionableSnsProposalsStore.resetForTesting();
   });
 
   describe("logged in user", () => {

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -97,7 +97,6 @@ describe("actionable-proposals.services", () => {
     let spyConsoleError;
 
     beforeEach(() => {
-      actionableNnsProposalsStore.reset();
       resetIdentity();
       spyQueryProposals = vi
         .spyOn(api, "queryProposals")

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -128,7 +128,6 @@ describe("actionable-sns-proposals.services", () => {
 
     beforeEach(() => {
       resetSnsProjects();
-      actionableSnsProposalsStore.resetForTesting();
       resetIdentity();
 
       resetIdentity();

--- a/frontend/src/tests/lib/stores/actionable-nns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-nns-proposals.store.spec.ts
@@ -3,10 +3,6 @@ import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { get } from "svelte/store";
 
 describe("actionable Nns proposals store", () => {
-  beforeEach(() => {
-    actionableNnsProposalsStore.reset();
-  });
-
   it("should push proposal", () => {
     actionableNnsProposalsStore.setProposals([mockProposalInfo]);
     expect(get(actionableNnsProposalsStore).proposals).toEqual([

--- a/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
@@ -19,9 +19,6 @@ describe("actionableSnsProposalsStore", () => {
   const principal1 = principal(0);
   const principal2 = principal(1);
   const principal3 = principal(2);
-  beforeEach(() => {
-    actionableSnsProposalsStore.resetForTesting();
-  });
 
   it("should store sns proposals", () => {
     actionableSnsProposalsStore.set({

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -1,6 +1,5 @@
 import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
 import { initAuthWorker } from "$lib/services/worker-auth.services";
-import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import App from "$routes/+layout.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
@@ -25,8 +24,6 @@ vi.mock("$lib/proxy/app.services.proxy");
 
 describe("Layout", () => {
   beforeEach(() => {
-    actionableNnsProposalsStore.reset();
-
     setNoIdentity();
   });
 


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) get reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of 1 store at a time.

This PR does so for `actionableNnsProposalsStore` and `actionableSnsProposals`.

# Changes

1. Remove resetting of `actionableNnsProposalsStore` and `actionableSnsProposals` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary