### PR TITLE
Display confirm following banner

### DIFF
--- a/frontend/src/lib/components/neurons/MakeNeuronsPublicBanner.svelte
+++ b/frontend/src/lib/components/neurons/MakeNeuronsPublicBanner.svelte
@@ -101,7 +101,6 @@
     border-radius: var(--border-radius);
     padding: var(--padding) var(--padding-1_5x);
     gap: var(--padding-1_5x);
-    margin-bottom: var(--padding-2x);
     flex-wrap: wrap;
     @include media.min-width(small) {
       flex-wrap: nowrap;

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -13,6 +13,8 @@
   import { tableNeuronsFromNeuronInfos } from "$lib/utils/neurons-table.utils";
   import { Spinner } from "@dfinity/gix-components";
   import { onMount } from "svelte";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
+  import LosingRewardsBanner from "$lib/components/neurons/LosingRewardsBanner.svelte";
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;
@@ -34,6 +36,9 @@
   {#if isLoading}
     <Spinner />
   {:else if tableNeurons.length > 0}
+    {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION}
+      <LosingRewardsBanner />
+    {/if}
     <MakeNeuronsPublicBanner />
     <NeuronsTable neurons={tableNeurons} />
   {:else}

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -36,12 +36,22 @@
   {#if isLoading}
     <Spinner />
   {:else if tableNeurons.length > 0}
-    {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION}
-      <LosingRewardsBanner />
-    {/if}
-    <MakeNeuronsPublicBanner />
-    <NeuronsTable neurons={tableNeurons} />
+    <div class="container">
+      {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION}
+        <LosingRewardsBanner />
+      {/if}
+      <MakeNeuronsPublicBanner />
+      <NeuronsTable neurons={tableNeurons} />
+    </div>
   {:else}
     <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>
   {/if}
 </TestIdWrapper>
+
+<style lang="scss">
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+  }
+</style>

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -27,6 +27,8 @@
     type Token,
   } from "@dfinity/utils";
   import { get } from "svelte/store";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
+  import LosingRewardsBanner from "$lib/components/neurons/LosingRewardsBanner.svelte";
 
   const getShowStakingBanner = ({
     isSignedIn,
@@ -155,6 +157,10 @@
           <p class="description" slot="description">{$i18n.staking.text}</p>
           <SignInGuard slot="actions" />
         </PageBanner>
+      {/if}
+
+      {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION}
+        <LosingRewardsBanner />
       {/if}
 
       <ProjectsTable on:nnsStakeTokens={openStakingModal} />

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -4,11 +4,14 @@ import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import * as snsApi from "$lib/api/sns.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import Staking from "$lib/routes/Staking.svelte";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import { page } from "$mocks/$app/stores";
 import {
   mockIdentity,
@@ -16,7 +19,7 @@ import {
   setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import { StakingPo } from "$tests/page-objects/Staking.page-object";
@@ -394,6 +397,42 @@ describe("Staking", () => {
       await form.enterAmount(snsMinimumStake);
       expect(await form.getAmountInputPo().hasError()).toBe(false);
       expect(await form.isContinueButtonEnabled()).toBe(true);
+    });
+  });
+
+  describe.only("LosingRewardsBanner", () => {
+    beforeEach(() => {
+      neuronsStore.setNeurons({
+        neurons: [
+          {
+            ...mockNeuron,
+            fullNeuron: {
+              ...mockFullNeuron,
+              votingPowerRefreshedTimestampSeconds: BigInt(
+                nowInSeconds() - SECONDS_IN_HALF_YEAR
+              ),
+            },
+          },
+        ],
+        certified: true,
+      });
+    });
+
+    it("should not display LosingRewardsBanner by default", async () => {
+      const po = await renderComponent();
+      // It should be behind the feature flag
+      expect(await po.getLosingRewardsBannerPo().isPresent()).toBe(false);
+    });
+
+    it("should display LosingRewardsBanner", async () => {
+      overrideFeatureFlagsStore.setFlag(
+        "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+        true
+      );
+      const po = await renderComponent();
+
+      expect(await po.getLosingRewardsBannerPo().isPresent()).toBe(true);
+      expect(await po.getLosingRewardsBannerPo().isVisible()).toBe(true);
     });
   });
 });

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -400,7 +400,7 @@ describe("Staking", () => {
     });
   });
 
-  describe.only("LosingRewardsBanner", () => {
+  describe("LosingRewardsBanner", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({
         neurons: [

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -1,6 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { LosingRewardsBannerPo } from "./LosingRewardsBanner.page-object";
 import { MakeNeuronsPublicBannerPo } from "./MakeNeuronsPublicBanner.page-object";
 
 export class NnsNeuronsPo extends BasePageObject {
@@ -42,5 +43,9 @@ export class NnsNeuronsPo extends BasePageObject {
 
   getMakeNeuronsPublicBannerPo(): MakeNeuronsPublicBannerPo {
     return MakeNeuronsPublicBannerPo.under(this.root);
+  }
+
+  getLosingRewardsBannerPo(): LosingRewardsBannerPo {
+    return LosingRewardsBannerPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/Staking.page-object.ts
+++ b/frontend/src/tests/page-objects/Staking.page-object.ts
@@ -1,3 +1,4 @@
+import { LosingRewardsBannerPo } from "$tests/page-objects/LosingRewardsBanner.page-object";
 import { NnsStakeNeuronModalPo } from "$tests/page-objects/NnsStakeNeuronModal.page-object";
 import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
 import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
@@ -18,6 +19,10 @@ export class StakingPo extends BasePageObject {
       element: this.root,
       testId: "staking-page-banner",
     });
+  }
+
+  getLosingRewardsBannerPo(): LosingRewardsBannerPo {
+    return LosingRewardsBannerPo.under(this.root);
   }
 
   getSignInPo(): SignInPo {


### PR DESCRIPTION
# Motivation

As part of the periodic confirmation feature, a banner should be displayed on the Staking and ICP Neurons pages whenever a neuron is losing or about to lose rewards. This implementation ensures the banner is displayed on the specified pages.

# Changes

- [Display LosingRewardsBanner on staking page](https://github.com/dfinity/nns-dapp/commit/8a40a32d21d37e6340f8487119b592533894799d). 
- [Display LosingRewardsBanner on neurons page](https://github.com/dfinity/nns-dapp/commit/9975b6b9c3d9f84a427fdc6a6f8a06b2a6d8db18).
- Replaced the bottom margin of `MakeNeuronsPublicBanner` with a gap on `NnsNeurons`.

# Tests

- Added.

# Screenshots

### Staging page
<img width="1188" alt="image" src="https://github.com/user-attachments/assets/69156190-20c2-4cf2-88b6-d430cc9bc261">

### Neurons page
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/b4e30726-a80a-46f8-984a-976b57ed42bb">



# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.