### PR TITLE
NNS1-3485: migrate ExportNeurons component to new page

### DIFF
--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import ExportNeuronsButton from "$lib/components/header/ExportNeuronsButton.svelte";
   import ManageInternetIdentityButton from "$lib/components/header/ManageInternetIdentityButton.svelte";
   import LinkToSettings from "$lib/components/header/LinkToSettings.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
@@ -44,8 +43,6 @@
 
         {#if $ENABLE_EXPORT_NEURONS_REPORT}
           <LinkToReporting on:nnsLink={closeMenu} />
-
-          <ExportNeuronsButton on:nnsExportNeuronsCsvTriggered={toggle} />
         {/if}
 
         <Logout on:nnsLogoutTriggered={toggle} />

--- a/frontend/src/lib/components/reporting/ReportingNeuronsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingNeuronsButton.svelte
@@ -115,7 +115,7 @@
 </script>
 
 <button
-  data-tid="export-neurons-button-component"
+  data-tid="reporting-neurons-button-component"
   on:click={exportNeurons}
   class="text"
   disabled={isDisabled}

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ReportingNeuronsButton from "$lib/components/reporting/ReportingNeuronsButton.svelte";
   import ReportingTransactionsButton from "$lib/components/reporting/ReportingTransactionsButton.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { i18n } from "$lib/stores/i18n";
@@ -24,6 +25,7 @@
     <div>
       <h3>{$i18n.reporting.neurons_title}</h3>
       <p class="description">{$i18n.reporting.neurons_description}</p>
+      <ReportingNeuronsButton />
     </div>
     <Separator spacing="medium" />
     <div>

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -8,7 +8,7 @@ import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { AccountMenuPo } from "$tests/page-objects/AccountMenu.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { render, waitFor } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 
 describe("AccountMenu", () => {
   const renderComponent = () => {
@@ -128,44 +128,6 @@ describe("AccountMenu", () => {
     describe("export feature flag", () => {
       beforeEach(() => {
         vi.spyOn(console, "error").mockImplementation(() => {});
-      });
-
-      it("should not show the Export Neurons Report button if feature flag is off(by default)", async () => {
-        const { accountMenuPo } = renderComponent();
-
-        await accountMenuPo.openMenu();
-
-        expect(await accountMenuPo.getExportNeuronsButtonPo().isPresent()).toBe(
-          false
-        );
-      });
-
-      it("should show the Export Neurons Report button if feature flag is on", async () => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_EXPORT_NEURONS_REPORT", true);
-        const { accountMenuPo } = renderComponent();
-
-        await accountMenuPo.openMenu();
-
-        expect(await accountMenuPo.getExportNeuronsButtonPo().isPresent()).toBe(
-          true
-        );
-      });
-
-      it("should close the menu once the Export Neurons Report button is clicked", async () => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_EXPORT_NEURONS_REPORT", true);
-        const { accountMenuPo } = renderComponent();
-
-        await accountMenuPo.openMenu();
-
-        expect(await accountMenuPo.getAccountDetailsPo().isPresent()).toBe(
-          true
-        );
-
-        await accountMenuPo.getExportNeuronsButtonPo().click();
-
-        await waitFor(async () => {
-          expect(await accountMenuPo.isOpen()).toBe(false);
-        });
       });
 
       it("should not show the LinkToReporting button if feature flag is off(by default", async () => {

--- a/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
@@ -1,4 +1,4 @@
-import ExportNeuronsButton from "$lib/components/header/ExportNeuronsButton.svelte";
+import ReportingNeuronsButton from "$lib/components/reporting/ReportingNeuronsButton.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import * as toastsStore from "$lib/stores/toasts.store";
@@ -7,11 +7,11 @@ import * as exportToCsv from "$lib/utils/export-to-csv.utils";
 import { generateCsvFileToSave } from "$lib/utils/export-to-csv.utils";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { ExportNeuronsButtonPo } from "$tests/page-objects/ExportNeuronsButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ReportingNeuronsButtonPo } from "$tests/page-objects/ReportingNeuronsButon.page-object";
 import { render } from "@testing-library/svelte";
 
-describe("ExportNeuronsButton", () => {
+describe("ReportingNeuronsButton", () => {
   beforeEach(() => {
     vi.clearAllTimers();
     vi.spyOn(exportToCsv, "generateCsvFileToSave").mockImplementation(vi.fn());
@@ -37,9 +37,9 @@ describe("ExportNeuronsButton", () => {
   });
 
   const renderComponent = ({ onTrigger }: { onTrigger?: () => void } = {}) => {
-    const { container, component } = render(ExportNeuronsButton);
+    const { container, component } = render(ReportingNeuronsButton);
 
-    const po = ExportNeuronsButtonPo.under({
+    const po = ReportingNeuronsButtonPo.under({
       element: new JestPageObjectElement(container),
     });
 

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -1,6 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
-import { ExportNeuronsButtonPo } from "$tests/page-objects/ExportNeuronsButton.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AccountDetailsPo } from "./AccountDetails.page-object";
 import { LinkPo } from "./Link.page-object";
@@ -65,10 +64,6 @@ export class AccountMenuPo extends BasePageObject {
 
   getAccountDetailsPo(): AccountDetailsPo {
     return AccountDetailsPo.under(this.root);
-  }
-
-  getExportNeuronsButtonPo(): ExportNeuronsButtonPo {
-    return ExportNeuronsButtonPo.under({ element: this.root });
   }
 
   getLinkToReportingPo(): LinkPo {

--- a/frontend/src/tests/page-objects/ReportingNeuronsButon.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingNeuronsButon.page-object.ts
@@ -1,17 +1,17 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ExportNeuronsButtonPo extends ButtonPo {
-  static readonly TID = "export-neurons-button-component";
+export class ReportingNeuronsButtonPo extends ButtonPo {
+  static readonly TID = "reporting-neurons-button-component";
 
   static under({
     element,
   }: {
     element: PageObjectElement;
-  }): ExportNeuronsButtonPo {
+  }): ReportingNeuronsButtonPo {
     return ButtonPo.under({
       element,
-      testId: ExportNeuronsButtonPo.TID,
+      testId: ReportingNeuronsButtonPo.TID,
     });
   }
 }


### PR DESCRIPTION
# Motivation

Moves the existing `ExportNeuronsButton` from the `AccountMenu` to the `Reporting` page.
A follow up PR will handle the changes(styles, copy, ...)

# Changes

- Moves component and tests to a new location.
- Renames the component to fit the new location.

# Tests

- Moves tests, but none were added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.