### PR TITLE
Give useful output in scripts/vote

### DIFF
--- a/scripts/vote
+++ b/scripts/vote
@@ -53,7 +53,12 @@ get_all_neuron_ids() {
 }
 
 if [[ "${NEURON_ID:-}" == "all" ]]; then
-  for neuron_id in $(get_all_neuron_ids); do
+  mapfile -t neuron_ids < <(get_all_neuron_ids)
+  if [[ "${#neuron_ids[@]}" -eq 0 ]]; then
+    echo "No neurons found that can vote belonging to identity $DFX_IDENTITY."
+    exit 1
+  fi
+  for neuron_id in "${neuron_ids[@]}"; do
     "$0" \
       --neuron "$neuron_id" \
       --proposal "${PROPOSAL_ID:-}" \
@@ -83,7 +88,9 @@ get_all_proposal_ids() {
 
 if [[ "${PROPOSAL_ID:-}" == "all" ]]; then
   pids=()
-  for proposal_id in $(get_all_proposal_ids); do
+  mapfile -t proposal_ids < <(get_all_proposal_ids)
+  echo "Voting on ${#proposal_ids[@]} open proposals with neuron $NEURON_ID."
+  for proposal_id in "${proposal_ids[@]}"; do
     "$0" \
       --neuron "$NEURON_ID" \
       --proposal "$proposal_id" \


### PR DESCRIPTION
# Motivation

I was trying to use `scripts/vote` to vote on a proposal on my DevEnv but it didn't do anything because I was using the wrong identity which didn't have any neurons.
This was confusing because the script didn't output anything and didn't give any error.

# Changes

Provide some useful output about the neurons and number of proposals.

# Tests

Tested manually by specifying a wrong identity and a correct identity.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary