### PR TITLE
housekeeping: Refactors SettingsButton into a link

### DIFF
--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -2,7 +2,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import ExportNeuronsButton from "$lib/components/header/ExportNeuronsButton.svelte";
   import ManageInternetIdentityButton from "$lib/components/header/ManageInternetIdentityButton.svelte";
-  import SettingsButton from "$lib/components/header/SettingsButton.svelte";
+  import LinkToSettings from "$lib/components/header/LinkToSettings.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { ENABLE_EXPORT_NEURONS_REPORT } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
@@ -37,7 +37,7 @@
 
         <ManageInternetIdentityButton />
 
-        <SettingsButton on:nnsLink={closeMenu} />
+        <LinkToSettings on:nnsLink={closeMenu} />
 
         <LinkToCanisters on:nnsLink={closeMenu} />
 

--- a/frontend/src/lib/components/header/LinkToSettings.svelte
+++ b/frontend/src/lib/components/header/LinkToSettings.svelte
@@ -1,29 +1,28 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
+  import { beforeNavigate } from "$app/navigation";
   import { i18n } from "$lib/stores/i18n";
   import { IconSettings } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
 
   const dispatcher = createEventDispatcher();
+  
+  beforeNavigate(() => dispatcher("nnsLink"));
 </script>
 
-<button
-  data-tid="settings"
-  on:click={async () => {
-    await goto("/settings");
-    dispatcher("nnsLink");
-  }}
-  class="text"
->
+<a data-tid="settings" href="/settings" class="text">
   <IconSettings />
   {$i18n.navigation.settings}
-</button>
+</a>
 
 <style lang="scss">
   @use "../../themes/mixins/account-menu";
 
-  button {
+  a {
     @include account-menu.button;
-    padding: 0;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 </style>

--- a/frontend/src/lib/components/header/LinkToSettings.svelte
+++ b/frontend/src/lib/components/header/LinkToSettings.svelte
@@ -5,11 +5,12 @@
   import { createEventDispatcher } from "svelte";
 
   const dispatcher = createEventDispatcher();
+  const linkToSettings = "/settings";
 
   beforeNavigate(() => dispatcher("nnsLink"));
 </script>
 
-<a data-tid="settings" href="/settings" class="text">
+<a data-tid="settings" href={linkToSettings} class="text">
   <IconSettings />
   {$i18n.navigation.settings}
 </a>

--- a/frontend/src/lib/components/header/LinkToSettings.svelte
+++ b/frontend/src/lib/components/header/LinkToSettings.svelte
@@ -5,7 +5,7 @@
   import { createEventDispatcher } from "svelte";
 
   const dispatcher = createEventDispatcher();
-  
+
   beforeNavigate(() => dispatcher("nnsLink"));
 </script>
 

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -59,7 +59,7 @@ describe("AccountMenu", () => {
       const { accountMenuPo } = renderComponent();
       await accountMenuPo.openMenu();
 
-      expect(await accountMenuPo.getSettingsButtonPo().isPresent()).toBe(true);
+      expect(await accountMenuPo.getLinkToSettingsPo().isPresent()).toBe(true);
     });
 
     it('should display "Manage ii" button', async () => {
@@ -81,11 +81,12 @@ describe("AccountMenu", () => {
       const { accountMenuPo } = renderComponent();
       await accountMenuPo.openMenu();
 
-      await accountMenuPo.getSettingsButtonPo().click();
+      await accountMenuPo.getLinkToSettingsPo().click();
 
-      await waitFor(async () =>
-        expect(await accountMenuPo.isOpen()).toBe(false)
-      );
+      //wait for goto to be triggered
+      await runResolvedPromises();
+
+      expect(await accountMenuPo.isOpen()).toBe(false);
     });
 
     it("should render account details component", async () => {
@@ -112,7 +113,7 @@ describe("AccountMenu", () => {
       //wait for goto to be triggered
       await runResolvedPromises();
 
-      expect(await accountMenuPo.getAccountDetailsPo().isPresent()).toBe(false);
+      expect(await accountMenuPo.isOpen()).toBe(false);
     });
 
     describe("export feature flag", () => {

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -18,10 +18,12 @@ describe("AccountMenu", () => {
       new JestPageObjectElement(container)
     );
     const canistersLinkPo = accountMenuPo.getCanistersLinkPo();
+    const linkToSettingsPo = accountMenuPo.getLinkToSettingsPo();
 
     canistersLinkPo.root.addEventListener("click", mockLinkClickEvent);
+    linkToSettingsPo.root.addEventListener("click", mockLinkClickEvent);
 
-    return { accountMenuPo, canistersLinkPo };
+    return { accountMenuPo, canistersLinkPo, linkToSettingsPo };
   };
 
   it("should be closed by default", async () => {
@@ -78,10 +80,10 @@ describe("AccountMenu", () => {
     });
 
     it("should close popover on click on settings", async () => {
-      const { accountMenuPo } = renderComponent();
+      const { accountMenuPo, linkToSettingsPo } = renderComponent();
       await accountMenuPo.openMenu();
 
-      await accountMenuPo.getLinkToSettingsPo().click();
+      await linkToSettingsPo.click();
 
       //wait for goto to be triggered
       await runResolvedPromises();

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -45,8 +45,8 @@ export class AccountMenuPo extends BasePageObject {
     });
   }
 
-  getSettingsButtonPo(): ButtonPo {
-    return ButtonPo.under({
+  getLinkToSettingsPo(): LinkPo {
+    return LinkPo.under({
       element: this.root,
       testId: "settings",
     });


### PR DESCRIPTION
# Motivation

`SettingsButton` is a button that triggers a page redirect. An anchor is a more semantically correct HTML element for such a component.

It can be checked [here](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Changes

- Refactors `SettingsButton` into `LinkToSettings`

# Tests

- Updates impacted tests
- Manually tested

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary