### PR TITLE
Add ICP Swap URL to CSP

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -205,6 +205,7 @@ const cspConnectSrc = () => {
     "'self'",
     "${{HOST}}",
     "${{SNS_AGGREGATOR_URL}}",
+    "${{ICP_SWAP_URL}}",
     // TODO: solve with a worker
     // Used for the metrics of OC launch
     "https://2hx64-daaaa-aaaaq-aaana-cai.raw.icp0.io",


### PR DESCRIPTION
# Motivation

When trying to load the ICP Swap tickers URL, we get an error because of the Content Security Policy.

# Changes

1. Add the `${{ICP_SWAP_URL}}` placeholder to the content security policy template such that the canister replaces it with the URL from the canister args during installation. We do the same for the SNS aggregator URL.

# Tests

1. Tested manually on DevEnv. Without this we can't load ICP Swap tickers and with this we can.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet