### PR TITLE
Refactor neuron tag

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -13,9 +13,9 @@
   import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
   import PageHeading from "../common/PageHeading.svelte";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
-  import { Tag } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+  import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -52,7 +52,7 @@
   </HeadingSubtitle>
   <svelte:fragment slot="tags">
     {#each neuronTags as tag}
-      <Tag size="large" testId="neuron-tag">{tag.text}</Tag>
+      <NeuronTag size="large" {tag} />
     {/each}
   </svelte:fragment>
 </PageHeading>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -2,7 +2,8 @@
   import Hash from "$lib/components/ui/Hash.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { TableNeuron } from "$lib/types/neurons-table";
-  import { IconPublicBadge, Tag, Tooltip } from "@dfinity/gix-components";
+  import { IconPublicBadge, Tooltip } from "@dfinity/gix-components";
+  import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
 
   export let rowData: TableNeuron;
 </script>
@@ -29,7 +30,7 @@
   {#if rowData.tags.length > 0}
     <span class="tags" data-tid="neuron-tags">
       {#each rowData.tags as tag}
-        <Tag testId="neuron-tag">{tag}</Tag>
+        <NeuronTag {tag} />
       {/each}
     </span>
   {/if}

--- a/frontend/src/lib/components/ui/NeuronTag.svelte
+++ b/frontend/src/lib/components/ui/NeuronTag.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import type { NeuronTagData } from "$lib/utils/neuron.utils";
   import { Tag } from "@dfinity/gix-components";
 
   export let tag: NeuronTagData;
+  export let size: "medium" | "large" | undefined = undefined;
 </script>
 
-<TestIdWrapper testId="neuron-tag">
-  <Tag>{tag.text}</Tag>
-</TestIdWrapper>
+<Tag testId="neuron-tag-component" {size}>{tag.text}</Tag>

--- a/frontend/src/lib/components/ui/NeuronTag.svelte
+++ b/frontend/src/lib/components/ui/NeuronTag.svelte
@@ -3,7 +3,7 @@
   import { Tag } from "@dfinity/gix-components";
 
   export let tag: NeuronTagData;
-  export let size: "medium" | "large" | undefined = undefined;
+  export let size: "medium" | "large" = "medium";
 </script>
 
 <Tag testId="neuron-tag-component" {size}>{tag.text}</Tag>

--- a/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
+++ b/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
@@ -7,9 +7,9 @@
     IconKey,
     IconLedger,
     IconPublicBadge,
-    Tag,
     Tooltip,
   } from "@dfinity/gix-components";
+  import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
 
   const typeToIcon: {
     hardwareWallet: typeof IconLedger;
@@ -52,7 +52,7 @@
         {#if rowData.tags.length > 0}
           <span class="tags" data-tid="neuron-tags">
             {#each rowData.tags as tag}
-              <Tag testId="neuron-tag">{tag}</Tag>
+              <NeuronTag {tag} />
             {/each}
           </span>
         {/if}

--- a/frontend/src/lib/types/neuron-visibility-row.ts
+++ b/frontend/src/lib/types/neuron-visibility-row.ts
@@ -1,9 +1,10 @@
 import type { TokenAmountV2 } from "@dfinity/utils";
+import type { NeuronTagData } from "../utils/neuron.utils";
 
 export type NeuronVisibilityRowData = {
   neuronId: string;
   isPublic: boolean;
-  tags: string[];
+  tags: NeuronTagData[];
   stake?: TokenAmountV2;
   uncontrolledNeuronDetails?: UncontrolledNeuronDetailsData;
 };

--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -2,6 +2,7 @@ import type {
   ResponsiveTableColumn,
   ResponsiveTableOrder,
 } from "$lib/types/responsive-table";
+import type { NeuronTagData } from "$lib/utils/neuron.utils";
 import type { Comparator } from "$lib/utils/sort.utils";
 import type { NeuronState } from "@dfinity/nns";
 import type { TokenAmountV2 } from "@dfinity/utils";
@@ -15,7 +16,7 @@ export type TableNeuron = {
   stakedMaturity: bigint;
   dissolveDelaySeconds: bigint;
   state: NeuronState;
-  tags: string[];
+  tags: NeuronTagData[];
   isPublic: boolean;
 };
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -515,7 +515,7 @@ export const createNeuronVisibilityRowData = ({
     tags: getNeuronTagsUnrelatedToController({
       neuron,
       i18n,
-    }).map(({ text }) => text),
+    }),
     uncontrolledNeuronDetails: getNeuronVisibilityRowUncontrolledNeuronDetails({
       neuron,
       identity,

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -73,7 +73,7 @@ export const tableNeuronsFromNeuronInfos = ({
         identity,
         accounts,
         i18n,
-      }).map(({ text }) => text),
+      }),
       isPublic: isPublicNeuron(neuronInfo),
     };
   });
@@ -115,7 +115,7 @@ export const tableNeuronsFromSnsNeurons = ({
         neuron: snsNeuron,
         identity,
         i18n,
-      }).map(({ text }) => text),
+      }),
       isPublic: false,
     };
   });

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -484,7 +484,8 @@ describe("NeuronsTable", () => {
   });
 
   it("should render tags", async () => {
-    const tags = ["Neuron's fund", "Hotkey control"];
+    const tagTexts = ["Neuron's fund", "Hotkey control"];
+    const tags = tagTexts.map((text) => ({ text }));
     const po = renderComponent({
       neurons: [
         {
@@ -503,7 +504,7 @@ describe("NeuronsTable", () => {
     expect(await cell1.getTags()).toEqual([]);
     expect(await cell1.hasTagsElement()).toBe(false);
     const cell2 = rowPos[1].getNeuronIdCellPo();
-    expect(await cell2.getTags()).toEqual(tags);
+    expect(await cell2.getTags()).toEqual(tagTexts);
     expect(await cell2.hasTagsElement()).toBe(true);
   });
 

--- a/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
@@ -70,7 +70,7 @@ describe("NeuronVisibilityRow", () => {
     const rowData: NeuronVisibilityRowData = {
       neuronId: BigInt(123).toString(),
       isPublic: false,
-      tags: ["Tag1", "Tag2"],
+      tags: [{ text: "Tag1" }, { text: "Tag2" }],
     };
 
     const { po } = renderComponent({ rowData });
@@ -155,7 +155,7 @@ describe("NeuronVisibilityRow", () => {
     const rowData: NeuronVisibilityRowData = {
       neuronId: BigInt(123).toString(),
       isPublic: false,
-      tags: ["First tag", "Second tag"],
+      tags: [{ text: "First tag" }, { text: "Second tag" }],
     };
 
     const { po } = renderComponent({ rowData });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3108,7 +3108,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
       });
-      expect(result.tags).toEqual(["Seed"]);
+      expect(result.tags).toEqual([{ text: "Seed" }]);
     });
 
     it("should create neuron visibility row data for an ECT neuron", () => {
@@ -3122,7 +3122,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
       });
-      expect(result.tags).toEqual(["Early Contributor Token"]);
+      expect(result.tags).toEqual([{ text: "Early Contributor Token" }]);
     });
 
     it("should create neuron visibility row data for a neuron in the community fund", () => {
@@ -3136,7 +3136,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
       });
-      expect(result.tags).toEqual(["Neurons' fund"]);
+      expect(result.tags).toEqual([{ text: "Neurons' fund" }]);
     });
 
     it("should return Ledger device details for Ledger device controlled neuron", () => {

--- a/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
@@ -231,7 +231,7 @@ describe("neurons-table.utils", () => {
       expect(tableNeurons).toEqual([
         {
           ...defaultExpectedTableNeuron,
-          tags: ["Hotkey control"],
+          tags: [{ text: "Hotkey control" }],
         },
       ]);
     });
@@ -385,7 +385,7 @@ describe("neurons-table.utils", () => {
       expect(tableNeurons).toEqual([
         {
           ...expectedTableNeuron,
-          tags: ["Hotkey control"],
+          tags: [{ text: "Hotkey control" }],
         },
       ]);
     });

--- a/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NeuronTagPo } from "./NeuronTag.page-object";
 import { TooltipPo } from "./Tooltip.page-object";
 
 export class NeuronIdCellPo extends BasePageObject {
@@ -22,8 +23,12 @@ export class NeuronIdCellPo extends BasePageObject {
     return this.root.byTestId("neuron-tags").isPresent();
   }
 
+  async getTagPos(): Promise<NeuronTagPo[]> {
+    return NeuronTagPo.allUnder(this.root.byTestId("neuron-tags"));
+  }
+
   async getTags(): Promise<string[]> {
-    const tagElements = await this.root.allByTestId("neuron-tag");
+    const tagElements = await this.getTagPos();
     return Promise.all(tagElements.map((el) => el.getText()));
   }
 

--- a/frontend/src/tests/page-objects/NeuronTag.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronTag.page-object.ts
@@ -1,0 +1,20 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NeuronTagPo extends BasePageObject {
+  private static readonly TID = "neuron-tag-component";
+
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static async allUnder(element: PageObjectElement): Promise<NeuronTagPo[]> {
+    return Array.from(await element.allByTestId(NeuronTagPo.TID)).map(
+      (el) => new NeuronTagPo(el)
+    );
+  }
+
+  async isStatusDanger(): Promise<boolean> {
+    return (await this.root.getClasses()).includes("error");
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
@@ -3,6 +3,7 @@ import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NeuronTagPo } from "./NeuronTag.page-object";
 
 export class NeuronVisibilityRowPo extends BasePageObject {
   private static readonly BASE_TID = "neuron-visibility-row-component";
@@ -31,9 +32,7 @@ export class NeuronVisibilityRowPo extends BasePageObject {
   }
 
   async getTags(): Promise<string[]> {
-    const tagElements = await this.root.querySelectorAll(
-      "[data-tid='neuron-tag']"
-    );
+    const tagElements = await NeuronTagPo.allUnder(this.root);
     return Promise.all(tagElements.map((el) => el.getText()));
   }
 

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NeuronTagPo } from "./NeuronTag.page-object";
 
 export class NnsNeuronCardTitlePo extends BasePageObject {
   private static readonly TID = "neuron-card-title";
@@ -13,7 +14,7 @@ export class NnsNeuronCardTitlePo extends BasePageObject {
   }
 
   async getNeuronTags(): Promise<string[]> {
-    const elements = await this.root.allByTestId("neuron-tag");
+    const elements = await NeuronTagPo.allUnder(this.root);
     return Promise.all(elements.map((tag) => tag.getText()));
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
@@ -1,6 +1,7 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NeuronTagPo } from "./NeuronTag.page-object";
 
 export class NnsNeuronPageHeadingPo extends BasePageObject {
   private static readonly TID = "nns-neuron-page-heading-component";
@@ -24,7 +25,7 @@ export class NnsNeuronPageHeadingPo extends BasePageObject {
   }
 
   async getNeuronTags(): Promise<string[]> {
-    const elements = await this.root.allByTestId("neuron-tag");
+    const elements = await NeuronTagPo.allUnder(this.root);
     return Promise.all(elements.map((tag) => tag.getText()));
   }
 }


### PR DESCRIPTION
# Motivation

For inactive neurons, a 🔴 red tag (styled as `danger`) needs to be shown. Currently, in many places, the information for neuron tags is provided as a `string` and rendered using the base `Tag` component. With this PR, we replace the `string` with `NeuronTagData` for tag data type and replace the `Tag` component with the `NeuronTag` component.

Note: The neuron tag will be extended with the status in a separate PR.

# Changes

- Add size property to the NeuronTag.
- Replace string with NeuronTagData for the neuron tag data.
- Replace Tag with NeuronTag component for neuron tags.

# Tests

- Added NeuronTagPo
- Updated tests to use it.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary