### PR TITLE
NNS1-3480: Neurons Transactions

### DIFF
--- a/frontend/src/lib/components/header/ExportIcpTransactionsButton.svelte
+++ b/frontend/src/lib/components/header/ExportIcpTransactionsButton.svelte
@@ -34,14 +34,16 @@
   let swapCanisterAccounts: Set<string>;
   let neuronAccounts: Set<string>;
   let nnsAccounts: Account[];
+  let nnsNeurons: NeuronInfo[];
   let swapCanisterAccountsStore: Readable<Set<string>> | undefined;
-  let nnsNeurons: NeuronInfo[] | undefined;
 
   $: identity = $authStore.identity;
   $: neuronAccounts = $neuronAccountsStore;
   $: nnsAccounts = $nnsAccountsListStore;
   $: nnsNeurons = $neuronsStore.neurons ?? [];
-  $: isDisabled = isNullish(identity) || nnsAccounts.length === 0;
+  $: isDisabled =
+    isNullish(identity) ||
+    (nnsAccounts.length === 0 && nnsNeurons.length === 0);
   $: swapCanisterAccountsStore = createSwapCanisterAccountsStore(
     identity?.getPrincipal()
   );

--- a/frontend/src/lib/components/header/ExportIcpTransactionsButton.svelte
+++ b/frontend/src/lib/components/header/ExportIcpTransactionsButton.svelte
@@ -35,7 +35,7 @@
   let neuronAccounts: Set<string>;
   let nnsAccounts: Account[];
   let nnsNeurons: NeuronInfo[];
-  let swapCanisterAccountsStore: Readable<Set<string>> | undefined;
+  let swapCanisterAccountsStore: Readable<Set<string>>;
 
   $: identity = $authStore.identity;
   $: neuronAccounts = $neuronAccountsStore;

--- a/frontend/src/tests/lib/components/header/ExportIcpTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/header/ExportIcpTransactionsButton.spec.ts
@@ -7,7 +7,10 @@ import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { createTransactionWithId } from "$tests/mocks/icp-transactions.mock";
 import { ExportIcpTransactionsButtonPo } from "$tests/page-objects/ExportIcpTransactionsButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 
@@ -65,6 +68,12 @@ describe("ExportIcpTransactionsButton", () => {
 
   it("should be disabled when there is no identity", async () => {
     setNoIdentity();
+    const po = renderComponent();
+    expect(await po.isDisabled()).toBe(true);
+  });
+
+  it("should be disabled when there is no accounts nor neurons", async () => {
+    resetAccountsForTesting();
     const po = renderComponent();
     expect(await po.isDisabled()).toBe(true);
   });


### PR DESCRIPTION
# Motivation

We want to retrieve neuron transactions when generating a report for all transactions. We aim to request transactions for both Neurons and Accounts simultaneously, allowing us to parallelize these calls to the Ledger Canister.

# Changes

- Changes `getAccountTransactionsConcurrently` to handle generic entities(neurons or accounts)

# Tests

- Unit test for the new logic that parallelizes both types of entities: accounts and neurons.

# Todos

- [ ] Add entry to changelog (if necessary).

Prev. PR: #5941 