### PR TITLE
Update golden mainnet canister IDs with ICP Swap canister ID

### DIFF
--- a/scripts/canister_ids.mainnet.golden
+++ b/scripts/canister_ids.mainnet.golden
@@ -30,7 +30,7 @@
     "mainnet": "identity"
   },
   "icp-swap": {
-    "mainnet": ""
+    "mainnet": "uvevg-iyaaa-aaaak-ac27q-cai"
   },
   "nns-dapp": {
     "mainnet": "qoctq-giaaa-aaaaa-aaaea-cai"


### PR DESCRIPTION
# Motivation

We have a script `./scripts/canister_ids` which can import canister IDs based on an existing deployed NNS dapp canister on any network.
We also have a test that tests that this works for `mainnet`.
With the latest nns-dapp mainnet upgrade, there is a new canister ID imported for ICP Swap.
So the test started [failing](https://github.com/dfinity/nns-dapp/actions/runs/12234467204/job/34123959181) on CI and we need to update the golden state to make the test pass again.

# Changes

Update golden mainnet canister IDs.

# Tests

CI should pass again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary