### PR TITLE
chore(IDX): replace custom token with workflow permissions

### DIFF
--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -15,13 +15,10 @@ on:
 jobs:
   update-next-dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -44,7 +41,6 @@ jobs:
         # Note: If there were no changes, this step creates no PR.
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ steps.app-token.outputs.token }}
           commit-message: Bump
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>


### PR DESCRIPTION
# Motivation

Upon another review, it does not appear that this workflow requires a token at all, since the same behavior should be able to be achieved just by updating permissions.

# Changes

Replaces the need for a token with workflow permissions.

# Tests

How can I best test this?

# Todos

- [ ] Test
