### PR TITLE
Load ICP Swap tickers on account page

### DIFF
--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -8,7 +8,13 @@
   import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
   import AccountsModals from "$lib/modals/accounts/AccountsModals.svelte";
   import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { ENABLE_USD_VALUES } from "$lib/stores/feature-flags.store";
   import { Spinner } from "@dfinity/gix-components";
+
+  $: if ($ENABLE_USD_VALUES) {
+    loadIcpSwapTickers();
+  }
 
   $: {
     // For now, the Accounts page is enabled only for NNS


### PR DESCRIPTION
# Motivation

In order to have exchange rate data available, we need to call `loadIcpSwapTickers`.

# Changes

1. Call `loadIcpSwapTickers()` from the accounts pages.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet