### PR TITLE
NNS1-3480: Utility to get a transactions amount symbol

### DIFF
--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -270,3 +270,14 @@ export const mapIcpTransactionToUi = ({
     });
   }
 };
+
+export const getTransactionSymbol = (type: AccountTransactionType) => {
+  const positiveTypes = [
+    AccountTransactionType.Receive,
+    AccountTransactionType.Mint,
+    AccountTransactionType.RefundSwap
+  ];
+
+  if (positiveTypes.includes(type)) return "+";
+  return "-";
+};

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -3,8 +3,12 @@ import {
   TOP_UP_CANISTER_MEMO,
 } from "$lib/constants/api.constants";
 import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
-import type { UiTransaction } from "$lib/types/transaction";
 import {
+  AccountTransactionType,
+  type UiTransaction,
+} from "$lib/types/transaction";
+import {
+  getTransactionSymbol,
   mapIcpTransactionToReport,
   mapIcpTransactionToUi,
   mapToSelfTransactions,
@@ -755,6 +759,41 @@ describe("icp-transactions.utils", () => {
         secondTransaction,
         firstTransaction,
       ]);
+    });
+  });
+
+  describe("getTransactionSymbol", () => {
+    it("should return '+' for MINT and RECEIVE operations", () => {
+      expect(getTransactionSymbol(AccountTransactionType.Receive)).toEqual("+");
+      expect(getTransactionSymbol(AccountTransactionType.Mint)).toEqual("+");
+      expect(getTransactionSymbol(AccountTransactionType.RefundSwap)).toEqual(
+        "+"
+      );
+    });
+
+    it("should return '-' for rest of operation types", () => {
+      expect(getTransactionSymbol(AccountTransactionType.Send)).toEqual("-");
+      expect(getTransactionSymbol(AccountTransactionType.Approve)).toEqual("-");
+      expect(getTransactionSymbol(AccountTransactionType.Burn)).toEqual("-");
+      expect(
+        getTransactionSymbol(AccountTransactionType.CreateCanister)
+      ).toEqual("-");
+      expect(
+        getTransactionSymbol(AccountTransactionType.ParticipateSwap)
+      ).toEqual("-");
+
+      expect(getTransactionSymbol(AccountTransactionType.StakeNeuron)).toEqual(
+        "-"
+      );
+      expect(
+        getTransactionSymbol(AccountTransactionType.StakeNeuronNotification)
+      ).toEqual("-");
+      expect(
+        getTransactionSymbol(AccountTransactionType.TopUpCanister)
+      ).toEqual("-");
+      expect(getTransactionSymbol(AccountTransactionType.TopUpNeuron)).toEqual(
+        "-"
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

We already have a use case for this in [here](https://github.com/dfinity/nns-dapp/blob/069f11046d41bda85cb2ec6ee953e344f51bd3ab/frontend/src/lib/components/accounts/TransactionCard.svelte#L71) where we define it as transaction to one self like [here](https://github.com/dfinity/nns-dapp/blob/069f11046d41bda85cb2ec6ee953e344f51bd3ab/frontend/src/lib/utils/icp-transactions.utils.ts#L220).
We can rely on the concept of the [`transaction.type`](https://github.com/dfinity/nns-dapp/blob/069f11046d41bda85cb2ec6ee953e344f51bd3ab/frontend/src/lib/utils/icp-transactions.utils.ts#L57) to define the symbol.

# Changes

- New utility function to get a transaction's amount symbol

# Tests

- Unit Tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
