### PR TITLE
Show error tooltip in USD value banner

### DIFF
--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -19,6 +19,6 @@
   .wrapper {
     display: inline-flex;
     align-items: center;
-    color: var(--elements-icons);
+    color: var(--tooltip-icon-color, --elements-icons);
   }
 </style>

--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -19,6 +19,6 @@
   .wrapper {
     display: inline-flex;
     align-items: center;
-    color: var(--tooltip-icon-color, --elements-icons);
+    color: var(--tooltip-icon-color, var(--elements-icons));
   }
 </style>

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -11,10 +11,15 @@
 
   const absentValue = "-/-";
 
+  let hasError: boolean;
+  $: hasError = $icpSwapUsdPricesStore === "error";
+
+  let hasPrices: boolean;
+  $: hasPrices = !hasError && nonNullish($icpSwapUsdPricesStore);
+
   let usdAmountFormatted: string;
-  $: usdAmountFormatted = nonNullish(usdAmount)
-    ? formatNumber(usdAmount)
-    : absentValue;
+  $: usdAmountFormatted =
+    nonNullish(usdAmount) && hasPrices ? formatNumber(usdAmount) : absentValue;
 
   let icpPrice: number | undefined;
   $: icpPrice =
@@ -36,7 +41,11 @@
     : absentValue;
 </script>
 
-<div class="wrapper" data-tid="usd-value-banner-component">
+<div
+  class="wrapper"
+  data-tid="usd-value-banner-component"
+  class:has-error={hasError}
+>
   <div class="table-banner-icon">
     <slot name="icon" />
   </div>
@@ -62,12 +71,16 @@
         >
       </span>
       <TooltipIcon>
-        <div class="mobile-only">
-          1 {$i18n.core.icp} = ${icpPriceFormatted}
-        </div>
-        <div>
-          {$i18n.accounts.token_price_source}
-        </div>
+        {#if hasError}
+          {$i18n.accounts.token_price_error}
+        {:else}
+          <div class="mobile-only">
+            1 {$i18n.core.icp} = ${icpPriceFormatted}
+          </div>
+          <div>
+            {$i18n.accounts.token_price_source}
+          </div>
+        {/if}
       </TooltipIcon>
     </div>
   </div>
@@ -118,6 +131,10 @@
           height: 20px;
         }
       }
+    }
+
+    &.has-error {
+      --tooltip-icon-color: var(--tag-failed-text);
     }
   }
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -274,6 +274,7 @@
     "received_amount_notice": "Received Amount *",
     "transaction_time": "Transaction Time",
     "transaction_time_seconds": "Seconds",
+    "token_price_error": "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment.",
     "token_price_source": "Token prices are provided by ICPSwap."
   },
   "neuron_types": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -285,6 +285,7 @@ interface I18nAccounts {
   received_amount_notice: string;
   transaction_time: string;
   transaction_time_seconds: string;
+  token_price_error: string;
   token_price_source: string;
 }
 

--- a/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
@@ -24,6 +24,10 @@ describe("UsdValueBanner", () => {
 
   it("should display the USD amount", async () => {
     const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
     const po = renderComponent(usdAmount);
 
     expect(await po.getPrimaryAmount()).toEqual("$50.00");
@@ -82,6 +86,31 @@ describe("UsdValueBanner", () => {
 
     expect(await po.getTooltipIconPo().getTooltipText()).toEqual(
       "1 ICP = $10.00 Token prices are provided by ICPSwap."
+    );
+  });
+
+  it("should not have an error by default", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent(usdAmount);
+
+    expect(await po.hasError()).toBe(false);
+  });
+
+  it("should have an error without ICP price", async () => {
+    const usdAmount = 50;
+    const icpPrice = 0;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent(usdAmount);
+
+    expect(await po.hasError()).toBe(true);
+    expect(await po.getTooltipIconPo().getTooltipText()).toEqual(
+      "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment."
     );
   });
 });

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -1,11 +1,14 @@
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import TokensPage from "$lib/pages/Tokens.svelte";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import {
   createIcpUserToken,
@@ -71,6 +74,13 @@ describe("Tokens page", () => {
     vi.useFakeTimers();
 
     importedTokensStore.set({ importedTokens: [], certified: true });
+    icpSwapTickersStore.set([
+      {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+        last_price: "10.00",
+      },
+    ]);
   });
 
   it("should render the tokens table", async () => {

--- a/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
@@ -24,4 +24,9 @@ export class UsdValueBannerPo extends BasePageObject {
   getIcpPrice(): Promise<string> {
     return this.getText("icp-price");
   }
+
+  async hasError(): Promise<boolean> {
+    const classNames = await this.root.getClasses();
+    return classNames.includes("has-error");
+  }
 }


### PR DESCRIPTION
# Motivation

If we can't load token prices from ICP Swap, we should show an orange tooltip icon with explanation.

# Changes

1. Add `--tooltip-icon-color` CSS variable to customize tooltip icon color.
2. Use a different tooltip icon color and text if `icpSwapUsdPricesStore` is in error state.
3. 

# Tests

1. Unit tests added.
2. Tested manually by hardcoding a bad response in `frontend/src/lib/api/icp-swap.api.ts`.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet