### PR TITLE
fix: error handling for getTransactionInformation

### DIFF
--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -17,6 +17,7 @@ import {
   ICPToken,
   TokenAmountV2,
   fromNullable,
+  isNullish,
   nonNullish,
 } from "@dfinity/utils";
 import { transactionName } from "./transactions.utils";
@@ -122,7 +123,7 @@ const getTransactionInformation = (
     data = operation.Transfer;
   }
   // Edge case, a transaction will have either "Approve", "Burn", "Mint" or "Transfer" data.
-  if (data === undefined) return undefined;
+  if (isNullish(data)) return undefined;
 
   return {
     from: "from" in data ? data.from : undefined,
@@ -147,7 +148,7 @@ export const mapIcpTransactionToReport = ({
   swapCanisterAccounts: Set<string>;
 }) => {
   const txInfo = getTransactionInformation(transaction.transaction.operation);
-  if (txInfo === undefined) {
+  if (isNullish(txInfo)) {
     throw new Error(
       `Unknown transaction type "${
         Object.keys(transaction.transaction.operation)[0]
@@ -210,7 +211,7 @@ export const mapIcpTransactionToUi = ({
 }): UiTransaction | undefined => {
   try {
     const txInfo = getTransactionInformation(transaction.transaction.operation);
-    if (txInfo === undefined) {
+    if (isNullish(txInfo)) {
       throw new Error(
         `Unknown transaction type "${
           Object.keys(transaction.transaction.operation)[0]

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -122,9 +122,7 @@ const getTransactionInformation = (
     data = operation.Transfer;
   }
   // Edge case, a transaction will have either "Approve", "Burn", "Mint" or "Transfer" data.
-  if (data === undefined) {
-    throw new Error(`Unknown transaction type ${JSON.stringify(operation)}`);
-  }
+  if (data === undefined) return undefined;
 
   return {
     from: "from" in data ? data.from : undefined,
@@ -151,9 +149,9 @@ export const mapIcpTransactionToReport = ({
   const txInfo = getTransactionInformation(transaction.transaction.operation);
   if (txInfo === undefined) {
     throw new Error(
-      `Unknown transaction type ${
+      `Unknown transaction type "${
         Object.keys(transaction.transaction.operation)[0]
-      }`
+      }"`
     );
   }
 
@@ -214,9 +212,9 @@ export const mapIcpTransactionToUi = ({
     const txInfo = getTransactionInformation(transaction.transaction.operation);
     if (txInfo === undefined) {
       throw new Error(
-        `Unknown transaction type ${
+        `Unknown transaction type "${
           Object.keys(transaction.transaction.operation)[0]
-        }`
+        }"`
       );
     }
     const isReceive =

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -502,6 +502,7 @@ describe("icp-transactions.utils", () => {
         swapCanisterAccounts: new Set<string>(),
         i18n: en,
       });
+      expect(spyToastError).toBeCalledTimes(1);
       expect(spyToastError).toBeCalledWith({
         err: new Error('Unknown transaction type "Unknown"'),
         labelKey: "error.transaction_data",


### PR DESCRIPTION
# Motivation

`getTransactionInformation` was throwing an error while its consumers were expecting an `undefined` and they will handle the error.

# Changes

- `getTransactionInformation` should return `undefined` if the transaction type is unknown.

# Tests

- New unit tests for `mapIcpTransactionToUi` check for a toast message when an error is thrown.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.