### PR TITLE
Fix: Pushes abandoned SNS to the bottom of the nsAggregatorStore

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,8 +22,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
-- Adds an override for the name and token.symbol values for abandoned SNS 
-- Position of abandoned SNSs
+- Handles abandoned SNSs by adding an override for the name and token.symbol values as well as sorting them down on the lists. 
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 - Adds an override for the name and token.symbol values for abandoned SNS 
+- Position of abandoned SNSs
 
 #### Security
 

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -67,7 +67,7 @@ const brokenSnsOverrides: Record<
 > = {
   // Overrided for CYCLES_TRANSFER_STATION as discussed in https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649
   "ibahq-taaaa-aaaaq-aadna-cai": {
-    name: "CYCLES_TRANSFER_STATION",
+    name: "CYCLES-TRANSFER-STATION",
     tokenSymbol: "CTS",
   },
 };
@@ -92,7 +92,7 @@ const fixBrokenSnsMetadataBasedOnId = (
       return [
         name,
         {
-          Text: `${hiddenCharacterToPushSnsToEndOfList}${value.Text} (${override.tokenSymbol})`,
+          Text: `${value.Text} (${override.tokenSymbol})`,
         },
       ];
     }

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -1,4 +1,7 @@
-import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import type {
+  CachedSnsDto,
+  CachedSnsTokenMetadataDto,
+} from "$lib/types/sns-aggregator";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
@@ -35,10 +38,52 @@ export const snsAggregatorIncludingAbortedProjectsStore =
 export const snsAggregatorStore: SnsAggregatorStore = derived(
   snsAggregatorIncludingAbortedProjectsStore,
   (store) => ({
-    data: store.data?.filter(
-      (sns) =>
-        nonNullish(sns.lifecycle) &&
-        sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
-    ),
+    data: store.data
+      ?.filter(
+        (sns) =>
+          nonNullish(sns.lifecycle) &&
+          sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
+      )
+      .map(fixBrokenSnsMetadataBasedOnId),
   })
 );
+
+// TODO: Find a better way to fix broken SNS metadata.
+const brokenSnsOverrides: Record<
+  string,
+  { name: string; tokenSymbol: string }
+> = {
+  "bd3sg-teaaa-aaaaa-qaaba-cai": {
+    name: "CYCLES_TRANSFER_STATION",
+    tokenSymbol: "CTS",
+  },
+};
+
+const fixBrokenSnsMetadataBasedOnId = (sns: CachedSnsDto): CachedSnsDto => {
+  const override = brokenSnsOverrides[sns.list_sns_canisters.root];
+  if (!nonNullish(override)) return sns;
+  const newMeta = {
+    ...sns.meta,
+    name: `${sns.meta.name} (formerly ${override.name})`,
+  };
+
+  const newIcrc1Metadata = sns.icrc1_metadata.map<
+    [string, CachedSnsTokenMetadataDto[0][1]]
+  >(([name, value]) => {
+    if (name === "icrc1:symbol" && "Text" in value) {
+      return [
+        name,
+        {
+          Text: `${value.Text} (${override.tokenSymbol})`,
+        },
+      ];
+    }
+    return [name, value];
+  });
+
+  return {
+    ...sns,
+    meta: { ...newMeta },
+    icrc1_metadata: [...newIcrc1Metadata],
+  };
+};

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -93,7 +93,7 @@ const fixBrokenSnsMetadataBasedOnId = (
       return [
         name,
         {
-          Text: `${value.Text} (${override.tokenSymbol})`,
+          Text: `${hiddenCharacterToPushSnsToEndOfList}${value.Text} (${override.tokenSymbol})`,
         },
       ];
     }

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -76,7 +76,7 @@ const fixBrokenSnsMetadataBasedOnId = (
 ): CachedSnsDto & { isAbandoned?: boolean } => {
   const override = brokenSnsOverrides[sns.list_sns_canisters.root];
 
-  // Required for the tokens and stakin routes
+  // Required for the tokens and staking routes as they apply their own sort logic
   const hiddenCharacterToPushSnsToEndOfList = "\u200B";
   if (!nonNullish(override)) return sns;
   const newMeta = {
@@ -106,7 +106,7 @@ const fixBrokenSnsMetadataBasedOnId = (
   };
 };
 
-// Required for the proposals route
+// Required for the proposals route as it doesnt apply sort logic
 const sortedListBasedOnAbandoned = (
   list: (CachedSnsDto & { isAbandoned?: boolean })[]
 ) => [

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -3,7 +3,7 @@ import type {
   CachedSnsTokenMetadataDto,
 } from "$lib/types/sns-aggregator";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { nonNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
 
 /**
@@ -43,10 +43,12 @@ export const snsAggregatorStore: SnsAggregatorStore = derived(
         nonNullish(sns.lifecycle) &&
         sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
     );
+    
+    if (isNullish(data)) return { data: undefined };
 
     // TODO: Find a better way to fix broken SNS metadata. These transformations will be remove once we have a better solution.
     const handledAbandonedSnsData =
-      data?.map(fixBrokenSnsMetadataBasedOnId) ?? [];
+      data?.map(fixBrokenSnsMetadataBasedOnId);
     const sortedAbandonesSnsData = sortedListBasedOnAbandoned(
       handledAbandonedSnsData
     );

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -43,12 +43,11 @@ export const snsAggregatorStore: SnsAggregatorStore = derived(
         nonNullish(sns.lifecycle) &&
         sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
     );
-    
+
     if (isNullish(data)) return { data: undefined };
 
     // TODO: Find a better way to fix broken SNS metadata. These transformations will be remove once we have a better solution.
-    const handledAbandonedSnsData =
-      data?.map(fixBrokenSnsMetadataBasedOnId);
+    const handledAbandonedSnsData = data?.map(fixBrokenSnsMetadataBasedOnId);
     const sortedAbandonesSnsData = sortedListBasedOnAbandoned(
       handledAbandonedSnsData
     );

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -53,7 +53,8 @@ const brokenSnsOverrides: Record<
   string,
   { name: string; tokenSymbol: string }
 > = {
-  "bd3sg-teaaa-aaaaa-qaaba-cai": {
+  // Overrided for CYCLES_TRANSFER_STATION as discussed in https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649
+  "ibahq-taaaa-aaaaq-aadna-cai": {
     name: "CYCLES_TRANSFER_STATION",
     tokenSymbol: "CTS",
   },

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -504,13 +504,6 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.swapParams) &&
   nonNullish(entry.lifecycle);
 
-const brokenUniverses: Record<string, { name: string; tokenSymbol: string }> = {
-  "bd3sg-teaaa-aaaaa-qaaba-cai": {
-    name: "CYCLES_TRANSFER_STATION",
-    tokenSymbol: "CTS",
-  },
-};
-
 export const convertDtoToSnsSummary = ({
   canister_ids: {
     root_canister_id,
@@ -543,23 +536,6 @@ export const convertDtoToSnsSummary = ({
       : undefined,
     lifecycle: convertDtoToLifecycle(lifecycle),
   };
-  // const override = brokenUniverses[partialSummary.rootCanisterId.toText()];
-  // const metadata = partialSummary.metadata;
-
-  // if (!isNullish(metadata) && !isNullish(override)) {
-  //   partialSummary.metadata = {
-  //     ...metadata,
-  //     name: `${metadata.name} (formerly known as ${override.name})`,
-  //   };
-  // }
-  // const token = partialSummary.token;
-
-  // if (!isNullish(token) && !isNullish(override)) {
-  //   partialSummary.token = {
-  //     ...token,
-  //     symbol: `${token.symbol} (${override.tokenSymbol})`,
-  //   };
-  // }
 
   return isValidSummary(partialSummary)
     ? new SnsSummaryWrapper(partialSummary)

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -504,6 +504,13 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.swapParams) &&
   nonNullish(entry.lifecycle);
 
+const brokenUniverses: Record<string, { name: string; tokenSymbol: string }> = {
+  "bd3sg-teaaa-aaaaa-qaaba-cai": {
+    name: "CYCLES_TRANSFER_STATION",
+    tokenSymbol: "CTS",
+  },
+};
+
 export const convertDtoToSnsSummary = ({
   canister_ids: {
     root_canister_id,
@@ -536,6 +543,23 @@ export const convertDtoToSnsSummary = ({
       : undefined,
     lifecycle: convertDtoToLifecycle(lifecycle),
   };
+  // const override = brokenUniverses[partialSummary.rootCanisterId.toText()];
+  // const metadata = partialSummary.metadata;
+
+  // if (!isNullish(metadata) && !isNullish(override)) {
+  //   partialSummary.metadata = {
+  //     ...metadata,
+  //     name: `${metadata.name} (formerly known as ${override.name})`,
+  //   };
+  // }
+  // const token = partialSummary.token;
+
+  // if (!isNullish(token) && !isNullish(override)) {
+  //   partialSummary.token = {
+  //     ...token,
+  //     symbol: `${token.symbol} (${override.tokenSymbol})`,
+  //   };
+  // }
 
   return isValidSummary(partialSummary)
     ? new SnsSummaryWrapper(partialSummary)

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -191,7 +191,7 @@ describe("sns-aggregator store", () => {
       expect(result.meta.name).toBe(
         "\u200B--- (formerly CYCLES_TRANSFER_STATION)"
       );
-      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "\u200B--- (CTS)" });
     });
 
     it("should sort sns by temporal isAbandoded property", () => {

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -153,7 +153,7 @@ describe("sns-aggregator store", () => {
       },
     });
 
-    it("should override information for SNS with universeId ibahq-taaaa-aaaaq-aadna-cai", () => {
+    it("should override information for SNS with rootCanisterId ibahq-taaaa-aaaaq-aadna-cai", () => {
       const brokenSns = withBrokenSns({
         sns: aggregatorMockSnsesDataDto[0],
         rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -194,7 +194,7 @@ describe("sns-aggregator store", () => {
       expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
 
-    it("should sort sns by temporal isAbandoded property", () => {
+    it("should sort sns by temporary isAbandoded property", () => {
       const data = [brokenSns, ...aggregatorMockSnsesDataDto];
       snsAggregatorIncludingAbortedProjectsStore.setData(data);
       expect(

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -189,9 +189,9 @@ describe("sns-aggregator store", () => {
 
       const result = get(snsAggregatorStore).data[0];
       expect(result.meta.name).toBe(
-        "\u200B--- (formerly CYCLES_TRANSFER_STATION)"
+        "\u200B--- (formerly CYCLES-TRANSFER-STATION)"
       );
-      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "\u200B--- (CTS)" });
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
 
     it("should sort sns by temporal isAbandoded property", () => {
@@ -208,9 +208,9 @@ describe("sns-aggregator store", () => {
       const result =
         get(snsAggregatorStore).data[get(snsAggregatorStore).data.length - 1];
       expect(result.meta.name).toBe(
-        "\u200B--- (formerly CYCLES_TRANSFER_STATION)"
+        "\u200B--- (formerly CYCLES-TRANSFER-STATION)"
       );
-      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "\u200B--- (CTS)" });
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -210,7 +210,7 @@ describe("sns-aggregator store", () => {
       expect(result.meta.name).toBe(
         "\u200B--- (formerly CYCLES_TRANSFER_STATION)"
       );
-      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "\u200B--- (CTS)" });
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -153,41 +153,63 @@ describe("sns-aggregator store", () => {
       },
     });
 
-    it("should override information for SNS with rootCanisterId ibahq-taaaa-aaaaq-aadna-cai", () => {
-      const mockedSns = aggregatorMockSnsesDataDto[0];
-      const brokenSns = withBrokenSns({
-        sns: {
-          ...mockedSns,
-          meta: {
-            ...mockedSns.meta,
-            name: "---",
-          },
-          icrc1_metadata: [...mockedSns.icrc1_metadata].map(([name, value]) => {
-            if (name === "icrc1:symbol" && "Text" in value) {
-              return [
-                name,
-                {
-                  Text: "---",
-                },
-              ];
-            }
-            return [name, value];
-          }),
+    const mockedSns = aggregatorMockSnsesDataDto[0];
+    const brokenSns = withBrokenSns({
+      sns: {
+        ...mockedSns,
+        meta: {
+          ...mockedSns.meta,
+          name: "---",
         },
-        rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",
-      });
+        icrc1_metadata: [...mockedSns.icrc1_metadata].map(([name, value]) => {
+          if (name === "icrc1:symbol" && "Text" in value) {
+            return [
+              name,
+              {
+                Text: "---",
+              },
+            ];
+          }
+          return [name, value];
+        }),
+      },
+      rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",
+    });
 
+    it("should override information for SNS with rootCanisterId ibahq-taaaa-aaaaq-aadna-cai", () => {
       const data = [brokenSns];
       snsAggregatorIncludingAbortedProjectsStore.setData(data);
-      expect(get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name).toBe(
-        "---"
-      );
       expect(
-        get(snsAggregatorIncludingAbortedProjectsStore).data[0].icrc1_metadata[3][1]
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name
+      ).toBe("---");
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0]
+          .icrc1_metadata[3][1]
       ).toEqual({ Text: "---" });
 
       const result = get(snsAggregatorStore).data[0];
-      expect(result.meta.name).toBe("--- (formerly CYCLES_TRANSFER_STATION)");
+      expect(result.meta.name).toBe(
+        "\u200B--- (formerly CYCLES_TRANSFER_STATION)"
+      );
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
+    });
+
+    it("should sort sns by temporal isAbandoded property", () => {
+      const data = [brokenSns, ...aggregatorMockSnsesDataDto];
+      snsAggregatorIncludingAbortedProjectsStore.setData(data);
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name
+      ).toBe("---");
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0]
+          .icrc1_metadata[3][1]
+      ).toEqual({ Text: "---" });
+
+      const result =
+        get(snsAggregatorStore).data[get(snsAggregatorStore).data.length - 1];
+      expect(result.meta.name).toBe(
+        "\u200B--- (formerly CYCLES_TRANSFER_STATION)"
+      );
       expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
   });

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -137,4 +137,35 @@ describe("sns-aggregator store", () => {
       expect(get(snsAggregatorStore).data).toEqual(nonAbortedData);
     });
   });
+
+  describe("brokenSnsOverrides", () => {
+    const withBrokenSns = ({
+      sns,
+      rootCanisterId,
+    }: {
+      sns: CachedSnsDto;
+      rootCanisterId: string;
+    }) => ({
+      ...sns,
+      list_sns_canisters: {
+        ...sns.list_sns_canisters,
+        root: rootCanisterId,
+      },
+    });
+
+    it("should override information for SNS with universeId ibahq-taaaa-aaaaq-aadna-cai", () => {
+      const brokenSns = withBrokenSns({
+        sns: aggregatorMockSnsesDataDto[0],
+        rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",
+      });
+
+      const data = [brokenSns];
+      snsAggregatorIncludingAbortedProjectsStore.setData(data);
+      const result = get(snsAggregatorStore).data[0];
+      expect(result.meta.name).toBe(
+        "Dragginz (formerly CYCLES_TRANSFER_STATION)"
+      );
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "DKP (CTS)" });
+    });
+  });
 });

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -179,10 +179,15 @@ describe("sns-aggregator store", () => {
 
       const data = [brokenSns];
       snsAggregatorIncludingAbortedProjectsStore.setData(data);
-      const result = get(snsAggregatorStore).data[0];
-      expect(result.meta.name).toBe(
-        "--- (formerly CYCLES_TRANSFER_STATION)"
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name).toBe(
+        "---"
       );
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0].icrc1_metadata[3][1]
+      ).toEqual({ Text: "---" });
+
+      const result = get(snsAggregatorStore).data[0];
+      expect(result.meta.name).toBe("--- (formerly CYCLES_TRANSFER_STATION)");
       expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
   });

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -154,8 +154,26 @@ describe("sns-aggregator store", () => {
     });
 
     it("should override information for SNS with rootCanisterId ibahq-taaaa-aaaaq-aadna-cai", () => {
+      const mockedSns = aggregatorMockSnsesDataDto[0];
       const brokenSns = withBrokenSns({
-        sns: aggregatorMockSnsesDataDto[0],
+        sns: {
+          ...mockedSns,
+          meta: {
+            ...mockedSns.meta,
+            name: "---",
+          },
+          icrc1_metadata: [...mockedSns.icrc1_metadata].map(([name, value]) => {
+            if (name === "icrc1:symbol" && "Text" in value) {
+              return [
+                name,
+                {
+                  Text: "---",
+                },
+              ];
+            }
+            return [name, value];
+          }),
+        },
         rootCanisterId: "ibahq-taaaa-aaaaq-aadna-cai",
       });
 
@@ -163,9 +181,9 @@ describe("sns-aggregator store", () => {
       snsAggregatorIncludingAbortedProjectsStore.setData(data);
       const result = get(snsAggregatorStore).data[0];
       expect(result.meta.name).toBe(
-        "Dragginz (formerly CYCLES_TRANSFER_STATION)"
+        "--- (formerly CYCLES_TRANSFER_STATION)"
       );
-      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "DKP (CTS)" });
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
   });
 });


### PR DESCRIPTION
# Motivation

As discussed [here](https://dfinity.slack.com/archives/C03H6QEPW5D/p1733263773416409) and [here](https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649), we have a situation with the SNS `CYCLES-TRANSFER-STATION`. They have decided to change all their metadata, resulting in the name and token being displayed as `---`.

This second PR moves abandoned SNSs to the bottom of both the `nsAggregatorStore` and any alphabetical sort.

# Changes

- Adds the hidden character `"\u200B"` to the beginning of the name of an abandoned SNS, so alphabetical sorting pushes them to the end.
- Sorts `nsAggregatorStore` by the temporal parameter `isAbandoned`.

# Tests

- Unit test for the aggregator store derived data to verify that sort functionality works as expected.

# Todos

- [x] Add entry to changelog (if necessary).

Prev. PR: #5915 
