### PR TITLE
Support icp-swap in canister import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,6 +253,7 @@ jobs:
           	cketh_ledger
           	ckusdc_index
           	ckusdc_ledger
+          	icp-swap
           	internet_identity
           	nns-dapp
           	nns-index

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -135,6 +135,8 @@ if [ "$command" = "import-from-index-html" ]; then
 
   identityServiceUrl="$(get_value_from_html data-identity-service-url "$tmp_index_html")"
   internetIdentity="$(canister_id_from_url "$identityServiceUrl")"
+  icpSwapUrl="$(get_value_from_html data-icp-swap-url "$tmp_index_html")"
+  icpSwap="$(canister_id_from_url "$icpSwapUrl")"
 
   snsAggregatorUrl="$(get_value_from_html data-sns-aggregator-url "$tmp_index_html")"
   snsAggregator="$(canister_id_from_url "$snsAggregatorUrl")"
@@ -162,6 +164,7 @@ if [ "$command" = "import-from-index-html" ]; then
     .ckusdc_ledger[$network] = $ckusdcLedger |
     .["nns-sns-wasm"][$network] = $snsWasm |
     .internet_identity[$network] = $internetIdentity |
+    .["icp-swap"][$network] = $icpSwap |
     .["nns-dapp"][$network] = $nnsDapp |
     .sns_aggregator[$network] = $snsAggregator' \
     --arg network "$NETWORK" \
@@ -175,6 +178,7 @@ if [ "$command" = "import-from-index-html" ]; then
     --arg ckusdcLedger "$ckusdcLedger" \
     --arg snsWasm "$snsWasm" \
     --arg internetIdentity "$internetIdentity" \
+    --arg icpSwap "$icpSwap" \
     --arg nnsDapp "$nnsDapp" \
     --arg snsAggregator "$snsAggregator" \
     "$JSON_FILE" >"$tmp_file"

--- a/scripts/canister_ids.mainnet.golden
+++ b/scripts/canister_ids.mainnet.golden
@@ -29,6 +29,9 @@
   "internet_identity": {
     "mainnet": "identity"
   },
+  "icp-swap": {
+    "mainnet": ""
+  },
   "nns-dapp": {
     "mainnet": "qoctq-giaaa-aaaaa-aaaea-cai"
   },

--- a/scripts/canister_ids.test
+++ b/scripts/canister_ids.test
@@ -45,6 +45,7 @@ cat >"$test_index_html" <<-EOF
         data-fetch-root-key="true"
         data-governance-canister-id="rrkah-fqaaa-aaaaa-aaaaq-cai"
         data-host="https://fubar.dfinity.network"
+        data-icp-swap-url="https://mrfq3-7eaaa-aaaaa-qabja-cai.fubar.dfinity.network"
         data-identity-service-url="https://wqmuk-5qaaa-aaaaa-aaaqq-cai.fubar.dfinity.network"
         data-index-canister-id="bkyz2-fmaaa-aaaaa-qaaaq-cai"
         data-ledger-canister-id="ryjl3-tyaaa-aaaaa-aaaba-cai"
@@ -175,6 +176,9 @@ if ! diff "$test_json_file" <(
   },
   "nns-sns-wasm": {
     "staging": "qaa6y-5yaaa-aaaaa-aaafa-cai"
+  },
+  "icp-swap": {
+    "staging": "mrfq3-7eaaa-aaaaa-qabja-cai"
   },
   "sns_aggregator": {
     "staging": "p5kov-xqaaa-aaaaa-aacmq-cai"


### PR DESCRIPTION
# Motivation

If we want to deploy to DevEnv from another machine, we first need to import the canister IDs with
```
./scripts/canister_ids --import-from-index-html https://qsgjb-riaaa-aaaaa-aaaga-cai.$USER-ingress.devenv.dfinity.network/ --network devenv_$USER
```
to be able to deploy with the correct canister IDs in the canister args.
We do this during the release process, for example.

# Changes

1. Include the `icp-swap` canister ID in the IDs that get imported with `scripts/canister_ids --import-from-index-html`

# Tests

1. Test updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary