### PR TITLE
secondsUntilLosingReward util

### DIFF
--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1186,7 +1186,7 @@ const getVotingPowerRefreshedTimestampSeconds = ({
   // to avoid unnecessary notifications.
   fullNeuron?.votingPowerRefreshedTimestampSeconds ?? BigInt(nowInSeconds());
 
-export const secondsUntilLosingReward = (neuron: NeuronInfo): number => {
+export const secondsUntilLosingRewards = (neuron: NeuronInfo): number => {
   const rewardLossStart =
     Number(getVotingPowerRefreshedTimestampSeconds(neuron)) +
     START_REDUCING_VOTING_POWER_AFTER_SECONDS;
@@ -1194,11 +1194,11 @@ export const secondsUntilLosingReward = (neuron: NeuronInfo): number => {
 };
 
 export const isNeuronLosingRewards = (neuron: NeuronInfo): boolean =>
-  secondsUntilLosingReward(neuron) <= 0;
+  secondsUntilLosingRewards(neuron) <= 0;
 
 // e.g. "Neuron will start losing rewards in 30 days"
 export const shouldDisplayRewardLossNotification = (
   neuron: NeuronInfo
 ): boolean =>
-  secondsUntilLosingReward(neuron) <=
+  secondsUntilLosingRewards(neuron) <=
   daysToSeconds(NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS);

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1186,16 +1186,19 @@ const getVotingPowerRefreshedTimestampSeconds = ({
   // to avoid unnecessary notifications.
   fullNeuron?.votingPowerRefreshedTimestampSeconds ?? BigInt(nowInSeconds());
 
+export const secondsUntilLosingReward = (neuron: NeuronInfo): number => {
+  const rewardLossStart =
+    Number(getVotingPowerRefreshedTimestampSeconds(neuron)) +
+    START_REDUCING_VOTING_POWER_AFTER_SECONDS;
+  return rewardLossStart - nowInSeconds();
+};
+
 export const isNeuronLosingRewards = (neuron: NeuronInfo): boolean =>
-  nowInSeconds() >=
-  getVotingPowerRefreshedTimestampSeconds(neuron) +
-    BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS);
+  secondsUntilLosingReward(neuron) <= 0;
 
 // e.g. "Neuron will start losing rewards in 30 days"
 export const shouldDisplayRewardLossNotification = (
   neuron: NeuronInfo
 ): boolean =>
-  nowInSeconds() >=
-  getVotingPowerRefreshedTimestampSeconds(neuron) +
-    BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS) -
-    BigInt(daysToSeconds(NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS));
+  secondsUntilLosingReward(neuron) <=
+  daysToSeconds(NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS);

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -65,7 +65,7 @@ import {
   neuronStakedMaturity,
   neuronVotingPower,
   neuronsVotingPower,
-  secondsUntilLosingReward,
+  secondsUntilLosingRewards,
   shouldDisplayRewardLossNotification,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
@@ -3295,10 +3295,10 @@ describe("neuron-utils", () => {
     const losingRewardsPeriod = SECONDS_IN_HALF_YEAR;
     const notificationPeriod = 30 * SECONDS_IN_DAY;
 
-    describe("secondsUntilLosingReward", () => {
+    describe("secondsUntilLosingRewards", () => {
       it("should return future date when no fullNeuron", () => {
         expect(
-          secondsUntilLosingReward({
+          secondsUntilLosingRewards({
             ...mockNeuron,
             fullNeuron: undefined,
           })
@@ -3307,14 +3307,14 @@ describe("neuron-utils", () => {
 
       it("should return seconds until losing rewards", () => {
         expect(
-          secondsUntilLosingReward(
+          secondsUntilLosingRewards(
             neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: 0,
             })
           )
         ).toBe(SECONDS_IN_HALF_YEAR);
         expect(
-          secondsUntilLosingReward(
+          secondsUntilLosingRewards(
             neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod,
             })

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -65,6 +65,7 @@ import {
   neuronStakedMaturity,
   neuronVotingPower,
   neuronsVotingPower,
+  secondsUntilLosingReward,
   shouldDisplayRewardLossNotification,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
@@ -3293,6 +3294,34 @@ describe("neuron-utils", () => {
     });
     const losingRewardsPeriod = SECONDS_IN_HALF_YEAR;
     const notificationPeriod = 30 * SECONDS_IN_DAY;
+
+    describe("secondsUntilLosingReward", () => {
+      it("should return future date when no fullNeuron", () => {
+        expect(
+          secondsUntilLosingReward({
+            ...mockNeuron,
+            fullNeuron: undefined,
+          })
+        ).toEqual(BigInt(SECONDS_IN_HALF_YEAR));
+      });
+
+      it("should return seconds until losing rewards", () => {
+        expect(
+          secondsUntilLosingReward(
+            neuronWithRefreshedTimestamp({
+              votingPowerRefreshedTimestampAgeSecs: 0,
+            })
+          )
+        ).toBe(SECONDS_IN_HALF_YEAR);
+        expect(
+          secondsUntilLosingReward(
+            neuronWithRefreshedTimestamp({
+              votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod,
+            })
+          )
+        ).toBe(0);
+      });
+    });
 
     describe("isNeuronLosingRewards", () => {
       it("should return false by default", () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3302,7 +3302,7 @@ describe("neuron-utils", () => {
             ...mockNeuron,
             fullNeuron: undefined,
           })
-        ).toEqual(BigInt(SECONDS_IN_HALF_YEAR));
+        ).toEqual(SECONDS_IN_HALF_YEAR);
       });
 
       it("should return seconds until losing rewards", () => {


### PR DESCRIPTION
# Motivation

For the periodic confirmation feature, the time until the neuron starts losing rewards should be displayed. A function to retrieve this value in seconds has been added here.

# Changes

- New util `secondsUntilLosingReward`.
- Refactor relater utils to use it.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary