### PR TITLE
allows plus-mins simbols in csv

### DIFF
--- a/frontend/src/lib/utils/export-to-csv.utils.ts
+++ b/frontend/src/lib/utils/export-to-csv.utils.ts
@@ -20,12 +20,12 @@ const escapeCsvValue = (value: unknown): string => {
 
   let stringValue = String(value);
 
-  const patternForSpecialCharacters = /[",\r\n=+-@|]/;
+  const patternForSpecialCharacters = /[",\r\n=@|]/;
   if (!patternForSpecialCharacters.test(stringValue)) {
     return stringValue;
   }
 
-  const formulaInjectionCharacters = "=+-@|";
+  const formulaInjectionCharacters = "=@|";
   const characterToBreakFormula = "'";
   if (formulaInjectionCharacters.includes(stringValue[0])) {
     stringValue = `${characterToBreakFormula}${stringValue}`;

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -81,8 +81,6 @@ describe("Export to Csv", () => {
     it("should prevent formula injection by prefixing with single quote", () => {
       const data: TestFormulaData[] = [
         { formula: "=SUM(A1:A10)", value: 100 },
-        { formula: "+1234567", value: 200 },
-        { formula: "-1234567", value: 300 },
         { formula: "@SUM(A1)", value: 400 },
         { formula: "|MACRO", value: 500 },
       ];
@@ -91,7 +89,7 @@ describe("Export to Csv", () => {
         { id: "value", label: "value" },
       ];
       const expected =
-        "formula,value\n'=SUM(A1:A10),100\n'+1234567,200\n'-1234567,300\n'@SUM(A1),400\n'|MACRO,500";
+        "formula,value\n'=SUM(A1:A10),100\n'@SUM(A1),400\n'|MACRO,500";
       expect(convertToCsv({ data, headers })).toBe(expected);
     });
 
@@ -104,7 +102,7 @@ describe("Export to Csv", () => {
         { id: "formula", label: "formula" },
         { id: "value", label: "value" },
       ];
-      const expected = "formula,value\n'=SUM(A1:A10),100\n\"'+1234567,12\",200";
+      const expected = "formula,value\n'=SUM(A1:A10),100\n\"+1234567,12\",200";
       expect(convertToCsv({ data, headers })).toBe(expected);
     });
 


### PR DESCRIPTION
# Motivation

For the transactions report showing the symbol is helpful to identify the typo of operation(in/out).

# Changes

- Changes `escapeCsvValue` to allow `+` and `-`

# Tests

- Updated tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary