### PR TITLE
Fix: Adds an override for the name and token.symbol values for abandoned SNS

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- Adds an override for the name and token.symbol values for abandoned SNS 
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -1,4 +1,7 @@
-import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import type {
+  CachedSnsDto,
+  CachedSnsTokenMetadataDto,
+} from "$lib/types/sns-aggregator";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
@@ -35,10 +38,52 @@ export const snsAggregatorIncludingAbortedProjectsStore =
 export const snsAggregatorStore: SnsAggregatorStore = derived(
   snsAggregatorIncludingAbortedProjectsStore,
   (store) => ({
-    data: store.data?.filter(
-      (sns) =>
-        nonNullish(sns.lifecycle) &&
-        sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
-    ),
+    data: store.data
+      ?.filter(
+        (sns) =>
+          nonNullish(sns.lifecycle) &&
+          sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
+      )
+      .map(fixBrokenSnsMetadataBasedOnId),
   })
 );
+
+// TODO: Find a better way to fix broken SNS metadata.
+const brokenSnsOverrides: Record<
+  string,
+  { name: string; tokenSymbol: string }
+> = {
+  "bd3sg-teaaa-aaaaa-qaaba-cai": {
+    name: "CYCLES_TRANSFER_STATION",
+    tokenSymbol: "CTS",
+  },
+};
+
+const fixBrokenSnsMetadataBasedOnId = (sns: CachedSnsDto): CachedSnsDto => {
+  const override = brokenSnsOverrides[sns.list_sns_canisters.root];
+  if (!nonNullish(override)) return sns;
+  const newMeta = {
+    ...sns.meta,
+    name: `${sns.meta.name} (formerly ${override.name})`,
+  };
+
+  const newIcrc1Metadata = sns.icrc1_metadata.map<
+    [string, CachedSnsTokenMetadataDto[0][1]]
+  >(([name, value]) => {
+    if (name === "icrc1:symbol" && "Text" in value) {
+      return [
+        name,
+        {
+          Text: `${value.Text} (${override.tokenSymbol})`,
+        },
+      ];
+    }
+    return [name, value];
+  });
+
+  return {
+    ...sns,
+    meta: { ...newMeta },
+    icrc1_metadata: [...newIcrc1Metadata],
+  };
+};

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -53,7 +53,8 @@ const brokenSnsOverrides: Record<
   string,
   { name: string; tokenSymbol: string }
 > = {
-  "bd3sg-teaaa-aaaaa-qaaba-cai": {
+  // Overrided for CYCLES_TRANSFER_STATION as discussed in https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649
+  "ibahq-taaaa-aaaaq-aadna-cai": {
     name: "CYCLES_TRANSFER_STATION",
     tokenSymbol: "CTS",
   },

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -504,13 +504,6 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.swapParams) &&
   nonNullish(entry.lifecycle);
 
-const brokenUniverses: Record<string, { name: string; tokenSymbol: string }> = {
-  "bd3sg-teaaa-aaaaa-qaaba-cai": {
-    name: "CYCLES_TRANSFER_STATION",
-    tokenSymbol: "CTS",
-  },
-};
-
 export const convertDtoToSnsSummary = ({
   canister_ids: {
     root_canister_id,
@@ -543,23 +536,6 @@ export const convertDtoToSnsSummary = ({
       : undefined,
     lifecycle: convertDtoToLifecycle(lifecycle),
   };
-  // const override = brokenUniverses[partialSummary.rootCanisterId.toText()];
-  // const metadata = partialSummary.metadata;
-
-  // if (!isNullish(metadata) && !isNullish(override)) {
-  //   partialSummary.metadata = {
-  //     ...metadata,
-  //     name: `${metadata.name} (formerly known as ${override.name})`,
-  //   };
-  // }
-  // const token = partialSummary.token;
-
-  // if (!isNullish(token) && !isNullish(override)) {
-  //   partialSummary.token = {
-  //     ...token,
-  //     symbol: `${token.symbol} (${override.tokenSymbol})`,
-  //   };
-  // }
 
   return isValidSummary(partialSummary)
     ? new SnsSummaryWrapper(partialSummary)

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -504,6 +504,13 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.swapParams) &&
   nonNullish(entry.lifecycle);
 
+const brokenUniverses: Record<string, { name: string; tokenSymbol: string }> = {
+  "bd3sg-teaaa-aaaaa-qaaba-cai": {
+    name: "CYCLES_TRANSFER_STATION",
+    tokenSymbol: "CTS",
+  },
+};
+
 export const convertDtoToSnsSummary = ({
   canister_ids: {
     root_canister_id,
@@ -536,6 +543,23 @@ export const convertDtoToSnsSummary = ({
       : undefined,
     lifecycle: convertDtoToLifecycle(lifecycle),
   };
+  // const override = brokenUniverses[partialSummary.rootCanisterId.toText()];
+  // const metadata = partialSummary.metadata;
+
+  // if (!isNullish(metadata) && !isNullish(override)) {
+  //   partialSummary.metadata = {
+  //     ...metadata,
+  //     name: `${metadata.name} (formerly known as ${override.name})`,
+  //   };
+  // }
+  // const token = partialSummary.token;
+
+  // if (!isNullish(token) && !isNullish(override)) {
+  //   partialSummary.token = {
+  //     ...token,
+  //     symbol: `${token.symbol} (${override.tokenSymbol})`,
+  //   };
+  // }
 
   return isValidSummary(partialSummary)
     ? new SnsSummaryWrapper(partialSummary)

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -153,7 +153,7 @@ describe("sns-aggregator store", () => {
       },
     });
 
-    it("should override information for SNS with universeId ibahq-taaaa-aaaaq-aadna-cai", () => {
+    it("should override information for SNS with rootCanisterId ibahq-taaaa-aaaaq-aadna-cai", () => {
       const brokenSns = withBrokenSns({
         sns: aggregatorMockSnsesDataDto[0],
         rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -179,11 +179,12 @@ describe("sns-aggregator store", () => {
 
       const data = [brokenSns];
       snsAggregatorIncludingAbortedProjectsStore.setData(data);
-      expect(get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name).toBe(
-        "---"
-      );
       expect(
-        get(snsAggregatorIncludingAbortedProjectsStore).data[0].icrc1_metadata[3][1]
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name
+      ).toBe("---");
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0]
+          .icrc1_metadata[3][1]
       ).toEqual({ Text: "---" });
 
       const result = get(snsAggregatorStore).data[0];

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -137,4 +137,35 @@ describe("sns-aggregator store", () => {
       expect(get(snsAggregatorStore).data).toEqual(nonAbortedData);
     });
   });
+
+  describe("brokenSnsOverrides", () => {
+    const withBrokenSns = ({
+      sns,
+      rootCanisterId,
+    }: {
+      sns: CachedSnsDto;
+      rootCanisterId: string;
+    }) => ({
+      ...sns,
+      list_sns_canisters: {
+        ...sns.list_sns_canisters,
+        root: rootCanisterId,
+      },
+    });
+
+    it("should override information for SNS with universeId ibahq-taaaa-aaaaq-aadna-cai", () => {
+      const brokenSns = withBrokenSns({
+        sns: aggregatorMockSnsesDataDto[0],
+        rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",
+      });
+
+      const data = [brokenSns];
+      snsAggregatorIncludingAbortedProjectsStore.setData(data);
+      const result = get(snsAggregatorStore).data[0];
+      expect(result.meta.name).toBe(
+        "Dragginz (formerly CYCLES_TRANSFER_STATION)"
+      );
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "DKP (CTS)" });
+    });
+  });
 });

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -179,10 +179,15 @@ describe("sns-aggregator store", () => {
 
       const data = [brokenSns];
       snsAggregatorIncludingAbortedProjectsStore.setData(data);
-      const result = get(snsAggregatorStore).data[0];
-      expect(result.meta.name).toBe(
-        "--- (formerly CYCLES_TRANSFER_STATION)"
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name).toBe(
+        "---"
       );
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0].icrc1_metadata[3][1]
+      ).toEqual({ Text: "---" });
+
+      const result = get(snsAggregatorStore).data[0];
+      expect(result.meta.name).toBe("--- (formerly CYCLES_TRANSFER_STATION)");
       expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
   });

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -154,8 +154,26 @@ describe("sns-aggregator store", () => {
     });
 
     it("should override information for SNS with rootCanisterId ibahq-taaaa-aaaaq-aadna-cai", () => {
+      const mockedSns = aggregatorMockSnsesDataDto[0];
       const brokenSns = withBrokenSns({
-        sns: aggregatorMockSnsesDataDto[0],
+        sns: {
+          ...mockedSns,
+          meta: {
+            ...mockedSns.meta,
+            name: "---",
+          },
+          icrc1_metadata: [...mockedSns.icrc1_metadata].map(([name, value]) => {
+            if (name === "icrc1:symbol" && "Text" in value) {
+              return [
+                name,
+                {
+                  Text: "---",
+                },
+              ];
+            }
+            return [name, value];
+          }),
+        },
         rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",
       });
 
@@ -163,9 +181,9 @@ describe("sns-aggregator store", () => {
       snsAggregatorIncludingAbortedProjectsStore.setData(data);
       const result = get(snsAggregatorStore).data[0];
       expect(result.meta.name).toBe(
-        "Dragginz (formerly CYCLES_TRANSFER_STATION)"
+        "--- (formerly CYCLES_TRANSFER_STATION)"
       );
-      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "DKP (CTS)" });
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
   });
 });


### PR DESCRIPTION
# Motivation

As discussed [here](https://dfinity.slack.com/archives/C03H6QEPW5D/p1733263773416409) and [here](https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649), we have a situation with the SNS `CYCLES-TRANSFER-STATION`. They have decided to change all their metadata, resulting in the name and token being displayed as `---`.

This first PR introduces a method to override the values we receive from the SNS-Aggregator, allowing the rest of the application to use them.

# Changes

- Checks a dictionary of "broken" SNSs for matches and overrides `name` and `token.symbol` for any that are found.

# Tests

- Unit test for the aggregator store derived data to verify that when `rootCanisterId` is present in the dictionary, the values for `name` and `token.symbol` are replaced.

# Todos

- [ ] Add entry to changelog (if necessary).
