### PR TITLE
Fix gap between token balance and USD balance

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -47,7 +47,7 @@
   .values {
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-0_5x);
     align-items: flex-end;
 
     .usd-value {


### PR DESCRIPTION
# Motivation

There is too much space between the token balance and USD balance in the tokens table, compared to the Figma design.

# Changes

1. Change the gap from `8px` to `4px`.

# Tests

Manually

# Todos

- [ ] Add entry to changelog (if necessary).
not yet