### PR TITLE
Remove ParticipateSwap transaction type from backend

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -246,7 +246,6 @@ pub enum TransactionType {
     TransferFrom,
     StakeNeuronNotification,
     CreateCanister,
-    ParticipateSwap(CanisterId),
 }
 
 #[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
@@ -582,7 +581,7 @@ impl AccountsStore {
                     if let Some(principal) = self.try_get_principal(&from) {
                         let transaction_type =
                             Self::get_transaction_type(from, to, memo, &principal, default_transaction_type);
-                        self.process_transaction_type(transaction_type, principal, from, to, block_height);
+                        self.process_transaction_type(transaction_type, principal, block_height);
                     }
                 }
             }
@@ -930,24 +929,13 @@ impl AccountsStore {
         &mut self,
         transaction_type: TransactionType,
         principal: PrincipalId,
-        from: AccountIdentifier,
-        to: AccountIdentifier,
         block_height: BlockIndex,
     ) {
-        match transaction_type {
-            TransactionType::ParticipateSwap(swap_canister_id) => {
-                self.multi_part_transactions_processor.push(
-                    block_height,
-                    MultiPartTransactionToBeProcessed::ParticipateSwap(principal, from, to, swap_canister_id),
-                );
-            }
-            TransactionType::CreateCanister => {
-                self.multi_part_transactions_processor.push(
-                    block_height,
-                    MultiPartTransactionToBeProcessed::CreateCanisterV2(principal),
-                );
-            }
-            _ => {}
+        if transaction_type == TransactionType::CreateCanister {
+            self.multi_part_transactions_processor.push(
+                block_height,
+                MultiPartTransactionToBeProcessed::CreateCanisterV2(principal),
+            );
         };
     }
     fn assert_account_limit(&self) {

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -1,6 +1,5 @@
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId};
-use icp_ledger::AccountIdentifier;
 use icp_ledger::{BlockIndex, Memo};
 use serde::Deserialize;
 use std::collections::VecDeque;
@@ -20,8 +19,6 @@ pub enum MultiPartTransactionToBeProcessed {
     //       not add TopUpCanisterV2 to the multi-part transaction queue
     //       anymore.
     TopUpCanisterV2(PrincipalId, CanisterId),
-    // ParticipateSwap(buyer_id, from, to, swap_canister_id)
-    ParticipateSwap(PrincipalId, AccountIdentifier, AccountIdentifier, CanisterId),
 }
 
 impl MultiPartTransactionsProcessor {

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -16,10 +16,6 @@ pub async fn run_periodic_tasks() {
     let maybe_transaction_to_process = with_state_mut(|s| s.accounts_store.try_take_next_transaction_to_process());
     if let Some((block_height, transaction_to_process)) = maybe_transaction_to_process {
         match transaction_to_process {
-            MultiPartTransactionToBeProcessed::ParticipateSwap(_principal, _from, _to, _swap_canister_id) => {
-                // DO NOTHING
-                // Handling ParticipateSwap is not supported.
-            }
             // TODO: Remove StakeNeuron after a version has been released that
             //       does not add StakeNeuron to the multi-part transaction
             //       queue anymore.


### PR DESCRIPTION
# Motivation

[get_transaction_type](https://github.com/dfinity/nns-dapp/blob/b1bc79f602907794dac188d7a2000fb654e0fe90/rs/backend/src/accounts_store.rs#L888) never returns `ParticipateSwap`. And as far as I can tell, it never did.
So there is no point in checking if `transaction_type` matches `ParticipateSwap`.

Also, if it would match `ParticipateSwap`, we wouldn't do anything once the `MultiPartTransactionToBeProcessed` comes out of the queue.

# Changes

1. Remove `TransactionType::ParticipateSwap`.
2. Stop matching against `TransactionType::ParticipateSwap`.
3. Turn the `match` into a simple `if` since we now only match against a single remaining type.
4. Stop passing now unused parameters to `process_transaction_type`.
5. Remove `MultiPartTransactionToBeProcessed::ParticipateSwap`.
6. Stop matching against `MultiPartTransactionToBeProcessed::ParticipateSwap`.

# Tests

Not tested

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary