### PR TITLE
Load ICP Swap tickers on tokens page

### DIFF
--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -24,9 +24,11 @@
   import Tokens from "$lib/pages/Tokens.svelte";
   import { updateBalance } from "$lib/services/ckbtc-minter.services";
   import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
   import { removeImportedTokens } from "$lib/services/imported-tokens.services";
   import { uncertifiedLoadSnsesAccountsBalances } from "$lib/services/sns-accounts-balance.services";
   import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-uncertified-accounts.services";
+  import { ENABLE_USD_VALUES } from "$lib/stores/feature-flags.store";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import type { Account } from "$lib/types/account";
   import { ActionType, type Action } from "$lib/types/actions";
@@ -169,6 +171,9 @@
   }
   $: if ($authSignedInStore) {
     loadIcrcTokenAccounts($icrcCanistersStore);
+  }
+  $: if ($authSignedInStore && $ENABLE_USD_VALUES) {
+    loadIcpSwapTickers();
   }
 
   type ModalType =

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -530,13 +530,11 @@ describe("Tokens route", () => {
       it("should load ICP Swap tickers", async () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES", true);
 
-        const icpPrice = 10;
-
         const tickers = [
           {
             ...mockIcpSwapTicker,
             base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-            last_price: icpPrice,
+            last_price: "10.00",
           },
         ];
         vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue(tickers);


### PR DESCRIPTION
# Motivation

In order to have exchange rate data available, we need to call `loadIcpSwapTickers`.

# Changes

1. Call `loadIcpSwapTickers()` from the tokens pages.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet