### PR TITLE
Remove timestamp from icpSwapTickersStore

### DIFF
--- a/frontend/src/lib/derived/icp-swap.derived.ts
+++ b/frontend/src/lib/derived/icp-swap.derived.ts
@@ -8,41 +8,37 @@ import { derived } from "svelte/store";
 
 /// Holds a record mapping ledger canister IDs to the ckUSDC price of their
 /// tokens.
-export const icpSwapUsdPricesStore = derived(
-  icpSwapTickersStore,
-  ($icpSwapTickersStore) => {
-    if (isNullish($icpSwapTickersStore)) {
-      return undefined;
-    }
-    const tickers = $icpSwapTickersStore?.tickers;
-    const icpLedgerCanisterId = LEDGER_CANISTER_ID.toText();
-    const ledgerCanisterIdToTicker: Record<string, IcpSwapTicker> =
-      Object.fromEntries(
-        tickers
-          // Only keep ICP based tickers
-          .filter((ticker) => ticker.target_id === icpLedgerCanisterId)
-          .map((ticker) => [ticker.base_id, ticker])
-      );
-
-    const ckusdcTicker =
-      ledgerCanisterIdToTicker[CKUSDC_LEDGER_CANISTER_ID.toText()];
-    if (isNullish(ckusdcTicker)) {
-      return {};
-    }
-
-    const icpPriceInCkusdc = Number(ckusdcTicker?.last_price);
-
-    const ledgerCanisterIdToUsdPrice: Record<string, number> = mapEntries({
-      obj: ledgerCanisterIdToTicker,
-      mapFn: ([ledgerCanisterId, ticker]) => [
-        ledgerCanisterId,
-        icpPriceInCkusdc / Number(ticker.last_price),
-      ],
-    });
-
-    // There is no ticker for ICP to ICP but we do want the ICP price in ckUSDC.
-    ledgerCanisterIdToUsdPrice[LEDGER_CANISTER_ID.toText()] = icpPriceInCkusdc;
-
-    return ledgerCanisterIdToUsdPrice;
+export const icpSwapUsdPricesStore = derived(icpSwapTickersStore, (tickers) => {
+  if (isNullish(tickers)) {
+    return undefined;
   }
-);
+  const icpLedgerCanisterId = LEDGER_CANISTER_ID.toText();
+  const ledgerCanisterIdToTicker: Record<string, IcpSwapTicker> =
+    Object.fromEntries(
+      tickers
+        // Only keep ICP based tickers
+        .filter((ticker) => ticker.target_id === icpLedgerCanisterId)
+        .map((ticker) => [ticker.base_id, ticker])
+    );
+
+  const ckusdcTicker =
+    ledgerCanisterIdToTicker[CKUSDC_LEDGER_CANISTER_ID.toText()];
+  if (isNullish(ckusdcTicker)) {
+    return {};
+  }
+
+  const icpPriceInCkusdc = Number(ckusdcTicker?.last_price);
+
+  const ledgerCanisterIdToUsdPrice: Record<string, number> = mapEntries({
+    obj: ledgerCanisterIdToTicker,
+    mapFn: ([ledgerCanisterId, ticker]) => [
+      ledgerCanisterId,
+      icpPriceInCkusdc / Number(ticker.last_price),
+    ],
+  });
+
+  // There is no ticker for ICP to ICP but we do want the ICP price in ckUSDC.
+  ledgerCanisterIdToUsdPrice[LEDGER_CANISTER_ID.toText()] = icpPriceInCkusdc;
+
+  return ledgerCanisterIdToUsdPrice;
+});

--- a/frontend/src/lib/services/icp-swap.services.ts
+++ b/frontend/src/lib/services/icp-swap.services.ts
@@ -1,14 +1,10 @@
 import { queryIcpSwapTickers } from "$lib/api/icp-swap.api";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
-import { nowInSeconds } from "$lib/utils/date.utils";
 
 export const loadIcpSwapTickers = async (): Promise<void> => {
   try {
     const tickers = await queryIcpSwapTickers();
-    icpSwapTickersStore.set({
-      tickers,
-      lastUpdateTimestampSeconds: nowInSeconds(),
-    });
+    icpSwapTickersStore.set(tickers);
   } catch (error) {
     console.error(error);
   }

--- a/frontend/src/lib/stores/icp-swap.store.ts
+++ b/frontend/src/lib/stores/icp-swap.store.ts
@@ -1,10 +1,7 @@
 import type { IcpSwapTicker } from "$lib/types/icp-swap";
 import { writable, type Readable } from "svelte/store";
 
-export interface IcpSwapTickersStoreData {
-  tickers: IcpSwapTicker[];
-  lastUpdateTimestampSeconds: number;
-}
+export type IcpSwapTickersStoreData = IcpSwapTicker[];
 
 export interface IcpSwapTickersStore
   extends Readable<IcpSwapTickersStoreData | undefined> {

--- a/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
@@ -13,15 +13,12 @@ describe("icp-swap.derived", () => {
     });
 
     it("should be empty if there are no tickers", () => {
-      icpSwapTickersStore.set({ tickers: [], lastUpdateTimestampSeconds: 0 });
+      icpSwapTickersStore.set([]);
       expect(get(icpSwapUsdPricesStore)).toEqual({});
     });
 
     it("should be empty if there is no ckUSDC ticker", () => {
-      icpSwapTickersStore.set({
-        tickers: [mockIcpSwapTicker],
-        lastUpdateTimestampSeconds: 0,
-      });
+      icpSwapTickersStore.set([mockIcpSwapTicker]);
       expect(get(icpSwapUsdPricesStore)).toEqual({});
     });
 
@@ -34,10 +31,7 @@ describe("icp-swap.derived", () => {
         last_price: `${icpPriceInUsd}`,
       };
 
-      icpSwapTickersStore.set({
-        tickers: [ckusdcTicker],
-        lastUpdateTimestampSeconds: 0,
-      });
+      icpSwapTickersStore.set([ckusdcTicker]);
       expect(get(icpSwapUsdPricesStore)).toEqual({
         [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
         [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,
@@ -60,10 +54,7 @@ describe("icp-swap.derived", () => {
         last_price: `${icpPriceInCketh}`,
       };
 
-      icpSwapTickersStore.set({
-        tickers: [ckusdcTicker, ckethTicker],
-        lastUpdateTimestampSeconds: 0,
-      });
+      icpSwapTickersStore.set([ckusdcTicker, ckethTicker]);
       expect(get(icpSwapUsdPricesStore)).toEqual({
         [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
         [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,
@@ -88,10 +79,7 @@ describe("icp-swap.derived", () => {
         last_price: `${ckethPriceInUsd}`,
       };
 
-      icpSwapTickersStore.set({
-        tickers: [ckusdcTicker, ckethTicker],
-        lastUpdateTimestampSeconds: 0,
-      });
+      icpSwapTickersStore.set([ckusdcTicker, ckethTicker]);
       expect(get(icpSwapUsdPricesStore)).toEqual({
         [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
         [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,

--- a/frontend/src/tests/lib/services/icp-swap.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-swap.services.spec.ts
@@ -5,12 +5,6 @@ import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { get } from "svelte/store";
 
 describe("icp-swap.services", () => {
-  const nowSeconds = 123456789;
-
-  beforeEach(() => {
-    vi.useFakeTimers().setSystemTime(nowSeconds * 1000);
-  });
-
   describe("loadIcpSwapTickers", () => {
     it("should load tickers into the store", async () => {
       vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue([
@@ -21,10 +15,7 @@ describe("icp-swap.services", () => {
 
       await loadIcpSwapTickers();
 
-      expect(get(icpSwapTickersStore)).toEqual({
-        tickers: [mockIcpSwapTicker],
-        lastUpdateTimestampSeconds: nowSeconds,
-      });
+      expect(get(icpSwapTickersStore)).toEqual([mockIcpSwapTicker]);
 
       expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
     });
@@ -41,10 +32,7 @@ describe("icp-swap.services", () => {
 
       await loadIcpSwapTickers();
 
-      const expectedStoreData = {
-        tickers: [mockIcpSwapTicker],
-        lastUpdateTimestampSeconds: nowSeconds,
-      };
+      const expectedStoreData = [mockIcpSwapTicker];
 
       expect(get(icpSwapTickersStore)).toEqual(expectedStoreData);
       expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/stores/icp-swap.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-swap.store.spec.ts
@@ -20,14 +20,12 @@ describe("icp-swap.store", () => {
         base_currency: "ckUSDC",
       };
       const tickers = [ticker1, ticker2];
-      const now = new Date(2023, 11, 31).getTime() / 1000;
-      const data = { tickers, lastUpdateTimestampSeconds: now };
 
       expect(get(icpSwapTickersStore)).toBeUndefined();
 
-      icpSwapTickersStore.set(data);
+      icpSwapTickersStore.set(tickers);
 
-      expect(get(icpSwapTickersStore)).toEqual(data);
+      expect(get(icpSwapTickersStore)).toEqual(tickers);
     });
   });
 });


### PR DESCRIPTION
# Motivation

I thought there was a requirement for the ICP Swap exchange rates to be updated every 10 minutes.
So I added a timestamp in the store to see when they were last updated.
But this turned out to be a misunderstanding and we want the exchanges rates to remain fixed until the session ends (within 30 minutes).
So there is no need to have a timestamp in the store.

# Changes

Remove `lastUpdateTimestampSeconds` from `icpSwapTickersStore` and make the array of tickers the stored data.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary