### PR TITLE
Losing rewards modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-25.tgz",
-      "integrity": "sha512-QfzR3UquuumjkacZt6jdFtxiIXSVMREyIixGOuIxjaQYZbFajFWReboXEgmRKIPVVc7+gDUD9l3zJNBO5LMi3A==",
+      "version": "5.0.0-next-2024-12-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.0.0-next-2024-12-03.tgz",
+      "integrity": "sha512-xX9EJMxPsuq/o1lIqFRtv9KHlU7yAGZVKfFEZdegq+vk8NPyNyuahzq+j40wHwhi/sn5uk38HTpsKgQ3+K/Lqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.1.6",
@@ -6693,9 +6693,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.8.0-next-2024-11-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.8.0-next-2024-11-25.tgz",
-      "integrity": "sha512-QfzR3UquuumjkacZt6jdFtxiIXSVMREyIixGOuIxjaQYZbFajFWReboXEgmRKIPVVc7+gDUD9l3zJNBO5LMi3A==",
+      "version": "5.0.0-next-2024-12-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.0.0-next-2024-12-03.tgz",
+      "integrity": "sha512-xX9EJMxPsuq/o1lIqFRtv9KHlU7yAGZVKfFEZdegq+vk8NPyNyuahzq+j40wHwhi/sn5uk38HTpsKgQ3+K/Lqg==",
       "requires": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -14,6 +14,7 @@
   import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import LosingRewardNeuronsModal from "$lib/modals/neurons/LosingRewardNeuronsModal.svelte";
 
   // The neurons in the store are sorted by the time they will lose rewards.
   let mostInactiveNeuron: NeuronInfo | undefined;
@@ -35,9 +36,7 @@
     ),
   });
 
-  const onConfirm = () => {
-    // TODO: Display the modal
-  };
+  let isModalVisible = false;
 </script>
 
 <TestIdWrapper testId="losing-rewards-banner-component">
@@ -47,10 +46,14 @@
         <IconInfo />
       </BannerIcon>
       <div slot="actions">
-        <button class="danger" on:click={onConfirm}
+        <button class="danger" on:click={() => (isModalVisible = true)}
           >{$i18n.losing_rewards_banner.confirm}</button
         >
       </div>
     </Banner>
+  {/if}
+
+  {#if isModalVisible}
+    <LosingRewardNeuronsModal on:nnsClose={() => (isModalVisible = false)} />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -46,7 +46,10 @@
         <IconInfo />
       </BannerIcon>
       <div slot="actions">
-        <button class="danger" on:click={() => (isModalVisible = true)}
+        <button
+          data-tid="confirm-button"
+          class="danger"
+          on:click={() => (isModalVisible = true)}
           >{$i18n.losing_rewards_banner.confirm}</button
         >
       </div>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -371,6 +371,10 @@
   },
   "losing_rewards_modal": {
     "goto_neuron": "Go to neuron details",
+    "title": "Review your following for neurons",
+    "description": "ICP neurons that are inactive for $period start losing voting rewards. In order to avoid losing rewards, vote manually, edit or confirm your following.",
+    "label": "Neurons",
+    "confirm": "Confirm Following",
     "no_following": "This neuron has no following configured."
   },
   "new_followee": {

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { Modal } from "@dfinity/gix-components";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { soonLosingRewardNeuronsStore } from "$lib/derived/neurons.derived";
   import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
+  import { listKnownNeurons } from "$lib/services/known-neurons.services";
 
   const dispatcher = createEventDispatcher();
+
+  // Load KnownNeurons which are used in the FollowNnsTopicSections
+  onMount(() => listKnownNeurons());
 
   const confirm = () => {
     // TBD

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { Modal } from "@dfinity/gix-components";
+  import { createEventDispatcher } from "svelte";
+  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { soonLosingRewardNeuronsStore } from "$lib/derived/neurons.derived";
+  import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
+
+  const dispatcher = createEventDispatcher();
+
+  const confirm = () => {
+    // TBD
+  };
+</script>
+
+<Modal on:nnsClose testId="losing-reward-neurons-modal-component">
+  <svelte:fragment slot="title">
+    {$i18n.losing_rewards_modal.title}
+  </svelte:fragment>
+
+  <div class="wrapper">
+    <p class="description">
+      {replacePlaceholders($i18n.losing_rewards_modal.description, {
+        $period: secondsToDissolveDelayDuration(
+          BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS)
+        ),
+      })}
+    </p>
+
+    <h3 class="label">{$i18n.losing_rewards_modal.label}</h3>
+    <ul class="cards">
+      {#each $soonLosingRewardNeuronsStore as neuron (neuron.neuronId)}
+        <li>
+          <NnsLosingRewardsNeuronCard {neuron} />
+        </li>
+      {/each}
+    </ul>
+    <div class="toolbar">
+      <button on:click={() => dispatcher("nnsClose")} class="secondary"
+        >{$i18n.core.cancel}</button
+      >
+      <button on:click={confirm} class="primary" data-tid="confirm-button"
+        >{$i18n.losing_rewards_modal.confirm}</button
+      >
+    </div>
+  </div>
+</Modal>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .description {
+    margin: 0 0 var(--padding-3x);
+  }
+
+  .label {
+    margin-bottom: var(--padding);
+    @include fonts.standard(false);
+    color: var(--description-color);
+  }
+
+  .cards {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+    margin-bottom: var(--padding-3x);
+
+    padding: 0;
+    list-style-type: none;
+  }
+</style>

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -38,8 +38,10 @@
       {/each}
     </ul>
     <div class="toolbar">
-      <button on:click={() => dispatcher("nnsClose")} class="secondary"
-        >{$i18n.core.cancel}</button
+      <button
+        on:click={() => dispatcher("nnsClose")}
+        class="secondary"
+        data-tid="cancel-button">{$i18n.core.cancel}</button
       >
       <button on:click={confirm} class="primary" data-tid="confirm-button"
         >{$i18n.losing_rewards_modal.confirm}</button

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -387,6 +387,10 @@ interface I18nLosing_rewards_banner {
 
 interface I18nLosing_rewards_modal {
   goto_neuron: string;
+  title: string;
+  description: string;
+  label: string;
+  confirm: string;
   no_following: string;
 }
 

--- a/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
@@ -1,10 +1,14 @@
+import { clearCache } from "$lib/api-services/governance.api-service";
+import * as governanceApi from "$lib/api/governance.api";
 import { SECONDS_IN_DAY, SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import LosingRewardNeuronsModal from "$lib/modals/neurons/LosingRewardNeuronsModal.svelte";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { nonNullish } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
@@ -52,9 +56,15 @@ describe("LosingRewardNeuronsModal", () => {
   };
 
   beforeEach(() => {
+    resetIdentity();
+    // Remove known neurons from the cache.
+    clearCache();
+
     vi.useFakeTimers({
       now: nowSeconds * 1000,
     });
+
+    vi.spyOn(governanceApi, "queryKnownNeurons").mockResolvedValue([]);
   });
 
   it("should not display active neurons", async () => {
@@ -87,5 +97,28 @@ describe("LosingRewardNeuronsModal", () => {
     expect(onClose).toHaveBeenCalledTimes(0);
     await po.clickCancel();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fetch known neurons", async () => {
+    const queryKnownNeuronsSpy = vi
+      .spyOn(governanceApi, "queryKnownNeurons")
+      .mockResolvedValue([]);
+    neuronsStore.setNeurons({
+      neurons: [activeNeuron, in10DaysLosingRewardsNeuron, losingRewardsNeuron],
+      certified: true,
+    });
+
+    expect(queryKnownNeuronsSpy).toHaveBeenCalledTimes(0);
+    await renderComponent();
+    await runResolvedPromises();
+    expect(queryKnownNeuronsSpy).toHaveBeenCalledTimes(2);
+    expect(queryKnownNeuronsSpy).toHaveBeenCalledWith({
+      certified: true,
+      identity: mockIdentity,
+    });
+    expect(queryKnownNeuronsSpy).toHaveBeenCalledWith({
+      certified: false,
+      identity: mockIdentity,
+    });
   });
 });

--- a/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
@@ -1,0 +1,91 @@
+import { SECONDS_IN_DAY, SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
+import LosingRewardNeuronsModal from "$lib/modals/neurons/LosingRewardNeuronsModal.svelte";
+import { neuronsStore } from "$lib/stores/neurons.store";
+import { nowInSeconds } from "$lib/utils/date.utils";
+import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { nonNullish } from "@dfinity/utils";
+import { render } from "@testing-library/svelte";
+
+describe("LosingRewardNeuronsModal", () => {
+  const nowSeconds = nowInSeconds();
+  const activeNeuron = {
+    ...mockNeuron,
+    neuronId: 0n,
+    fullNeuron: {
+      ...mockFullNeuron,
+      votingPowerRefreshedTimestampSeconds: BigInt(nowSeconds),
+    },
+  };
+  const in10DaysLosingRewardsNeuron = {
+    ...mockNeuron,
+    neuronId: 1n,
+    fullNeuron: {
+      ...mockFullNeuron,
+      votingPowerRefreshedTimestampSeconds: BigInt(
+        nowSeconds - SECONDS_IN_HALF_YEAR + 10 * SECONDS_IN_DAY
+      ),
+    },
+  };
+  const losingRewardsNeuron = {
+    ...mockNeuron,
+    neuronId: 2n,
+    fullNeuron: {
+      ...mockFullNeuron,
+      votingPowerRefreshedTimestampSeconds: BigInt(
+        nowSeconds - SECONDS_IN_HALF_YEAR
+      ),
+    },
+  };
+
+  const renderComponent = ({ onClose }: { onClose?: () => void } = {}) => {
+    const { container, component } = render(LosingRewardNeuronsModal);
+
+    if (nonNullish(onClose)) {
+      component.$on("nnsClose", onClose);
+    }
+
+    return LosingRewardNeuronsModalPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers({
+      now: nowSeconds * 1000,
+    });
+  });
+
+  it("should not display active neurons", async () => {
+    neuronsStore.setNeurons({
+      neurons: [activeNeuron, in10DaysLosingRewardsNeuron, losingRewardsNeuron],
+      certified: true,
+    });
+    const po = await renderComponent();
+    const cards = await po.getNnsLosingRewardsNeuronCardPos();
+
+    expect(cards.length).toEqual(2);
+    expect(await cards[0].getNeuronId()).toEqual(
+      `${losingRewardsNeuron.neuronId}`
+    );
+    expect(await cards[1].getNeuronId()).toEqual(
+      `${in10DaysLosingRewardsNeuron.neuronId}`
+    );
+  });
+
+  it("should dispatch on close", async () => {
+    neuronsStore.setNeurons({
+      neurons: [activeNeuron, in10DaysLosingRewardsNeuron, losingRewardsNeuron],
+      certified: true,
+    });
+    const onClose = vi.fn();
+    const po = await renderComponent({
+      onClose,
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(0);
+    await po.clickCancel();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
@@ -5,9 +5,7 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { LosingRewardsBannerPo } from "$tests/page-objects/LosingRewardsBanner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { render } from "@testing-library/svelte";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "$tests/utils/svelte.test-utils";
 
 describe("LosingRewardsBanner", () => {
   const nowSeconds = nowInSeconds();
@@ -94,7 +92,7 @@ describe("LosingRewardsBanner", () => {
       certified: true,
     });
     const po = await renderComponent();
-    await runResolvedPromises();
+
     expect(await po.getText()).toBe(
       "ICP neurons that are inactive for 6 months start losing voting rewards. In order to avoid losing rewards, vote manually, edit or confirm your following."
     );

--- a/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
@@ -99,4 +99,16 @@ describe("LosingRewardsBanner", () => {
       "ICP neurons that are inactive for 6 months start losing voting rewards. In order to avoid losing rewards, vote manually, edit or confirm your following."
     );
   });
+
+  it("should open losing reward neurons modal", async () => {
+    neuronsStore.setNeurons({
+      neurons: [activeNeuron, in10DaysLosingRewardsNeuron],
+      certified: true,
+    });
+    const po = await renderComponent();
+
+    expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(false);
+    await po.clickConfirm();
+    expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(true);
+  });
 });

--- a/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
@@ -1,0 +1,17 @@
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NnsLosingRewardsNeuronCardPo } from "./NnsLosingRewardsNeuronCard.page-object";
+
+export class LosingRewardNeuronsModalPo extends ModalPo {
+  static readonly TID = "losing-reward-neurons-modal-component";
+
+  static under(element: PageObjectElement): LosingRewardNeuronsModalPo {
+    return new LosingRewardNeuronsModalPo(
+      element.byTestId(LosingRewardNeuronsModalPo.TID)
+    );
+  }
+
+  getNnsLosingRewardsNeuronCardPos(): Promise<NnsLosingRewardsNeuronCardPo[]> {
+    return NnsLosingRewardsNeuronCardPo.allUnder(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
@@ -14,4 +14,8 @@ export class LosingRewardNeuronsModalPo extends ModalPo {
   getNnsLosingRewardsNeuronCardPos(): Promise<NnsLosingRewardsNeuronCardPo[]> {
     return NnsLosingRewardsNeuronCardPo.allUnder(this.root);
   }
+
+  async clickCancel(): Promise<void> {
+    return this.getButton("cancel-button").click();
+  }
 }

--- a/frontend/src/tests/page-objects/LosingRewardsBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardsBanner.page-object.ts
@@ -1,6 +1,7 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BannerPo } from "./Banner.page-object";
 import { BasePageObject } from "./base.page-object";
+import { LosingRewardNeuronsModalPo } from "./LosingRewardNeuronsModal.page-object";
 
 export class LosingRewardsBannerPo extends BasePageObject {
   private static readonly TID = "losing-rewards-banner-component";
@@ -13,6 +14,10 @@ export class LosingRewardsBannerPo extends BasePageObject {
 
   getBannerPo(): BannerPo {
     return BannerPo.under(this.root);
+  }
+
+  getLosingRewardNeuronsModalPo(): LosingRewardNeuronsModalPo {
+    return LosingRewardNeuronsModalPo.under(this.root);
   }
 
   async isVisible(): Promise<boolean> {
@@ -28,6 +33,6 @@ export class LosingRewardsBannerPo extends BasePageObject {
   }
 
   async clickConfirm(): Promise<void> {
-    // TBD
+    return this.getButton("confirm-button").click();
   }
 }

--- a/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
@@ -26,4 +26,8 @@ export class NnsLosingRewardsNeuronCardPo extends CardPo {
   async hasNoFollowingMessage(): Promise<boolean> {
     return this.isPresent("no-following");
   }
+
+  async getNeuronId(): Promise<string> {
+    return this.getElement("neuron-id").getText();
+  }
 }


### PR DESCRIPTION
# Motivation

Users should not only be notified about neurons that are losing rewards but also be able to refresh all these neurons to keep them active. To achieve this, the Confirm Following modal was created. It displays all inactive neurons along with their followings.

Out of scope:
- Refresh api call.
- The gaps in the Following component need to be adjusted to match the new design.
- Tags status.
- Page reload after navigation to the neuron details page.

# Changes

- New LosingRewardNeuronsModal component.
  - Should fetch known neurons, to display them in the following neurons component.
- Display the modal from the LosingRewardsBanner.

# Tests

- Unit tests updated.
- Tested manually in a separate branch.

| Dark | Light |
|--------|--------|
| <img width="216" alt="image" src="https://github.com/user-attachments/assets/aff0b79a-64d1-4b1f-9ab0-1d7511103584"> | <img width="214" alt="image" src="https://github.com/user-attachments/assets/ca9ac573-0a01-4aa5-9556-0461ec6a8ea2"> |
| <img width="634" alt="image" src="https://github.com/user-attachments/assets/ce57d668-4ab8-4fe8-aeab-35758482acf9"> | <img width="661" alt="image" src="https://github.com/user-attachments/assets/6dce7954-2fd2-465a-a23a-c02d1c8eb088"> | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.