### PR TITLE
Add banner to show total USD value

### DIFF
--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -25,7 +25,7 @@
     : absentValue;
 
   let icpAmount: number | undefined;
-  $: icpAmount = icpPrice && usdAmount && (usdAmount / icpPrice);
+  $: icpAmount = icpPrice && usdAmount && usdAmount / icpPrice;
 
   let icpAmountFormatted: string;
   $: icpAmountFormatted = nonNullish(icpAmount)

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -25,7 +25,7 @@
     : absentValue;
 
   let icpAmount: number | undefined;
-  $: icpAmount = icpPrice && usdAmount && usdAmount / icpPrice;
+  $: icpAmount = icpPrice && usdAmount && (usdAmount / icpPrice);
 
   let icpAmountFormatted: string;
   $: icpAmountFormatted = nonNullish(icpAmount)

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { nonNullish } from "@dfinity/utils";
+
+  export let usdAmount: number | undefined;
+
+  const absentValue = "-/-";
+
+  let usdAmountFormatted: string;
+  $: usdAmountFormatted = nonNullish(usdAmount)
+    ? formatNumber(usdAmount)
+    : absentValue;
+
+  let icpPrice: number | undefined;
+  $: icpPrice = $icpSwapUsdPricesStore?.[LEDGER_CANISTER_ID.toText()];
+
+  let icpPriceFormatted: string;
+  $: icpPriceFormatted = nonNullish(icpPrice)
+    ? formatNumber(icpPrice)
+    : absentValue;
+
+  let icpAmount: number | undefined;
+  $: icpAmount = icpPrice && usdAmount && usdAmount / icpPrice;
+
+  let icpAmountFormatted: string;
+  $: icpAmountFormatted = nonNullish(icpAmount)
+    ? formatNumber(icpAmount)
+    : absentValue;
+</script>
+
+<div class="wrapper" data-tid="usd-value-banner-component">
+  <div class="table-banner-icon">
+    <slot name="icon" />
+  </div>
+  <div class="text-content">
+    <div class="totals">
+      <h1 class="primary-amount" data-tid="primary-amount">
+        ${usdAmountFormatted}
+      </h1>
+      <div class="secondary-amount" data-tid="secondary-amount">
+        {icpAmountFormatted}
+        {$i18n.core.icp}
+      </div>
+    </div>
+    <div class="exchange-rate">
+      <img
+        src={IC_LOGO_ROUNDED}
+        alt={$i18n.auth.ic_logo}
+        class="icp-icon desktop-only"
+      />
+      <span class="desktop-only">
+        1 {$i18n.core.icp} = $<span data-tid="icp-price"
+          >{icpPriceFormatted}</span
+        >
+      </span>
+      <TooltipIcon>
+        <div class="mobile-only">
+          1 {$i18n.core.icp} = ${icpPriceFormatted}
+        </div>
+        {$i18n.accounts.token_price_source}
+      </TooltipIcon>
+    </div>
+  </div>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--padding-2x);
+
+    background-color: var(--card-background-tint);
+    padding: var(--padding-2x);
+    border-radius: var(--padding);
+    border: 1.5px solid var(--card-border);
+
+    .table-banner-icon {
+      display: flex;
+      width: 72px;
+    }
+
+    .text-content {
+      flex-grow: 1;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      justify-content: space-between;
+
+      .totals {
+        .primary-amount {
+          margin: 0;
+        }
+        display: flex;
+        flex-direction: column;
+      }
+
+      .exchange-rate {
+        display: flex;
+        align-items: center;
+        gap: var(--padding-0_5x);
+
+        .icp-icon {
+          width: 20px;
+          height: 20px;
+        }
+      }
+    }
+  }
+
+  .desktop-only {
+    display: none;
+  }
+
+  @include media.min-width(medium) {
+    .desktop-only {
+      display: initial;
+    }
+    .mobile-only {
+      display: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -62,7 +62,9 @@
         <div class="mobile-only">
           1 {$i18n.core.icp} = ${icpPriceFormatted}
         </div>
-        {$i18n.accounts.token_price_source}
+        <div>
+          {$i18n.accounts.token_price_source}
+        </div>
       </TooltipIcon>
     </div>
   </div>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -262,7 +262,8 @@
     "received_amount": "Received Amount",
     "received_amount_notice": "Received Amount *",
     "transaction_time": "Transaction Time",
-    "transaction_time_seconds": "Seconds"
+    "transaction_time_seconds": "Seconds",
+    "token_price_source": "Token prices are provided by ICPSwap."
   },
   "neuron_types": {
     "seed": "Seed",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -274,6 +274,7 @@ interface I18nAccounts {
   received_amount_notice: string;
   transaction_time: string;
   transaction_time_seconds: string;
+  token_price_source: string;
 }
 
 interface I18nNeuron_types {

--- a/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
@@ -1,0 +1,87 @@
+import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("UsdValueBanner", () => {
+  const renderComponent = (usdAmount: number) => {
+    const { container } = render(UsdValueBanner, { usdAmount });
+    return UsdValueBannerPo.under(new JestPageObjectElement(container));
+  };
+
+  const setIcpPrice = (icpPrice: number) => {
+    icpSwapTickersStore.set([
+      {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+        last_price: String(icpPrice),
+      },
+    ]);
+  };
+
+  it("should display the USD amount", async () => {
+    const usdAmount = 50;
+    const po = renderComponent(usdAmount);
+
+    expect(await po.getPrimaryAmount()).toEqual("$50.00");
+  });
+
+  it("should display the USD amount as absent", async () => {
+    const usdAmount = undefined;
+    const po = renderComponent(usdAmount);
+
+    expect(await po.getPrimaryAmount()).toEqual("$-/-");
+  });
+
+  it("should display the ICP amount", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent(usdAmount);
+
+    expect(await po.getSecondaryAmount()).toEqual("5.00 ICP");
+  });
+
+  it("should display the ICP amount as absent without exchange rates", async () => {
+    const usdAmount = 50;
+    const po = renderComponent(usdAmount);
+
+    expect(await po.getSecondaryAmount()).toEqual("-/- ICP");
+  });
+
+  it("should display the ICP price", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent(usdAmount);
+
+    expect(await po.getIcpPrice()).toEqual("10.00");
+  });
+
+  it("should display the ICP price as absent without exchange rates", async () => {
+    const usdAmount = 50;
+    const po = renderComponent(usdAmount);
+
+    expect(await po.getIcpPrice()).toEqual("-/-");
+  });
+
+  it("should display the ICP price in the tooltip", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent(usdAmount);
+
+    expect(await po.getTooltipIconPo().getTooltipText()).toEqual(
+      "1 ICP = $10.00 Token prices are provided by ICPSwap."
+    );
+  });
+});

--- a/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
@@ -1,0 +1,27 @@
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class UsdValueBannerPo extends BasePageObject {
+  private static readonly TID = "usd-value-banner-component";
+
+  static under(element: PageObjectElement): UsdValueBannerPo {
+    return new UsdValueBannerPo(element.byTestId(UsdValueBannerPo.TID));
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
+  }
+
+  getPrimaryAmount(): Promise<string> {
+    return this.getText("primary-amount");
+  }
+
+  getSecondaryAmount(): Promise<string> {
+    return this.getText("secondary-amount");
+  }
+
+  getIcpPrice(): Promise<string> {
+    return this.getText("icp-price");
+  }
+}


### PR DESCRIPTION
# Motivation

At the top of both the tokens page and the neurons page we want to show a banner with the total value in USD of the listed assets.

This PR adds a first version of that banner component, not yet used on any page.

<img width="768" alt="image" src="https://github.com/user-attachments/assets/1eb14377-c8e6-428a-b199-8bfba891d9e3">

<img width="451" alt="image" src="https://github.com/user-attachments/assets/998169ee-8a74-49b3-aaf8-8db1194b0350">

Switching the USD/ICP values and error state will be added in subsequence PRs.

# Changes

1. Add banner component.

# Tests

1. Added unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary