### PR TITLE
housekeeping: Removes the need to wait for getCurrentIdentity

### DIFF
--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -19,7 +19,7 @@ export const loadIcpAccountTransactions = async ({
 }: LoadIcrcAccountTransactionsParams) => {
   try {
     const maxResults = DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT;
-    const identity = await getCurrentIdentity();
+    const identity = getCurrentIdentity();
     const { transactions, oldestTxId } = await getTransactions({
       accountIdentifier,
       identity,

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -170,7 +170,7 @@ export const loadOpenTicket = async ({
   maxAttempts?: number;
 }): Promise<void> => {
   try {
-    const identity = await getCurrentIdentity();
+    const identity = getCurrentIdentity();
     const ticket = await pollGetOpenTicket({
       identity,
       swapCanisterId,
@@ -349,7 +349,7 @@ export const loadNewSaleTicket = async ({
 }): Promise<void> => {
   logWithTimestamp("[sale]newSaleTicket:", amount_icp_e8s, Boolean(subaccount));
   try {
-    const identity = await getCurrentIdentity();
+    const identity = getCurrentIdentity();
     const ticket = await pollNewSaleTicket({
       identity,
       rootCanisterId,


### PR DESCRIPTION
# Motivation

`getCurrentIdentity` doesn't return a promise; thus, it is not necessary to `await` it.


# Changes

- Remove `await` from some calls to `getCurrentIdentity`

# Tests

- Tests work as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary