### PR TITLE
Add balanceInUsd to UserTokenData

### DIFF
--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -51,6 +51,8 @@ export type UserTokenFailed = UserTokenBase & {
 
 export type UserTokenData = UserTokenBase & {
   balance: TokenAmountV2 | UnavailableTokenAmount;
+  // The above balance converted to USD, if price data is available.
+  balanceInUsd?: number;
   // Identifier of the account related to the row (only if the row represents one account, not multiple)
   accountIdentifier?: string;
   token: Token;


### PR DESCRIPTION
# Motivation

We want to show USD values in the tokens table.

In this PR we add a field `balanceInUsd` to `UserTokenData`, so that it can be used in a later PR to display USD values.

# Changes

1. Add `balanceInUsd` field to `UserTokenData` type.
2. In `tokensListUserStore` populate the `balanceInUsd` field if price data is available.

# Tests

1. Unit tests added with price data loaded and not loaded.
2. Tested manually in a branch with more changes.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet