### PR TITLE
Load ICP Swap tickers once per session

### DIFF
--- a/frontend/src/lib/services/icp-swap.services.ts
+++ b/frontend/src/lib/services/icp-swap.services.ts
@@ -1,7 +1,12 @@
 import { queryIcpSwapTickers } from "$lib/api/icp-swap.api";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { get } from "svelte/store";
 
 export const loadIcpSwapTickers = async (): Promise<void> => {
+  if (get(icpSwapTickersStore) !== undefined) {
+    // We keep the existing tickers for the duration of the session.
+    return;
+  }
   try {
     const tickers = await queryIcpSwapTickers();
     icpSwapTickersStore.set(tickers);

--- a/frontend/src/tests/lib/services/icp-swap.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-swap.services.spec.ts
@@ -20,30 +20,30 @@ describe("icp-swap.services", () => {
       expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
     });
 
+    it("should only load tickers once", async () => {
+      vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue([
+        mockIcpSwapTicker,
+      ]);
+
+      expect(get(icpSwapTickersStore)).toBeUndefined();
+
+      await loadIcpSwapTickers();
+      await loadIcpSwapTickers();
+
+      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
+    });
+
     it("should not change the store when there is an error", async () => {
       vi.spyOn(console, "error").mockReturnValue();
 
       const error = new Error("Failed to fetch tickers");
-      vi.spyOn(icpSwapApi, "queryIcpSwapTickers")
-        .mockResolvedValueOnce([mockIcpSwapTicker])
-        .mockRejectedValueOnce(error);
+      vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockRejectedValueOnce(error);
 
       expect(get(icpSwapTickersStore)).toBeUndefined();
 
       await loadIcpSwapTickers();
 
-      const expectedStoreData = [mockIcpSwapTicker];
-
-      expect(get(icpSwapTickersStore)).toEqual(expectedStoreData);
-      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
-      expect(console.error).toBeCalledTimes(0);
-
-      await loadIcpSwapTickers();
-
-      expect(get(icpSwapTickersStore)).toEqual(expectedStoreData);
-      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(2);
-      expect(console.error).toBeCalledWith(error);
-      expect(console.error).toBeCalledTimes(1);
+      expect(get(icpSwapTickersStore)).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
# Motivation

We agree with PM to load exchange rates only once per session.

# Changes

1. In `loadIcpSwapTickers` if the store is already loaded, do nothing.

# Tests

1. Unit test added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet