### PR TITLE
docs: remove wrong comment for the neuronsStore

### DIFF
--- a/frontend/src/lib/stores/neurons.store.ts
+++ b/frontend/src/lib/stores/neurons.store.ts
@@ -8,7 +8,7 @@ export interface NeuronsStore {
 }
 
 /**
- * A store that contains the neurons that have a valid stake.
+ * A store that contains all the neurons.
  *
  * - setNeurons: replace the current list of neurons with a new list
  * - pushNeurons: append neurons to the current list of neurons. Notably useful when staking a new neuron.


### PR DESCRIPTION
# Motivation

The `neuronsStore` was initially changed to hold only neurons with valid stake #719. However, it was later modified to retain all neurons, while a `derivedStore` would provide the subset #1476.

The comment is outdated and leads to confusion.

# Changes

- Removes outdated comment

# Tests

Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary