### PR TITLE
NNS1-3269: Renames Hardware Wallet to Ledger Device

### DIFF
--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -405,7 +405,7 @@ export const stakeNeuron = async ({
   logWithTimestamp(`Staking Neuron call...`);
   const { canister } = await governanceCanister({ identity });
 
-  // The use case of staking from Hardware wallet uses a different agent for governance and ledger canister.
+  // The use case of staking from Ledger device uses a different agent for governance and ledger canister.
   const { canister: ledgerCanister } = await getLedgerCanister({
     identity: ledgerCanisterIdentity,
   });

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -352,7 +352,7 @@ export class LedgerIdentity extends SignIdentity {
   }
 
   /**
-   * Convert the HttpAgentRequest body into cbor which can be signed by the Ledger Hardware Wallet.
+   * Convert the HttpAgentRequest body into cbor which can be signed by the Ledger Ledger Device.
    * @param request - body of the HttpAgentRequest
    */
   private prepareCborForLedger = (

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -352,7 +352,7 @@ export class LedgerIdentity extends SignIdentity {
   }
 
   /**
-   * Convert the HttpAgentRequest body into cbor which can be signed by the Ledger Ledger Device.
+   * Convert the HttpAgentRequest body into cbor which can be signed by the Ledger Device.
    * @param request - body of the HttpAgentRequest
    */
   private prepareCborForLedger = (

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -37,7 +37,7 @@ import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
-  // TODO: Support Hardware Wallets
+  // TODO: Support Ledger Devices
   return getAuthenticatedIdentity();
 };
 

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -210,7 +210,7 @@ export const getSnsNeuron = async ({
   });
 };
 
-// Implement when SNS neurons can be controlled with Hardware wallets
+// Implement when SNS neurons can be controlled with Ledger devices
 export const getSnsNeuronIdentity = (): Promise<Identity> =>
   getAuthenticatedIdentity();
 

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -154,7 +154,7 @@ describe("TokensTable", () => {
   });
 
   it("should render the subtitle if present", async () => {
-    const subtitle = "Hardware Wallet";
+    const subtitle = "Ledger Device";
     const token1 = createUserToken({
       universeId: OWN_CANISTER_ID,
       balance: TokenAmount.fromE8s({ amount: 314000000n, token: ICPToken }),

--- a/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
@@ -97,14 +97,14 @@ describe("NeuronVisibilityRow", () => {
       tags: [],
       uncontrolledNeuronDetails: {
         type: "hardwareWallet",
-        text: "Hardware Wallet",
+        text: "Ledger Device",
       },
     };
 
     const { po } = renderComponent({ rowData });
 
     expect(await po.getUncontrolledNeuronDetailsText()).toEqual(
-      "Hardware Wallet"
+      "Ledger Device"
     );
   });
 

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -974,7 +974,7 @@ describe("NnsWallet", () => {
     });
   });
 
-  describe("accounts loaded (Hardware Wallet)", () => {
+  describe("accounts loaded (Ledger Device)", () => {
     const testHwPrincipalText = "5dstn-f5lvo-v2xk5-lvmja-g";
     const testHwPrincipal = Principal.fromText(testHwPrincipalText);
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1570,7 +1570,7 @@ describe("neuron-utils", () => {
       ).toEqual([nfTag, hotkeyTag]);
     });
 
-    it("returns 'Neurons' Fund' and 'Hardware Wallet Controlled'", () => {
+    it("returns 'Neurons' Fund' and 'Ledger Device Controlled'", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
         joinedCommunityFundTimestampSeconds: 123_445n,
@@ -1628,7 +1628,7 @@ describe("neuron-utils", () => {
       ).toEqual([ectTag]);
     });
 
-    it("returns 'Seed' and 'Neurons' Fund' and 'Hardware Wallet Controlled'", () => {
+    it("returns 'Seed' and 'Neurons' Fund' and 'Ledger Device Controlled'", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
         neuronType: NeuronType.Seed,


### PR DESCRIPTION
# Motivation

In the scope of [NNS1-3269](https://dfinity.atlassian.net/browse/NNS1-3269), we want to replace the term "hardware wallet" with "ledger device" for greater accuracy.

#5860 addressed this change for user-facing content and their tests. This and subsequent PRs will implement the change in the codebase. We will split it into multiple PRs to facilitate easier review.

# Changes

- Changes `Hardware Wallet` to `Ledger Device`.
- Changes `Hardware wallet` to `Ledger device`.

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev. PR: #5860

[NNS1-3269]: https://dfinity.atlassian.net/browse/NNS1-3269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ