### PR TITLE
Add service to load ICP Swap tickers

### DIFF
--- a/frontend/src/lib/services/icp-swap.services.ts
+++ b/frontend/src/lib/services/icp-swap.services.ts
@@ -1,0 +1,15 @@
+import { queryIcpSwapTickers } from "$lib/api/icp-swap.api";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { nowInSeconds } from "$lib/utils/date.utils";
+
+export const loadIcpSwapTickers = async (): Promise<void> => {
+  try {
+    const tickers = await queryIcpSwapTickers();
+    icpSwapTickersStore.set({
+      tickers,
+      lastUpdateTimestampSeconds: nowInSeconds(),
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/frontend/src/tests/lib/services/icp-swap.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-swap.services.spec.ts
@@ -1,0 +1,61 @@
+import * as icpSwapApi from "$lib/api/icp-swap.api";
+import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { get } from "svelte/store";
+
+describe("icp-swap.services", () => {
+  const nowSeconds = 123456789;
+
+  beforeEach(() => {
+    vi.useFakeTimers().setSystemTime(nowSeconds * 1000);
+  });
+
+  describe("loadIcpSwapTickers", () => {
+    it("should load tickers into the store", async () => {
+      vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue([
+        mockIcpSwapTicker,
+      ]);
+
+      expect(get(icpSwapTickersStore)).toBeUndefined();
+
+      await loadIcpSwapTickers();
+
+      expect(get(icpSwapTickersStore)).toEqual({
+        tickers: [mockIcpSwapTicker],
+        lastUpdateTimestampSeconds: nowSeconds,
+      });
+
+      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
+    });
+
+    it("should not change the store when there is an error", async () => {
+      vi.spyOn(console, "error").mockReturnValue();
+
+      const error = new Error("Failed to fetch tickers");
+      vi.spyOn(icpSwapApi, "queryIcpSwapTickers")
+        .mockResolvedValueOnce([mockIcpSwapTicker])
+        .mockRejectedValueOnce(error);
+
+      expect(get(icpSwapTickersStore)).toBeUndefined();
+
+      await loadIcpSwapTickers();
+
+      const expectedStoreData = {
+        tickers: [mockIcpSwapTicker],
+        lastUpdateTimestampSeconds: nowSeconds,
+      };
+
+      expect(get(icpSwapTickersStore)).toEqual(expectedStoreData);
+      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
+      expect(console.error).toBeCalledTimes(0);
+
+      await loadIcpSwapTickers();
+
+      expect(get(icpSwapTickersStore)).toEqual(expectedStoreData);
+      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(2);
+      expect(console.error).toBeCalledWith(error);
+      expect(console.error).toBeCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to show USD values of assets. For this we want to use data from ICP Swap.

This PR adds a function to load ticker data and put it into the store.

# Changes

1. Add `loadIcpSwapTickers`. We don't have product requirements yet so for now we don't do anything with an error except logging it on the console.

# Tests

1. Added unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet