### PR TITLE
Add derived store with token prices in ckUSDC

### DIFF
--- a/frontend/src/lib/derived/icp-swap.derived.ts
+++ b/frontend/src/lib/derived/icp-swap.derived.ts
@@ -1,0 +1,48 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { CKUSDC_LEDGER_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import type { IcpSwapTicker } from "$lib/types/icp-swap";
+import { mapEntries } from "$lib/utils/utils";
+import { isNullish } from "@dfinity/utils";
+import { derived } from "svelte/store";
+
+/// Holds a record mapping ledger canister IDs to the ckUSDC price of their
+/// tokens.
+export const icpSwapUsdPricesStore = derived(
+  icpSwapTickersStore,
+  ($icpSwapTickersStore) => {
+    if (isNullish($icpSwapTickersStore)) {
+      return undefined;
+    }
+    const tickers = $icpSwapTickersStore?.tickers;
+    const icpLedgerCanisterId = LEDGER_CANISTER_ID.toText();
+    const ledgerCanisterIdToTicker: Record<string, IcpSwapTicker> =
+      Object.fromEntries(
+        tickers
+          // Only keep ICP based tickers
+          .filter((ticker) => ticker.target_id === icpLedgerCanisterId)
+          .map((ticker) => [ticker.base_id, ticker])
+      );
+
+    const ckusdcTicker =
+      ledgerCanisterIdToTicker[CKUSDC_LEDGER_CANISTER_ID.toText()];
+    if (isNullish(ckusdcTicker)) {
+      return {};
+    }
+
+    const icpPriceInCkusdc = Number(ckusdcTicker?.last_price);
+
+    const ledgerCanisterIdToUsdPrice: Record<string, number> = mapEntries({
+      obj: ledgerCanisterIdToTicker,
+      mapFn: ([ledgerCanisterId, ticker]) => [
+        ledgerCanisterId,
+        icpPriceInCkusdc / Number(ticker.last_price),
+      ],
+    });
+
+    // There is no ticker for ICP to ICP but we do want the ICP price in ckUSDC.
+    ledgerCanisterIdToUsdPrice[LEDGER_CANISTER_ID.toText()] = icpPriceInCkusdc;
+
+    return ledgerCanisterIdToUsdPrice;
+  }
+);

--- a/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
@@ -1,0 +1,101 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import { CKUSDC_LEDGER_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { get } from "svelte/store";
+
+describe("icp-swap.derived", () => {
+  describe("icpSwapUsdPricesStore", () => {
+    it("should be initialized as undefined", () => {
+      expect(get(icpSwapUsdPricesStore)).toBeUndefined();
+    });
+
+    it("should be empty if there are no tickers", () => {
+      icpSwapTickersStore.set({ tickers: [], lastUpdateTimestampSeconds: 0 });
+      expect(get(icpSwapUsdPricesStore)).toEqual({});
+    });
+
+    it("should be empty if there is no ckUSDC ticker", () => {
+      icpSwapTickersStore.set({
+        tickers: [mockIcpSwapTicker],
+        lastUpdateTimestampSeconds: 0,
+      });
+      expect(get(icpSwapUsdPricesStore)).toEqual({});
+    });
+
+    it("should have an ICP price if there is a ckUSDC ticker", () => {
+      const icpPriceInUsd = 12.4;
+
+      const ckusdcTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        last_price: `${icpPriceInUsd}`,
+      };
+
+      icpSwapTickersStore.set({
+        tickers: [ckusdcTicker],
+        lastUpdateTimestampSeconds: 0,
+      });
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
+        [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,
+      });
+    });
+
+    it("should have a ckETH price", () => {
+      const icpPriceInUsd = 12.4;
+      const icpPriceInCketh = 0.004;
+      const ckethPriceInUsd = icpPriceInUsd / icpPriceInCketh;
+
+      const ckusdcTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        last_price: `${icpPriceInUsd}`,
+      };
+      const ckethTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKETH_LEDGER_CANISTER_ID.toText(),
+        last_price: `${icpPriceInCketh}`,
+      };
+
+      icpSwapTickersStore.set({
+        tickers: [ckusdcTicker, ckethTicker],
+        lastUpdateTimestampSeconds: 0,
+      });
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
+        [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,
+        [CKETH_LEDGER_CANISTER_ID.toText()]: ckethPriceInUsd,
+      });
+    });
+
+    it("should skip non-ICP base tickers", () => {
+      const icpPriceInUsd = 12.4;
+      const icpPriceInCketh = 0.004;
+      const ckethPriceInUsd = icpPriceInUsd / icpPriceInCketh;
+
+      const ckusdcTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        last_price: `${icpPriceInUsd}`,
+      };
+      const ckethTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        target_id: CKETH_LEDGER_CANISTER_ID.toText(),
+        last_price: `${ckethPriceInUsd}`,
+      };
+
+      icpSwapTickersStore.set({
+        tickers: [ckusdcTicker, ckethTicker],
+        lastUpdateTimestampSeconds: 0,
+      });
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
+        [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to show USD values of assets. For this we want to use data from ICP Swap.

This PR creates a stored derived from the tickers store, which holds ckUSDC prices of all available tokens based on their ledger canister ID. This depends on the `ckUSDC_ICP` ticker being available and `XYZ_ICP` tickers being available for the relevant tokens.

# Changes

1. Add `icpSwapUsdPricesStore`.

# Tests

1. Add unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet