### PR TITLE
Move losing rewards labels

### DIFF
--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -29,7 +29,7 @@
             i18n: $i18n.time,
           }),
         });
-  const text = replacePlaceholders($i18n.losing_rewards_banner.description, {
+  const text = replacePlaceholders($i18n.losing_rewards.description, {
     // TODO(mstr): Rename to secondsToRoundedDuration
     $period: secondsToDissolveDelayDuration(
       BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS)
@@ -50,7 +50,7 @@
           data-tid="confirm-button"
           class="danger"
           on:click={() => (isModalVisible = true)}
-          >{$i18n.losing_rewards_banner.confirm}</button
+          >{$i18n.losing_rewards.confirm}</button
         >
       </div>
     </Banner>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -386,18 +386,18 @@
     "create_as_public_tooltip": "Public neurons reveal more information about themselves including how they vote on proposals.",
     "create_as_public_neuron_failure": "Making your neuron public has failed, so it was created as a private neuron. You can change neuron visibility at any time under \"Advanced Details & Settings\""
   },
-  "losing_rewards_banner": {
-    "days_left_title": "$timeLeft left to confirm your neuron following",
-    "rewards_missing_title": "One or more of your neurons are missing voting rewards",
+  "losing_rewards": {
     "description": "ICP neurons that are inactive for $period start losing voting rewards. In order to avoid losing rewards, vote manually, edit or confirm your following.",
     "confirm": "Confirm Following"
+  },
+  "losing_rewards_banner": {
+    "days_left_title": "$timeLeft left to confirm your neuron following",
+    "rewards_missing_title": "One or more of your neurons are missing voting rewards"
   },
   "losing_rewards_modal": {
     "goto_neuron": "Go to neuron details",
     "title": "Review your following for neurons",
-    "description": "ICP neurons that are inactive for $period start losing voting rewards. In order to avoid losing rewards, vote manually, edit or confirm your following.",
     "label": "Neurons",
-    "confirm": "Confirm Following",
     "no_following": "This neuron has no following configured."
   },
   "new_followee": {

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -41,7 +41,7 @@
 
   <div class="wrapper">
     <p class="description">
-      {replacePlaceholders($i18n.losing_rewards_modal.description, {
+      {replacePlaceholders($i18n.losing_rewards.description, {
         $period: secondsToDissolveDelayDuration(
           BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS)
         ),
@@ -64,7 +64,7 @@
         >{$i18n.core.cancel}</button
       >
       <button on:click={confirm} class="primary" data-tid="confirm-button"
-        >{$i18n.losing_rewards_modal.confirm}</button
+        >{$i18n.losing_rewards.confirm}</button
       >
     </div>
   </div>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -402,19 +402,20 @@ interface I18nNeurons {
   create_as_public_neuron_failure: string;
 }
 
+interface I18nLosing_rewards {
+  description: string;
+  confirm: string;
+}
+
 interface I18nLosing_rewards_banner {
   days_left_title: string;
   rewards_missing_title: string;
-  description: string;
-  confirm: string;
 }
 
 interface I18nLosing_rewards_modal {
   goto_neuron: string;
   title: string;
-  description: string;
   label: string;
-  confirm: string;
   no_following: string;
 }
 
@@ -1485,6 +1486,7 @@ interface I18n {
   neuron_types: I18nNeuron_types;
   staking: I18nStaking;
   neurons: I18nNeurons;
+  losing_rewards: I18nLosing_rewards;
   losing_rewards_banner: I18nLosing_rewards_banner;
   losing_rewards_modal: I18nLosing_rewards_modal;
   new_followee: I18nNew_followee;


### PR DESCRIPTION
# Motivation

There are a couple of texts that are supposed to be the same across multiple elements. To avoid duplication, we moved these labels to a single place.

# Changes

- Move description and confirm labels.

# Tests

- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.