### PR TITLE
Add ledgerCanisterId to UserTokenBase

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -1,3 +1,4 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import {
   icpAccountsStore,
@@ -30,6 +31,7 @@ const convertAccountToUserTokenData = ({
   if (isNullish(account)) {
     return {
       universeId: Principal.fromText(nnsUniverse.canisterId),
+      ledgerCanisterId: LEDGER_CANISTER_ID,
       title: i18nObj.accounts.main,
       balance: "loading",
       logo: nnsUniverse.logo,
@@ -50,6 +52,7 @@ const convertAccountToUserTokenData = ({
 
   return {
     universeId: Principal.fromText(nnsUniverse.canisterId),
+    ledgerCanisterId: LEDGER_CANISTER_ID,
     title,
     subtitle: subtitleMap[account.type],
     balance: TokenAmountV2.fromUlps({

--- a/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
@@ -1,4 +1,7 @@
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import {
+  LEDGER_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
@@ -19,6 +22,7 @@ export const icpTokensListVisitors = derived<
   return [
     {
       universeId: Principal.fromText(nnsUniverse.canisterId),
+      ledgerCanisterId: LEDGER_CANISTER_ID,
       title: nnsUniverse.title,
       balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
       logo: nnsUniverse.logo,

--- a/frontend/src/lib/derived/tokens-list-base.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-base.derived.ts
@@ -1,11 +1,27 @@
+import {
+  LEDGER_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import type { UserTokenBase } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
 
+const getLedgerCanisterIdFromUniverse = (universe: Universe): Principal => {
+  if (universe.canisterId === OWN_CANISTER_ID_TEXT) {
+    return LEDGER_CANISTER_ID;
+  }
+  if (nonNullish(universe.summary)) {
+    return universe.summary.ledgerCanisterId;
+  }
+  return Principal.fromText(universe.canisterId);
+};
+
 const convertUniverseToBaseTokenData = (universe: Universe): UserTokenBase => ({
   universeId: Principal.fromText(universe.canisterId),
+  ledgerCanisterId: getLedgerCanisterIdFromUniverse(universe),
   title: universe.title,
   logo: universe.logo,
   actions: [],

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -23,6 +23,7 @@ export enum UserTokenAction {
 
 export type UserTokenBase = {
   universeId: Principal;
+  ledgerCanisterId: Principal;
   title: string;
   subtitle?: string;
   logo: string;

--- a/frontend/src/lib/utils/user-token.utils.ts
+++ b/frontend/src/lib/utils/user-token.utils.ts
@@ -27,12 +27,16 @@ export const isUserTokenData = (
 
 export const toUserTokenFailed = (
   ledgerCanisterIdText: string
-): UserTokenFailed => ({
-  universeId: Principal.fromText(ledgerCanisterIdText),
-  // Title will be used for sorting.
-  title: ledgerCanisterIdText,
-  logo: UNKNOWN_LOGO,
-  balance: "failed",
-  domKey: ledgerCanisterIdText,
-  actions: [UserTokenAction.GoToDashboard, UserTokenAction.Remove],
-});
+): UserTokenFailed => {
+  const ledgerCanisterId = Principal.fromText(ledgerCanisterIdText);
+  return {
+    universeId: ledgerCanisterId,
+    ledgerCanisterId,
+    // Title will be used for sorting.
+    title: ledgerCanisterIdText,
+    logo: UNKNOWN_LOGO,
+    balance: "failed",
+    domKey: ledgerCanisterIdText,
+    actions: [UserTokenAction.GoToDashboard, UserTokenAction.Remove],
+  };
+};

--- a/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
@@ -2,7 +2,10 @@ import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { UserTokenBase } from "$lib/types/tokens-page";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
-import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import {
+  ledgerCanisterIdMock,
+  rootCanisterIdMock,
+} from "$tests/mocks/sns.api.mock";
 import {
   ckBTCTokenBase,
   ckTESTBTCTokenBase,
@@ -16,6 +19,7 @@ describe("tokens-list-base.derived", () => {
   const snsTetrisToken = mockSnsToken;
   const snsTetris = {
     rootCanisterId: rootCanisterIdMock,
+    ledgerCanisterId: ledgerCanisterIdMock,
     projectName: "Tetris",
     lifecycle: SnsSwapLifecycle.Committed,
     tokenMetadata: snsTetrisToken,
@@ -26,18 +30,21 @@ describe("tokens-list-base.derived", () => {
   };
   const snsPacman = {
     rootCanisterId: principal(1),
+    ledgerCanisterId: principal(2),
     projectName: "Pacman",
     lifecycle: SnsSwapLifecycle.Committed,
     tokenMetadata: snsPackmanToken,
   };
   const tetrisTokenBase: UserTokenBase = {
     universeId: snsTetris.rootCanisterId,
+    ledgerCanisterId: snsTetris.ledgerCanisterId,
     title: snsTetris.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
     actions: [],
   };
   const pacmanTokenBase: UserTokenBase = {
     universeId: snsPacman.rootCanisterId,
+    ledgerCanisterId: snsPacman.ledgerCanisterId,
     title: snsPacman.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
     actions: [],

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -94,6 +94,7 @@ describe("tokens-list-user.derived", () => {
   });
   const tetrisTokenLoading: UserTokenLoading = {
     universeId: snsTetris.rootCanisterId,
+    ledgerCanisterId: snsTetris.ledgerCanisterId,
     title: snsTetris.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
     balance: "loading",
@@ -122,6 +123,7 @@ describe("tokens-list-user.derived", () => {
   });
   const pacmanTokenLoading: UserTokenLoading = {
     universeId: snsPacman.rootCanisterId,
+    ledgerCanisterId: snsPacman.ledgerCanisterId,
     title: snsPacman.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
     balance: "loading",

--- a/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
@@ -15,7 +15,10 @@ import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
-import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import {
+  ledgerCanisterIdMock,
+  rootCanisterIdMock,
+} from "$tests/mocks/sns.api.mock";
 import {
   ckBTCTokenBase,
   ckETHTokenBase,
@@ -32,6 +35,7 @@ describe("tokens-list-base.derived", () => {
   const snsTetrisToken = mockSnsToken;
   const snsTetris = {
     rootCanisterId: rootCanisterIdMock,
+    ledgerCanisterId: ledgerCanisterIdMock,
     projectName: "Tetris",
     lifecycle: SnsSwapLifecycle.Committed,
     tokenMetadata: snsTetrisToken,
@@ -42,6 +46,7 @@ describe("tokens-list-base.derived", () => {
   };
   const snsPacman = {
     rootCanisterId: principal(1),
+    ledgerCanisterId: principal(2),
     projectName: "Pacman",
     lifecycle: SnsSwapLifecycle.Committed,
     tokenMetadata: snsPackmanToken,
@@ -62,6 +67,7 @@ describe("tokens-list-base.derived", () => {
   const tetrisHref = `/wallet/?u=${snsTetris.rootCanisterId.toText()}`;
   const tetrisTokenLoading: UserTokenLoading = {
     universeId: snsTetris.rootCanisterId,
+    ledgerCanisterId: snsTetris.ledgerCanisterId,
     title: snsTetris.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
     balance: "loading",
@@ -84,6 +90,7 @@ describe("tokens-list-base.derived", () => {
   const pacmanHref = `/wallet/?u=${snsPacman.rootCanisterId.toText()}`;
   const pacmanTokenLoading: UserTokenLoading = {
     universeId: snsPacman.rootCanisterId,
+    ledgerCanisterId: snsPacman.ledgerCanisterId,
     title: snsPacman.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
     balance: "loading",

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -1,4 +1,7 @@
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import {
+  LEDGER_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { UserTokenAction, type UserToken } from "$lib/types/tokens-page";
@@ -838,6 +841,7 @@ describe("token-utils", () => {
     };
     const userToken = (balanceUlps: bigint): UserToken => ({
       universeId: Principal.fromText(nnsUniverseMock.canisterId),
+      ledgerCanisterId: LEDGER_CANISTER_ID,
       title: "a title",
       subtitle: undefined,
       balance: TokenAmountV2.fromUlps({

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -3,6 +3,7 @@ import CKETH_LOGO from "$lib/assets/ckETH.svg";
 import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
 import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
 import {
+  LEDGER_CANISTER_ID,
   OWN_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
@@ -25,6 +26,7 @@ import { mockSnsToken, principal } from "./sns-projects.mock";
 
 export const icpTokenBase: UserTokenBase = {
   universeId: OWN_CANISTER_ID,
+  ledgerCanisterId: LEDGER_CANISTER_ID,
   title: "Internet Computer",
   logo: IC_LOGO_ROUNDED,
   actions: [],
@@ -48,18 +50,21 @@ const snsPackmanToken = {
 };
 export const ckBTCTokenBase: UserTokenBase = {
   universeId: CKBTC_UNIVERSE_CANISTER_ID,
+  ledgerCanisterId: CKBTC_UNIVERSE_CANISTER_ID,
   title: "ckBTC",
   logo: CKBTC_LOGO,
   actions: [],
 };
 export const ckETHTokenBase: UserTokenBase = {
   universeId: CKETH_UNIVERSE_CANISTER_ID,
+  ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
   title: "ckETH",
   logo: CKETH_LOGO,
   actions: [],
 };
 export const ckTESTBTCTokenBase: UserTokenBase = {
   universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+  ledgerCanisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
   title: "ckTESTBTC",
   logo: CKTESTBTC_LOGO,
   actions: [],
@@ -68,6 +73,7 @@ export const ckTESTBTCTokenBase: UserTokenBase = {
 const snsHref = `/wallet/?u=${principal(0).toText()}`;
 export const userTokenPageMock: UserTokenData = {
   universeId: principal(0),
+  ledgerCanisterId: principal(1),
   title: "Test SNS",
   balance: TokenAmountV2.fromUlps({
     amount: 2160000000n,
@@ -104,6 +110,7 @@ export const userTokensPageMock: UserTokenData[] = [
   },
   {
     universeId: principal(0),
+    ledgerCanisterId: principal(2),
     title: "Test SNS",
     balance: TokenAmountV2.fromUlps({
       amount: 2160000000n,
@@ -121,6 +128,7 @@ export const userTokensPageMock: UserTokenData[] = [
   },
   {
     universeId: principal(1),
+    ledgerCanisterId: principal(3),
     title: "Test SNS 2",
     balance: TokenAmountV2.fromUlps({
       amount: 1180000000n,
@@ -159,6 +167,7 @@ export const createIcpUserToken = (params: Partial<UserTokenData> = {}) => ({
 
 export const defaultUserTokenLoading: UserTokenLoading = {
   universeId: principal(0),
+  ledgerCanisterId: principal(2),
   title: "Test SNS",
   balance: "loading",
   logo: "sns-logo.svg",


### PR DESCRIPTION
# Motivation

ICP Swap provides exchange rates per token based on ledger canister ID.
So in the tokens table, to get the exchange rate of a token, we need to know its ledger canister ID.
`UserTokenBase` is the base type of row data used in the tokens table.

In this PR we just make sure that the ledger canister ID is available for each token in the table.
This can then be used in later PRs to get the exchange rate.

# Changes

1. Add `ledgerCanisterId` field to `UserTokenBase`.
2. When constructing instances of `UserTokenBase`, add `ledgerCanisterId`.

# Tests

1. Unit tests have been updated.
2. Tested manually in another branch that we can display dollar values in the tokens table.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet