### PR TITLE
Show error state when ICPSwap API call fails.

### DIFF
--- a/frontend/src/lib/derived/icp-swap.derived.ts
+++ b/frontend/src/lib/derived/icp-swap.derived.ts
@@ -18,8 +18,8 @@ export type IcpSwapUsdPricesStore = Readable<IcpSwapUsdPricesStoreData>;
 export const icpSwapUsdPricesStore: IcpSwapUsdPricesStore = derived(
   icpSwapTickersStore,
   (tickers) => {
-    if (isNullish(tickers)) {
-      return undefined;
+    if (isNullish(tickers) || tickers === "error") {
+      return tickers;
     }
     // The contents of icpSwapTickersStore come from ICP Swap, so there's no
     // guarantee that it's format is as expected.

--- a/frontend/src/lib/services/icp-swap.services.ts
+++ b/frontend/src/lib/services/icp-swap.services.ts
@@ -12,5 +12,6 @@ export const loadIcpSwapTickers = async (): Promise<void> => {
     icpSwapTickersStore.set(tickers);
   } catch (error) {
     console.error(error);
+    icpSwapTickersStore.set("error");
   }
 };

--- a/frontend/src/lib/stores/icp-swap.store.ts
+++ b/frontend/src/lib/stores/icp-swap.store.ts
@@ -1,17 +1,14 @@
 import type { IcpSwapTicker } from "$lib/types/icp-swap";
 import { writable, type Readable } from "svelte/store";
 
-export type IcpSwapTickersStoreData = IcpSwapTicker[];
+export type IcpSwapTickersStoreData = IcpSwapTicker[] | undefined | "error";
 
-export interface IcpSwapTickersStore
-  extends Readable<IcpSwapTickersStoreData | undefined> {
+export interface IcpSwapTickersStore extends Readable<IcpSwapTickersStoreData> {
   set: (data: IcpSwapTickersStoreData) => void;
 }
 
 const initIcpSwapTickersStore = (): IcpSwapTickersStore => {
-  const { subscribe, set } = writable<IcpSwapTickersStoreData | undefined>(
-    undefined
-  );
+  const { subscribe, set } = writable<IcpSwapTickersStoreData>(undefined);
 
   return {
     subscribe,

--- a/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
@@ -13,6 +13,12 @@ describe("icp-swap.derived", () => {
       expect(get(icpSwapUsdPricesStore)).toBeUndefined();
     });
 
+    it("should forward 'error' state", () => {
+      icpSwapTickersStore.set("error");
+
+      expect(get(icpSwapUsdPricesStore)).toBe("error");
+    });
+
     it("should be 'error' if tickers are not an array", () => {
       // This is theoretically possible because the tickers store content is
       // read from ICP Swap, which we have no control over.

--- a/frontend/src/tests/lib/services/icp-swap.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-swap.services.spec.ts
@@ -33,7 +33,7 @@ describe("icp-swap.services", () => {
       expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
     });
 
-    it("should not change the store when there is an error", async () => {
+    it("should set error state on store when there is an error", async () => {
       vi.spyOn(console, "error").mockReturnValue();
 
       const error = new Error("Failed to fetch tickers");
@@ -43,7 +43,7 @@ describe("icp-swap.services", () => {
 
       await loadIcpSwapTickers();
 
-      expect(get(icpSwapTickersStore)).toBeUndefined();
+      expect(get(icpSwapTickersStore)).toBe("error");
     });
   });
 });


### PR DESCRIPTION
# Motivation

We loaded token prices from ICP Swap.
If this results in an error, we want to show `-/-` as USD values and show an error state with tooltip.
There can be 2 reasons why there is an error:
1. Fetching the ICP Swap data fails.
2. Parsing the ICP Swap data fails.

In this PR we set the error state when fetching the data fails.

# Changes

1. Add `"error"` as a possible value for `initIcpSwapTickersStore`.
2. Forward `"error"` from `initIcpSwapTickersStore` to `icpSwapUsdPricesStore` (which already has the state for when parsing fails).
3. Set `"error"` when the API call fails in the service.

# Tests

1. Unit tests added.
2. Added manually by adding `throw new Error()` in the API function.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet