### PR TITLE
NNS1-3480: New util function mapIcpTransactionToReport 

### DIFF
--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -177,12 +177,6 @@ export const mapIcpTransactionToReport = ({
     transaction.transaction.created_at_time
   )?.timestamp_nanos;
   const timestampNanos = blockTimestampNanos ?? createdTimestampNanos;
-  const timestampMilliseconds = nonNullish(timestampNanos)
-    ? Number(timestampNanos) / NANO_SECONDS_IN_MILLISECOND
-    : undefined;
-  const timestamp = nonNullish(timestampMilliseconds)
-    ? new Date(timestampMilliseconds)
-    : undefined;
 
   const tokenAmount = TokenAmountV2.fromUlps({
     amount: amount + feeApplied,
@@ -194,7 +188,7 @@ export const mapIcpTransactionToReport = ({
     to,
     from,
     tokenAmount,
-    timestamp,
+    timestampNanos,
   };
 };
 

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -137,7 +137,7 @@ const getTransactionInformation = (
   };
 };
 
-export const mapIcpTransaction = ({
+export const mapIcpTransactionToReport = ({
   transaction,
   accountIdentifier,
   neuronAccounts,
@@ -190,7 +190,6 @@ export const mapIcpTransaction = ({
   });
 
   return {
-    isReceive,
     type,
     to,
     from,

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -123,7 +123,7 @@ const getTransactionInformation = (
   }
   // Edge case, a transaction will have either "Approve", "Burn", "Mint" or "Transfer" data.
   if (data === undefined) {
-    return undefined;
+    throw new Error(`Unknown transaction type ${JSON.stringify(operation)}`);
   }
 
   return {

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -123,8 +123,9 @@ const getTransactionInformation = (
   }
   // Edge case, a transaction will have either "Approve", "Burn", "Mint" or "Transfer" data.
   if (data === undefined) {
-    throw new Error(`Unknown transaction type ${JSON.stringify(operation)}`);
+    return undefined;
   }
+
   return {
     from: "from" in data ? data.from : undefined,
     to: "to" in data ? data.to : undefined,
@@ -243,6 +244,7 @@ export const mapIcpTransactionToUi = ({
     const blockTimestampNanos = fromNullable(
       transaction.transaction.timestamp
     )?.timestamp_nanos;
+
     const createdTimestampNanos = fromNullable(
       transaction.transaction.created_at_time
     )?.timestamp_nanos;

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -31,7 +31,7 @@ describe("icp-transactions.utils", () => {
       spender: [],
     },
   };
-  const defaultTokenAmountWithOutFee = TokenAmountV2.fromUlps({
+  const defaultTokenAmountWithoutFee = TokenAmountV2.fromUlps({
     amount: amount,
     token: ICPToken,
   });
@@ -134,7 +134,7 @@ describe("icp-transactions.utils", () => {
         ...defaultReportTransaction,
         type: "receive",
         to: from,
-        tokenAmount: defaultTokenAmountWithOutFee,
+        tokenAmount: defaultTokenAmountWithoutFee,
       };
 
       expect(

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -83,7 +83,7 @@ describe("icp-transactions.utils", () => {
         amount: amount + fee,
         token: ICPToken,
       }),
-      timestamp: defaultTimestamp,
+      timestampNanos: BigInt(defaultTimestamp.getTime()) * 1_000_000n,
     };
     it("should throw an error if no transaction information is found", () => {
       const transaction = createTransaction({
@@ -250,7 +250,7 @@ describe("icp-transactions.utils", () => {
 
         const expectedIcpTransaction = {
           ...defaultReportTransaction,
-          timestamp: blockDate,
+          timestampNanos: blockTimestamps.timestamp_nanos,
         };
 
         expect(
@@ -272,7 +272,7 @@ describe("icp-transactions.utils", () => {
 
         const expectedIcpTransaction = {
           ...defaultReportTransaction,
-          timestamp: createdDate,
+          timestampNanos: createTimestamps.timestamp_nanos,
         };
 
         expect(

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -31,6 +31,10 @@ describe("icp-transactions.utils", () => {
       spender: [],
     },
   };
+  const defaultTokenAmountWithOutFee = TokenAmountV2.fromUlps({
+    amount: amount,
+    token: ICPToken,
+  });
   const defaultUiTransaction: UiTransaction = {
     domKey: `${transactionId}-1`,
     isIncoming: false,
@@ -123,10 +127,10 @@ describe("icp-transactions.utils", () => {
       });
       const expectedIcpTransaction = {
         isReceive: true,
-        type: "send",
-        to,
+        type: "receive",
+        to: from,
         from,
-        tokenAmount: defaultUiTransaction.tokenAmount,
+        tokenAmount: defaultTokenAmountWithOutFee,
         timestamp: defaultTimestamp,
       };
 
@@ -138,6 +142,104 @@ describe("icp-transactions.utils", () => {
           swapCanisterAccounts: new Set<string>(),
         })
       ).toEqual(expectedIcpTransaction);
+    });
+
+    describe("should map to the correct transaction type", () => {
+      it("maps stake neuron transaction", () => {
+        const transaction = createTransaction({
+          operation: defaultTransferOperation,
+          memo: 12345n,
+        });
+        const expectedIcpTransaction = {
+          isReceive: false,
+          type: "stakeNeuron",
+          to,
+          from,
+          tokenAmount: defaultUiTransaction.tokenAmount,
+          timestamp: defaultTimestamp,
+        };
+
+        expect(
+          mapIcpTransaction({
+            transaction,
+            accountIdentifier: from,
+            neuronAccounts: new Set<string>([to]),
+            swapCanisterAccounts: new Set<string>(),
+          })
+        ).toEqual(expectedIcpTransaction);
+      });
+
+      it("maps top up neuron transaction", () => {
+        const transaction = createTransaction({
+          operation: defaultTransferOperation,
+          memo: 0n,
+        });
+        const expectedIcpTransaction = {
+          isReceive: false,
+          type: "topUpNeuron",
+          to,
+          from,
+          tokenAmount: defaultUiTransaction.tokenAmount,
+          timestamp: defaultTimestamp,
+        };
+
+        expect(
+          mapIcpTransaction({
+            transaction,
+            accountIdentifier: from,
+            neuronAccounts: new Set<string>([to]),
+            swapCanisterAccounts: new Set<string>(),
+          })
+        ).toEqual(expectedIcpTransaction);
+      });
+
+      it("maps create canister transaction", () => {
+        const transaction = createTransaction({
+          operation: defaultTransferOperation,
+          memo: CREATE_CANISTER_MEMO,
+        });
+        const expectedIcpTransaction = {
+          isReceive: false,
+          type: "createCanister",
+          to,
+          from,
+          tokenAmount: defaultUiTransaction.tokenAmount,
+          timestamp: defaultTimestamp,
+        };
+
+        expect(
+          mapIcpTransaction({
+            transaction,
+            accountIdentifier: from,
+            neuronAccounts: new Set<string>(),
+            swapCanisterAccounts: new Set<string>(),
+          })
+        ).toEqual(expectedIcpTransaction);
+      });
+
+      it("maps top up canister transaction", () => {
+        const transaction = createTransaction({
+          operation: defaultTransferOperation,
+          memo: TOP_UP_CANISTER_MEMO,
+        });
+        const expectedIcpTransaction = {
+          isReceive: false,
+          type: "topUpCanister",
+          to,
+          from,
+          tokenAmount: defaultUiTransaction.tokenAmount,
+          timestamp: defaultTimestamp,
+        };
+
+        expect(
+          mapIcpTransaction({
+            transaction,
+            accountIdentifier: from,
+            neuronAccounts: new Set<string>(),
+            swapCanisterAccounts: new Set<string>(),
+          })
+        ).toEqual(expectedIcpTransaction);
+      });
     });
   });
 

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -90,7 +90,7 @@ describe("icp-transactions.utils", () => {
           neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
         })
-      ).toThrowError("Unknown transaction type Unknown");
+      ).toThrowError("Unknown transaction type {\"Unknown\":{}}");
     });
 
     it("should return transaction information", () => {

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -5,7 +5,7 @@ import {
 import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
 import type { UiTransaction } from "$lib/types/transaction";
 import {
-  mapIcpTransaction,
+  mapIcpTransactionToReport,
   mapIcpTransactionToUi,
   mapToSelfTransactions,
   sortTransactionsByIdDescendingOrder,
@@ -74,7 +74,7 @@ describe("icp-transactions.utils", () => {
       memo,
     });
 
-  describe("mapIcpTransaction", () => {
+  describe("mapIcpTransactionToReport", () => {
     it("should throw an error if no transaction information is found", () => {
       const transaction = createTransaction({
         operation: {
@@ -84,7 +84,7 @@ describe("icp-transactions.utils", () => {
       });
 
       expect(() =>
-        mapIcpTransaction({
+        mapIcpTransactionToReport({
           transaction,
           accountIdentifier: from,
           neuronAccounts: new Set<string>(),
@@ -98,7 +98,6 @@ describe("icp-transactions.utils", () => {
         operation: defaultTransferOperation,
       });
       const expectedIcpTransaction = {
-        isReceive: false,
         type: "send",
         to,
         from,
@@ -107,7 +106,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToReport({
           transaction,
           accountIdentifier: from,
           neuronAccounts: new Set<string>(),
@@ -126,7 +125,6 @@ describe("icp-transactions.utils", () => {
         },
       });
       const expectedIcpTransaction = {
-        isReceive: true,
         type: "receive",
         to: from,
         from,
@@ -135,7 +133,7 @@ describe("icp-transactions.utils", () => {
       };
 
       expect(
-        mapIcpTransaction({
+        mapIcpTransactionToReport({
           transaction,
           accountIdentifier: from,
           neuronAccounts: new Set<string>(),
@@ -151,7 +149,6 @@ describe("icp-transactions.utils", () => {
           memo: 12345n,
         });
         const expectedIcpTransaction = {
-          isReceive: false,
           type: "stakeNeuron",
           to,
           from,
@@ -160,7 +157,7 @@ describe("icp-transactions.utils", () => {
         };
 
         expect(
-          mapIcpTransaction({
+          mapIcpTransactionToReport({
             transaction,
             accountIdentifier: from,
             neuronAccounts: new Set<string>([to]),
@@ -175,7 +172,6 @@ describe("icp-transactions.utils", () => {
           memo: 0n,
         });
         const expectedIcpTransaction = {
-          isReceive: false,
           type: "topUpNeuron",
           to,
           from,
@@ -184,7 +180,7 @@ describe("icp-transactions.utils", () => {
         };
 
         expect(
-          mapIcpTransaction({
+          mapIcpTransactionToReport({
             transaction,
             accountIdentifier: from,
             neuronAccounts: new Set<string>([to]),
@@ -199,7 +195,6 @@ describe("icp-transactions.utils", () => {
           memo: CREATE_CANISTER_MEMO,
         });
         const expectedIcpTransaction = {
-          isReceive: false,
           type: "createCanister",
           to,
           from,
@@ -208,7 +203,7 @@ describe("icp-transactions.utils", () => {
         };
 
         expect(
-          mapIcpTransaction({
+          mapIcpTransactionToReport({
             transaction,
             accountIdentifier: from,
             neuronAccounts: new Set<string>(),
@@ -223,7 +218,6 @@ describe("icp-transactions.utils", () => {
           memo: TOP_UP_CANISTER_MEMO,
         });
         const expectedIcpTransaction = {
-          isReceive: false,
           type: "topUpCanister",
           to,
           from,
@@ -232,7 +226,7 @@ describe("icp-transactions.utils", () => {
         };
 
         expect(
-          mapIcpTransaction({
+          mapIcpTransactionToReport({
             transaction,
             accountIdentifier: from,
             neuronAccounts: new Set<string>(),


### PR DESCRIPTION
# Motivation

This is a follow-up to #5891. It introduces a new function, `mapIcpTransactionToReport`, which provides information for the report.

A third PR will follow to extract smaller functions from `mapIcpTransactionToReport` and `mapIcpTransactionToUI` for reuse between both.

# Changes

- New `mapIcpTransactionToReport` function

# Tests

- Unit tests for the function

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev. PR: #5891 