### PR TITLE
fix: Checks for empty transactions to define getTransactions as completed

### DIFF
--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -4,7 +4,7 @@ import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { toToastError } from "$lib/utils/error.utils";
 import { sortTransactionsByIdDescendingOrder } from "$lib/utils/icp-transactions.utils";
-import { nonNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getCurrentIdentity } from "./auth.services";
 
@@ -28,7 +28,7 @@ export const loadIcpAccountTransactions = async ({
     });
 
     const completed =
-      transactions.length === 0 ||
+      isNullish(oldestTxId) ||
       transactions.some(({ id }) => id === oldestTxId);
 
     icpTransactionsStore.addTransactions({

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -27,7 +27,7 @@ export const loadIcpAccountTransactions = async ({
       start,
     });
 
-    // We consider it complete if we find the oldestTxId in the list of transactions or if oldestTxId is null. 
+    // We consider it complete if we find the oldestTxId in the list of transactions or if oldestTxId is null.
     // The latter condition is necessary if the list of transactions is empty, which would otherwise return false.
     const completed =
       isNullish(oldestTxId) || transactions.some(({ id }) => id === oldestTxId);

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -27,7 +27,10 @@ export const loadIcpAccountTransactions = async ({
       start,
     });
 
-    const completed = transactions.some(({ id }) => id === oldestTxId);
+    const completed =
+      transactions.length === 0 ||
+      transactions.some(({ id }) => id === oldestTxId);
+
     icpTransactionsStore.addTransactions({
       accountIdentifier,
       transactions,

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -28,8 +28,7 @@ export const loadIcpAccountTransactions = async ({
     });
 
     const completed =
-      isNullish(oldestTxId) ||
-      transactions.some(({ id }) => id === oldestTxId);
+      isNullish(oldestTxId) || transactions.some(({ id }) => id === oldestTxId);
 
     icpTransactionsStore.addTransactions({
       accountIdentifier,

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -27,6 +27,8 @@ export const loadIcpAccountTransactions = async ({
       start,
     });
 
+    // We consider it complete if we find the oldestTxId in the list of transactions or if oldestTxId is null. 
+    // The latter condition is necessary if the list of transactions is empty, which would otherwise return false.
     const completed =
       isNullish(oldestTxId) || transactions.some(({ id }) => id === oldestTxId);
 

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -134,6 +134,24 @@ describe("icp-transactions services", () => {
       expect(get(icpTransactionsStore)[accountIdentifier].completed).toBe(true);
     });
 
+    it("sets complete to true when empty array", async () => {
+      const oldestTxId = 10n;
+      const transactions = []; 
+      
+      vi.spyOn(indexApi, "getTransactions").mockResolvedValue({
+        oldestTxId,
+        transactions: transactions,
+        balance: 200_000_000n,
+      });
+
+      await loadIcpAccountTransactions({
+        accountIdentifier,
+        start: undefined,
+      });
+
+      expect(get(icpTransactionsStore)[accountIdentifier].completed).toBe(true);
+    });
+
     it("toasts error if api fails", async () => {
       vi.spyOn(indexApi, "getTransactions").mockRejectedValue(
         new Error("Something happened")

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -135,7 +135,7 @@ describe("icp-transactions services", () => {
     });
 
     it("sets complete to true when empty array", async () => {
-      const oldestTxId = 10n;
+      const oldestTxId = null;
       const transactions = []; 
       
       vi.spyOn(indexApi, "getTransactions").mockResolvedValue({

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -136,8 +136,8 @@ describe("icp-transactions services", () => {
 
     it("sets complete to true when empty array", async () => {
       const oldestTxId = null;
-      const transactions = []; 
-      
+      const transactions = [];
+
       vi.spyOn(indexApi, "getTransactions").mockResolvedValue({
         oldestTxId,
         transactions: transactions,


### PR DESCRIPTION
# Motivation

The `.some` function returns `false` when the transactions array is empty because it cannot find `null` (`oldestTxId`). This is an error, as it should handle this case.

You can reproduce the issue by following these steps:
-  Navigate to the transactions page of a SubAccount with no transactions.
-  The `InfiniteScroll` will never be disabled as expected [here](https://github.com/dfinity/nns-dapp/blob/74767085476d849d58943233ea36da723aedf96a/frontend/src/lib/components/accounts/UiTransactionsList.svelte#L22).
-  However, since we check the size of transactions [here](https://github.com/dfinity/nns-dapp/blob/74767085476d849d58943233ea36da723aedf96a/frontend/src/lib/components/accounts/UiTransactionsList.svelte#L16), the bug does not have an impact.

# Changes

- Added a check to `oldestTxId` to determine whether `getTransactions` is complete.

# Tests

- Added new test to catch the empty flow.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary