### PR TITLE
Add icpSwapTickersStore

### DIFF
--- a/frontend/src/lib/stores/icp-swap.store.ts
+++ b/frontend/src/lib/stores/icp-swap.store.ts
@@ -1,0 +1,42 @@
+import { writable, type Readable } from "svelte/store";
+
+export interface IcpSwapTicker {
+  ticker_id: string; // E.g. "ne2vj-6yaaa-aaaag-qb3ia-cai"
+  ticker_name: string; // E.g. "CHAT_ICP"
+  base_id: string; // E.g. "2ouva-viaaa-aaaaq-aaamq-cai" (This is the OpenChat ledger canister ID)
+  base_currency: string; // E.g. "CHAT"
+  target_id: string; // E.g. "ryjl3-tyaaa-aaaaa-aaaba-cai" (This is always the same for ICP based tickers)
+  target_currency: string; // E.g. "ICP"
+  last_price: string; // E.g. "26.476703"
+  base_volume: string; // E.g. "14707114.222300"
+  target_volume: string; // E.g. "14639835.630040"
+  base_volume_24H: string; // E.g. "22003.751724"
+  target_volume_24H: string; // E.g. "835.647456"
+  total_volume_usd: string; // E.g. "12946455.718022"
+  volume_usd_24H: string; // E.g. "9360.261112"
+  fee_usd: string; // E.g. "15.411505"
+  liquidity_in_usd: string; // E.g. "493835.903685
+}
+
+export interface IcpSwapTickersStoreData {
+  tickers: IcpSwapTicker[];
+  lastUpdateTimestampSeconds: number;
+}
+
+export interface IcpSwapTickersStore
+  extends Readable<IcpSwapTickersStoreData | undefined> {
+  set: (data: IcpSwapTickersStoreData) => void;
+}
+
+const initIcpSwapTickersStore = (): IcpSwapTickersStore => {
+  const { subscribe, set } = writable<IcpSwapTickersStoreData | undefined>(
+    undefined
+  );
+
+  return {
+    subscribe,
+    set,
+  };
+};
+
+export const icpSwapTickersStore = initIcpSwapTickersStore();

--- a/frontend/src/tests/lib/stores/icp-swap.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-swap.store.spec.ts
@@ -1,0 +1,33 @@
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { get } from "svelte/store";
+
+describe("icp-swap.store", () => {
+  describe("icpSwapTickersStore", () => {
+    it("should initialize to undefined", () => {
+      expect(get(icpSwapTickersStore)).toBeUndefined();
+    });
+
+    it("should store ticker data", () => {
+      const ticker1 = {
+        ...mockIcpSwapTicker,
+        ticker_name: "CHAT_ICP",
+        base_currency: "CHAT",
+      };
+      const ticker2 = {
+        ...mockIcpSwapTicker,
+        ticker_name: "ckUSDC_ICP",
+        base_currency: "ckUSDC",
+      };
+      const tickers = [ticker1, ticker2];
+      const now = new Date(2023, 11, 31).getTime() / 1000;
+      const data = { tickers, lastUpdateTimestampSeconds: now };
+
+      expect(get(icpSwapTickersStore)).toBeUndefined();
+
+      icpSwapTickersStore.set(data);
+
+      expect(get(icpSwapTickersStore)).toEqual(data);
+    });
+  });
+});

--- a/frontend/src/tests/mocks/icp-swap.mock.ts
+++ b/frontend/src/tests/mocks/icp-swap.mock.ts
@@ -1,0 +1,19 @@
+import type { IcpSwapTicker } from "$lib/stores/icp-swap.store";
+
+export const mockIcpSwapTicker: IcpSwapTicker = {
+  ticker_id: "ne2vj-6yaaa-aaaag-qb3ia-cai",
+  ticker_name: "CHAT_ICP",
+  base_id: "2ouva-viaaa-aaaaq-aaamq-cai",
+  base_currency: "CHAT",
+  target_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+  target_currency: "ICP",
+  last_price: "26.476703",
+  base_volume: "14707114.222300",
+  target_volume: "14639835.630040",
+  base_volume_24H: "22003.751724",
+  target_volume_24H: "835.647456",
+  total_volume_usd: "12946455.718022",
+  volume_usd_24H: "9360.261112",
+  fee_usd: "15.411505",
+  liquidity_in_usd: "493835.903685",
+};


### PR DESCRIPTION
# Motivation

We want to show USD values of assets. For this we want to use data from ICP Swap.

In this PR we add a Svelte store to keep this data in.

# Changes

1. Add `icpSwapTickersStore`.

# Tests

1. Added unit tests.
2. Added mock data for unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet