### PR TITLE
Add queryIcpSwapTickers API

### DIFF
--- a/frontend/src/lib/api/icp-swap.api.ts
+++ b/frontend/src/lib/api/icp-swap.api.ts
@@ -1,0 +1,14 @@
+import { ICP_SWAP_URL } from "$lib/constants/environment.constants";
+import type { IcpSwapTicker } from "$lib/types/icp-swap";
+
+export const queryIcpSwapTickers = async (): Promise<IcpSwapTicker[]> => {
+  const url = new URL(ICP_SWAP_URL);
+  url.pathname = "/tickers";
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch ticker information from ICP Swap");
+  }
+
+  return response.json();
+};

--- a/frontend/src/lib/stores/icp-swap.store.ts
+++ b/frontend/src/lib/stores/icp-swap.store.ts
@@ -1,22 +1,5 @@
+import type { IcpSwapTicker } from "$lib/types/icp-swap";
 import { writable, type Readable } from "svelte/store";
-
-export interface IcpSwapTicker {
-  ticker_id: string; // E.g. "ne2vj-6yaaa-aaaag-qb3ia-cai"
-  ticker_name: string; // E.g. "CHAT_ICP"
-  base_id: string; // E.g. "2ouva-viaaa-aaaaq-aaamq-cai" (This is the OpenChat ledger canister ID)
-  base_currency: string; // E.g. "CHAT"
-  target_id: string; // E.g. "ryjl3-tyaaa-aaaaa-aaaba-cai" (This is always the same for ICP based tickers)
-  target_currency: string; // E.g. "ICP"
-  last_price: string; // E.g. "26.476703"
-  base_volume: string; // E.g. "14707114.222300"
-  target_volume: string; // E.g. "14639835.630040"
-  base_volume_24H: string; // E.g. "22003.751724"
-  target_volume_24H: string; // E.g. "835.647456"
-  total_volume_usd: string; // E.g. "12946455.718022"
-  volume_usd_24H: string; // E.g. "9360.261112"
-  fee_usd: string; // E.g. "15.411505"
-  liquidity_in_usd: string; // E.g. "493835.903685
-}
 
 export interface IcpSwapTickersStoreData {
   tickers: IcpSwapTicker[];

--- a/frontend/src/lib/types/icp-swap.ts
+++ b/frontend/src/lib/types/icp-swap.ts
@@ -1,0 +1,17 @@
+export interface IcpSwapTicker {
+  ticker_id: string; // E.g. "ne2vj-6yaaa-aaaag-qb3ia-cai"
+  ticker_name: string; // E.g. "CHAT_ICP"
+  base_id: string; // E.g. "2ouva-viaaa-aaaaq-aaamq-cai" (This is the OpenChat ledger canister ID)
+  base_currency: string; // E.g. "CHAT"
+  target_id: string; // E.g. "ryjl3-tyaaa-aaaaa-aaaba-cai" (This is always the same for ICP based tickers)
+  target_currency: string; // E.g. "ICP"
+  last_price: string; // E.g. "26.476703"
+  base_volume: string; // E.g. "14707114.222300"
+  target_volume: string; // E.g. "14639835.630040"
+  base_volume_24H: string; // E.g. "22003.751724"
+  target_volume_24H: string; // E.g. "835.647456"
+  total_volume_usd: string; // E.g. "12946455.718022"
+  volume_usd_24H: string; // E.g. "9360.261112"
+  fee_usd: string; // E.g. "15.411505"
+  liquidity_in_usd: string; // E.g. "493835.903685
+}

--- a/frontend/src/tests/lib/api/icp-swap.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-swap.api.spec.ts
@@ -1,0 +1,31 @@
+import { queryIcpSwapTickers } from "$lib/api/icp-swap.api";
+import { ICP_SWAP_URL } from "$lib/constants/environment.constants";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+
+describe("icp-swap.api", () => {
+  describe("queryIcpSwapTickers", () => {
+    it("should fetch ICP swap tickers", async () => {
+      const tickersResponse = [mockIcpSwapTicker];
+
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => tickersResponse,
+      } as Response);
+
+      expect(await queryIcpSwapTickers()).toEqual(tickersResponse);
+
+      expect(global.fetch).toBeCalledWith(new URL(`${ICP_SWAP_URL}/tickers`));
+      expect(global.fetch).toBeCalledTimes(1);
+    });
+
+    it("should throw if fetch fails", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+      } as Response);
+
+      expect(queryIcpSwapTickers()).rejects.toThrow(
+        new Error("Failed to fetch ticker information from ICP Swap")
+      );
+    });
+  });
+});

--- a/frontend/src/tests/mocks/icp-swap.mock.ts
+++ b/frontend/src/tests/mocks/icp-swap.mock.ts
@@ -1,4 +1,4 @@
-import type { IcpSwapTicker } from "$lib/stores/icp-swap.store";
+import type { IcpSwapTicker } from "$lib/types/icp-swap";
 
 export const mockIcpSwapTicker: IcpSwapTicker = {
   ticker_id: "ne2vj-6yaaa-aaaag-qb3ia-cai",

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -89,6 +89,7 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
     host: "https://icp-api.io",
     governanceCanisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai",
     identityServiceUrl: "http://localhost:8000/",
+    icpSwapUrl: "http://mrfq3-7eaaa-aaaaa-qabja-cai.localhost:8080",
     ledgerCanisterId: "ryjl3-tyaaa-aaaaa-aaaba-cai",
     indexCanisterId: "ryjl3-tyaaa-aaaaa-aaaba-cai",
     ownCanisterId: "qhbym-qaaaa-aaaaa-aaafq-cai",


### PR DESCRIPTION
# Motivation

We want to show USD values of assets. For this we want to use data from ICP Swap.

In this PR we add an API function to load ticker data from the ICP Swap API.

# Changes

1. Move `IcpSwapTicker` type from the store to a type module so it can be resused in the API layer.
2. Add `queryIcpSwapTickers` which fetchers tickers from the ICP Swap API.

# Tests

1. Add missing ICP Swap URL to unit test environment.
2. Add unit tests for successful and failing request.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet