### PR TITLE
Upgrade next ic js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -297,10 +297,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.3-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.3-next-2024-11-27.tgz",
-      "integrity": "sha512-3ohNEDnwI/qA74G0p1/2gLLLewvmZX9bDM4O2SK0+CvN+fcTsKAnAGDnVPajNhcsKd+jmArL85oswLJodeCoyQ==",
-      "license": "Apache-2.0",
+      "version": "3.1.4-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.4-next-2024-12-10.tgz",
+      "integrity": "sha512-zSv418sYALn8P+lNJ8WVc5auw9+bFPjPpyfGDG80SZpPfb9LaYfbTT9vXCNCTLPEYGI37RRKkkSdJFCEFDX9QA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -314,10 +313,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "4.0.1-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.1-next-2024-11-27.tgz",
-      "integrity": "sha512-DzHOpyJ+FiXsjVfkAWtXXgijaG0IYm6KRBe7RE/G2k4GN8EnFv3IuaG3JthS78BsNxzSvd4zngNTbYykExuBdg==",
-      "license": "Apache-2.0",
+      "version": "4.0.2-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-10.tgz",
+      "integrity": "sha512-Fx2mQAhPdnUA9peL2xfYhugCwKg2nJe9cDUC26irR1BE0XffZeZVU/zqAphL4HlyxTCyvHiQSP4n2F4ZSHiDHA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -342,10 +340,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "6.0.0-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.0-next-2024-11-27.tgz",
-      "integrity": "sha512-zL/FTfdlrwnfGHtsl2vM0ND2YIvXhBjFHsSfZSm2isU2HHWz4KtgIgiS57M4tWiA0O55GRj8pncv+kSIScLl+g==",
-      "license": "Apache-2.0",
+      "version": "6.0.1-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.1-next-2024-12-10.tgz",
+      "integrity": "sha512-iPO5PaQj77LEJrp8rrgPVE9KQU3tcKKIYqTjunwFCfOYS7DC+CKIuA0R9xxurtPAy0Up92c6KP37hP591X5i+g==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -369,10 +366,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.6.3-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.3-next-2024-11-27.tgz",
-      "integrity": "sha512-gGt0pLM6SnaQtgFLvKzRqxj5kGe0jhjjwK3Z2ofJRiU3Ye1GPcUWp5jc3p4aa6Tf8tLFcq/3QTw34pt6v75Y5Q==",
-      "license": "Apache-2.0",
+      "version": "2.6.4-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.4-next-2024-12-10.tgz",
+      "integrity": "sha512-a9aVFEOA+IwKvmu0D022jZ6nEnO/xn61cN+eLGssiGhZ7ixPO5oWqW2gcH6IalDokN2RfzIvDK0ucT9mYUHqgw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -381,10 +377,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.6.3-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.3-next-2024-11-27.tgz",
-      "integrity": "sha512-G91pyMh9L4A2cglloHRX+Y8VH7yE/6tRs9aaQR/WhK6KXF9pddoIKeApApFu28iLgRWUeKahLAkMdwQZq5hvKw==",
-      "license": "Apache-2.0",
+      "version": "2.6.4-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.4-next-2024-12-10.tgz",
+      "integrity": "sha512-9we7lwJjho/lUk8eaibRuxW01RSDJXT6hz9ao7kuls6WEMypkkzN2GYp1jzk8e+4h4HzLKJ0XuFWKNVLtx08sA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -393,10 +388,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "8.0.0-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.0-next-2024-11-27.tgz",
-      "integrity": "sha512-Sco4URgQeQ4btjSLbtZyRhZo6AJki3TXCz0EQ2DR6fjIxVrbhP6YYyBrCw0Y09Wgm72E16ZAm+pzZoJPbUwjzQ==",
-      "license": "Apache-2.0",
+      "version": "8.0.1-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.1-next-2024-12-10.tgz",
+      "integrity": "sha512-7aMEWDJoppeYkSp3+Eq8SmOe6PTtmdI75OAnU9e2nAUrbAVVTKNY06oEf4e0mdQZQsY4okjrNq/W5UclWcUAnw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -418,10 +412,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.2.4-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.4-next-2024-11-27.tgz",
-      "integrity": "sha512-LBo1KAyJsLl9iliWAFmCfgyHWvpaALCaIQSed0DOV/y+/ubEk3RSU10uvDaCjrD1ulZbetrKfzdecU6LRyiSdg==",
-      "license": "Apache-2.0",
+      "version": "3.2.5-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.5-next-2024-12-10.tgz",
+      "integrity": "sha512-GsNHQ7nVDySR1bBdy6kTq0rwS0i4QltkCJQUh3Jpe51SQCzhyfazPXh2Q3reefc17TuGNrqyUADDsia91EkCrA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -434,10 +427,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.7.0-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.0-next-2024-11-27.tgz",
-      "integrity": "sha512-GECrtHGwSo9y1+x1WYkbzD9iIprVUqMpSxC5GxNchKoMa8mBovudML+KJNpgRsmwFN74TRcJvnak5ZiSv4z8fg==",
-      "license": "Apache-2.0",
+      "version": "2.7.1-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.1-next-2024-12-10.tgz",
+      "integrity": "sha512-j8YCW6DKm+vSdW0/uLWYv3Z4bi7egB/hHaq4ucdpv8aaKtRu7wpIziKnc75p+kSdDjrtdas0Z1BTfZKw05TR0g==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -2245,7 +2237,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
       "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2280,8 +2271,7 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
@@ -4969,7 +4959,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -6677,9 +6666,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "3.1.3-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.3-next-2024-11-27.tgz",
-      "integrity": "sha512-3ohNEDnwI/qA74G0p1/2gLLLewvmZX9bDM4O2SK0+CvN+fcTsKAnAGDnVPajNhcsKd+jmArL85oswLJodeCoyQ==",
+      "version": "3.1.4-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.4-next-2024-12-10.tgz",
+      "integrity": "sha512-zSv418sYALn8P+lNJ8WVc5auw9+bFPjPpyfGDG80SZpPfb9LaYfbTT9vXCNCTLPEYGI37RRKkkSdJFCEFDX9QA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -6687,9 +6676,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "4.0.1-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.1-next-2024-11-27.tgz",
-      "integrity": "sha512-DzHOpyJ+FiXsjVfkAWtXXgijaG0IYm6KRBe7RE/G2k4GN8EnFv3IuaG3JthS78BsNxzSvd4zngNTbYykExuBdg==",
+      "version": "4.0.2-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-10.tgz",
+      "integrity": "sha512-Fx2mQAhPdnUA9peL2xfYhugCwKg2nJe9cDUC26irR1BE0XffZeZVU/zqAphL4HlyxTCyvHiQSP4n2F4ZSHiDHA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -6704,9 +6693,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "6.0.0-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.0-next-2024-11-27.tgz",
-      "integrity": "sha512-zL/FTfdlrwnfGHtsl2vM0ND2YIvXhBjFHsSfZSm2isU2HHWz4KtgIgiS57M4tWiA0O55GRj8pncv+kSIScLl+g==",
+      "version": "6.0.1-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.1-next-2024-12-10.tgz",
+      "integrity": "sha512-iPO5PaQj77LEJrp8rrgPVE9KQU3tcKKIYqTjunwFCfOYS7DC+CKIuA0R9xxurtPAy0Up92c6KP37hP591X5i+g==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -6720,21 +6709,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.6.3-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.3-next-2024-11-27.tgz",
-      "integrity": "sha512-gGt0pLM6SnaQtgFLvKzRqxj5kGe0jhjjwK3Z2ofJRiU3Ye1GPcUWp5jc3p4aa6Tf8tLFcq/3QTw34pt6v75Y5Q==",
+      "version": "2.6.4-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.4-next-2024-12-10.tgz",
+      "integrity": "sha512-a9aVFEOA+IwKvmu0D022jZ6nEnO/xn61cN+eLGssiGhZ7ixPO5oWqW2gcH6IalDokN2RfzIvDK0ucT9mYUHqgw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.6.3-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.3-next-2024-11-27.tgz",
-      "integrity": "sha512-G91pyMh9L4A2cglloHRX+Y8VH7yE/6tRs9aaQR/WhK6KXF9pddoIKeApApFu28iLgRWUeKahLAkMdwQZq5hvKw==",
+      "version": "2.6.4-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.4-next-2024-12-10.tgz",
+      "integrity": "sha512-9we7lwJjho/lUk8eaibRuxW01RSDJXT6hz9ao7kuls6WEMypkkzN2GYp1jzk8e+4h4HzLKJ0XuFWKNVLtx08sA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "8.0.0-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.0-next-2024-11-27.tgz",
-      "integrity": "sha512-Sco4URgQeQ4btjSLbtZyRhZo6AJki3TXCz0EQ2DR6fjIxVrbhP6YYyBrCw0Y09Wgm72E16ZAm+pzZoJPbUwjzQ==",
+      "version": "8.0.1-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.1-next-2024-12-10.tgz",
+      "integrity": "sha512-7aMEWDJoppeYkSp3+Eq8SmOe6PTtmdI75OAnU9e2nAUrbAVVTKNY06oEf4e0mdQZQsY4okjrNq/W5UclWcUAnw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -6749,17 +6738,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.2.4-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.4-next-2024-11-27.tgz",
-      "integrity": "sha512-LBo1KAyJsLl9iliWAFmCfgyHWvpaALCaIQSed0DOV/y+/ubEk3RSU10uvDaCjrD1ulZbetrKfzdecU6LRyiSdg==",
+      "version": "3.2.5-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.5-next-2024-12-10.tgz",
+      "integrity": "sha512-GsNHQ7nVDySR1bBdy6kTq0rwS0i4QltkCJQUh3Jpe51SQCzhyfazPXh2Q3reefc17TuGNrqyUADDsia91EkCrA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.7.0-next-2024-11-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.0-next-2024-11-27.tgz",
-      "integrity": "sha512-GECrtHGwSo9y1+x1WYkbzD9iIprVUqMpSxC5GxNchKoMa8mBovudML+KJNpgRsmwFN74TRcJvnak5ZiSv4z8fg==",
+      "version": "2.7.1-next-2024-12-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.1-next-2024-12-10.tgz",
+      "integrity": "sha512-j8YCW6DKm+vSdW0/uLWYv3Z4bi7egB/hHaq4ucdpv8aaKtRu7wpIziKnc75p+kSdDjrtdas0Z1BTfZKw05TR0g==",
       "requires": {}
     },
     "@esbuild/aix-ppc64": {

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -29,7 +29,7 @@ export const mockFullNeuron: Neuron = {
   followees: [],
   visibility: undefined,
   votingPowerRefreshedTimestampSeconds: 0n,
-  potentialVotingPower: 0n, 
+  potentialVotingPower: 0n,
   decidingVotingPower: 0n,
 };
 

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -29,6 +29,8 @@ export const mockFullNeuron: Neuron = {
   followees: [],
   visibility: undefined,
   votingPowerRefreshedTimestampSeconds: 0n,
+  potentialVotingPower: 0n, 
+  decidingVotingPower: 0n,
 };
 
 export const createMockFullNeuron = (id: number | bigint) => {


### PR DESCRIPTION
# Motivation

We want to pull in the latest changes to make the reset following api accessible for the nns-dapp.
Related ic-js pr: https://github.com/dfinity/ic-js/pull/787

# Changes

- npm run upgrade:next.
- Add new fields to the mock - the reason why the CI action upgrade is failing.

# Tests

- Should pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.