### PR TITLE
Align dollar values right on mobile

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -48,6 +48,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding);
+    align-items: flex-end;
 
     .usd-value {
       color: var(--text-description);


### PR DESCRIPTION
# Motivation

On desktop, token values are already right-aligned.
On mobile they seemed to be right aligned because the row has `justify: space-between` but now that we have 2 different values, the smaller dollar value is left-aligned relative to the original token value.

# Changes

Apply `align-items: flex-end` to the token values element.

# Tests

Before:

<img width="407" alt="image" src="https://github.com/user-attachments/assets/ded347e0-f5fb-4dc9-8840-202f54004b62">

After:

<img width="408" alt="image" src="https://github.com/user-attachments/assets/980d869a-7d0f-4659-9896-ebb62ff97d73">

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary