### PR TITLE
NNS1-3485: gets all neurons(non-empty and empty) in ReportingTransactionsButton 

### DIFF
--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -141,24 +141,13 @@
   };
 </script>
 
-<div class="wrapper">
-  <button
-    data-tid="reporting-transactions-button-component"
-    on:click={exportIcpTransactions}
-    class="primary with-icon"
-    disabled={loading}
-    aria-label={$i18n.reporting.transactions_download}
-  >
-    <IconDown />
-    {$i18n.reporting.transactions_download}
-  </button>
-</div>
-
-<style lang="scss">
-  .wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: var(--padding-2x);
-  }
-</style>
+<button
+  data-tid="reporting-transactions-button-component"
+  on:click={exportIcpTransactions}
+  class="primary with-icon"
+  disabled={loading}
+  aria-label={$i18n.reporting.transactions_download}
+>
+  <IconDown />
+  {$i18n.reporting.transactions_download}
+</button>

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { IconDown, Spinner, stopBusy } from "@dfinity/gix-components";
+  import { IconDown, Spinner } from "@dfinity/gix-components";
   import { ICPToken, isNullish, nonNullish } from "@dfinity/utils";
   import {
     buildTransactionsDatasets,

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { IconDown, Spinner } from "@dfinity/gix-components";
-  import { ICPToken, isNullish, nonNullish } from "@dfinity/utils";
+  import { ICPToken, nonNullish } from "@dfinity/utils";
   import {
     buildTransactionsDatasets,
     CsvGenerationError,
@@ -13,7 +13,6 @@
   import { toastsError } from "$lib/stores/toasts.store";
   import { formatDateCompact } from "$lib/utils/date.utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { getAccountTransactionsConcurrently } from "$lib/services/export-data.services";
   import { SignIdentity, type Identity } from "@dfinity/agent";
   import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
@@ -21,31 +20,34 @@
   import type { Account } from "$lib/types/account";
   import type { Readable } from "svelte/store";
   import type { NeuronInfo } from "@dfinity/nns";
+  import { queryNeurons } from "$lib/api/governance.api";
+  import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
+  import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 
-  export let nnsNeurons: NeuronInfo[] = [];
-
-  let isDisabled = true;
   let identity: Identity | null | undefined;
   let swapCanisterAccounts: Set<string>;
-  let neuronAccounts: Set<string>;
   let nnsAccounts: Account[];
   let swapCanisterAccountsStore: Readable<Set<string>>;
   let loading = false;
 
   $: identity = $authStore.identity;
-  $: neuronAccounts = new Set(
-    nnsNeurons
-      .filter((neuron) => nonNullish(neuron.fullNeuron?.accountIdentifier))
-      .map((neuron) => neuron.fullNeuron!.accountIdentifier)
-  );
   $: nnsAccounts = $nnsAccountsListStore;
-  $: isDisabled =
-    isNullish(identity) ||
-    (nnsAccounts.length === 0 && nnsNeurons.length === 0);
   $: swapCanisterAccountsStore = createSwapCanisterAccountsStore(
     identity?.getPrincipal()
   );
   $: swapCanisterAccounts = $swapCanisterAccountsStore ?? new Set();
+
+  const fetchAllNnsNeuronsAndSortThemByStake = async (
+    identity: Identity
+  ): Promise<NeuronInfo[]> => {
+    const data = await queryNeurons({
+      certified: true,
+      identity: identity,
+      includeEmptyNeurons: true,
+    });
+
+    return sortNeuronsByStake(data);
+  };
 
   const exportIcpTransactions = async () => {
     try {
@@ -53,6 +55,15 @@
 
       // we are logged in to be able to interact with the button
       const signIdentity = identity as SignIdentity;
+
+      const nnsNeurons =
+        await fetchAllNnsNeuronsAndSortThemByStake(signIdentity);
+      const neuronAccounts = new Set(
+        nnsNeurons
+          .filter((neuron) => nonNullish(neuron.fullNeuron?.accountIdentifier))
+          .map((neuron) => neuron.fullNeuron!.accountIdentifier)
+      );
+
       const entities = [...nnsAccounts, ...nnsNeurons];
       const transactions = await getAccountTransactionsConcurrently({
         entities,
@@ -135,7 +146,7 @@
     data-tid="reporting-transactions-button-component"
     on:click={exportIcpTransactions}
     class="primary with-icon"
-    disabled={isDisabled || loading}
+    disabled={loading}
     aria-label={$i18n.reporting.transactions_download}
   >
     <IconDown />

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { IconDown, Spinner } from "@dfinity/gix-components";
+  import { IconDown } from "@dfinity/gix-components";
   import { ICPToken, nonNullish } from "@dfinity/utils";
   import {
     buildTransactionsDatasets,
@@ -152,12 +152,6 @@
     <IconDown />
     {$i18n.reporting.transactions_download}
   </button>
-
-  {#if loading}
-    <div>
-      <Spinner inline size="tiny" />
-    </div>
-  {/if}
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -192,8 +192,9 @@
   "reporting": {
     "neurons_title": "Neurons Portfolio",
     "neurons_description": "Download a detailed CSV report of your neuron portfolio, which includes the stake, maturity, and neuron account ID for manual tracking and analysis.",
-    "transactions_title": "Transactions",
-    "transactions_description": "Download a detailed CSV report of your token transaction history. This report includes both regular token accounts and neurons, showing neuron staking and minting transactions for manual tracking and analysis."
+    "transactions_title": "ICP Transactions",
+    "transactions_description": "Download a detailed CSV report of your token transaction history, including both regular token accounts and neurons that will show neuron staking and minting transactions for manual tracking and analysis.",
+    "transactions_download": "Export Transactions"
   },
   "auth": {
     "login": "Sign in with Internet Identity",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -155,8 +155,7 @@
     "account_menu": "Open menu to access logout button",
     "main_icp_account_id": "Main ICP Account ID",
     "account_id_tooltip": "You can send ICP both to your principal ID and account ID, however some exchanges or wallets may not support transactions using a principal ID.",
-    "export_neurons": "Export Neurons Info",
-    "export_transactions": "Export Transactions"
+    "export_neurons": "Export Neurons Info"
   },
   "export_csv_neurons": {
     "account_id": "Account ID",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -190,6 +190,7 @@
     "neurons": "There was an error exporting the neurons. Please try again."
   },
   "reporting": {
+    "fetching_neurons_error": "There was an error fetching the neurons. Please try again.",
     "neurons_title": "Neurons Portfolio",
     "neurons_description": "Download a detailed CSV report of your neuron portfolio, which includes the stake, maturity, and neuron account ID for manual tracking and analysis.",
     "transactions_title": "Transactions",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -190,7 +190,6 @@
     "neurons": "There was an error exporting the neurons. Please try again."
   },
   "reporting": {
-    "fetching_neurons_error": "There was an error fetching the neurons. Please try again.",
     "neurons_title": "Neurons Portfolio",
     "neurons_description": "Download a detailed CSV report of your neuron portfolio, which includes the stake, maturity, and neuron account ID for manual tracking and analysis.",
     "transactions_title": "Transactions",

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -11,7 +11,7 @@
   import type { Identity } from "@dfinity/agent";
   import { Island } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { debounce } from "@dfinity/utils";
+  import { debounce, nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
 
   // Defer the title to avoid a visual glitch where the title moves from left to center in the header if navigation happens from Accounts page
@@ -26,17 +26,19 @@
   );
 
   let identity: Identity | null | undefined;
+  // TODO: It will be remove soon
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let neurons: NeuronInfo[] = [];
 
   $: identity = $authStore.identity;
 
-  const loadNeurons = async (id: typeof identity) => {
-    if (!id) return;
+  const loadNeurons = async (identity: Identity) => {
+    if (!identity) return;
 
     try {
       const data = await queryNeurons({
         certified: true,
-        identity: id,
+        identity: identity,
         includeEmptyNeurons: true,
       });
 
@@ -49,7 +51,7 @@
     }
   };
 
-  $: if (identity) {
+  $: if (nonNullish(identity)) {
     loadNeurons(identity);
   }
 </script>

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import ReportingNeuronsButton from "$lib/components/reporting/ReportingNeuronsButton.svelte";
+  import { queryNeurons } from "$lib/api/governance.api";
   import ReportingTransactionsButton from "$lib/components/reporting/ReportingTransactionsButton.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
+  import type { Identity } from "@dfinity/agent";
   import { Island } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
   import { debounce } from "@dfinity/utils";
   import { onMount } from "svelte";
 
@@ -18,6 +24,34 @@
       500
     )
   );
+
+  let identity: Identity | null | undefined;
+  let neurons: NeuronInfo[] = [];
+
+  $: identity = $authStore.identity;
+
+  const loadNeurons = async (id: typeof identity) => {
+    if (!id) return;
+
+    try {
+      const data = await queryNeurons({
+        certified: true,
+        identity: id,
+        includeEmptyNeurons: true,
+      });
+
+      neurons = sortNeuronsByStake(data);
+    } catch (err) {
+      console.error("Failed to load neurons:", err);
+      toastsError({
+        labelKey: "reporting.fetching_neurons_error",
+      });
+    }
+  };
+
+  $: if (identity) {
+    loadNeurons(identity);
+  }
 </script>
 
 <Island>

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
   import ReportingNeuronsButton from "$lib/components/reporting/ReportingNeuronsButton.svelte";
-  import { queryNeurons } from "$lib/api/governance.api";
   import ReportingTransactionsButton from "$lib/components/reporting/ReportingTransactionsButton.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
-  import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import { layoutTitleStore } from "$lib/stores/layout.store";
-  import { toastsError } from "$lib/stores/toasts.store";
-  import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
-  import type { Identity } from "@dfinity/agent";
   import { Island } from "@dfinity/gix-components";
-  import type { NeuronInfo } from "@dfinity/nns";
-  import { debounce, nonNullish } from "@dfinity/utils";
+  import { debounce } from "@dfinity/utils";
   import { onMount } from "svelte";
 
   // Defer the title to avoid a visual glitch where the title moves from left to center in the header if navigation happens from Accounts page
@@ -24,36 +18,6 @@
       500
     )
   );
-
-  let identity: Identity | null | undefined;
-  // TODO: It will be remove soon
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let neurons: NeuronInfo[] = [];
-
-  $: identity = $authStore.identity;
-
-  const loadNeurons = async (identity: Identity) => {
-    if (!identity) return;
-
-    try {
-      const data = await queryNeurons({
-        certified: true,
-        identity: identity,
-        includeEmptyNeurons: true,
-      });
-
-      neurons = sortNeuronsByStake(data);
-    } catch (err) {
-      console.error("Failed to load neurons:", err);
-      toastsError({
-        labelKey: "reporting.fetching_neurons_error",
-      });
-    }
-  };
-
-  $: if (nonNullish(identity)) {
-    loadNeurons(identity);
-  }
 </script>
 
 <Island>

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -31,7 +31,6 @@
     </div>
 
     <Separator spacing="medium" />
-
     <div class="wrapper">
       <div>
         <h3>{$i18n.reporting.transactions_title}</h3>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -204,6 +204,7 @@ interface I18nReporting {
   neurons_description: string;
   transactions_title: string;
   transactions_description: string;
+  transactions_download: string;
 }
 
 interface I18nAuth {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -163,7 +163,6 @@ interface I18nHeader {
   main_icp_account_id: string;
   account_id_tooltip: string;
   export_neurons: string;
-  export_transactions: string;
 }
 
 interface I18nExport_csv_neurons {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -200,6 +200,7 @@ interface I18nExport_error {
 }
 
 interface I18nReporting {
+  fetching_neurons_error: string;
   neurons_title: string;
   neurons_description: string;
   transactions_title: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -200,7 +200,6 @@ interface I18nExport_error {
 }
 
 interface I18nReporting {
-  fetching_neurons_error: string;
   neurons_title: string;
   neurons_description: string;
   transactions_title: string;

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -277,4 +277,14 @@ describe("ReportingTransactionsButton", () => {
     });
     expect(spyToastError).toBeCalledTimes(1);
   });
+
+  it("should disable the button while exporting", async () => {
+    const po = renderComponent();
+
+    expect(await po.isDisabled()).toBe(false);
+
+    await po.click();
+
+    expect(await po.isDisabled()).toBe(true);
+  });
 });

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -1,4 +1,4 @@
-import * as gobernanceApi from "$lib/api/governance.api";
+import * as governanceApi from "$lib/api/governance.api";
 import * as icpIndexApi from "$lib/api/icp-index.api";
 import ReportingTransactionsButton from "$lib/components/reporting/ReportingTransactionsButton.svelte";
 import * as exportDataService from "$lib/services/export-data.services";
@@ -40,7 +40,7 @@ describe("ReportingTransactionsButton", () => {
       .mockImplementation(() => Promise.resolve());
     spyToastError = vi.spyOn(toastsStore, "toastsError");
     spyQueryNeurons = vi
-      .spyOn(gobernanceApi, "queryNeurons")
+      .spyOn(governanceApi, "queryNeurons")
       .mockResolvedValue([]);
     spyExportDataService = vi.spyOn(
       exportDataService,
@@ -173,11 +173,13 @@ describe("ReportingTransactionsButton", () => {
     const po = renderComponent();
 
     expect(spyExportDataService).toBeCalledTimes(0);
+    expect(spyQueryNeurons).toBeCalledTimes(0);
 
     await po.click();
     await runResolvedPromises();
 
     const expectation = [mockMainAccount, mockNeuron];
+    expect(spyQueryNeurons).toBeCalledTimes(1);
     expect(spyExportDataService).toHaveBeenCalledTimes(1);
     expect(spyExportDataService).toHaveBeenCalledWith({
       entities: expectation,
@@ -286,5 +288,9 @@ describe("ReportingTransactionsButton", () => {
     await po.click();
 
     expect(await po.isDisabled()).toBe(true);
+
+    await runResolvedPromises();
+
+    expect(await po.isDisabled()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -16,7 +16,7 @@ import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/api/icp-ledger.api");
 
-describe("ExportIcpTransactionsButton", () => {
+describe("ReportingTransactionsButton", () => {
   let spyGenerateCsvFileToSave;
   let spyToastError;
 
@@ -72,7 +72,7 @@ describe("ExportIcpTransactionsButton", () => {
     expect(await po.isDisabled()).toBe(true);
   });
 
-  it("should be disabled when there is no accounts nor neurons", async () => {
+  it("should be disabled when there are no accounts nor neurons", async () => {
     resetAccountsForTesting();
     const po = renderComponent();
     expect(await po.isDisabled()).toBe(true);

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -154,17 +154,6 @@ describe("ReportingTransactionsButton", () => {
     expect(spyGenerateCsvFileToSave).toBeCalledTimes(1);
   });
 
-  it("should dispatch nnsExportIcpTransactionsCsvTriggered event after click to close the menu", async () => {
-    const onTrigger = vi.fn();
-    const po = renderComponent({ onTrigger });
-
-    expect(onTrigger).toHaveBeenCalledTimes(0);
-
-    await po.click();
-    await runResolvedPromises();
-    expect(onTrigger).toHaveBeenCalledTimes(1);
-  });
-
   it("should show error toast when file system access fails", async () => {
     vi.spyOn(exportToCsv, "generateCsvFileToSave").mockRejectedValueOnce(
       new exportToCsv.FileSystemAccessError("File system access denied")

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -1,13 +1,10 @@
+import * as gobernanceApi from "$lib/api/governance.api";
 import * as icpIndexApi from "$lib/api/icp-index.api";
 import ReportingTransactionsButton from "$lib/components/reporting/ReportingTransactionsButton.svelte";
 import * as exportDataService from "$lib/services/export-data.services";
 import * as toastsStore from "$lib/stores/toasts.store";
 import * as exportToCsv from "$lib/utils/export-to-csv.utils";
-import {
-  mockIdentity,
-  resetIdentity,
-  setNoIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountsStoreData,
   mockMainAccount,
@@ -30,21 +27,31 @@ vi.mock("$lib/api/governance.api");
 describe("ReportingTransactionsButton", () => {
   let spyGenerateCsvFileToSave;
   let spyToastError;
+  let spyQueryNeurons;
+  let spyExportDataService;
 
   beforeEach(() => {
     vi.clearAllTimers();
+    resetIdentity();
+    resetAccountsForTesting();
 
     spyGenerateCsvFileToSave = vi
       .spyOn(exportToCsv, "generateCsvFileToSave")
       .mockImplementation(() => Promise.resolve());
     spyToastError = vi.spyOn(toastsStore, "toastsError");
+    spyQueryNeurons = vi
+      .spyOn(gobernanceApi, "queryNeurons")
+      .mockResolvedValue([]);
+    spyExportDataService = vi.spyOn(
+      exportDataService,
+      "getAccountTransactionsConcurrently"
+    );
+
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     const mockDate = new Date("2023-10-14T00:00:00Z");
     vi.useFakeTimers();
     vi.setSystemTime(mockDate);
-
-    resetIdentity();
 
     setAccountsForTesting({
       ...mockAccountsStoreData,
@@ -64,14 +71,8 @@ describe("ReportingTransactionsButton", () => {
     });
   });
 
-  const renderComponent = ({
-    onTrigger,
-    nnsNeurons,
-  }: { onTrigger?: () => void; nnsNeurons?: NeuronInfo[] } = {}) => {
-    const { container, component } = render(ReportingTransactionsButton, {
-      nnsNeurons: nnsNeurons ?? [],
-    });
-
+  const renderComponent = ({ onTrigger }: { onTrigger?: () => void } = {}) => {
+    const { container, component } = render(ReportingTransactionsButton);
     const po = ReportingTransactionsButtonPo.under({
       element: new JestPageObjectElement(container),
     });
@@ -81,18 +82,6 @@ describe("ReportingTransactionsButton", () => {
     }
     return po;
   };
-
-  it("should be disabled when there is no identity", async () => {
-    setNoIdentity();
-    const po = renderComponent();
-    expect(await po.isDisabled()).toBe(true);
-  });
-
-  it("should be disabled when there are no accounts nor neurons", async () => {
-    resetAccountsForTesting();
-    const po = renderComponent();
-    expect(await po.isDisabled()).toBe(true);
-  });
 
   it("should name the file with the date of the export", async () => {
     const po = renderComponent();
@@ -116,6 +105,7 @@ describe("ReportingTransactionsButton", () => {
     const po = renderComponent();
 
     expect(spyGenerateCsvFileToSave).toBeCalledTimes(0);
+
     await po.click();
     await runResolvedPromises();
 
@@ -171,10 +161,6 @@ describe("ReportingTransactionsButton", () => {
   });
 
   it("should fetch transactions for accounts and neurons", async () => {
-    const spy = vi.spyOn(
-      exportDataService,
-      "getAccountTransactionsConcurrently"
-    );
     resetAccountsForTesting();
 
     setAccountsForTesting({
@@ -182,16 +168,58 @@ describe("ReportingTransactionsButton", () => {
     });
 
     const mockNeurons: NeuronInfo[] = [mockNeuron];
-    const po = renderComponent({ nnsNeurons: mockNeurons });
+    spyQueryNeurons.mockResolvedValue(mockNeurons);
 
-    expect(spy).toBeCalledTimes(0);
+    const po = renderComponent();
+
+    expect(spyExportDataService).toBeCalledTimes(0);
 
     await po.click();
     await runResolvedPromises();
 
     const expectation = [mockMainAccount, mockNeuron];
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({
+    expect(spyExportDataService).toHaveBeenCalledTimes(1);
+    expect(spyExportDataService).toHaveBeenCalledWith({
+      entities: expectation,
+      identity: mockIdentity,
+    });
+  });
+
+  it("should sort neurons by stake before fetching their transactions", async () => {
+    resetAccountsForTesting();
+
+    const mockLowMaturityNeuron: NeuronInfo = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        cachedNeuronStake: 1n,
+      },
+    };
+
+    const mockHighMaturityNeuron: NeuronInfo = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        cachedNeuronStake: 100n,
+      },
+    };
+
+    const mockNeurons: NeuronInfo[] = [
+      mockLowMaturityNeuron,
+      mockHighMaturityNeuron,
+    ];
+    spyQueryNeurons.mockResolvedValue(mockNeurons);
+
+    const po = renderComponent();
+
+    expect(spyExportDataService).toBeCalledTimes(0);
+
+    await po.click();
+    await runResolvedPromises();
+
+    const expectation = [mockHighMaturityNeuron, mockLowMaturityNeuron];
+    expect(spyExportDataService).toHaveBeenCalledTimes(1);
+    expect(spyExportDataService).toHaveBeenCalledWith({
       entities: expectation,
       identity: mockIdentity,
     });

--- a/frontend/src/tests/lib/routes/Reporting.spec.ts
+++ b/frontend/src/tests/lib/routes/Reporting.spec.ts
@@ -1,15 +1,32 @@
+import * as gobernanceApi from "$lib/api/governance.api";
 import ReportingPage from "$lib/routes/Reporting.svelte";
 import { layoutTitleStore } from "$lib/stores/layout.store";
+import * as toastsStore from "$lib/stores/toasts.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ReportingPagePo } from "$tests/page-objects/ReportingPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
+vi.mock("$lib/api/governance.api");
+
 describe("Reporting", () => {
+  const mockNeurons = [mockNeuron];
+  let spyQueryNeurons;
+  let spyToastError;
+
   beforeEach(() => {
     resetIdentity();
+
+    spyToastError = vi.spyOn(toastsStore, "toastsError");
+    spyQueryNeurons = vi
+      .spyOn(gobernanceApi, "queryNeurons")
+      .mockResolvedValue(mockNeurons);
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   const renderComponent = () => {
@@ -29,5 +46,24 @@ describe("Reporting", () => {
       expect(get(layoutTitleStore)).toEqual({
         title: en.navigation.reporting,
       }));
+  });
+
+  it("should reload neurons when identity changes", async () => {
+    // Wait for initial load
+    renderComponent();
+    await runResolvedPromises();
+
+    expect(spyQueryNeurons).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show a toast error if queryNeurons fails", async () => {
+    spyQueryNeurons.mockRejectedValueOnce(new Error("Error"));
+
+    // Wait for initial load
+    renderComponent();
+    await runResolvedPromises();
+
+    expect(spyQueryNeurons).toHaveBeenCalledTimes(1);
+    expect(spyToastError).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/tests/lib/routes/Reporting.spec.ts
+++ b/frontend/src/tests/lib/routes/Reporting.spec.ts
@@ -7,8 +7,6 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/api/governance.api");
-
 describe("Reporting", () => {
   beforeEach(() => {
     resetIdentity();

--- a/frontend/src/tests/lib/routes/Reporting.spec.ts
+++ b/frontend/src/tests/lib/routes/Reporting.spec.ts
@@ -1,32 +1,17 @@
-import * as gobernanceApi from "$lib/api/governance.api";
 import ReportingPage from "$lib/routes/Reporting.svelte";
 import { layoutTitleStore } from "$lib/stores/layout.store";
-import * as toastsStore from "$lib/stores/toasts.store";
-import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ReportingPagePo } from "$tests/page-objects/ReportingPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/governance.api");
 
 describe("Reporting", () => {
-  const mockNeurons = [mockNeuron];
-  let spyQueryNeurons;
-  let spyToastError;
-
   beforeEach(() => {
     resetIdentity();
-
-    spyToastError = vi.spyOn(toastsStore, "toastsError");
-    spyQueryNeurons = vi
-      .spyOn(gobernanceApi, "queryNeurons")
-      .mockResolvedValue(mockNeurons);
-
-    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   const renderComponent = () => {
@@ -46,34 +31,5 @@ describe("Reporting", () => {
       expect(get(layoutTitleStore)).toEqual({
         title: en.navigation.reporting,
       }));
-  });
-
-  it("should not call queryNeurons if there is no identity", async () => {
-    setNoIdentity();
-    // Wait for initial load
-    renderComponent();
-    await runResolvedPromises();
-
-    expect(spyQueryNeurons).toHaveBeenCalledTimes(0);
-  });
-
-  it("should call queryNeurons if there is an identity", async () => {
-    // Wait for initial load
-    renderComponent();
-    await runResolvedPromises();
-
-    expect(spyQueryNeurons).toHaveBeenCalledTimes(1);
-    expect(spyToastError).toHaveBeenCalledTimes(0);
-  });
-
-  it("should show a toast error if queryNeurons fails", async () => {
-    spyQueryNeurons.mockRejectedValueOnce(new Error("Error"));
-
-    // Wait for initial load
-    renderComponent();
-    await runResolvedPromises();
-
-    expect(spyQueryNeurons).toHaveBeenCalledTimes(1);
-    expect(spyToastError).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/tests/lib/routes/Reporting.spec.ts
+++ b/frontend/src/tests/lib/routes/Reporting.spec.ts
@@ -2,7 +2,7 @@ import * as gobernanceApi from "$lib/api/governance.api";
 import ReportingPage from "$lib/routes/Reporting.svelte";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import * as toastsStore from "$lib/stores/toasts.store";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ReportingPagePo } from "$tests/page-objects/ReportingPage.page-object";
@@ -48,12 +48,22 @@ describe("Reporting", () => {
       }));
   });
 
-  it("should reload neurons when identity changes", async () => {
+  it("should not call queryNeurons if there is no identity", async () => {
+    setNoIdentity();
+    // Wait for initial load
+    renderComponent();
+    await runResolvedPromises();
+
+    expect(spyQueryNeurons).toHaveBeenCalledTimes(0);
+  });
+
+  it("should call queryNeurons if there is an identity", async () => {
     // Wait for initial load
     renderComponent();
     await runResolvedPromises();
 
     expect(spyQueryNeurons).toHaveBeenCalledTimes(1);
+    expect(spyToastError).toHaveBeenCalledTimes(0);
   });
 
   it("should show a toast error if queryNeurons fails", async () => {

--- a/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
@@ -2,7 +2,7 @@ import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ReportingTransactionsButtonPo extends ButtonPo {
-  static readonly TID = "export-icp-transactions-button-component";
+  static readonly TID = "reporting-transactions-button-component";
 
   static under({
     element,

--- a/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
@@ -9,9 +9,8 @@ export class ReportingTransactionsButtonPo extends ButtonPo {
   }: {
     element: PageObjectElement;
   }): ReportingTransactionsButtonPo {
-    return ButtonPo.under({
-      element,
-      testId: ReportingTransactionsButtonPo.TID,
-    });
+    return new ReportingTransactionsButtonPo(
+      element.byTestId(ReportingTransactionsButtonPo.TID)
+    );
   }
 }


### PR DESCRIPTION
# Motivation

We want to use all neurons not only the non-empty ones thus we need to fetch them directly from the governance canister.

It can be checked [here](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/tokens/)

# Changes

- Fetch all neurons from the governance canister and sort by stake
- Disable button while async work is happening
- Styled the button

# Tests

- Unit test to ensure that transactions for neurons are fetched when provided
- Unit test to check that neurons are sorted by stake
- Unit test to check that the button is disable while async operations

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.