### PR TITLE
Missing rewards soon tag

### DIFF
--- a/frontend/src/lib/components/ui/NeuronTag.svelte
+++ b/frontend/src/lib/components/ui/NeuronTag.svelte
@@ -5,8 +5,13 @@
   export let tag: NeuronTagData;
   export let size: "medium" | "large" = "medium";
 
-  let intent: "error" | "info";
-  $: intent = tag.status === "danger" ? "error" : "info";
+  let intent: "error" | "warning" | "info";
+  $: intent =
+    tag.status === "danger"
+      ? "error"
+      : tag.status === "warning"
+        ? "warning"
+        : "info";
 </script>
 
 <Tag testId="neuron-tag-component" {size} {intent}>{tag.text}</Tag>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -316,6 +316,7 @@
     "community_fund": "Neurons' fund",
     "hotkey_control": "Hotkey control",
     "missing_rewards": "Missing rewards",
+    "missing_rewards_soon": "$timeLeft to confirm",
     "hardware_wallet_control": "Ledger Device Controlled",
     "amount_icp_stake": "$amount ICP Stake",
     "ic_stake": "$token staked",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -330,6 +330,7 @@ interface I18nNeurons {
   community_fund: string;
   hotkey_control: string;
   missing_rewards: string;
+  missing_rewards_soon: string;
   hardware_wallet_control: string;
   amount_icp_stake: string;
   ic_stake: string;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -60,6 +60,7 @@ import {
   fromNullable,
   isNullish,
   nonNullish,
+  secondsToDuration,
 } from "@dfinity/utils";
 import type { ComponentType } from "svelte";
 import { get } from "svelte/store";
@@ -493,14 +494,23 @@ const getNeuronTagsUnrelatedToController = ({
     tags.push({ text: i18n.neurons.community_fund });
   }
 
-  if (
-    get(ENABLE_PERIODIC_FOLLOWING_CONFIRMATION) &&
-    isNeuronLosingRewards(neuron)
-  ) {
-    tags.push({
-      text: i18n.neurons.missing_rewards,
-      status: "danger",
-    });
+  if (get(ENABLE_PERIODIC_FOLLOWING_CONFIRMATION)) {
+    if (isNeuronLosingRewards(neuron)) {
+      tags.push({
+        text: i18n.neurons.missing_rewards,
+        status: "danger",
+      });
+    } else if (shouldDisplayRewardLossNotification(neuron)) {
+      tags.push({
+        text: replacePlaceholders(i18n.neurons.missing_rewards_soon, {
+          $timeLeft: secondsToDuration({
+            seconds: BigInt(secondsUntilLosingRewards(neuron)),
+            i18n: i18n.time,
+          }),
+        }),
+        status: "warning",
+      });
+    }
   }
 
   return tags;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -443,7 +443,7 @@ export const isHotKeyControllable = ({
 
 export type NeuronTagData = {
   text: string;
-  status?: "danger";
+  status?: "danger" | "warning";
 };
 
 export const getNeuronTags = ({

--- a/frontend/src/tests/lib/components/ui/NeuronTag.spec.ts
+++ b/frontend/src/tests/lib/components/ui/NeuronTag.spec.ts
@@ -16,6 +16,7 @@ describe("NeuronTag", () => {
 
     expect(await po.getText()).toEqual("test");
     expect(await po.isIntentError()).toEqual(false);
+    expect(await po.isIntentWarning()).toEqual(false);
     expect(await po.isSizeLarge()).toEqual(false);
   });
 
@@ -24,7 +25,17 @@ describe("NeuronTag", () => {
       props: { tag: { text: "test", status: "danger" } },
     });
 
+    expect(await po.isIntentWarning()).toEqual(false);
     expect(await po.isIntentError()).toEqual(true);
+  });
+
+  it("should render in warning status", async () => {
+    const po = renderComponent({
+      props: { tag: { text: "test", status: "warning" } },
+    });
+
+    expect(await po.isIntentError()).toEqual(false);
+    expect(await po.isIntentWarning()).toEqual(true);
   });
 
   it("should render large tag", async () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1439,8 +1439,9 @@ describe("neuron-utils", () => {
       text: "Missing rewards",
       status: "danger",
     } as NeuronTagData;
+    const daysBeforeMissingRewardsSoon = 10;
     const missingRewardsSoonTag = {
-      text: "10 days to confirm",
+      text: `${daysBeforeMissingRewardsSoon} days to confirm`,
       status: "warning",
     } as NeuronTagData;
     const ectTag = {
@@ -1669,12 +1670,16 @@ describe("neuron-utils", () => {
           ),
         },
       };
+      const timestampSixMonthsAgoPlus10Days =
+        nowInSeconds() -
+        SECONDS_IN_HALF_YEAR +
+        daysBeforeMissingRewardsSoon * SECONDS_IN_DAY;
       const losingRewardSoonNeuron: NeuronInfo = {
         ...mockNeuron,
         fullNeuron: {
           ...mockNeuron.fullNeuron,
           votingPowerRefreshedTimestampSeconds: BigInt(
-            nowInSeconds() - SECONDS_IN_HALF_YEAR + 10 * SECONDS_IN_DAY
+            timestampSixMonthsAgoPlus10Days
           ),
         },
       };

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1439,6 +1439,10 @@ describe("neuron-utils", () => {
       text: "Missing rewards",
       status: "danger",
     } as NeuronTagData;
+    const missingRewardsSoonTag = {
+      text: "10 days to confirm",
+      status: "warning",
+    } as NeuronTagData;
     const ectTag = {
       text: "Early Contributor Token",
     } as NeuronTagData;
@@ -1665,6 +1669,15 @@ describe("neuron-utils", () => {
           ),
         },
       };
+      const losingRewardSoonNeuron: NeuronInfo = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          votingPowerRefreshedTimestampSeconds: BigInt(
+            nowInSeconds() - SECONDS_IN_HALF_YEAR + 10 * SECONDS_IN_DAY
+          ),
+        },
+      };
 
       it("returns 'Missing rewards' tag", () => {
         overrideFeatureFlagsStore.setFlag(
@@ -1691,6 +1704,38 @@ describe("neuron-utils", () => {
         expect(
           getNeuronTags({
             neuron: losingRewardNeuron,
+            identity: mockIdentity,
+            accounts: accountsWithHW,
+            i18n: en,
+          })
+        ).toEqual([]);
+      });
+
+      it("returns 'Missing rewards soon' tag", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+
+        expect(
+          getNeuronTags({
+            neuron: losingRewardSoonNeuron,
+            identity: mockIdentity,
+            accounts: accountsWithHW,
+            i18n: en,
+          })
+        ).toEqual([missingRewardsSoonTag]);
+      });
+
+      it("returns no 'Missing rewards soon' tag without feature flag", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          false
+        );
+
+        expect(
+          getNeuronTags({
+            neuron: losingRewardSoonNeuron,
             identity: mockIdentity,
             accounts: accountsWithHW,
             i18n: en,

--- a/frontend/src/tests/page-objects/Tag.page-object.ts
+++ b/frontend/src/tests/page-objects/Tag.page-object.ts
@@ -14,6 +14,10 @@ export class TagPo extends BasePageObject {
     return (await this.root.getClasses()).includes("error");
   }
 
+  async isIntentWarning(): Promise<boolean> {
+    return (await this.root.getClasses()).includes("warning");
+  }
+
   async isSizeLarge(): Promise<boolean> {
     return (await this.root.getClasses()).includes("tag--large");
   }


### PR DESCRIPTION
# Motivation

Neurons that are about to start missing rewards need to be marked with a tag to draw users' attention, indicating that action needs to be taken to avoid missing rewards. This PR introduces a "warning" state to the `NeuronsTag` component and applies it to the tags for "missing soon" neurons.

# Changes

- Added a "warning" neuron tag status.
- Introduced a "...to confirm" tag.

# Tests

- Added.
- Tested manually.

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/1a105dd1-c64f-449c-bef4-0dd5fb57b703">


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.