### PR TITLE
NNS1-3485: disables showSaveFilePicker download method

### DIFF
--- a/frontend/src/lib/utils/export-to-csv.utils.ts
+++ b/frontend/src/lib/utils/export-to-csv.utils.ts
@@ -243,9 +243,12 @@ export const generateCsvFileToSave = async <T>({
       type: "text/csv;charset=utf-8;",
     });
 
+    // TODO: Investigate the random issues with showSaveFilePicker.
+    const isShowSaveFilePickerEnabled = false;
     if (
       "showSaveFilePicker" in window &&
-      typeof window.showSaveFilePicker === "function"
+      typeof window.showSaveFilePicker === "function" &&
+      isShowSaveFilePickerEnabled
     ) {
       await saveFileWithPicker({ blob, fileName, description });
     } else {

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -220,7 +220,8 @@ describe("Export to Csv", () => {
       vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    describe("Modern Browser (File System Access API)", () => {
+    // TODO: Investigate the random issues with showSaveFilePicker.
+    describe.skip("Modern Browser (File System Access API)", () => {
       let mockWritable;
       let mockHandle;
 

--- a/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/export-to-csv.utils.spec.ts
@@ -221,7 +221,7 @@ describe("Export to Csv", () => {
     });
 
     // TODO: Investigate the random issues with showSaveFilePicker.
-    describe.skip("Modern Browser (File System Access API)", () => {
+    describe("Modern Browser (File System Access API)", () => {
       let mockWritable;
       let mockHandle;
 
@@ -241,7 +241,22 @@ describe("Export to Csv", () => {
         );
       });
 
-      it("should use File System Access API when available", async () => {
+      it("should use Legacy Browser Link as feature is disabled", async () => {
+        URL.createObjectURL = vi.fn();
+        URL.revokeObjectURL = vi.fn();
+
+        await generateCsvFileToSave({
+          datasets: [],
+          headers: [],
+          fileName: "test",
+        });
+
+        expect(window.showSaveFilePicker).toHaveBeenCalledTimes(0);
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+      });
+
+      it.skip("should use File System Access API when available", async () => {
         await generateCsvFileToSave({
           datasets: [],
           headers: [],
@@ -263,7 +278,7 @@ describe("Export to Csv", () => {
         expect(mockWritable.close).toHaveBeenCalledTimes(1);
       });
 
-      it("should gracefully handle user cancellation of save dialog", async () => {
+      it.skip("should gracefully handle user cancellation of save dialog", async () => {
         const abortError = new Error("User cancelled");
         abortError.name = "AbortError";
 
@@ -277,7 +292,7 @@ describe("Export to Csv", () => {
         ).resolves.not.toThrow();
       });
 
-      it("should throw FileSystemAccessError when modern API fails", async () => {
+      it.skip("should throw FileSystemAccessError when modern API fails", async () => {
         vi.stubGlobal(
           "showSaveFilePicker",
           vi.fn().mockRejectedValue(new Error("API Error"))


### PR DESCRIPTION
# Motivation

The new `showSaveFilePicker` browser API allows users to define where the file will be saved and its name. Some manual tests are producing the error below, which requires further investigation. The feature will be disabled until the issues are resolved.

```
Error exporting neurons: FileSystemAccessError: Failed to save file using File System Access API
    at Uq (index.BHFanVrx.js:18:481)
    at async LS (index.BHFanVrx.js:21:354)
    at async HTMLButtonElement.D (index.BHFanVrx.js:21:23629)
Caused by: SecurityError: Failed to execute 'showSaveFilePicker' on 'Window': Must be handling a user gesture to show a file picker.
```
Disabling the feature until we are able to reproduce it locally.

# Changes

- Skips the `showSaveFilePicker` code path.

# Tests

- Skipped tests until we make use of it.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary