### PR TITLE
NNS1-3497: new function to sort SNS projects from newest to oldest

### DIFF
--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -14,6 +14,7 @@ import type {
 } from "$lib/types/sns";
 import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { StoreData } from "$lib/types/store";
+import { createDescendingComparator } from "$lib/utils/sort.utils";
 import type { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
 import {
@@ -457,3 +458,8 @@ export const isCommitmentSplitWithNeuronsFund = (
 
 export const snsProjectDashboardUrl = (rootCanisterId: Principal): string =>
   `https://dashboard.internetcomputer.org/sns/${rootCanisterId.toText()}`;
+
+export const comparesByDecentralizationSaleOpenTimestampDesc =
+  createDescendingComparator((sns: SnsFullProject): number =>
+    Number(sns.summary.swap?.decentralization_sale_open_timestamp_seconds)
+  );

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -461,5 +461,5 @@ export const snsProjectDashboardUrl = (rootCanisterId: Principal): string =>
 
 export const comparesByDecentralizationSaleOpenTimestampDesc =
   createDescendingComparator((sns: SnsFullProject): number =>
-    Number(sns.summary.swap?.decentralization_sale_open_timestamp_seconds)
+    Number(sns.summary.swap?.decentralization_sale_open_timestamp_seconds ?? 0)
   );

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1404,12 +1404,14 @@ describe("project-utils", () => {
 });
 
 describe("comparesByDecentralizationSaleOpenTimestamp", () => {
+  const initialValue = 1000n;
+
   it("should return -1 if the first project is newer", () => {
     const project1 = createMockSnsFullProject({
       rootCanisterId: rootCanisterIdMock,
       summaryParams: {
         lifecycle: SnsSwapLifecycle.Open,
-        swapOpenTimestampSeconds: BigInt(nowInSeconds() + 1),
+        swapOpenTimestampSeconds: initialValue + 1n,
       },
     });
 
@@ -1417,7 +1419,7 @@ describe("comparesByDecentralizationSaleOpenTimestamp", () => {
       rootCanisterId: rootCanisterIdMock,
       summaryParams: {
         lifecycle: SnsSwapLifecycle.Open,
-        swapOpenTimestampSeconds: BigInt(nowInSeconds()),
+        swapOpenTimestampSeconds: initialValue,
       },
     });
     expect(
@@ -1429,14 +1431,14 @@ describe("comparesByDecentralizationSaleOpenTimestamp", () => {
     const project1 = createMockSnsFullProject({
       rootCanisterId: rootCanisterIdMock,
       summaryParams: {
-        swapOpenTimestampSeconds: BigInt(nowInSeconds()),
+        swapOpenTimestampSeconds: initialValue,
       },
     });
 
     const project2 = createMockSnsFullProject({
       rootCanisterId: rootCanisterIdMock,
       summaryParams: {
-        swapOpenTimestampSeconds: BigInt(nowInSeconds() + 1),
+        swapOpenTimestampSeconds: initialValue + 1n,
       },
     });
     expect(
@@ -1448,7 +1450,7 @@ describe("comparesByDecentralizationSaleOpenTimestamp", () => {
     const project1 = createMockSnsFullProject({
       rootCanisterId: rootCanisterIdMock,
       summaryParams: {
-        swapOpenTimestampSeconds: BigInt(nowInSeconds()),
+        swapOpenTimestampSeconds: initialValue,
       },
     });
 

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -6,6 +6,7 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import {
   canUserParticipateToSwap,
   commitmentExceedsAmountLeft,
+  comparesByDecentralizationSaleOpenTimestampDesc,
   currentUserMaxCommitment,
   differentSummaries,
   durationTillSwapDeadline,
@@ -23,6 +24,7 @@ import {
 } from "$lib/utils/projects.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
+  createMockSnsFullProject,
   createSummary,
   createTransferableAmount,
   mockSnsFullProject,
@@ -33,6 +35,7 @@ import {
   principal,
   summaryForLifecycle,
 } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
@@ -1397,5 +1400,66 @@ describe("project-utils", () => {
         "https://dashboard.internetcomputer.org/sns/pin7y-wyaaa-aaaaa-aacpa-cai"
       );
     });
+  });
+});
+
+describe("comparesByDecentralizationSaleOpenTimestamp", () => {
+  it("should return -1 if the first project is newer", () => {
+    const project1 = createMockSnsFullProject({
+      rootCanisterId: rootCanisterIdMock,
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Open,
+        swapOpenTimestampSeconds: BigInt(nowInSeconds() + 1),
+      },
+    });
+
+    const project2 = createMockSnsFullProject({
+      rootCanisterId: rootCanisterIdMock,
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Open,
+        swapOpenTimestampSeconds: BigInt(nowInSeconds()),
+      },
+    });
+    expect(
+      comparesByDecentralizationSaleOpenTimestampDesc(project1, project2)
+    ).toBe(-1);
+  });
+
+  it("should return 1 if the second project is newer", () => {
+    const project1 = createMockSnsFullProject({
+      rootCanisterId: rootCanisterIdMock,
+      summaryParams: {
+        swapOpenTimestampSeconds: BigInt(nowInSeconds()),
+      },
+    });
+
+    const project2 = createMockSnsFullProject({
+      rootCanisterId: rootCanisterIdMock,
+      summaryParams: {
+        swapOpenTimestampSeconds: BigInt(nowInSeconds() + 1),
+      },
+    });
+    expect(
+      comparesByDecentralizationSaleOpenTimestampDesc(project1, project2)
+    ).toBe(1);
+  });
+
+  it("should return -1 if the second project is not defined", () => {
+    const project1 = createMockSnsFullProject({
+      rootCanisterId: rootCanisterIdMock,
+      summaryParams: {
+        swapOpenTimestampSeconds: BigInt(nowInSeconds()),
+      },
+    });
+
+    const project2 = createMockSnsFullProject({
+      rootCanisterId: rootCanisterIdMock,
+      summaryParams: {
+        swapOpenTimestampSeconds: undefined,
+      },
+    });
+    expect(
+      comparesByDecentralizationSaleOpenTimestampDesc(project1, project2)
+    ).toBe(-1);
   });
 });


### PR DESCRIPTION
# Motivation

This is a follow-up to #5918 regarding the display of SNS projects in the Launchpad section. We aim to sort them in descending order, from newest to oldest. 
This initial PR introduces a function to sort based on `swapOpenTimestampSeconds`. 
The subsequent PR will implement the requirements outlined in [NNS-3497](https://dfinity.atlassian.net/jira/software/c/projects/NNS1/boards/333?selectedIssue=NNS1-3497).

# Changes

-  New descending sort function based on SNS summary `swapOpenTimestampSeconds`.

# Tests

- Unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary