### PR TITLE
Remove MultiPartTransactionToBeProcessed::StakeNeuron

### DIFF
--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -1,7 +1,7 @@
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId};
 use icp_ledger::AccountIdentifier;
-use icp_ledger::{BlockIndex, Memo};
+use icp_ledger::BlockIndex;
 use serde::Deserialize;
 use std::collections::VecDeque;
 
@@ -12,9 +12,6 @@ pub struct MultiPartTransactionsProcessor {
 
 #[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub enum MultiPartTransactionToBeProcessed {
-    // TODO: Remove StakeNeuron after a version has been released that does not
-    //       add StakeNeuron to the multi-part transaction queue anymore.
-    StakeNeuron(PrincipalId, Memo),
     CreateCanisterV2(PrincipalId),
     // TODO: Remove TopUpCanisterV2 after a version has been released that does
     //       not add TopUpCanisterV2 to the multi-part transaction queue
@@ -55,15 +52,14 @@ mod tests {
         let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
 
         for i in 0..10 {
-            processor.push(i, MultiPartTransactionToBeProcessed::StakeNeuron(principal, Memo(i)));
+            processor.push(i, MultiPartTransactionToBeProcessed::CreateCanisterV2(principal));
         }
 
         for i in 0..10 {
             let (block_height, to_be_processed) = processor.take_next().unwrap();
             assert_eq!(block_height, i);
-            if let MultiPartTransactionToBeProcessed::StakeNeuron(p, m) = to_be_processed {
+            if let MultiPartTransactionToBeProcessed::CreateCanisterV2(p) = to_be_processed {
                 assert_eq!(p, principal);
-                assert_eq!(m.0, i);
             }
         }
 

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -20,10 +20,6 @@ pub async fn run_periodic_tasks() {
                 // DO NOTHING
                 // Handling ParticipateSwap is not supported.
             }
-            // TODO: Remove StakeNeuron after a version has been released that
-            //       does not add StakeNeuron to the multi-part transaction
-            //       queue anymore.
-            MultiPartTransactionToBeProcessed::StakeNeuron(_principal, _memo) => {}
             MultiPartTransactionToBeProcessed::CreateCanisterV2(controller) => {
                 handle_create_canister_v2(block_height, controller).await;
             }


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5738, the backend no longer claims unclaimed neurons.
We still left the `MultiPartTransactionToBeProcessed::StakeNeuron` enum value behind, in case there were still instances of it in the queue.
Now that the nns-dapp canister has been upgraded, we can safely clean up this enum value completely.

# Changes

1. Remove `MultiPartTransactionToBeProcessed::StakeNeuron`.
2. Stop matching against `MultiPartTransactionToBeProcessed::StakeNeuron`.

# Tests

1. In the test `push_then_take_next`, use `CreateCanisterV2` instead of `StakeNeuron`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary