### PR TITLE
NNS1-3269: Renames hardware wallet to Ledger device in src/tests

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -102,7 +102,7 @@ export const icrcTransfer = async ({
 /**
  * Transfer Icrc tokens from one account to another.
  *
- * param.fee is mandatory to ensure that it's show for hardware wallets.
+ * param.fee is mandatory to ensure that it's show for Ledger devices.
  * Otherwise, the fee would not show in the device and the user would not know how much they are paying.
  *
  * This als adds an extra layer of safety because we show the fee before the user confirms the transaction.

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -268,7 +268,7 @@ export const querySnsLifecycle = async ({
 /**
  * Stake SNS neuron.
  *
- * param.fee is mandatory to ensure that it's show for hardware wallets.
+ * param.fee is mandatory to ensure that it's show for Ledger devices.
  * Otherwise, the fee would not show in the device and the user would not know how much they are paying.
  *
  * This als adds an extra layer of safety because we show the fee before the user confirms the transaction.

--- a/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -11,7 +11,7 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { getContext } from "svelte";
 
-  // Get the store for the neurons of the hardware wallet from the dedicated context
+  // Get the store for the neurons of the Ledger device from the dedicated context
   const context: WalletContext = getContext<WalletContext>(WALLET_CONTEXT_KEY);
   const { store }: WalletContext = context;
 

--- a/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -17,7 +17,7 @@
 
   // Add the auth identity principal as hotkey
   const addCurrentUserToHotkey = async () => {
-    // This screen is only for hardware wallet.
+    // This screen is only for Ledger device.
     const { success } = await addHotkeyForHardwareWalletNeuron({
       neuronId,
       accountIdentifier: account.identifier,

--- a/frontend/src/lib/constants/ledger.constants.ts
+++ b/frontend/src/lib/constants/ledger.constants.ts
@@ -7,7 +7,7 @@ export enum LedgerConnectionState {
   INCORRECT_DEVICE,
 }
 
-// Errors throw by hardware wallet but not defined in LedgerError (https://github.com/zondax/ledger-icp)
+// Errors throw by Ledger device but not defined in LedgerError (https://github.com/zondax/ledger-icp)
 export enum ExtendedLedgerError {
   AppNotOpen = 28161,
   CannotFetchPublicKey = 65535,

--- a/frontend/src/lib/modals/accounts/AddAccountModal.svelte
+++ b/frontend/src/lib/modals/accounts/AddAccountModal.svelte
@@ -45,7 +45,7 @@
   let steps: WizardSteps = [startStep, ...subAccountSteps];
 
   /**
-   * A store that contains the type of account that will be added (subaccount or hardware wallet) and addition data that can be used across multiple steps of the wizard.
+   * A store that contains the type of account that will be added (subaccount or Ledger device) and addition data that can be used across multiple steps of the wizard.
    */
   const addAccountStore = writable<AddAccountStore>({
     type: undefined,
@@ -55,7 +55,7 @@
   debugAddAccountStore(addAccountStore);
 
   const selectType = async (type: AccountType) => {
-    // Set the type in store and reset other values only if the new type is not the one that was previously used - e.g. user first select hardware wallet, entered a name, clicked continue, went twice back and go to subaccount
+    // Set the type in store and reset other values only if the new type is not the one that was previously used - e.g. user first select Ledger device, entered a name, clicked continue, went twice back and go to subaccount
     addAccountStore.update(({ type: previousType, hardwareWalletName }) => ({
       type,
       hardwareWalletName:

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -55,8 +55,8 @@
 
     stopBusy("accounts");
 
-    // We close the modal in case of success or error if the selected source is not a hardware wallet.
-    // In case of hardware wallet, the error messages might contain interesting information for the user such as "your device is idle"
+    // We close the modal in case of success or error if the selected source is not a Ledger device.
+    // In case of Ledger device, the error messages might contain interesting information for the user such as "your device is idle"
     if (success || !isAccountHardwareWallet(sourceAccount)) {
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -56,8 +56,8 @@
 
     stopBusy("top-up-neuron");
 
-    // We close the modal in case of success or error if the selected source is not a hardware wallet.
-    // In case of hardware wallet, the error messages might contain interesting information for the user such as "your device is idle"
+    // We close the modal in case of success or error if the selected source is not a Ledger device.
+    // In case of Ledger device, the error messages might contain interesting information for the user such as "your device is idle"
     if (success || !isAccountHardwareWallet(sourceAccount)) {
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -129,7 +129,7 @@
   // binding from SetNnsDissolveDelay.
   $: updateDelayFromNeuron(newNeuron);
 
-  // If source account is a hardware wallet, ask user to add a hotkey
+  // If source account is a Ledger device, ask user to add a hotkey
   const extendWizardSteps = async () => {
     steps = [
       firstStep,

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -73,7 +73,7 @@ export const registerHardwareWallet = async ({
     return;
   }
 
-  logWithTimestamp(`Register hardware wallet ${hashCode(name)}...`);
+  logWithTimestamp(`Register Ledger device ${hashCode(name)}...`);
 
   const identity: Identity = await getAuthenticatedIdentity();
 
@@ -85,7 +85,7 @@ export const registerHardwareWallet = async ({
       principal: ledgerIdentity.getPrincipal(),
     });
 
-    logWithTimestamp(`Register hardware wallet ${hashCode(name)} complete.`);
+    logWithTimestamp(`Register Ledger device ${hashCode(name)} complete.`);
 
     await syncAccounts();
   } catch (err: unknown) {

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -151,7 +151,7 @@ export const getIdentityOfControllerByNeuronId = async (
   if (neuronIdentity === undefined) {
     throw new NotAuthorizedNeuronError();
   }
-  // `getAccountIdentityByPrincipal` returns the current user identity (because of `getIdentity`) if the account is not a hardware wallet.
+  // `getAccountIdentityByPrincipal` returns the current user identity (because of `getIdentity`) if the account is not a Ledger device.
   // If we enable visiting neurons which are not ours, we will need this service to throw `NotAuthorizedNeuronError`.
   if (isIdentityController({ neuron, identity: neuronIdentity })) {
     return neuronIdentity;
@@ -173,7 +173,7 @@ const getStakeNeuronPropsByAccount = ({
   fromSubAccount?: SubAccountArray;
 } => {
   if (isAccountHardwareWallet(account)) {
-    // The software of the hardware wallet cannot sign the call to the governance canister to claim the neuron.
+    // The software of the Ledger device cannot sign the call to the governance canister to claim the neuron.
     // Therefore we use an `AnonymousIdentity`.
     return {
       ledgerCanisterIdentity: accountIdentity,
@@ -503,7 +503,7 @@ export const simulateMergeNeurons = async ({
   }
 };
 
-// This service is used to add a "hotkey" - i.e. delegate the control of a neuron to NNS-dapp - to a neuron created with the hardware wallet.
+// This service is used to add a "hotkey" - i.e. delegate the control of a neuron to NNS-dapp - to a neuron created with the Ledger device.
 // It uses the auth identity - i.e. the identity of the current user - as principal of the new hotkey.
 // Once the neuron delegated, it adds it to the neuron store so that user can find this neuron in the "Neurons" tab as well
 // Note: it does not reload the all neurons store but "only" query (updated call) and push the newly attached neuron to the store

--- a/frontend/src/lib/services/seed-neurons.services.ts
+++ b/frontend/src/lib/services/seed-neurons.services.ts
@@ -26,7 +26,7 @@ export const claimSeedNeurons = async () => {
   }
   if (hardwareWallet === undefined) {
     alert(
-      "No hardware wallet linked to this account. Please link your hardware wallet and try again."
+      "No Ledger device linked to this account. Please link your Ledger device and try again."
     );
     return;
   }

--- a/frontend/src/lib/types/wallet.context.ts
+++ b/frontend/src/lib/types/wallet.context.ts
@@ -9,7 +9,7 @@ export interface HardwareWalletNeuronInfo extends NeuronInfo {
 /**
  * A store that contains the information for the Wallet context.
  * - selected account and it's transactions
- * - the neurons of the hardware wallet filled once the user approved listing neurons. We notably need a store because the user can add hotkeys to the neurons that are not yet controlled by NNS-dapp and only the UI needs to be updated after such an action has been executed.
+ * - the neurons of the Ledger device filled once the user approved listing neurons. We notably need a store because the user can add hotkeys to the neurons that are not yet controlled by NNS-dapp and only the UI needs to be updated after such an action has been executed.
  * - a modal the user can open from any child component but has to overflow over the island when the wallet is presented
  */
 export interface WalletStore {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -393,7 +393,7 @@ export const isNeuronControllableByUser = ({
  *  OR
  *  2. The main account (same as user) is the controller
  *  OR
- *  3. The user's hardware wallet is the controller.
+ *  3. The user's Ledger device is the controller.
  *
  */
 export const isNeuronControllable = ({
@@ -563,11 +563,11 @@ const getNeuronVisibilityRowUncontrolledNeuronDetails = ({
 /**
  * An identity can manage the neurons' fund participation when one of the below is true:
  * - User is the controller.
- * - User is a hotkey, but a hardware wallet account is NOT the controller.
+ * - User is a hotkey, but a Ledger device account is NOT the controller.
  *
  * Technically, HW can manage SNS neurons, but we don't support it yet in the NNS Dapp.
  * That's why we want to avoid HW controlled neurons from participating in a swap.
- * Both joining the Neurons' Fund and participating in a swap is disabled for hardware wallets.
+ * Both joining the Neurons' Fund and participating in a swap is disabled for Ledger devices.
  */
 export const canUserManageNeuronFundParticipation = ({
   neuron,

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -166,7 +166,7 @@ describe("NNSDapp", () => {
   });
 
   describe("NNSDapp.registerHardwareWallet", () => {
-    it("should register hardware wallet", async () => {
+    it("should register Ledger device", async () => {
       const service = mock<NNSDappService>();
       service.register_hardware_wallet.mockResolvedValue({ Ok: null });
 
@@ -196,7 +196,7 @@ describe("NNSDapp", () => {
       expect(call).rejects.toThrow(err);
     };
 
-    it("should throw register hardware wallet error not found", async () =>
+    it("should throw register Ledger device error not found", async () =>
       await testError(
         {
           AccountNotFound: null,
@@ -206,7 +206,7 @@ describe("NNSDapp", () => {
         )
       ));
 
-    it("should throw register hardware wallet error name too long", async () =>
+    it("should throw register Ledger device error name too long", async () =>
       await testError(
         {
           NameTooLong: null,
@@ -219,7 +219,7 @@ describe("NNSDapp", () => {
         )
       ));
 
-    it("should throw register hardware wallet error already registered", async () =>
+    it("should throw register Ledger device error already registered", async () =>
       await testError(
         {
           HardwareWalletAlreadyRegistered: null,
@@ -227,7 +227,7 @@ describe("NNSDapp", () => {
         new HardwareWalletAttachError("error__attach_wallet.already_registered")
       ));
 
-    it("should throw register hardware wallet error limit exceeded", async () =>
+    it("should throw register Ledger device error limit exceeded", async () =>
       await testError(
         {
           HardwareWalletLimitExceeded: null,

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletShowActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletShowActionButton.spec.ts
@@ -17,7 +17,7 @@ describe("HardwareWalletShowActionButton", () => {
     });
   });
 
-  it("should call show info on hardware wallet", async () => {
+  it("should call show info on Ledger device", async () => {
     const { getByRole } = render(HardwareWalletShowAction);
 
     fireEvent.click(getByRole("button"));

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -55,7 +55,7 @@ describe("SelectAccountDropdown", () => {
     it("should render accounts as options", () => {
       const { container } = render(SelectAccountDropdown, { props });
 
-      // main + subaccounts + hardware wallets
+      // main + subaccounts + Ledger devices
       expect(container.querySelectorAll("option").length).toBe(
         1 + subAccounts.length + hardwareWallets.length
       );
@@ -69,7 +69,7 @@ describe("SelectAccountDropdown", () => {
       );
     });
 
-    it("should not render accounts hardware wallets", () => {
+    it("should not render accounts Ledger devices", () => {
       const { container } = render(SelectAccountDropdown, {
         props: {
           filterAccounts: (account) => !isAccountHardwareWallet(account),

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -61,7 +61,7 @@ describe("NnsAvailableMaturityItemAction", () => {
     expect(await po.hasStakeButton()).toBe(true);
   });
 
-  it("should render buttons if controlled by attached hardware wallet", async () => {
+  it("should render buttons if controlled by attached Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -162,7 +162,7 @@ describe("NnsNeuronAdvancedSection", () => {
     ).toBeNull();
   });
 
-  it("should render not render join neurons' fund if user is a hotkey but controller is the attached hardware wallet", async () => {
+  it("should render not render join neurons' fund if user is a hotkey but controller is the attached Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
@@ -193,7 +193,7 @@ describe("NnsNeuronAdvancedSection", () => {
     expect(await po.getJoinNeuronsFundCheckbox().isPresent()).toBe(false);
   });
 
-  it("should render split button but not join neurons' fund if neuron is controlled by hardware wallet", async () => {
+  it("should render split button but not join neurons' fund if neuron is controlled by Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -116,7 +116,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
   });
 
-  it("should render increase dissolve delay button if controlled by hardware wallet", async () => {
+  it("should render increase dissolve delay button if controlled by Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -73,7 +73,7 @@ describe("NnsNeuronPageHeading", () => {
     expect(await po.getNeuronTags()).toEqual(["Neurons' fund"]);
   });
 
-  it("should render hotkey tag if user is a hotkey and not controlled by a hardware wallet", async () => {
+  it("should render hotkey tag if user is a hotkey and not controlled by a Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
@@ -113,7 +113,7 @@ describe("NnsNeuronPageHeading", () => {
     ]);
   });
 
-  it("should render hardware wallet tag and not hotkey if neuron is controlled by a hardware wallet", async () => {
+  it("should render Ledger device tag and not hotkey if neuron is controlled by a Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPublicVisibilityAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPublicVisibilityAction.spec.ts
@@ -139,7 +139,7 @@ describe("NnsNeuronPublicVisibilityAction", () => {
     expect(await po.getButtonPo().isPresent()).toBe(false);
   });
 
-  it("should render button disabled with tooltip for hardware wallet controlled neurons", async () => {
+  it("should render button disabled with tooltip for Ledger device controlled neurons", async () => {
     const po = await renderComponent(hwControlledNeuron);
 
     expect(await po.getTitleText()).toBe("Private Neuron");

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -89,7 +89,7 @@ describe("NnsNeuronStateItemAction", () => {
     expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
   });
 
-  it("should render dissolve button if hardware wallet is the controller", async () => {
+  it("should render dissolve button if Ledger device is the controller", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -135,7 +135,7 @@ describe("NnsNeuronCard", () => {
     expect(getByText(en.neurons.hotkey_control)).toBeInTheDocument();
   });
 
-  it("renders the hardware wallet label and not hotkey when neuron is controlled by hardware wallet", async () => {
+  it("renders the Ledger device label and not hotkey when neuron is controlled by Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -128,7 +128,7 @@ describe("icp-tokens-list-user.derived", () => {
       ]);
     });
 
-    it("should return hardware wallets, subaccounts and main", () => {
+    it("should return Ledger devices, subaccounts and main", () => {
       setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],

--- a/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -76,7 +76,7 @@ describe("AddAccountModal", () => {
     );
   };
 
-  it("should be able to select new hardware wallet ", async () => {
+  it("should be able to select new Ledger device ", async () => {
     const renderResult = await renderModal({ component: AddAccountModal });
     await shouldNavigateHardwareWalletStep(renderResult);
   });

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -166,8 +166,8 @@ describe("AddCyclesModal", () => {
     await testTopUp(mockSubAccount);
   });
 
-  // We added the hardware wallet in the accountsStore subscribe mock above.
-  it("should not show hardware wallets in the accounts list", async () => {
+  // We added the Ledger device in the accountsStore subscribe mock above.
+  it("should not show Ledger devices in the accounts list", async () => {
     const { container, queryByText } = await renderModal({
       component: AddCyclesModalTest,
       props,

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -174,8 +174,8 @@ describe("CreateCanisterModal", () => {
     await testCreateCanister({ canisterName: "" });
   });
 
-  // We added the hardware wallet in the accountsStore subscribe mock above.
-  it("should not show hardware wallets in the accounts list", async () => {
+  // We added the Ledger device in the accountsStore subscribe mock above.
+  it("should not show Ledger devices in the accounts list", async () => {
     const { container, queryByText } = await renderModal({
       component: CreateCanisterModal,
     });

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -626,7 +626,7 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
     expect(onNnsCancel).toHaveBeenCalled();
   });
 
-  it("should display controlled hardware wallet, and hotkey uncontrolled neurons in uncontrollable neurons list", async () => {
+  it("should display controlled Ledger device, and hotkey uncontrolled neurons in uncontrollable neurons list", async () => {
     neuronsStore.setNeurons({
       neurons: [
         publicNeuron1,

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -321,7 +321,7 @@ describe("MergeNeuronsModal", () => {
     });
   });
 
-  describe("when mergeable neurons by hardware wallet", () => {
+  describe("when mergeable neurons by Ledger device", () => {
     const controller = mockHardwareWalletAccount.principal?.toText() as string;
     const mergeableNeuron1 = {
       neuronId: 10n,
@@ -356,7 +356,7 @@ describe("MergeNeuronsModal", () => {
     });
   });
 
-  describe("when neurons from main user and hardware wallet", () => {
+  describe("when neurons from main user and Ledger device", () => {
     const neuronHW = {
       neuronId: 10n,
       state: NeuronState.Locked,

--- a/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
@@ -90,7 +90,7 @@ describe("NeuronVisibilityRow", () => {
     expect(await po.getTags()).toEqual([]);
   });
 
-  it("should display uncontrolled neuron details for hardware wallet", async () => {
+  it("should display uncontrolled neuron details for Ledger device", async () => {
     const rowData: NeuronVisibilityRowData = {
       neuronId: BigInt(123).toString(),
       isPublic: false,

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -409,7 +409,7 @@ describe("NnsStakeNeuronModal", () => {
     });
   });
 
-  describe("hardware wallet account selection", () => {
+  describe("Ledger device account selection", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [], certified: true });
       setAccountsForTesting({

--- a/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -103,7 +103,7 @@ describe("SpawnNeuronModal", () => {
     expect(spawnNeuron).toBeCalled();
   });
 
-  it("should show only confirm screen for hardware wallet controlled neurons", async () => {
+  it("should show only confirm screen for Ledger device controlled neurons", async () => {
     const neuronHW = {
       ...mockNeuron,
       fullNeuron: {

--- a/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
@@ -122,7 +122,7 @@ describe("ParticipateSwapModal", () => {
     expect(initiateSnsSaleParticipation).toBeCalledTimes(1);
   };
 
-  describe("when hardware wallet account is available", () => {
+  describe("when Ledger device account is available", () => {
     beforeEach(() => {
       setAccountsForTesting({
         main: mockMainAccount,
@@ -132,7 +132,7 @@ describe("ParticipateSwapModal", () => {
       });
     });
 
-    it("should not show hardware wallet account as selectable", async () => {
+    it("should not show Ledger device account as selectable", async () => {
       const po = await renderSwapModalPo();
       const form = po.getTransactionFormPo();
       expect(await form.getSourceAccounts()).toEqual([

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -573,11 +573,11 @@ describe("TransactionModal", () => {
       expect(await form.getSourceAccounts()).toEqual([
         "Main",
         "test subaccount",
-        "hardware wallet account test",
+        "Ledger device account test",
       ]);
     });
 
-    it("should not show the hardware wallet account if skipHardwareWallets is true", async () => {
+    it("should not show the Ledger device account if skipHardwareWallets is true", async () => {
       const { container } = await renderTransactionModal({
         skipHardwareWallets: true,
         rootCanisterId: OWN_CANISTER_ID,

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -1002,7 +1002,7 @@ describe("NnsWallet", () => {
       );
     });
 
-    it("should display hardware wallet buttons", async () => {
+    it("should display Ledger device buttons", async () => {
       const po = await renderWallet(props);
       expect(await po.getListNeuronsButtonPo().isPresent()).toBe(true);
       expect(await po.getShowHardwareWalletButtonPo().isPresent()).toBe(true);

--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -15,7 +15,7 @@ describe("busy-services", () => {
     startBusySpy = vi.spyOn(busyStore, "startBusy").mockImplementation(vi.fn());
   });
 
-  it("call start busy without message if neuron is not controlled by hardware wallet", async () => {
+  it("call start busy without message if neuron is not controlled by Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
     });
@@ -35,7 +35,7 @@ describe("busy-services", () => {
     expect(startBusySpy).toBeCalledWith({ initiator });
   });
 
-  it("call start busy with message if neuron controlled by hardware wallet", async () => {
+  it("call start busy with message if neuron controlled by Ledger device", async () => {
     setAccountsForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -870,7 +870,7 @@ describe("icp-accounts.services", () => {
       expect(expectedIdentity).toBe(mockIdentity);
     });
 
-    it("returns calls for hardware walleet identity if hardware wallet account", async () => {
+    it("returns calls for hardware walleet identity if Ledger device account", async () => {
       setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
@@ -895,7 +895,7 @@ describe("icp-accounts.services", () => {
       expect(expectedIdentity).toBe(mockIdentity);
     });
 
-    it("returns calls for hardware walleet identity if hardware wallet account", async () => {
+    it("returns calls for hardware walleet identity if Ledger device account", async () => {
       setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
@@ -908,7 +908,7 @@ describe("icp-accounts.services", () => {
       expect(getLedgerIdentityProxy).toBeCalled();
     });
 
-    it("returns null if no main account nor hardware wallet account", async () => {
+    it("returns null if no main account nor Ledger device account", async () => {
       setAccountsForTesting({
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -52,7 +52,7 @@ describe("icp-ledger.services", () => {
     );
   });
 
-  describe("connect hardware wallet", () => {
+  describe("connect Ledger device", () => {
     describe("success", () => {
       beforeEach(() => {
         vi.spyOn(LedgerIdentity, "create").mockImplementation(
@@ -114,7 +114,7 @@ describe("icp-ledger.services", () => {
     });
   });
 
-  describe("register hardware wallet", () => {
+  describe("register Ledger device", () => {
     const mockNNSDappCanister: MockNNSDappCanister = new MockNNSDappCanister();
 
     const ledgerIdentity = new MockLedgerIdentity();
@@ -362,7 +362,7 @@ describe("icp-ledger.services", () => {
         );
       });
 
-      it("should list neurons on hardware wallet", async () => {
+      it("should list neurons on Ledger device", async () => {
         const { neurons } = await listNeuronsHardwareWallet();
 
         expect(neurons).toEqual(mockNeurons);

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -264,7 +264,7 @@ describe("neurons-services", () => {
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
     });
 
-    it("should stake neuron from hardware wallet", async () => {
+    it("should stake neuron from Ledger device", async () => {
       const mockHardkwareWalletIdentity = {
         getPrincipal: () => mockHardwareWalletAccount.principal,
       } as unknown as Identity;

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -395,11 +395,11 @@ describe("accounts-utils", () => {
   });
 
   describe("isHardwareWallet", () => {
-    it("returns true if type hardware wallet", () => {
+    it("returns true if type Ledger device", () => {
       expect(isAccountHardwareWallet(mockHardwareWalletAccount)).toBeTruthy();
     });
 
-    it("returns false if type no hardware wallet", () => {
+    it("returns false if type no Ledger device", () => {
       expect(isAccountHardwareWallet(mockMainAccount)).toBe(false);
       expect(isAccountHardwareWallet(mockSubAccount)).toBe(false);
     });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -948,7 +948,7 @@ describe("neuron-utils", () => {
       ).toBe(false);
     });
 
-    it("should return true if neuron controller is a hardware wallet", () => {
+    it("should return true if neuron controller is a Ledger device", () => {
       const accounts = {
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
@@ -1008,7 +1008,7 @@ describe("neuron-utils", () => {
       ).toBe(false);
     });
 
-    it("should return false if neuron controller is a hardware wallet", () => {
+    it("should return false if neuron controller is a Ledger device", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1059,7 +1059,7 @@ describe("neuron-utils", () => {
       );
     });
 
-    it("should return true if neuron controller is hardware wallet", () => {
+    it("should return true if neuron controller is Ledger device", () => {
       const accounts = {
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
@@ -1437,7 +1437,7 @@ describe("neuron-utils", () => {
     const ectTag = {
       text: "Early Contributor Token",
     } as NeuronTagData;
-    it("returns 'hotkey' if neuron is controllable by hotkey and hardware wallet is not the controller", () => {
+    it("returns 'hotkey' if neuron is controllable by hotkey and Ledger device is not the controller", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1456,7 +1456,7 @@ describe("neuron-utils", () => {
       ).toEqual([hotkeyTag]);
     });
 
-    it("returns 'hotkey' if neuron is controllable by hotkey and no hardware wallet is attached", () => {
+    it("returns 'hotkey' if neuron is controllable by hotkey and no Ledger device is attached", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1475,7 +1475,7 @@ describe("neuron-utils", () => {
       ).toEqual([hotkeyTag]);
     });
 
-    it("returns 'Ledger Device Controlled' if neuron is controllable by hotkey and hardware wallet is the controller", () => {
+    it("returns 'Ledger Device Controlled' if neuron is controllable by hotkey and Ledger device is the controller", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -2810,7 +2810,7 @@ describe("neuron-utils", () => {
       ).toBe(false);
     });
 
-    it("should return true if user is hotkey and no hardware wallet is attached", () => {
+    it("should return true if user is hotkey and no Ledger device is attached", () => {
       const accounts: IcpAccountsStoreData = {
         main: identityMainAccount,
         subAccounts: [],
@@ -2833,7 +2833,7 @@ describe("neuron-utils", () => {
       ).toBe(true);
     });
 
-    it("should return false if user is hotkey and attached hardware wallet is controller", () => {
+    it("should return false if user is hotkey and attached Ledger device is controller", () => {
       const accounts: IcpAccountsStoreData = {
         main: identityMainAccount,
         subAccounts: [],
@@ -3139,7 +3139,7 @@ describe("neuron-utils", () => {
       expect(result.tags).toEqual(["Neurons' fund"]);
     });
 
-    it("should return hardware wallet details for hardware wallet controlled neuron", () => {
+    it("should return Ledger device details for Ledger device controlled neuron", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
         fullNeuron: {
@@ -3228,7 +3228,7 @@ describe("neuron-utils", () => {
       expect(result.uncontrolledNeuronDetails).toBeUndefined();
     });
 
-    it("should not include stake for hardware wallet controlled neuron", () => {
+    it("should not include stake for Ledger device controlled neuron", () => {
       const stake = 200_000_000n;
       const neuron: NeuronInfo = {
         ...mockNeuron,

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -39,7 +39,7 @@ export const mockHardwareWalletAccount: Account = {
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
   balanceUlps: 123456789010000n,
   principal: hardwareWalletPrincipal,
-  name: "hardware wallet account test",
+  name: "Ledger device account test",
   type: "hardwareWallet",
 };
 


### PR DESCRIPTION
# Motivation

In the scope of [NNS1-3269](https://dfinity.atlassian.net/browse/NNS1-3269), we want to replace the term "hardware wallet" with "ledger device" for greater accuracy.

# Changes

- Changes `hardware wallet` to `Ledger device` in `src/tests/**`.


# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
Not necesary

Prev. PRs: https://github.com/dfinity/nns-dapp/pull/5860 https://github.com/dfinity/nns-dapp/pull/5882 #5884 

[NNS1-3269]: https://dfinity.atlassian.net/browse/NNS1-3269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ