### PR TITLE
Refactor Followee Component

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -10,7 +10,7 @@
   import type { NeuronInfo, Topic } from "@dfinity/nns";
 
   export let followee: FolloweesNeuron;
-  export let neuron: NeuronInfo | undefined;
+  export let neuron: NeuronInfo;
   export let isInteractive = true;
 
   // TODO: Align with `en.governance.json` "topics.[topic]"

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -3,18 +3,15 @@
   import TagsList from "$lib/components/ui/TagsList.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
-  import {
-    NNS_NEURON_CONTEXT_KEY,
-    type NnsNeuronContext,
-  } from "$lib/types/nns-neuron-detail.context";
   import type { NnsNeuronModalVotingHistory } from "$lib/types/nns-neuron-detail.modal";
   import { emit } from "$lib/utils/events.utils";
   import { getTopicTitle, type FolloweesNeuron } from "$lib/utils/neuron.utils";
   import { Copy, Tag } from "@dfinity/gix-components";
-  import type { Topic } from "@dfinity/nns";
-  import { getContext } from "svelte";
+  import type { NeuronInfo, Topic } from "@dfinity/nns";
 
   export let followee: FolloweesNeuron;
+  export let neuron: NeuronInfo | undefined;
+  export let isInteractive = true;
 
   // TODO: Align with `en.governance.json` "topics.[topic]"
   const topicTitle = (topic: Topic) => getTopicTitle({ topic, i18n: $i18n });
@@ -25,16 +22,12 @@
     $knownNeuronsStore.find(({ id }) => id === followee.neuronId)?.name ??
     followee.neuronId.toString();
 
-  const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(
-    NNS_NEURON_CONTEXT_KEY
-  );
-
   const openVotingHistory = () =>
     emit<NnsNeuronModalVotingHistory>({
       message: "nnsNeuronDetailModal",
       detail: {
         type: "voting-history",
-        data: { followee, neuron: $store.neuron },
+        data: { followee, neuron },
       },
     });
 </script>
@@ -42,12 +35,16 @@
 <TestIdWrapper testId="followee-component">
   <TagsList {id}>
     <div class="neuron" slot="title">
-      <button name="title" {id} class="text" on:click={openVotingHistory}>
-        {name}
-      </button>
-      <div class="copy">
-        <Copy value={followee.neuronId.toString()} />
-      </div>
+      {#if isInteractive}
+        <button name="title" {id} class="text" on:click={openVotingHistory}>
+          {name}
+        </button>
+        <div class="copy">
+          <Copy value={followee.neuronId.toString()} />
+        </div>
+      {:else}
+        <span class="text">{name}</span>
+      {/if}
     </div>
 
     {#each followee.topics as topic}

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
@@ -14,6 +14,7 @@
   import Followee from "./Followee.svelte";
   import { KeyValuePairInfo } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
+  import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
 
   export let neuron: NeuronInfo;
@@ -42,10 +43,10 @@
     >
   </KeyValuePairInfo>
 
-  {#if followees.length > 0}
+  {#if followees.length > 0 && nonNullish(neuron)}
     <div class="frame">
       {#each followees as followee}
-        <Followee {followee} />
+        <Followee {followee} {neuron} />
       {/each}
     </div>
   {/if}

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -1,4 +1,5 @@
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { FolloweePo } from "$tests/page-objects/Followee.page-object";
 import { VotingHistoryModalPo } from "$tests/page-objects/VotingHistoryModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -26,19 +27,23 @@ describe("Followee", () => {
     });
   });
 
-  const renderComponent = () => {
+  const renderComponent = (isInteractive = true) => {
     const { container } = render(FolloweeTest, {
       props: {
         followee,
+        neuron: mockNeuron,
+        isInteractive,
       },
     });
     return FolloweePo.under(new JestPageObjectElement(container));
   };
 
-  const renderComponentAndModal = () => {
+  const renderComponentAndModal = (isInteractive = true) => {
     const { container } = render(FolloweeTest, {
       props: {
         followee,
+        neuron: mockNeuron,
+        isInteractive,
       },
     });
     const element = new JestPageObjectElement(container);
@@ -72,6 +77,13 @@ describe("Followee", () => {
     expect(await modalPo.isPresent()).toBe(true);
   });
 
+  it("should open modal", async () => {
+    const { componentPo, modalPo } = renderComponentAndModal();
+    expect(await modalPo.isPresent()).toBe(false);
+    await componentPo.openModal();
+    expect(await modalPo.isPresent()).toBe(true);
+  });
+
   it("should render known neurons name", async () => {
     const neuronName = "test-name";
     knownNeuronsStore.setNeurons([
@@ -92,5 +104,52 @@ describe("Followee", () => {
     expect(copySpy).not.toBeCalled();
     await po.copy();
     expect(copySpy).toBeCalledWith(`${followee.neuronId}`);
+  });
+
+  describe("when isInteractive is false", () => {
+    it("should not render open button", async () => {
+      const { componentPo } = renderComponentAndModal(false);
+      expect(await componentPo.getButton().isPresent()).toBe(false);
+    });
+
+    it("should not render copy button", async () => {
+      const po = renderComponent(false);
+      expect(await po.getCopyButton().isPresent()).toBe(false);
+    });
+
+    it("should render neuronId", async () => {
+      const po = renderComponent();
+      expect(await po.getName()).toBe(followee.neuronId.toString());
+    });
+
+    it("should render topics", async () => {
+      const po = renderComponent();
+      expect(await po.getTags()).toEqual([
+        "Exchange Rate",
+        "Governance",
+        "KYC",
+      ]);
+    });
+
+    it("should render ids", async () => {
+      const id = `followee-${followee.neuronId}`;
+      const po = renderComponent();
+      expect(await po.getId()).toBe(id);
+      expect(await po.getAriaLabeledBy()).toBe(id);
+    });
+
+    it("should render known neurons name", async () => {
+      const neuronName = "test-name";
+      knownNeuronsStore.setNeurons([
+        {
+          id: followee.neuronId,
+          name: neuronName,
+          description: "test-description",
+        },
+      ]);
+
+      const po = renderComponent();
+      expect(await po.getName()).toBe(neuronName);
+    });
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Followee from "$lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte";
   import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
-  import { FolloweesNeuron } from "$lib/utils/neuron.utils";
+  import type { FolloweesNeuron } from "$lib/utils/neuron.utils";
   import type { NeuronInfo } from "@dfinity/nns";
 
   export let followee: FolloweesNeuron;

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte
@@ -1,27 +1,14 @@
 <script lang="ts">
   import Followee from "$lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte";
   import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
-  import type {
-    NnsNeuronContext,
-    NnsNeuronStore,
-  } from "$lib/types/nns-neuron-detail.context";
-  import { NNS_NEURON_CONTEXT_KEY } from "$lib/types/nns-neuron-detail.context";
   import { FolloweesNeuron } from "$lib/utils/neuron.utils";
-  import { mockNeuron } from "$tests/mocks/neurons.mock";
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
+  import type { NeuronInfo } from "@dfinity/nns";
 
   export let followee: FolloweesNeuron;
-
-  export const neuronStore = writable<NnsNeuronStore>({
-    neuron: mockNeuron,
-  });
-
-  setContext<NnsNeuronContext>(NNS_NEURON_CONTEXT_KEY, {
-    store: neuronStore,
-  });
+  export let neuron: NeuronInfo;
+  export let isInteractive: boolean;
 </script>
 
-<Followee {followee} />
+<Followee {followee} {neuron} {isInteractive} />
 
 <NnsNeuronModals />

--- a/frontend/src/tests/page-objects/Followee.page-object.ts
+++ b/frontend/src/tests/page-objects/Followee.page-object.ts
@@ -1,6 +1,7 @@
 import { TagPo } from "$tests/page-objects/Tag.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import type { ButtonPo } from "./Button.page-object";
 
 export class FolloweePo extends BasePageObject {
   private static readonly TID = "followee-component";
@@ -11,6 +12,10 @@ export class FolloweePo extends BasePageObject {
 
   getTagPos(): Promise<TagPo[]> {
     return TagPo.allUnder(this.root);
+  }
+
+  getCopyButton(): ButtonPo {
+    return this.getButton("copy-component");
   }
 
   getName(): Promise<string> {
@@ -35,6 +40,6 @@ export class FolloweePo extends BasePageObject {
   }
 
   copy(): Promise<void> {
-    return this.getButton("copy-component").click();
+    return this.getCopyButton().click();
   }
 }


### PR DESCRIPTION
# Motivation

For the periodic confirmation modal, we need to display the neuron followings. We already have a component for this—Followee.svelte. However, the current `Followee` component is hard to reuse because:

1. It relies on the context store.
2. It provides functionality specific to the neuron details page (e.g., opening voting history).

In this PR, we make the component more reusable by introducing a `neuron` prop to pass the neuron directly and an `isInteractive` prop for rendering a text-only version.

# Changes

- Added a neuron prop (replacing the usage on the NeuronInfo from the context store).

# Tests

- Unit tests have been updated and extended to test the isInteractive.

### On the neuron details page

<img width="613" alt="image" src="https://github.com/user-attachments/assets/01030dd7-a703-48e2-86d3-2f4762035160">

### In the upcoming periodic confirmation modal
<img width="424" alt="image" src="https://github.com/user-attachments/assets/c448ee73-7272-4e96-85db-5965fb71928b">


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.