### PR TITLE
NNS1-3485: initial setup for the new reporting page

### DIFF
--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -12,6 +12,7 @@ export enum AppPath {
   Project = "/project",
   Settings = "/settings",
   Tokens = "/tokens",
+  Reporting = "/reporting",
 }
 
 // SvelteKit uses the group defined in src/routes/(app)/ as part of the routeId. It also prefixes it with /.

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -146,7 +146,8 @@
     "launchpad": "Launchpad",
     "manage_ii": "Manage Internet Identity",
     "source_code": "Source Code",
-    "settings": "Settings"
+    "settings": "Settings",
+    "reporting": "Reporting"
   },
   "header": {
     "menu": "Open menu to access navigation options",
@@ -155,7 +156,7 @@
     "main_icp_account_id": "Main ICP Account ID",
     "account_id_tooltip": "You can send ICP both to your principal ID and account ID, however some exchanges or wallets may not support transactions using a principal ID.",
     "export_neurons": "Export Neurons Info",
-    "export_transactions": "Export ICP Transactions"
+    "export_transactions": "Export Transactions"
   },
   "export_csv_neurons": {
     "account_id": "Account ID",
@@ -187,6 +188,12 @@
     "csv_generation": "Failed to generate CSV file",
     "file_system_access": "Unable to save file. Please check your permissions.",
     "neurons": "There was an error exporting the neurons. Please try again."
+  },
+  "reporting": {
+    "neurons_title": "Neurons Portfolio",
+    "neurons_description": "Download a detailed CSV report of your neuron portfolio, which includes the stake, maturity, and neuron account ID for manual tracking and analysis.",
+    "transactions_title": "Transactions",
+    "transactions_description": "Download a detailed CSV report of your token transaction history. This report includes both regular token accounts and neurons, showing neuron staking and minting transactions for manual tracking and analysis."
   },
   "auth": {
     "login": "Sign in with Internet Identity",
@@ -989,6 +996,10 @@
   "auth_accounts": {
     "title": "100% on-chain governance",
     "text": "Manage your ICP, ckBTC, and SNS governance tokens within the NNS wallet — hosted 100% on the Internet Computer blockchain. Transfer tokens, secure them with Ledger devices, or participate in governance to earn voting rewards."
+  },
+  "auth_report": {
+    "title": "Reporting",
+    "text": "Download a detailed CSV report of your neuron portfolio, which includes your stake, maturity, and neuron account ID for manual tracking and analysis, along with your ICP transactions."
   },
   "auth_neurons": {
     "title": "Earn staking rewards"

--- a/frontend/src/lib/pages/SignInReporting.svelte
+++ b/frontend/src/lib/pages/SignInReporting.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import EmptyCards from "$lib/components/common/EmptyCards.svelte";
+  import SignIn from "$lib/components/common/SignIn.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { IconSettingsPage, PageBanner } from "@dfinity/gix-components";
+</script>
+
+<main>
+  <div class="content">
+    <PageBanner>
+      <IconSettingsPage slot="image" />
+      <svelte:fragment slot="title">{$i18n.auth_report.title}</svelte:fragment>
+      <p class="description" slot="description">{$i18n.auth_report.text}</p>
+      <SignIn slot="actions" />
+    </PageBanner>
+
+    <EmptyCards />
+  </div>
+</main>
+
+<style lang="scss">
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+  }
+</style>

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import Separator from "$lib/components/ui/Separator.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { Island } from "@dfinity/gix-components";
+  import { debounce } from "@dfinity/utils";
+  import { onMount } from "svelte";
+
+  // Defer the title to avoid a visual glitch where the title moves from left to center in the header if navigation happens from Accounts page
+  onMount(
+    debounce(
+      () =>
+        layoutTitleStore.set({
+          title: $i18n.navigation.reporting,
+        }),
+      500
+    )
+  );
+</script>
+
+<Island>
+  <main>
+    <div>
+      <h3>{$i18n.reporting.neurons_title}</h3>
+      <p class="description">{$i18n.reporting.neurons_description}</p>
+    </div>
+    <Separator spacing="medium" />
+    <div>
+      <h3>{$i18n.reporting.transactions_title}</h3>
+      <p class="description">{$i18n.reporting.transactions_description}></p>
+    </div>
+  </main>
+</Island>
+
+<style lang="scss">
+  main {
+    padding: var(--padding-3x);
+  }
+</style>

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -27,7 +27,7 @@
     <Separator spacing="medium" />
     <div>
       <h3>{$i18n.reporting.transactions_title}</h3>
-      <p class="description">{$i18n.reporting.transactions_description}></p>
+      <p class="description">{$i18n.reporting.transactions_description}</p>
     </div>
   </main>
 </Island>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -153,6 +153,7 @@ interface I18nNavigation {
   manage_ii: string;
   source_code: string;
   settings: string;
+  reporting: string;
 }
 
 interface I18nHeader {
@@ -196,6 +197,13 @@ interface I18nExport_error {
   csv_generation: string;
   file_system_access: string;
   neurons: string;
+}
+
+interface I18nReporting {
+  neurons_title: string;
+  neurons_description: string;
+  transactions_title: string;
+  transactions_description: string;
 }
 
 interface I18nAuth {
@@ -1035,6 +1043,11 @@ interface I18nAuth_accounts {
   text: string;
 }
 
+interface I18nAuth_report {
+  title: string;
+  text: string;
+}
+
 interface I18nAuth_neurons {
   title: string;
 }
@@ -1458,6 +1471,7 @@ interface I18n {
   header: I18nHeader;
   export_csv_neurons: I18nExport_csv_neurons;
   export_error: I18nExport_error;
+  reporting: I18nReporting;
   auth: I18nAuth;
   accounts: I18nAccounts;
   neuron_types: I18nNeuron_types;
@@ -1493,6 +1507,7 @@ interface I18n {
   error__imported_tokens: I18nError__imported_tokens;
   error__sns: I18nError__sns;
   auth_accounts: I18nAuth_accounts;
+  auth_report: I18nAuth_report;
   auth_neurons: I18nAuth_neurons;
   auth_proposals: I18nAuth_proposals;
   auth_canisters: I18nAuth_canisters;

--- a/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
@@ -3,8 +3,14 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
+  import { ENABLE_EXPORT_NEURONS_REPORT } from "$lib/stores/feature-flags.store";
   import { referrerPathStore } from "$lib/stores/routes.store";
   import { nonNullish } from "@dfinity/utils";
+  import { onMount } from "svelte";
+
+  onMount(async () => {
+    if ($ENABLE_EXPORT_NEURONS_REPORT !== true) await goto(AppPath.Accounts);
+  });
 
   const back = async () => {
     if (nonNullish($referrerPathStore)) {

--- a/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import Content from "$lib/components/layout/Content.svelte";
+  import Layout from "$lib/components/layout/Layout.svelte";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { referrerPathStore } from "$lib/stores/routes.store";
+  import { nonNullish } from "@dfinity/utils";
+
+  const back = async () => {
+    if (nonNullish($referrerPathStore)) {
+      // Referrer might be a detail page which needs query parameters therefore we use the browser API to go back there
+      history.back();
+      return;
+    }
+
+    // We landed on the "Reporting" page from somewhere else than from the dapp
+    await goto(AppPath.Accounts);
+  };
+</script>
+
+<Layout>
+  <Content {back}>
+    <slot />
+  </Content>
+</Layout>

--- a/frontend/src/routes/(app)/(nns)/reporting/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/reporting/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import SignInReporting from "$lib/pages/SignInReport.svelte";
+  import Reporting from "$lib/routes/Report.svelte";
+</script>
+
+{#if $authSignedInStore}
+  <Reporting />
+{:else}
+  <SignInReporting />
+{/if}

--- a/frontend/src/routes/(app)/(nns)/reporting/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/reporting/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { authSignedInStore } from "$lib/derived/auth.derived";
-  import SignInReporting from "$lib/pages/SignInReport.svelte";
-  import Reporting from "$lib/routes/Report.svelte";
+  import SignInReporting from "$lib/pages/SignInReporting.svelte";
+  import Reporting from "$lib/routes/Reporting.svelte";
 </script>
 
 {#if $authSignedInStore}

--- a/frontend/src/tests/lib/routes/Reporting.spec.ts
+++ b/frontend/src/tests/lib/routes/Reporting.spec.ts
@@ -1,0 +1,33 @@
+import ReportingPage from "$lib/routes/Reporting.svelte";
+import { layoutTitleStore } from "$lib/stores/layout.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ReportingPagePo } from "$tests/page-objects/ReportingPage.page-object";
+import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("Reporting", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
+  const renderComponent = () => {
+    const { container } = render(ReportingPage);
+    const po = ReportingPagePo.under({
+      element: new JestPageObjectElement(container),
+    });
+    return po;
+  };
+
+  it("should set title", async () => {
+    const titleBefore = get(layoutTitleStore);
+    expect(titleBefore).toEqual({ title: "" });
+
+    renderComponent();
+    await (() =>
+      expect(get(layoutTitleStore)).toEqual({
+        title: en.navigation.reporting,
+      }));
+  });
+});

--- a/frontend/src/tests/page-objects/ReportingPage.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingPage.page-object.ts
@@ -1,0 +1,10 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ReportingPagePo extends BasePageObject {
+  private static readonly TID = "reporting-page-component";
+
+  static under({ element }: { element: PageObjectElement }): ReportingPagePo {
+    return new ReportingPagePo(element.byTestId(ReportingPagePo.TID));
+  }
+}

--- a/frontend/src/tests/routes/app/reporting/layout.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/layout.spec.ts
@@ -1,41 +1,66 @@
+import { goto } from "$app/navigation";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
-import Layout from "$routes/(app)/(nns)/settings/+layout.svelte";
+import Layout from "$routes/(app)/(nns)/reporting/+layout.svelte";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Layout", () => {
-  const renderReportingAndBack = () => {
+  vi.mock("$app/navigation", () => ({
+    goto: vi.fn(() => Promise.resolve()),
+  }));
+
+  const renderReporting = () => {
     page.mock({
       data: {
         universe: OWN_CANISTER_ID_TEXT,
       },
       routeId: AppPath.Reporting,
     });
-    const { queryByTestId } = render(Layout);
+
+    return render(Layout);
+  };
+
+  beforeEach(() => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_EXPORT_NEURONS_REPORT", true);
+  });
+
+  it("should redirect to /accounts if feature flag is off", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_EXPORT_NEURONS_REPORT", false);
+
+    renderReporting();
+
+    expect(goto).toHaveBeenCalledWith(AppPath.Accounts);
+    expect(goto).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stay in the page if feature flag is on", () => {
+    renderReporting();
+
+    expect(goto).not.toHaveBeenCalled();
+  });
+
+  it("should go back to the accounts page as fallback", async () => {
+    referrerPathStore.set(undefined);
+
+    const { queryByTestId } = renderReporting();
 
     const { path } = get(pageStore);
+
     expect(path).toEqual(AppPath.Reporting);
 
     const backButton = queryByTestId("back");
     expect(backButton).toBeInTheDocument();
 
     fireEvent.click(backButton);
-  };
 
-  it("should go back to the accounts page as fallback", async () => {
-    referrerPathStore.set(undefined);
-
-    renderReportingAndBack();
-
-    await waitFor(() => {
-      const { path } = get(pageStore);
-      expect(path).toEqual(AppPath.Accounts);
-    });
+    expect(goto).toHaveBeenCalledWith(AppPath.Accounts);
+    expect(goto).toHaveBeenCalledTimes(1);
   });
 
   it("should go back to referrer", async () => {
@@ -43,7 +68,16 @@ describe("Layout", () => {
 
     const spy = vi.spyOn(history, "back");
 
-    renderReportingAndBack();
+    const { queryByTestId } = renderReporting();
+
+    const { path } = get(pageStore);
+
+    expect(path).toEqual(AppPath.Reporting);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
   });

--- a/frontend/src/tests/routes/app/reporting/layout.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/layout.spec.ts
@@ -1,0 +1,50 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import { referrerPathStore } from "$lib/stores/routes.store";
+import { page } from "$mocks/$app/stores";
+import Layout from "$routes/(app)/(nns)/settings/+layout.svelte";
+import { fireEvent } from "@testing-library/dom";
+import { render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("Layout", () => {
+  const renderReportingAndBack = () => {
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+      },
+      routeId: AppPath.Reporting,
+    });
+    const { queryByTestId } = render(Layout);
+
+    const { path } = get(pageStore);
+    expect(path).toEqual(AppPath.Reporting);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+  };
+
+  it("should go back to the accounts page as fallback", async () => {
+    referrerPathStore.set(undefined);
+
+    renderReportingAndBack();
+
+    await waitFor(() => {
+      const { path } = get(pageStore);
+      expect(path).toEqual(AppPath.Accounts);
+    });
+  });
+
+  it("should go back to referrer", async () => {
+    referrerPathStore.set(AppPath.Wallet);
+
+    const spy = vi.spyOn(history, "back");
+
+    renderReportingAndBack();
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/tests/routes/app/reporting/page.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/page.spec.ts
@@ -1,0 +1,27 @@
+import ReportingPage from "$routes/(app)/(nns)/reporting/+page.svelte";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { render } from "@testing-library/svelte";
+
+describe("Reporting page", () => {
+  describe("not signed in", () => {
+    beforeEach(() => {
+      setNoIdentity();
+    });
+
+    it("should render sign-in if not logged in", () => {
+      const { getByTestId } = render(ReportingPage);
+
+      expect(getByTestId("login-button")).not.toBeNull();
+    });
+  });
+
+  describe("signed in", () => {
+    beforeEach(() => {
+      resetIdentity();
+    });
+
+    // TODO: Once the ExportNeurons and ExportTransactions components are migrated to this new page
+    it.skip("should render generate neurons report section", () => {});
+    it.skip("should render generate transactions report section", () => {});
+  });
+});


### PR DESCRIPTION
# Motivation

This new page will display all reporting functionalities currently found in the `AccountMenu`. 
This first iteration introduces the page without any logic. Subsequent pull requests will migrate the Export components from the `AccountMenu` to this page.

# Changes

- New Reporting page

# Tests

- Unit tests for the route's layout and page
- Unit tests for the page

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet

Next PR: #5965 