### PR TITLE
Losing rewards neuron card

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -36,14 +36,20 @@
   <TagsList {id}>
     <div class="neuron" slot="title">
       {#if isInteractive}
-        <button name="title" {id} class="text" on:click={openVotingHistory}>
+        <button
+          data-tid="title"
+          name="title"
+          {id}
+          class="text"
+          on:click={openVotingHistory}
+        >
           {name}
         </button>
         <div class="copy">
           <Copy value={followee.neuronId.toString()} />
         </div>
       {:else}
-        <span class="text">{name}</span>
+        <span data-tid="title" class="text">{name}</span>
       {/if}
     </div>
 

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <Card
-  testId="nns-neuron-card-component"
+  testId="nns-loosing-rewards-neuron-card-component"
   {href}
   noMargin
   ariaLabel={$i18n.losing_rewards_modal.goto_neuron}

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -63,7 +63,9 @@
         {/each}
       </div>
     {:else}
-      <p class="no-following">{$i18n.losing_rewards_modal.no_following}</p>
+      <p data-tid="no-following" class="no-following">
+        {$i18n.losing_rewards_modal.no_following}
+      </p>
     {/if}
   </div>
 </Card>

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -41,33 +41,48 @@
   noMargin
   ariaLabel={$i18n.losing_rewards_modal.goto_neuron}
 >
-  <div slot="start" class="title">
-    <h3 class="neuron-id" data-tid="neuron-id">
-      {neuron.neuronId}
-    </h3>
-    {#each neuronTags as tag}
-      <NeuronTag {tag} />
-    {/each}
-  </div>
-  <div class="icon-right" slot="end">
-    <IconRight />
-  </div>
-
-  {#if followees.length > 0}
-    <div class="frame">
-      {#each followees as followee}
-        <Followee {followee} {neuron} isInteractive={false} />
-      {/each}
+  <div class="wrapper">
+    <div class="header">
+      <div class="title">
+        <h3 class="neuron-id" data-tid="neuron-id">
+          {neuron.neuronId}
+        </h3>
+        {#each neuronTags as tag}
+          <NeuronTag {tag} />
+        {/each}
+      </div>
+      <div class="icon-right">
+        <IconRight />
+      </div>
     </div>
-  {:else}
-    <p class="no-following">{$i18n.losing_rewards_modal.no_following}</p>
-  {/if}
+
+    {#if followees.length > 0}
+      <div class="frame">
+        {#each followees as followee}
+          <Followee {followee} {neuron} isInteractive={false} />
+        {/each}
+      </div>
+    {:else}
+      <p class="no-following">{$i18n.losing_rewards_modal.no_following}</p>
+    {/if}
+  </div>
 </Card>
 
 <style lang="scss">
-  .title {
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+  }
+
+  .header {
     display: flex;
     align-items: center;
+  }
+
+  .title {
+    display: flex;
+    flex-grow: 1;
     flex-wrap: wrap;
     column-gap: var(--padding);
     row-gap: var(--padding-0_5x);

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { Card, IconRight } from "@dfinity/gix-components";
+  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+  import { buildNeuronUrl } from "$lib/utils/navigation.utils";
+  import {
+    followeesNeurons,
+    getNeuronTags,
+    type FolloweesNeuron,
+    type NeuronTagData,
+  } from "$lib/utils/neuron.utils";
+  import Followee from "../neuron-detail/NeuronFollowingCard/Followee.svelte";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { authStore } from "$lib/stores/auth.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
+
+  export let neuron: NeuronInfo;
+
+  let href: string;
+  $: href = buildNeuronUrl({
+    universe: OWN_CANISTER_ID_TEXT,
+    neuronId: neuron.neuronId,
+  });
+
+  let neuronTags: NeuronTagData[];
+  $: neuronTags = getNeuronTags({
+    neuron,
+    identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+    i18n: $i18n,
+  });
+
+  let followees: FolloweesNeuron[];
+  $: followees = followeesNeurons(neuron) ?? [];
+</script>
+
+<Card
+  testId="nns-neuron-card-component"
+  {href}
+  noMargin
+  ariaLabel={$i18n.losing_rewards_modal.goto_neuron}
+>
+  <div slot="start" class="title">
+    <h3 class="neuron-id" data-tid="neuron-id">
+      {neuron.neuronId}
+    </h3>
+    {#each neuronTags as tag}
+      <NeuronTag {tag} />
+    {/each}
+  </div>
+  <div class="icon-right" slot="end">
+    <IconRight />
+  </div>
+
+  {#if followees.length > 0}
+    <div class="frame">
+      {#each followees as followee}
+        <Followee {followee} {neuron} isInteractive={false} />
+      {/each}
+    </div>
+  {:else}
+    <p class="no-following">{$i18n.losing_rewards_modal.no_following}</p>
+  {/if}
+</Card>
+
+<style lang="scss">
+  .title {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    column-gap: var(--padding);
+    row-gap: var(--padding-0_5x);
+
+    h3 {
+      margin: 0;
+    }
+  }
+
+  .icon-right {
+    display: flex;
+    align-items: center;
+    color: var(--primary);
+  }
+
+  .no-following {
+    color: var(--description-color);
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -369,6 +369,10 @@
     "description": "ICP neurons that are inactive for $period start losing voting rewards. In order to avoid losing rewards, vote manually, edit or confirm your following.",
     "confirm": "Confirm Following"
   },
+  "losing_rewards_modal": {
+    "goto_neuron": "Go to neuron details",
+    "no_following": "This neuron has no following configured."
+  },
   "new_followee": {
     "title": "Enter New Followee",
     "placeholder": "Neuron Id",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -385,6 +385,11 @@ interface I18nLosing_rewards_banner {
   confirm: string;
 }
 
+interface I18nLosing_rewards_modal {
+  goto_neuron: string;
+  no_following: string;
+}
+
 interface I18nNew_followee {
   title: string;
   placeholder: string;
@@ -1442,6 +1447,7 @@ interface I18n {
   staking: I18nStaking;
   neurons: I18nNeurons;
   losing_rewards_banner: I18nLosing_rewards_banner;
+  losing_rewards_modal: I18nLosing_rewards_modal;
   new_followee: I18nNew_followee;
   follow_neurons: I18nFollow_neurons;
   voting: I18nVoting;

--- a/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
@@ -1,5 +1,5 @@
-import { OWN_CANISTER_ID_TEXT } from "$ib/constants/canister-ids.constants";
 import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsLosingRewardsNeuronCardPo } from "$tests/page-objects/NnsLosingRewardsNeuronCard.page-object";

--- a/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
@@ -1,0 +1,64 @@
+import { OWN_CANISTER_ID_TEXT } from "$ib/constants/canister-ids.constants";
+import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { NnsLosingRewardsNeuronCardPo } from "$tests/page-objects/NnsLosingRewardsNeuronCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Topic, type NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+
+describe("NnsLosingRewardsNeuronCard", () => {
+  const followNeuronId1 = 111n;
+  const followNeuronId2 = 222n;
+  const neuronId = 123n;
+  const neuron: NeuronInfo = {
+    ...mockNeuron,
+    neuronId,
+    fullNeuron: {
+      ...mockFullNeuron,
+      controller: mockIdentity.getPrincipal().toText(),
+      followees: [
+        {
+          topic: Topic.ExchangeRate,
+          followees: [followNeuronId1, followNeuronId2],
+        },
+        {
+          topic: Topic.Governance,
+          followees: [followNeuronId1],
+        },
+      ],
+    },
+  };
+
+  const renderComponent = (props) => {
+    const { container } = render(NnsLosingRewardsNeuronCard, {
+      props,
+    });
+    return NnsLosingRewardsNeuronCardPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render link", async () => {
+    const po = await renderComponent({ neuron });
+
+    expect(await po.getHref()).toEqual(
+      `/neuron/?u=${OWN_CANISTER_ID_TEXT}&neuron=${neuronId}`
+    );
+  });
+
+  it("should render following", async () => {
+    const po = await renderComponent({ neuron });
+
+    const followeePos = await po.getFolloweePos();
+
+    expect(followeePos.length).toBe(2);
+    expect(await followeePos[0].getName()).toEqual(`${followNeuronId1}`);
+    expect(await followeePos[0].getTags()).toEqual([
+      "Exchange Rate",
+      "Governance",
+    ]);
+    expect(await followeePos[1].getName()).toEqual(`${followNeuronId2}`);
+    expect(await followeePos[1].getTags()).toEqual(["Exchange Rate"]);
+  });
+});

--- a/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
@@ -52,6 +52,8 @@ describe("NnsLosingRewardsNeuronCard", () => {
 
     const followeePos = await po.getFolloweePos();
 
+    expect(await po.hasNoFollowingMessage()).toEqual(false);
+
     expect(followeePos.length).toBe(2);
     expect(await followeePos[0].getName()).toEqual(`${followNeuronId1}`);
     expect(await followeePos[0].getTags()).toEqual([
@@ -60,5 +62,21 @@ describe("NnsLosingRewardsNeuronCard", () => {
     ]);
     expect(await followeePos[1].getName()).toEqual(`${followNeuronId2}`);
     expect(await followeePos[1].getTags()).toEqual(["Exchange Rate"]);
+  });
+
+  it("should display no following message", async () => {
+    const po = await renderComponent({
+      neuron: {
+        ...neuron,
+        fullNeuron: {
+          ...neuron.fullNeuron,
+          // no followees
+          followees: [],
+        },
+      },
+    });
+
+    expect((await po.getFolloweePos()).length).toBe(0);
+    expect(await po.hasNoFollowingMessage()).toEqual(true);
   });
 });

--- a/frontend/src/tests/page-objects/Card.page-object.ts
+++ b/frontend/src/tests/page-objects/Card.page-object.ts
@@ -35,4 +35,8 @@ export class CardPo extends BasePageObject {
   async isButton(): Promise<boolean> {
     return (await this.root.getAttribute("role")) === "button";
   }
+
+  async getHref(): Promise<string> {
+    return await this.root.getAttribute("href");
+  }
 }

--- a/frontend/src/tests/page-objects/Followee.page-object.ts
+++ b/frontend/src/tests/page-objects/Followee.page-object.ts
@@ -10,6 +10,14 @@ export class FolloweePo extends BasePageObject {
     return new FolloweePo(element.byTestId(FolloweePo.TID));
   }
 
+  static async allUnder(element: PageObjectElement): Promise<FolloweePo[]> {
+    return Array.from(
+      (await element.allByTestId(FolloweePo.TID)).map(
+        (el) => new FolloweePo(el)
+      )
+    );
+  }
+
   getTagPos(): Promise<TagPo[]> {
     return TagPo.allUnder(this.root);
   }
@@ -19,7 +27,7 @@ export class FolloweePo extends BasePageObject {
   }
 
   getName(): Promise<string> {
-    return this.getButton().getText();
+    return this.root.byTestId("title").getText();
   }
 
   async getTags(): Promise<string[]> {

--- a/frontend/src/tests/page-objects/Followee.page-object.ts
+++ b/frontend/src/tests/page-objects/Followee.page-object.ts
@@ -27,7 +27,7 @@ export class FolloweePo extends BasePageObject {
   }
 
   getName(): Promise<string> {
-    return this.root.byTestId("title").getText();
+    return this.getText("title");
   }
 
   async getTags(): Promise<string[]> {

--- a/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
@@ -22,4 +22,8 @@ export class NnsLosingRewardsNeuronCardPo extends CardPo {
   async getFolloweePos(): Promise<FolloweePo[]> {
     return FolloweePo.allUnder(this.root);
   }
+
+  async hasNoFollowingMessage(): Promise<boolean> {
+    return this.root.byTestId("no-following").isPresent();
+  }
 }

--- a/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
@@ -24,6 +24,6 @@ export class NnsLosingRewardsNeuronCardPo extends CardPo {
   }
 
   async hasNoFollowingMessage(): Promise<boolean> {
-    return this.root.byTestId("no-following").isPresent();
+    return this.isPresent("no-following");
   }
 }

--- a/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
@@ -1,0 +1,25 @@
+import { CardPo } from "$tests/page-objects/Card.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { FolloweePo } from "./Followee.page-object";
+
+export class NnsLosingRewardsNeuronCardPo extends CardPo {
+  private static readonly TID = "nns-loosing-rewards-neuron-card-component";
+
+  static under(element: PageObjectElement): NnsLosingRewardsNeuronCardPo {
+    return new NnsLosingRewardsNeuronCardPo(
+      element.byTestId(NnsLosingRewardsNeuronCardPo.TID)
+    );
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<NnsLosingRewardsNeuronCardPo[]> {
+    return Array.from(
+      await element.allByTestId(NnsLosingRewardsNeuronCardPo.TID)
+    ).map((el) => new NnsLosingRewardsNeuronCardPo(el));
+  }
+
+  async getFolloweePos(): Promise<FolloweePo[]> {
+    return FolloweePo.allUnder(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

For the confirm following modal, we need to display inactive neurons with it's following. Here we add a neuron list item component that later will be used.

Note: In a later PR, the style of the Followee component will be slightly adjusted.

# Changes

- New NnsLosingRewardsNeuronCard component.

# Tests

- [Refactor FolloweePo to return the same title for active and inactive components.](https://github.com/dfinity/nns-dapp/pull/5909/commits/eecd8958f02a086a4d11fa416f68ca28e997398c)
- Added NnsLosingRewardsNeuronCardPo.
- Added test for NnsLosingRewardsNeuronCard.

- Tested locally in another branch.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/9ba5e510-66cb-43c6-9cb0-b18e8fb196b4">


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.