### PR TITLE
Mention ckUSDC in tooltip about ICPSwap

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -275,7 +275,7 @@
     "transaction_time": "Transaction Time",
     "transaction_time_seconds": "Seconds",
     "token_price_error": "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment.",
-    "token_price_source": "Token prices are provided by ICPSwap."
+    "token_price_source": "Token prices are in ckUSDC based on data provided by ICPSwap."
   },
   "neuron_types": {
     "seed": "Seed",

--- a/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
@@ -85,7 +85,7 @@ describe("UsdValueBanner", () => {
     const po = renderComponent(usdAmount);
 
     expect(await po.getTooltipIconPo().getTooltipText()).toEqual(
-      "1 ICP = $10.00 Token prices are provided by ICPSwap."
+      "1 ICP = $10.00 Token prices are in ckUSDC based on data provided by ICPSwap."
     );
   });
 


### PR DESCRIPTION
# Motivation

USD prices in NNS dapp are based on the ckUSDC price in ICP Swap.
Since ckUSDC is not strictly the same as USD, we should mention this.

# Changes

Mention "ckuSDC" in the tooltip that is shown next to the ICP exchange rate.

# Tests

Unit tests updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet