### PR TITLE
NNS1-3269: Renames hardware wallet to Ledger device in src/lib

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -102,7 +102,7 @@ export const icrcTransfer = async ({
 /**
  * Transfer Icrc tokens from one account to another.
  *
- * param.fee is mandatory to ensure that it's show for hardware wallets.
+ * param.fee is mandatory to ensure that it's show for Ledger devices.
  * Otherwise, the fee would not show in the device and the user would not know how much they are paying.
  *
  * This als adds an extra layer of safety because we show the fee before the user confirms the transaction.

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -268,7 +268,7 @@ export const querySnsLifecycle = async ({
 /**
  * Stake SNS neuron.
  *
- * param.fee is mandatory to ensure that it's show for hardware wallets.
+ * param.fee is mandatory to ensure that it's show for Ledger devices.
  * Otherwise, the fee would not show in the device and the user would not know how much they are paying.
  *
  * This als adds an extra layer of safety because we show the fee before the user confirms the transaction.

--- a/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -11,7 +11,7 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { getContext } from "svelte";
 
-  // Get the store for the neurons of the hardware wallet from the dedicated context
+  // Get the store for the neurons of the Ledger device from the dedicated context
   const context: WalletContext = getContext<WalletContext>(WALLET_CONTEXT_KEY);
   const { store }: WalletContext = context;
 

--- a/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -17,7 +17,7 @@
 
   // Add the auth identity principal as hotkey
   const addCurrentUserToHotkey = async () => {
-    // This screen is only for hardware wallet.
+    // This screen is only for Ledger device.
     const { success } = await addHotkeyForHardwareWalletNeuron({
       neuronId,
       accountIdentifier: account.identifier,

--- a/frontend/src/lib/constants/ledger.constants.ts
+++ b/frontend/src/lib/constants/ledger.constants.ts
@@ -7,7 +7,7 @@ export enum LedgerConnectionState {
   INCORRECT_DEVICE,
 }
 
-// Errors throw by hardware wallet but not defined in LedgerError (https://github.com/zondax/ledger-icp)
+// Errors throw by Ledger device but not defined in LedgerError (https://github.com/zondax/ledger-icp)
 export enum ExtendedLedgerError {
   AppNotOpen = 28161,
   CannotFetchPublicKey = 65535,

--- a/frontend/src/lib/modals/accounts/AddAccountModal.svelte
+++ b/frontend/src/lib/modals/accounts/AddAccountModal.svelte
@@ -45,7 +45,7 @@
   let steps: WizardSteps = [startStep, ...subAccountSteps];
 
   /**
-   * A store that contains the type of account that will be added (subaccount or hardware wallet) and addition data that can be used across multiple steps of the wizard.
+   * A store that contains the type of account that will be added (subaccount or Ledger device) and addition data that can be used across multiple steps of the wizard.
    */
   const addAccountStore = writable<AddAccountStore>({
     type: undefined,
@@ -55,7 +55,7 @@
   debugAddAccountStore(addAccountStore);
 
   const selectType = async (type: AccountType) => {
-    // Set the type in store and reset other values only if the new type is not the one that was previously used - e.g. user first select hardware wallet, entered a name, clicked continue, went twice back and go to subaccount
+    // Set the type in store and reset other values only if the new type is not the one that was previously used - e.g. user first select Ledger device, entered a name, clicked continue, went twice back and go to subaccount
     addAccountStore.update(({ type: previousType, hardwareWalletName }) => ({
       type,
       hardwareWalletName:

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -55,8 +55,8 @@
 
     stopBusy("accounts");
 
-    // We close the modal in case of success or error if the selected source is not a hardware wallet.
-    // In case of hardware wallet, the error messages might contain interesting information for the user such as "your device is idle"
+    // We close the modal in case of success or error if the selected source is not a Ledger device.
+    // In case of Ledger device, the error messages might contain interesting information for the user such as "your device is idle"
     if (success || !isAccountHardwareWallet(sourceAccount)) {
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -56,8 +56,8 @@
 
     stopBusy("top-up-neuron");
 
-    // We close the modal in case of success or error if the selected source is not a hardware wallet.
-    // In case of hardware wallet, the error messages might contain interesting information for the user such as "your device is idle"
+    // We close the modal in case of success or error if the selected source is not a Ledger device.
+    // In case of Ledger device, the error messages might contain interesting information for the user such as "your device is idle"
     if (success || !isAccountHardwareWallet(sourceAccount)) {
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -129,7 +129,7 @@
   // binding from SetNnsDissolveDelay.
   $: updateDelayFromNeuron(newNeuron);
 
-  // If source account is a hardware wallet, ask user to add a hotkey
+  // If source account is a Ledger device, ask user to add a hotkey
   const extendWizardSteps = async () => {
     steps = [
       firstStep,

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -73,7 +73,7 @@ export const registerHardwareWallet = async ({
     return;
   }
 
-  logWithTimestamp(`Register hardware wallet ${hashCode(name)}...`);
+  logWithTimestamp(`Register Ledger device ${hashCode(name)}...`);
 
   const identity: Identity = await getAuthenticatedIdentity();
 
@@ -85,7 +85,7 @@ export const registerHardwareWallet = async ({
       principal: ledgerIdentity.getPrincipal(),
     });
 
-    logWithTimestamp(`Register hardware wallet ${hashCode(name)} complete.`);
+    logWithTimestamp(`Register Ledger device ${hashCode(name)} complete.`);
 
     await syncAccounts();
   } catch (err: unknown) {

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -151,7 +151,7 @@ export const getIdentityOfControllerByNeuronId = async (
   if (neuronIdentity === undefined) {
     throw new NotAuthorizedNeuronError();
   }
-  // `getAccountIdentityByPrincipal` returns the current user identity (because of `getIdentity`) if the account is not a hardware wallet.
+  // `getAccountIdentityByPrincipal` returns the current user identity (because of `getIdentity`) if the account is not a Ledger device.
   // If we enable visiting neurons which are not ours, we will need this service to throw `NotAuthorizedNeuronError`.
   if (isIdentityController({ neuron, identity: neuronIdentity })) {
     return neuronIdentity;
@@ -173,7 +173,7 @@ const getStakeNeuronPropsByAccount = ({
   fromSubAccount?: SubAccountArray;
 } => {
   if (isAccountHardwareWallet(account)) {
-    // The software of the hardware wallet cannot sign the call to the governance canister to claim the neuron.
+    // The software of the Ledger device cannot sign the call to the governance canister to claim the neuron.
     // Therefore we use an `AnonymousIdentity`.
     return {
       ledgerCanisterIdentity: accountIdentity,
@@ -503,7 +503,7 @@ export const simulateMergeNeurons = async ({
   }
 };
 
-// This service is used to add a "hotkey" - i.e. delegate the control of a neuron to NNS-dapp - to a neuron created with the hardware wallet.
+// This service is used to add a "hotkey" - i.e. delegate the control of a neuron to NNS-dapp - to a neuron created with the Ledger device.
 // It uses the auth identity - i.e. the identity of the current user - as principal of the new hotkey.
 // Once the neuron delegated, it adds it to the neuron store so that user can find this neuron in the "Neurons" tab as well
 // Note: it does not reload the all neurons store but "only" query (updated call) and push the newly attached neuron to the store

--- a/frontend/src/lib/services/seed-neurons.services.ts
+++ b/frontend/src/lib/services/seed-neurons.services.ts
@@ -26,7 +26,7 @@ export const claimSeedNeurons = async () => {
   }
   if (hardwareWallet === undefined) {
     alert(
-      "No hardware wallet linked to this account. Please link your hardware wallet and try again."
+      "No Ledger device linked to this account. Please link your Ledger device and try again."
     );
     return;
   }

--- a/frontend/src/lib/types/wallet.context.ts
+++ b/frontend/src/lib/types/wallet.context.ts
@@ -9,7 +9,7 @@ export interface HardwareWalletNeuronInfo extends NeuronInfo {
 /**
  * A store that contains the information for the Wallet context.
  * - selected account and it's transactions
- * - the neurons of the hardware wallet filled once the user approved listing neurons. We notably need a store because the user can add hotkeys to the neurons that are not yet controlled by NNS-dapp and only the UI needs to be updated after such an action has been executed.
+ * - the neurons of the Ledger device filled once the user approved listing neurons. We notably need a store because the user can add hotkeys to the neurons that are not yet controlled by NNS-dapp and only the UI needs to be updated after such an action has been executed.
  * - a modal the user can open from any child component but has to overflow over the island when the wallet is presented
  */
 export interface WalletStore {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -393,7 +393,7 @@ export const isNeuronControllableByUser = ({
  *  OR
  *  2. The main account (same as user) is the controller
  *  OR
- *  3. The user's hardware wallet is the controller.
+ *  3. The user's Ledger device is the controller.
  *
  */
 export const isNeuronControllable = ({
@@ -563,11 +563,11 @@ const getNeuronVisibilityRowUncontrolledNeuronDetails = ({
 /**
  * An identity can manage the neurons' fund participation when one of the below is true:
  * - User is the controller.
- * - User is a hotkey, but a hardware wallet account is NOT the controller.
+ * - User is a hotkey, but a Ledger device account is NOT the controller.
  *
  * Technically, HW can manage SNS neurons, but we don't support it yet in the NNS Dapp.
  * That's why we want to avoid HW controlled neurons from participating in a swap.
- * Both joining the Neurons' Fund and participating in a swap is disabled for hardware wallets.
+ * Both joining the Neurons' Fund and participating in a swap is disabled for Ledger devices.
  */
 export const canUserManageNeuronFundParticipation = ({
   neuron,


### PR DESCRIPTION
# Motivation

In the scope of [NNS1-3269](https://dfinity.atlassian.net/browse/NNS1-3269), we want to replace the term "hardware wallet" with "ledger device" for greater accuracy.

It continues the work started in #5860 and #5882

# Changes

- Changes `hardware wallet` to `Ledger device` in `src/lib/**`.


# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
Not necesary

Prev. PRs: #5860 #5882


[NNS1-3269]: https://dfinity.atlassian.net/browse/NNS1-3269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ