### PR TITLE
Show tooltip when price data is missing for some tokens

### DIFF
--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -8,6 +8,7 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
 
   export let usdAmount: number | undefined;
+  export let hasUnpricedTokens: boolean;
 
   const absentValue = "-/-";
 
@@ -51,9 +52,16 @@
   </div>
   <div class="text-content">
     <div class="totals">
-      <h1 class="primary-amount" data-tid="primary-amount">
-        ${usdAmountFormatted}
-      </h1>
+      <div class="primary-amount-row">
+        <span class="primary-amount" data-tid="primary-amount">
+          ${usdAmountFormatted}
+        </span>
+        {#if hasPrices && hasUnpricedTokens}
+          <TooltipIcon>
+            {$i18n.accounts.unpriced_tokens_warning}
+          </TooltipIcon>
+        {/if}
+      </div>
       <div class="secondary-amount" data-tid="secondary-amount">
         {icpAmountFormatted}
         {$i18n.core.icp}
@@ -114,8 +122,15 @@
       justify-content: space-between;
 
       .totals {
-        .primary-amount {
-          margin: 0;
+        .primary-amount-row {
+          display: flex;
+          align-items: center;
+          gap: var(--padding-0_5x);
+
+          .primary-amount {
+            font-size: var(--font-size-h1);
+            font-weight: var(--font-weight-bold);
+          }
         }
         display: flex;
         flex-direction: column;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -275,6 +275,7 @@
     "transaction_time": "Transaction Time",
     "transaction_time_seconds": "Seconds",
     "token_price_error": "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment.",
+    "unpriced_tokens_warning": "Value may be inaccurate as some prices could not be fetched.",
     "token_price_source": "Token prices are provided by ICPSwap."
   },
   "neuron_types": {

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -33,6 +33,14 @@
     0
   );
 
+  let hasUnpricedTokens: boolean;
+  $: hasUnpricedTokens = userTokensData.some(
+    (token) =>
+      token.balance instanceof TokenAmountV2 &&
+      token.balance.toUlps() > 0n &&
+      (!("balanceInUsd" in token) || isNullish(token.balanceInUsd))
+  );
+
   let settingsButton: HTMLButtonElement | undefined;
   let settingsPopupVisible = false;
 
@@ -84,7 +92,7 @@
 
 <div class="wrapper" data-tid="tokens-page-component">
   {#if $ENABLE_USD_VALUES}
-    <UsdValueBanner usdAmount={totalBalanceInUsd}>
+    <UsdValueBanner usdAmount={totalBalanceInUsd} {hasUnpricedTokens}>
       <IconAccountsPage slot="icon" />
     </UsdValueBanner>
   {/if}

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -286,6 +286,7 @@ interface I18nAccounts {
   transaction_time: string;
   transaction_time_seconds: string;
   token_price_error: string;
+  unpriced_tokens_warning: string;
   token_price_source: string;
 }
 

--- a/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
@@ -7,8 +7,17 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
 
 describe("UsdValueBanner", () => {
-  const renderComponent = (usdAmount: number) => {
-    const { container } = render(UsdValueBanner, { usdAmount });
+  const renderComponent = ({
+    usdAmount,
+    hasUnpricedTokens,
+  }: {
+    usdAmount: number;
+    hasUnpricedTokens: boolean;
+  }) => {
+    const { container } = render(UsdValueBanner, {
+      usdAmount,
+      hasUnpricedTokens,
+    });
     return UsdValueBannerPo.under(new JestPageObjectElement(container));
   };
 
@@ -28,14 +37,14 @@ describe("UsdValueBanner", () => {
 
     setIcpPrice(icpPrice);
 
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.getPrimaryAmount()).toEqual("$50.00");
   });
 
   it("should display the USD amount as absent", async () => {
     const usdAmount = undefined;
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.getPrimaryAmount()).toEqual("$-/-");
   });
@@ -46,14 +55,14 @@ describe("UsdValueBanner", () => {
 
     setIcpPrice(icpPrice);
 
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.getSecondaryAmount()).toEqual("5.00 ICP");
   });
 
   it("should display the ICP amount as absent without exchange rates", async () => {
     const usdAmount = 50;
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.getSecondaryAmount()).toEqual("-/- ICP");
   });
@@ -64,14 +73,14 @@ describe("UsdValueBanner", () => {
 
     setIcpPrice(icpPrice);
 
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.getIcpPrice()).toEqual("10.00");
   });
 
   it("should display the ICP price as absent without exchange rates", async () => {
     const usdAmount = 50;
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.getIcpPrice()).toEqual("-/-");
   });
@@ -82,9 +91,9 @@ describe("UsdValueBanner", () => {
 
     setIcpPrice(icpPrice);
 
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
-    expect(await po.getTooltipIconPo().getTooltipText()).toEqual(
+    expect(await po.getExchangeRateTooltipIconPo().getTooltipText()).toEqual(
       "1 ICP = $10.00 Token prices are provided by ICPSwap."
     );
   });
@@ -95,7 +104,7 @@ describe("UsdValueBanner", () => {
 
     setIcpPrice(icpPrice);
 
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.hasError()).toBe(false);
   });
@@ -106,11 +115,39 @@ describe("UsdValueBanner", () => {
 
     setIcpPrice(icpPrice);
 
-    const po = renderComponent(usdAmount);
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
 
     expect(await po.hasError()).toBe(true);
-    expect(await po.getTooltipIconPo().getTooltipText()).toEqual(
+    expect(await po.getExchangeRateTooltipIconPo().getTooltipText()).toEqual(
       "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment."
+    );
+  });
+
+  it("should show a tooltip about unpriced tokens", async () => {
+    const hasUnpricedTokens = true;
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens });
+
+    expect(await po.getTotalsTooltipIconPo().isPresent()).toBe(
+      hasUnpricedTokens
+    );
+  });
+
+  it("should not show a tooltip about unpriced tokens", async () => {
+    const hasUnpricedTokens = false;
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens });
+
+    expect(await po.getTotalsTooltipIconPo().isPresent()).toBe(
+      hasUnpricedTokens
     );
   });
 });

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -331,6 +331,9 @@ describe("Tokens page", () => {
 
     expect(await po.getUsdValueBannerPo().isPresent()).toBe(true);
     expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$5.00");
+    expect(
+      await po.getUsdValueBannerPo().getTotalsTooltipIconPo().isPresent()
+    ).toBe(false);
   });
 
   it("should ignore tokens with unknown balance in USD when adding up the total", async () => {
@@ -352,5 +355,8 @@ describe("Tokens page", () => {
 
     expect(await po.getUsdValueBannerPo().isPresent()).toBe(true);
     expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$8.00");
+    expect(
+      await po.getUsdValueBannerPo().getTotalsTooltipIconPo().isPresent()
+    ).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
@@ -9,8 +9,12 @@ export class UsdValueBannerPo extends BasePageObject {
     return new UsdValueBannerPo(element.byTestId(UsdValueBannerPo.TID));
   }
 
-  getTooltipIconPo(): TooltipIconPo {
-    return TooltipIconPo.under(this.root);
+  getTotalsTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root.querySelector(".totals"));
+  }
+
+  getExchangeRateTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root.querySelector(".exchange-rate"));
   }
 
   getPrimaryAmount(): Promise<string> {


### PR DESCRIPTION
# Motivation

At the top of the tokens page, we want to show the total value of the user's tokens.
If we don't have price data for some tokens, we treat these tokens as having no value.
To indicate this, we show an extra tooltip if the user owns any tokens which we ignored in computing the total.

# Changes

1. Add `hasUnpricedTokens` prop to `UsdValueBanner`.
2. If the prop is true, show an extra tooltip.
3. Pass `hasUnpricedTokens` from `Tokens.svelte` based on whether the user has any tokens with positive `balance` but undefined `balanceInUsd`.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet