### PR TITLE
housekeeping: Migrate AccountMenu tests to utilize a page object

### DIFF
--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -43,7 +43,6 @@ describe("AccountMenu", () => {
     });
 
     it("should be open", async () => {
-      // const renderResult = render(AccountMenu);
       const { accountMenuPo } = renderComponent();
       await accountMenuPo.openMenu();
       expect(await accountMenuPo.isOpen()).toBe(true);
@@ -67,7 +66,7 @@ describe("AccountMenu", () => {
       const { accountMenuPo } = renderComponent();
       await accountMenuPo.openMenu();
 
-      expect(await accountMenuPo.getManangeIIButtonPo().isPresent()).toBe(true);
+      expect(await accountMenuPo.getManangeIILinkPo().isPresent()).toBe(true);
     });
 
     it('should display "Canisters" button', async () => {

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -1,4 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ExportNeuronsButtonPo } from "$tests/page-objects/ExportNeuronsButton.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AccountDetailsPo } from "./AccountDetails.page-object";
@@ -31,28 +32,28 @@ export class AccountMenuPo extends BasePageObject {
     });
   }
 
-  getSignInButtonPo(): LinkPo {
-    return LinkPo.under({
+  getSignInButtonPo(): ButtonPo {
+    return ButtonPo.under({
       element: this.root,
       testId: "toolbar-login",
     });
   }
 
-  getSignOutButtonPo(): LinkPo {
-    return LinkPo.under({
+  getSignOutButtonPo(): ButtonPo {
+    return ButtonPo.under({
       element: this.root,
       testId: "logout",
     });
   }
 
-  getSettingsButtonPo(): LinkPo {
-    return LinkPo.under({
+  getSettingsButtonPo(): ButtonPo {
+    return ButtonPo.under({
       element: this.root,
       testId: "settings",
     });
   }
 
-  getManangeIIButtonPo(): LinkPo {
+  getManangeIILinkPo(): LinkPo {
     return LinkPo.under({
       element: this.root,
       testId: "manage-ii-link",

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -11,6 +11,11 @@ export class AccountMenuPo extends BasePageObject {
     return new AccountMenuPo(element.byTestId(AccountMenuPo.TID));
   }
 
+  isOpen(): Promise<boolean> {
+    const popover = this.root.querySelector('[role="menu"]');
+    return popover.isPresent();
+  }
+
   openMenu(): Promise<void> {
     return this.click("account-menu");
   }
@@ -23,6 +28,34 @@ export class AccountMenuPo extends BasePageObject {
     return LinkPo.under({
       element: this.root,
       testId: "canisters-button",
+    });
+  }
+
+  getSignInButtonPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "toolbar-login",
+    });
+  }
+
+  getSignOutButtonPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "logout",
+    });
+  }
+
+  getSettingsButtonPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "settings",
+    });
+  }
+
+  getManangeIIButtonPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "manage-ii-link",
     });
   }
 

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -13,8 +13,7 @@ export class AccountMenuPo extends BasePageObject {
   }
 
   isOpen(): Promise<boolean> {
-    const popover = this.root.querySelector('[role="menu"]');
-    return popover.isPresent();
+    return this.isPresent("popover-component");
   }
 
   openMenu(): Promise<void> {


### PR DESCRIPTION
# Motivation

We want to be consistent in how we test components using page objects.

# Changes

- Migrate `AccountMenu` tests to only use PageObjects

# Tests

- They work as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary