### PR TITLE
housekeeping: removes fillTokensStoreFromAggregatorData

### DIFF
--- a/frontend/src/lib/utils/icrc-tokens.utils.ts
+++ b/frontend/src/lib/utils/icrc-tokens.utils.ts
@@ -1,14 +1,11 @@
 import { IMPORTANT_CK_TOKEN_IDS } from "$lib/constants/tokens.constants";
-import type { TokensStore, TokensStoreData } from "$lib/stores/tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type { CachedSnsDto } from "$lib/types/sns-aggregator";
-import { convertIcrc1Metadata } from "$lib/utils/sns-aggregator-converters.utils";
 import {
   IcrcMetadataResponseEntries,
   type IcrcTokenMetadataResponse,
 } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
-import { isNullish, nonNullish } from "@dfinity/utils";
+import { isNullish } from "@dfinity/utils";
 
 /**
  * Token metadata is given only if the properties NNS-dapp needs (name, symbol and fee) are defined.
@@ -52,41 +49,6 @@ export const mapOptionalToken = (
   }
 
   return nullishToken as IcrcTokenMetadata;
-};
-
-export const fillTokensStoreFromAggregatorData = ({
-  tokensStore,
-  aggregatorData,
-}: {
-  tokensStore: TokensStore;
-  aggregatorData: CachedSnsDto[];
-}) => {
-  tokensStore.setTokens(
-    aggregatorData
-      .map(({ icrc1_metadata, canister_ids }) => ({
-        token: mapOptionalToken(convertIcrc1Metadata(icrc1_metadata)),
-        // TODO: Remove root_canister_id and only used ledger_canister_id.
-        root_canister_id: canister_ids.root_canister_id,
-        ledger_canister_id: canister_ids.ledger_canister_id,
-      }))
-      .filter(({ token }) => nonNullish(token))
-      .reduce(
-        (acc, { root_canister_id, ledger_canister_id, token }) => ({
-          ...acc,
-          [root_canister_id]: {
-            // Above filter ensure the token is not undefined therefore it can be safely cast
-            token: token as IcrcTokenMetadata,
-            certified: true,
-          },
-          [ledger_canister_id]: {
-            // Above filter ensure the token is not undefined therefore it can be safely cast
-            token: token as IcrcTokenMetadata,
-            certified: true,
-          },
-        }),
-        {} as TokensStoreData
-      )
-  );
 };
 
 export const isImportantCkToken = ({

--- a/frontend/src/tests/lib/utils/icrc-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-tokens.utils.spec.ts
@@ -1,30 +1,20 @@
-import {
-  OWN_CANISTER_ID,
-  OWN_CANISTER_ID_TEXT,
-} from "$lib/constants/canister-ids.constants";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import {
   CKBTC_LEDGER_CANISTER_ID,
   CKTESTBTC_LEDGER_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { CKUSDC_LEDGER_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
-import { tokensStore } from "$lib/stores/tokens.store";
 import {
-  fillTokensStoreFromAggregatorData,
   isImportantCkToken,
   mapOptionalToken,
 } from "$lib/utils/icrc-tokens.utils";
-import {
-  aggregatorSnsMockDto,
-  aggregatorTokenMock,
-} from "$tests/mocks/sns-aggregator.mock";
 import {
   mockQueryTokenResponse,
   mockSnsToken,
   principal,
 } from "$tests/mocks/sns-projects.mock";
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger-icrc";
-import { get } from "svelte/store";
 
 describe("ICRC tokens utils", () => {
   describe("mapOptionalToken", () => {
@@ -73,31 +63,6 @@ describe("ICRC tokens utils", () => {
         decimals: 8,
         logo,
       });
-    });
-  });
-
-  describe("fillTokensStoreFromAggregatorData", () => {
-    it("should fill the tokens store with SNS tokens", () => {
-      expect(Object.keys(get(tokensStore))).toEqual([OWN_CANISTER_ID_TEXT]);
-      fillTokensStoreFromAggregatorData({
-        tokensStore,
-        aggregatorData: [aggregatorSnsMockDto],
-      });
-      const tokensStoreData = get(tokensStore);
-
-      expect(Object.keys(tokensStoreData)).toEqual([
-        OWN_CANISTER_ID_TEXT,
-        aggregatorSnsMockDto.canister_ids.root_canister_id,
-        aggregatorSnsMockDto.canister_ids.ledger_canister_id,
-      ]);
-      expect(
-        tokensStoreData[aggregatorSnsMockDto.canister_ids.ledger_canister_id]
-          .token
-      ).toEqual(aggregatorTokenMock);
-      expect(
-        tokensStoreData[aggregatorSnsMockDto.canister_ids.root_canister_id]
-          .token
-      ).toEqual(aggregatorTokenMock);
     });
   });
 


### PR DESCRIPTION
# Motivation

This function `fillTokensStoreFromAggregatorData` was initially added in #4455 and later removed in #4461. It seems that it was a transient function and no longer necessary.

# Changes

- Removes `fillTokensStoreFromAggregatorData`

# Tests

- Deletes tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary