### PR TITLE
Show USD balance on wallet page

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -215,6 +215,7 @@
                   token,
                 })
               : undefined}
+            {ledgerCanisterId}
           >
             <slot name="header-actions" />
             <SignInGuard />

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { onIntersection } from "$lib/directives/intersection.directives";
+  import { ENABLE_USD_VALUES } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import type { IntersectingDetail } from "$lib/types/intersection.types";
+  import { formatNumber } from "$lib/utils/format.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { formatTokenV2 } from "$lib/utils/token.utils";
   import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
@@ -16,6 +20,29 @@
   export let balance: TokenAmountV2 | undefined = undefined;
   export let accountName: string;
   export let principal: Principal | undefined = undefined;
+  export let ledgerCanisterId: Principal | undefined;
+
+  let icpSwapHasError: boolean;
+  $: icpSwapHasError = $icpSwapUsdPricesStore === "error";
+
+  let tokenPrice: number | undefined;
+  $: tokenPrice =
+    nonNullish(ledgerCanisterId) &&
+    nonNullish($icpSwapUsdPricesStore) &&
+    $icpSwapUsdPricesStore !== "error"
+      ? $icpSwapUsdPricesStore[ledgerCanisterId.toText()]
+      : undefined;
+
+  let balanceInUsd: number | undefined;
+  $: balanceInUsd =
+    nonNullish(balance) && nonNullish(tokenPrice)
+      ? (tokenPrice * Number(balance.toE8s())) / 100_000_000
+      : undefined;
+
+  let formattedBalanceInUsd: string;
+  $: formattedBalanceInUsd = nonNullish(balanceInUsd)
+    ? `$${formatNumber(balanceInUsd)}`
+    : "$-/-";
 
   let detailedAccountBalance: string | undefined;
   $: detailedAccountBalance = nonNullish(balance)
@@ -67,7 +94,24 @@
     use:onIntersection
   >
     <HeadingSubtitle testId="wallet-page-heading-subtitle">
-      {accountName}
+      <div class="subtitle">
+        {#if $ENABLE_USD_VALUES}
+          <div class="usd-balance" class:icp-swap-has-error={icpSwapHasError}>
+            <span data-tid="usd-balance">
+              {formattedBalanceInUsd}
+            </span>
+            <TooltipIcon>
+              {#if icpSwapHasError}
+                {$i18n.accounts.token_price_error}
+              {:else}
+                {$i18n.accounts.token_price_source}
+              {/if}
+            </TooltipIcon>
+          </div>
+          <div class="vertical-divider" />
+        {/if}
+        <div class="account-name">{accountName}</div>
+      </div>
     </HeadingSubtitle>
     {#if nonNullish(principal)}
       <p class="description" data-tid="wallet-page-heading-principal">
@@ -81,6 +125,25 @@
 </PageHeading>
 
 <style lang="scss">
+  .subtitle {
+    display: flex;
+    gap: var(--padding-2x);
+
+    .usd-balance {
+      display: flex;
+      gap: var(--padding-0_5x);
+      align-items: center;
+
+      &.icp-swap-has-error {
+        --tooltip-icon-color: var(--tag-failed-text);
+      }
+    }
+
+    .vertical-divider {
+      border-right: 1px solid var(--elements-divider);
+    }
+  }
+
   .subtitles {
     display: flex;
     flex-direction: column;

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -94,7 +94,6 @@
     use:onIntersection
   >
     <HeadingSubtitle testId="wallet-page-heading-subtitle">
-      <!-- prettier-ignore -->
       <div class="subtitle">
         {#if $ENABLE_USD_VALUES}
           <div class="usd-balance" class:icp-swap-has-error={icpSwapHasError}>
@@ -110,6 +109,7 @@
             </TooltipIcon>
           </div>
           <div class="vertical-divider" />
+        <!-- prettier-ignore -->
         {/if}<div class="account-name">
           {accountName}
         </div>

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -94,6 +94,7 @@
     use:onIntersection
   >
     <HeadingSubtitle testId="wallet-page-heading-subtitle">
+      <!-- prettier-ignore -->
       <div class="subtitle">
         {#if $ENABLE_USD_VALUES}
           <div class="usd-balance" class:icp-swap-has-error={icpSwapHasError}>
@@ -109,9 +110,7 @@
             </TooltipIcon>
           </div>
           <div class="vertical-divider" />
-          <!-- prettier-ignore -->
-        {/if}
-        <div class="account-name">
+        {/if}<div class="account-name">
           {accountName}
         </div>
       </div>

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -109,8 +109,9 @@
             </TooltipIcon>
           </div>
           <div class="vertical-divider" />
-        <!-- prettier-ignore -->
-        {/if}<div class="account-name">
+          <!-- prettier-ignore -->
+        {/if}
+        <div class="account-name">
           {accountName}
         </div>
       </div>

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -94,6 +94,7 @@
     use:onIntersection
   >
     <HeadingSubtitle testId="wallet-page-heading-subtitle">
+      <!-- prettier-ignore -->
       <div class="subtitle">
         {#if $ENABLE_USD_VALUES}
           <div class="usd-balance" class:icp-swap-has-error={icpSwapHasError}>
@@ -109,8 +110,9 @@
             </TooltipIcon>
           </div>
           <div class="vertical-divider" />
-        {/if}
-        <div class="account-name">{accountName}</div>
+        {/if}<div class="account-name">
+          {accountName}
+        </div>
       </div>
     </HeadingSubtitle>
     {#if nonNullish(principal)}

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -22,6 +22,7 @@
   import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { debugSelectedAccountStore } from "$lib/derived/debug.derived";
+  import { neuronAccountsStore } from "$lib/derived/neurons.derived";
   import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
   import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
   import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
@@ -46,7 +47,6 @@
     icpTransactionsStore,
     type IcpTransactionsStoreData,
   } from "$lib/stores/icp-transactions.store";
-  import { neuronAccountsStore } from "$lib/derived/neurons.derived";
   import { toastsError } from "$lib/stores/toasts.store";
   import type { Account } from "$lib/types/account";
   import type { AccountIdentifierText } from "$lib/types/account";
@@ -370,6 +370,7 @@
             principal={isHardwareWallet
               ? $selectedAccountStore.account?.principal
               : undefined}
+            ledgerCanisterId={LEDGER_CANISTER_ID}
           >
             {#if isHardwareWallet}
               <HardwareWalletListNeuronsButton />

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -16,6 +16,8 @@
   import IcrcWallet from "$lib/pages/IcrcWallet.svelte";
   import NnsWallet from "$lib/pages/NnsWallet.svelte";
   import SnsWallet from "$lib/pages/SnsWallet.svelte";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { ENABLE_USD_VALUES } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { layoutTitleStore } from "$lib/stores/layout.store";
@@ -23,6 +25,10 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
 
   export let accountIdentifier: string | undefined | null = undefined;
+
+  $: if ($authSignedInStore && $ENABLE_USD_VALUES) {
+    loadIcpSwapTickers();
+  }
 
   layoutTitleStore.set({
     title: $i18n.wallet.title,

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -229,7 +229,7 @@ describe("Wallet", () => {
       ];
       vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue(tickers);
 
-      vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockReturnValue(
+      vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(
         3_000_000_000n
       );
 

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -246,22 +246,6 @@ describe("Wallet", () => {
         await po.getSnsWalletPo().getWalletPageHeadingPo().getBalanceInUsd()
       ).toBe("$7.50");
     });
-
-    it("should not load ICP Swap tickers without feature flag", async () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES", false);
-
-      vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue([]);
-
-      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(0);
-
-      const po = renderComponent();
-      await runResolvedPromises();
-
-      expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(0);
-      expect(
-        await po.getSnsWalletPo().getWalletPageHeadingPo().hasBalanceInUsd()
-      ).toBe(false);
-    });
   });
 
   it("should render ckBTC wallet", () => {

--- a/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
@@ -3,6 +3,7 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AmountDisplayPo } from "./AmountDisplay.page-object";
 import { HashPo } from "./Hash.page-object";
 import { TooltipPo } from "./Tooltip.page-object";
+import { TooltipIconPo } from "./TooltipIcon.page-object";
 
 export class WalletPageHeadingPo extends BasePageObject {
   private static readonly TID = "wallet-page-heading-component";
@@ -28,6 +29,18 @@ export class WalletPageHeadingPo extends BasePageObject {
 
   getSubtitle(): Promise<string> {
     return this.getText("wallet-page-heading-subtitle");
+  }
+
+  hasBalanceInUsd(): Promise<boolean> {
+    return this.isPresent("usd-balance");
+  }
+
+  getBalanceInUsd(): Promise<string> {
+    return this.getText("usd-balance");
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
   }
 
   getPrincipal(): Promise<string> {


### PR DESCRIPTION
# Motivation

Like on the tokens and account page we also want to show your balance in USD on the wallet pages.

# Changes

1. Add `ledgerCanisterId` prop to `WalletPageHeading` component to identify the token for the ICP Swap price data.
2. Add USD price and tooltip to `WalletPageHeading` component.
3. Pass `ledgerCanisterId` prop from `NnsWallet` and `IcrcWalletPage`.
4. Load ICPSwap tickers from `Wallet` component to make sure the data is available.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/wallet/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet