### PR TITLE
NNS1-3485: migrates ExportTransactions component from AccountMenu to Reporting page

### DIFF
--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -11,7 +11,6 @@
   import LoginIconOnly from "./LoginIconOnly.svelte";
   import Logout from "./Logout.svelte";
   import { IconUser, Popover } from "@dfinity/gix-components";
-  import ExportIcpTransactionsButton from "$lib/components/header/ExportIcpTransactionsButton.svelte";
   import LinkToReporting from "$lib/components/header/LinkToReporting.svelte";
 
   let visible = false;
@@ -47,10 +46,6 @@
           <LinkToReporting on:nnsLink={closeMenu} />
 
           <ExportNeuronsButton on:nnsExportNeuronsCsvTriggered={toggle} />
-
-          <ExportIcpTransactionsButton
-            on:nnsExportIcpTransactionsCsvTriggered={toggle}
-          />
         {/if}
 
         <Logout on:nnsLogoutTriggered={toggle} />

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -138,7 +138,7 @@
   aria-label={$i18n.header.export_neurons}
 >
   <IconDown />
-  {$i18n.header.export_transactions}
+  {$i18n.reporting.transactions_title}
 </button>
 
 <style lang="scss">

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -138,7 +138,7 @@
   aria-label={$i18n.header.export_neurons}
 >
   <IconDown />
-  {$i18n.reporting.transactions_title}
+  {$i18n.header.export_transactions}
 </button>
 
 <style lang="scss">

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -26,7 +26,7 @@
       <p class="description">{$i18n.reporting.neurons_description}</p>
     </div>
     <Separator spacing="medium" />
-    <div class="wrapper">
+    <div>
       <h3>{$i18n.reporting.transactions_title}</h3>
       <p class="description">{$i18n.reporting.transactions_description}</p>
       <ReportingTransactionsButton />
@@ -37,11 +37,5 @@
 <style lang="scss">
   main {
     padding: var(--padding-3x);
-  }
-
-  .wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding-3x);
   }
 </style>

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ReportingTransactionsButton from "$lib/components/reporting/ReportingTransactionsButton.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { layoutTitleStore } from "$lib/stores/layout.store";
@@ -25,9 +26,10 @@
       <p class="description">{$i18n.reporting.neurons_description}</p>
     </div>
     <Separator spacing="medium" />
-    <div>
+    <div class="wrapper">
       <h3>{$i18n.reporting.transactions_title}</h3>
       <p class="description">{$i18n.reporting.transactions_description}</p>
+      <ReportingTransactionsButton />
     </div>
   </main>
 </Island>
@@ -35,5 +37,11 @@
 <style lang="scss">
   main {
     padding: var(--padding-3x);
+  }
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-3x);
   }
 </style>

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -168,42 +168,6 @@ describe("AccountMenu", () => {
         });
       });
 
-      it("should not show the Export ICP Transactions Report button if feature flag is off(by default)", async () => {
-        const { accountMenuPo } = renderComponent();
-
-        await accountMenuPo.openMenu();
-
-        expect(
-          await accountMenuPo.getExportIcpTransactionsButtonPo().isPresent()
-        ).toBe(false);
-      });
-
-      it("should show Export Icp Transactions Report button if feature flag is on", async () => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_EXPORT_NEURONS_REPORT", true);
-        const { accountMenuPo } = renderComponent();
-
-        await accountMenuPo.openMenu();
-
-        expect(
-          await accountMenuPo.getExportIcpTransactionsButtonPo().isPresent()
-        ).toBe(true);
-      });
-
-      it("should close the menu once the Export Icp Transactions Report button is clicked", async () => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_EXPORT_NEURONS_REPORT", true);
-        const { accountMenuPo } = renderComponent();
-
-        expect(await accountMenuPo.isOpen()).toBe(false);
-
-        await accountMenuPo.openMenu();
-        expect(await accountMenuPo.isOpen()).toBe(true);
-
-        await accountMenuPo.getExportIcpTransactionsButtonPo().click();
-        await waitFor(async () => {
-          expect(await accountMenuPo.isOpen()).toBe(false);
-        });
-      });
-
       it("should not show the LinkToReporting button if feature flag is off(by default", async () => {
         const { accountMenuPo } = renderComponent();
         await accountMenuPo.openMenu();

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -5,7 +5,7 @@ import * as exportToCsv from "$lib/utils/export-to-csv.utils";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { createTransactionWithId } from "$tests/mocks/icp-transactions.mock";
-import { ExportIcpTransactionsButtonPo } from "$tests/page-objects/ExportIcpTransactionsButton.page-object";
+import { ReportingTransactionsButtonPo } from "$tests/page-objects/ReportingTransactionsButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import {
   resetAccountsForTesting,
@@ -56,7 +56,7 @@ describe("ExportIcpTransactionsButton", () => {
   const renderComponent = ({ onTrigger }: { onTrigger?: () => void } = {}) => {
     const { container, component } = render(ReportingTransactionsButton);
 
-    const po = ExportIcpTransactionsButtonPo.under({
+    const po = ReportingTransactionsButtonPo.under({
       element: new JestPageObjectElement(container),
     });
 

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -1,5 +1,5 @@
 import * as icpIndexApi from "$lib/api/icp-index.api";
-import ExportIcpTransactionsButton from "$lib/components/header/ExportIcpTransactionsButton.svelte";
+import ReportingTransactionsButton from "$lib/components/reporting/ReportingTransactionsButton.svelte";
 import * as toastsStore from "$lib/stores/toasts.store";
 import * as exportToCsv from "$lib/utils/export-to-csv.utils";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
@@ -54,7 +54,7 @@ describe("ExportIcpTransactionsButton", () => {
   });
 
   const renderComponent = ({ onTrigger }: { onTrigger?: () => void } = {}) => {
-    const { container, component } = render(ExportIcpTransactionsButton);
+    const { container, component } = render(ReportingTransactionsButton);
 
     const po = ExportIcpTransactionsButtonPo.under({
       element: new JestPageObjectElement(container),

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -1,6 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
-import { ExportIcpTransactionsButtonPo } from "$tests/page-objects/ExportIcpTransactionsButton.page-object";
 import { ExportNeuronsButtonPo } from "$tests/page-objects/ExportNeuronsButton.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AccountDetailsPo } from "./AccountDetails.page-object";
@@ -70,10 +69,6 @@ export class AccountMenuPo extends BasePageObject {
 
   getExportNeuronsButtonPo(): ExportNeuronsButtonPo {
     return ExportNeuronsButtonPo.under({ element: this.root });
-  }
-
-  getExportIcpTransactionsButtonPo(): ExportIcpTransactionsButtonPo {
-    return ExportIcpTransactionsButtonPo.under({ element: this.root });
   }
 
   getLinkToReportingPo(): LinkPo {

--- a/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
@@ -1,17 +1,17 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ExportIcpTransactionsButtonPo extends ButtonPo {
+export class ReportingTransactionsButtonPo extends ButtonPo {
   static readonly TID = "export-icp-transactions-button-component";
 
   static under({
     element,
   }: {
     element: PageObjectElement;
-  }): ExportIcpTransactionsButtonPo {
+  }): ReportingTransactionsButtonPo {
     return ButtonPo.under({
       element,
-      testId: ExportIcpTransactionsButtonPo.TID,
+      testId: ReportingTransactionsButtonPo.TID,
     });
   }
 }


### PR DESCRIPTION
# Motivation

Moves the existing `ExportIcpTransactionsButton` from the `AccountMenu` to the `Reporting` page.
A follow up PR will handle the changes(styles, copy, ...)

# Changes

- Moves component and tests to a new location.
- Renames the component to fit the new location.

# Tests

- Moves tests but none added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.