### PR TITLE
Render balance in USD in TokenBalanceCell

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { ENABLE_USD_VALUES } from "$lib/stores/feature-flags.store";
   import type {
     UserTokenData,
     UserTokenFailed,
     UserTokenLoading,
   } from "$lib/types/tokens-page";
+  import { formatNumber } from "$lib/utils/format.utils";
   import {
     isUserTokenData,
     isUserTokenLoading,
   } from "$lib/utils/user-token.utils";
   import { Spinner } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 </script>
@@ -19,7 +22,18 @@
     ><Spinner inline size="tiny" /></span
   >
 {:else if isUserTokenData(rowData)}
-  <AmountDisplay singleLine amount={rowData.balance} />
+  <div class="values">
+    <AmountDisplay singleLine amount={rowData.balance} />
+    {#if $ENABLE_USD_VALUES}
+      <span data-tid="usd-value" class="usd-value">
+        {#if nonNullish(rowData.balanceInUsd)}
+          ${formatNumber(rowData.balanceInUsd)}
+        {:else}
+          $-/-
+        {/if}
+      </span>
+    {/if}
+  </div>
 {:else}
   <span data-tid="unavailable-balance" class="value">-/-</span>
 {/if}
@@ -28,5 +42,16 @@
   .balance-spinner {
     display: flex;
     align-items: center;
+  }
+
+  .values {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+
+    .usd-value {
+      color: var(--text-description);
+      font-size: var(--font-size-small);
+    }
   }
 </style>


### PR DESCRIPTION
# Motivation

We want to show USD values of assets.

In this PR we went balance in USD in the tokens table, if the feature flag is enabled.

Price data will not be available until (in another PR) we call `loadIcpSwapTickers()`.

# Changes

1. In `TokenBalanceCell.svelte`, if `ENABLE_USD_VALUES` is enabled, render either the USD value of the balance or `$-/-` if the price data is not available.

# Tests

1. Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet