### PR TITLE
NNS1-3480: Refactors mapIcpTransaction to allow for the introduction of a more generic function

### DIFF
--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -61,9 +61,9 @@
     findAccountOrDefaultToMain,
     isAccountHardwareWallet,
   } from "$lib/utils/accounts.utils";
-  import { remapIcpTransactionToUi } from "$lib/utils/i18n.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
-    mapIcpTransaction,
+    mapIcpTransactionToUi,
     mapToSelfTransactions,
     sortTransactionsByIdDescendingOrder,
   } from "$lib/utils/icp-transactions.utils";
@@ -185,7 +185,7 @@
         )
       )
         .map(({ transaction, toSelfTransaction }) =>
-          mapIcpTransaction({
+          mapIcpTransactionToUi({
             accountIdentifier: account.identifier,
             transaction,
             toSelfTransaction,
@@ -211,7 +211,7 @@
   const loadNextTransactions = async () => {
     if (nonNullish($selectedAccountStore.account)) {
       loadingTransactions = true;
-      await loadIcpAmapIcpTransactionToUitions(
+      await loadIcpAccountNextTransactions(
         $selectedAccountStore.account.identifier
       );
       loadingTransactions = false;

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -61,7 +61,7 @@
     findAccountOrDefaultToMain,
     isAccountHardwareWallet,
   } from "$lib/utils/accounts.utils";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { remapIcpTransactionToUi } from "$lib/utils/i18n.utils";
   import {
     mapIcpTransaction,
     mapToSelfTransactions,
@@ -211,7 +211,7 @@
   const loadNextTransactions = async () => {
     if (nonNullish($selectedAccountStore.account)) {
       loadingTransactions = true;
-      await loadIcpAccountNextTransactions(
+      await loadIcpAmapIcpTransactionToUitions(
         $selectedAccountStore.account.identifier
       );
       loadingTransactions = false;

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -59,6 +59,7 @@ export enum AccountTransactionType {
   Burn = "burn",
   Mint = "mint",
   Send = "send",
+  Receive = "receive",
   StakeNeuron = "stakeNeuron",
   StakeNeuronNotification = "stakeNeuronNotification",
   TopUpNeuron = "topUpNeuron",

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -131,7 +131,7 @@ const getTransactionInformation = (
   };
 };
 
-export const mapIcpTransaction = ({
+export const mapIcpTransactionToUi = ({
   transaction,
   accountIdentifier,
   toSelfTransaction,

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -58,7 +58,7 @@ const getTransactionType = ({
   transaction: { operation, memo },
   neuronAccounts,
   swapCanisterAccounts,
-  isReceive
+  isReceive,
 }: {
   transaction: Transaction;
   neuronAccounts: Set<string>;
@@ -169,12 +169,11 @@ export const mapIcpTransactionToUi = ({
       transaction: transaction.transaction,
       neuronAccounts,
       swapCanisterAccounts,
-      isReceive
+      isReceive,
     });
 
     const headline = transactionName({
       type,
-      isReceive,
       i18n,
     });
     const otherParty = isReceive ? txInfo.from : txInfo.to;

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -58,10 +58,12 @@ const getTransactionType = ({
   transaction: { operation, memo },
   neuronAccounts,
   swapCanisterAccounts,
+  isReceive
 }: {
   transaction: Transaction;
   neuronAccounts: Set<string>;
   swapCanisterAccounts: Set<string>;
+  isReceive: boolean;
 }): AccountTransactionType => {
   if ("Burn" in operation) {
     return AccountTransactionType.Burn;
@@ -92,7 +94,10 @@ const getTransactionType = ({
       : AccountTransactionType.TopUpNeuron;
   }
 
-  // Send is the default transaction type
+  // Send/Receive is the default transaction type
+  if (isReceive) {
+    return AccountTransactionType.Receive;
+  }
   return AccountTransactionType.Send;
 };
 
@@ -147,11 +152,6 @@ export const mapIcpTransactionToUi = ({
   i18n: I18n;
 }): UiTransaction | undefined => {
   try {
-    const type = getTransactionType({
-      transaction: transaction.transaction,
-      neuronAccounts,
-      swapCanisterAccounts,
-    });
     const txInfo = getTransactionInformation(transaction.transaction.operation);
     if (txInfo === undefined) {
       throw new Error(
@@ -164,6 +164,13 @@ export const mapIcpTransactionToUi = ({
       toSelfTransaction === true || txInfo.from !== accountIdentifier;
     const useFee = !isReceive;
     const feeApplied = useFee && txInfo.fee !== undefined ? txInfo.fee : 0n;
+
+    const type = getTransactionType({
+      transaction: transaction.transaction,
+      neuronAccounts,
+      swapCanisterAccounts,
+      isReceive
+    });
 
     const headline = transactionName({
       type,

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -24,18 +24,16 @@ export const transactionDisplayAmount = ({
 
 export const transactionName = ({
   type,
-  isReceive,
   i18n,
 }: {
   type: AccountTransactionType;
-  isReceive: boolean;
   i18n: I18n;
 }): string => {
   switch (type) {
     case AccountTransactionType.Send:
-      return isReceive
-        ? i18n.transaction_names.receive
-        : i18n.transaction_names.send;
+      return i18n.transaction_names.send;
+    case AccountTransactionType.Receive:
+      return i18n.transaction_names.receive;
     case AccountTransactionType.Approve:
       return i18n.transaction_names.approve;
     case AccountTransactionType.Burn:

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -5,7 +5,7 @@ import {
 import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
 import type { UiTransaction } from "$lib/types/transaction";
 import {
-  mapIcpTransaction,
+  mapIcpTransactionToUi,
   mapToSelfTransactions,
   sortTransactionsByIdDescendingOrder,
 } from "$lib/utils/icp-transactions.utils";
@@ -69,7 +69,7 @@ describe("icp-transactions.utils", () => {
       memo,
     });
 
-  describe("mapIcpTransaction", () => {
+  describe("mapIcpTransactionToUi", () => {
     it("maps stake neuron transaction", () => {
       const transaction = createTransaction({
         operation: defaultTransferOperation,
@@ -81,7 +81,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -103,7 +103,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -125,7 +125,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -147,7 +147,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -168,7 +168,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -195,7 +195,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: to,
           toSelfTransaction: false,
@@ -216,7 +216,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -243,7 +243,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: to,
           toSelfTransaction: false,
@@ -279,7 +279,7 @@ describe("icp-transactions.utils", () => {
         };
 
         expect(
-          mapIcpTransaction({
+          mapIcpTransactionToUi({
             transaction,
             accountIdentifier: from,
             toSelfTransaction: false,
@@ -303,7 +303,7 @@ describe("icp-transactions.utils", () => {
         };
 
         expect(
-          mapIcpTransaction({
+          mapIcpTransactionToUi({
             transaction,
             accountIdentifier: from,
             toSelfTransaction: false,
@@ -332,7 +332,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: true,
@@ -355,7 +355,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -392,7 +392,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -424,7 +424,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
@@ -456,7 +456,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToUi({
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -58,15 +58,6 @@ describe("transactions-utils", () => {
       }
     });
 
-    it("returns received name", () => {
-      expect(
-        transactionName({
-          type: AccountTransactionType.Send,
-          i18n: en,
-        })
-      ).toBe(en.transaction_names.receive);
-    });
-
     it("returns raw type if not label", () => {
       expect(
         transactionName({

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -52,7 +52,6 @@ describe("transactions-utils", () => {
         expect(
           transactionName({
             type: key as AccountTransactionType,
-            isReceive: false,
             i18n: en,
           })
         ).toBe(en.transaction_names[key as AccountTransactionType]);
@@ -63,7 +62,6 @@ describe("transactions-utils", () => {
       expect(
         transactionName({
           type: AccountTransactionType.Send,
-          isReceive: true,
           i18n: en,
         })
       ).toBe(en.transaction_names.receive);
@@ -73,7 +71,6 @@ describe("transactions-utils", () => {
       expect(
         transactionName({
           type: "test" as AccountTransactionType,
-          isReceive: true,
           i18n: en,
         })
       ).toBe("test");


### PR DESCRIPTION
# Motivation

Transactions need to be adapted to a user-friendly format. We already have a function called `mapIcpTransaction` that assists with this, but it is too specific to its current use case.
We can split it into two functions: a generic one that resolves transaction information and a specific one for the transactions table.
This first PR introduces changes that will allow for the implementation of a more generic function in a second PR, which will be reused in a third PR.

# Changes

- Renames `mapIcpTransaction` to `mapIcpTransactionToUi`.  
-  Moves the logic for differentiating between transaction types `Send` and `Receive` from `transactionName` to `getTransactionType` in both `icp-transactions` and `icrc-transactions`.  
-  Introduces a new type for `Receive` in `AccountTransactionType`.

# Tests

- Removes the unnecessary test for `transactionName` that checks for differentiation between `Send` and `Receive`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
