### PR TITLE
housekeeping: Refactors hardcoded aria-label values to use translations

### DIFF
--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
   import { Html, IconClose } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
 
@@ -25,7 +26,7 @@
       <button
         class="icon-only"
         on:click={() => dispatcher("nnsClose")}
-        aria-label="Close"
+        aria-label={$i18n.core.close}
         data-tid="close-button"
       >
         <IconClose />

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -5,6 +5,8 @@
     "icp": "ICP",
     "create": "Create",
     "filter": "Filter",
+    "filter_select_all": "Select all filters",
+    "filter_clear_all": "Clear all filters",
     "back": "Back",
     "confirm_yes": "Yes, I'm sure",
     "confirm_no": "Cancel",

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -49,11 +49,13 @@
       <button
         class="text"
         data-tid="filter-modal-select-all"
+        aria-label={$i18n.core.filter_select_all}
         on:click={selectAll}>{$i18n.voting.check_all}</button
       >
       <button
         class="text"
         data-tid="filter-modal-clear"
+        aria-label={$i18n.core.filter_clear_all}
         on:click={clearSelection}>{$i18n.voting.uncheck_all}</button
       >
     </div>
@@ -77,7 +79,7 @@
       <button
         class="secondary"
         type="button"
-        aria-label="select-all-filters"
+        aria-label={$i18n.core.filter_select_all}
         data-tid="close"
         on:click={close}
       >
@@ -86,7 +88,7 @@
       <button
         class="primary"
         type="button"
-        aria-label="clear-filters"
+        aria-label={$i18n.core.filter_clear_all}
         on:click={filter}
         data-tid="apply-filters"
       >

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -8,6 +8,8 @@ interface I18nCore {
   icp: string;
   create: string;
   filter: string;
+  filter_select_all: string;
+  filter_clear_all: string;
   back: string;
   confirm_yes: string;
   confirm_no: string;


### PR DESCRIPTION
# Motivation

We want all our content to be defined in our `en.json` file. This includes content tags related to assistive technology, such as `aria-label`.

# Changes

- Replaces the existing hardcoded `aria-label` values with their translations

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary