### PR TITLE
refactor: add explicit type annotation for transactionDirection

### DIFF
--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -160,7 +160,9 @@ export const mapIcpTransactionToReport = ({
   const { to, from, amount, fee } = txInfo;
   const isSelfTransaction = isToSelf(transaction.transaction);
   const isReceive = isSelfTransaction || from !== accountIdentifier;
-  const transactionDirection = isReceive ? "credit" : "debit";
+  const transactionDirection: "credit" | "debit" = isReceive
+    ? "credit"
+    : "debit";
 
   const useFee = !isReceive;
   const feeApplied = useFee && fee ? fee : 0n;


### PR DESCRIPTION
# Motivation

TypeScript was inferring a string type for `transactionDirection` when it should specifically be either "credit" or "debit". Adding an explicit type union improves type safety and prevents potential bugs from assigning invalid values.

# Changes

- Added literal type union `"credit" | "debit"` to `transactionDirection` variable

# Tests

Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary