### PR TITLE
Fix whitespace caused by prettier

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,5 +1,13 @@
 {
   "plugins": ["prettier-plugin-svelte", "prettier-plugin-organize-imports"],
-  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }],
+  "overrides": [
+    {
+      "files": "*.svelte",
+      "options": {
+        "parser": "svelte",
+        "htmlWhitespaceSensitivity": "strict"
+      }
+    }
+  ],
   "trailingComma": "es5"
 }

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -94,7 +94,6 @@
     use:onIntersection
   >
     <HeadingSubtitle testId="wallet-page-heading-subtitle">
-      <!-- prettier-ignore -->
       <div class="subtitle">
         {#if $ENABLE_USD_VALUES}
           <div class="usd-balance" class:icp-swap-has-error={icpSwapHasError}>

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -84,8 +84,7 @@
         {:else}
           <div class="mobile-only">
             1 {$i18n.core.icp} = ${icpPriceFormatted}
-          </div>
-          <div>
+          </div><div>
             {$i18n.accounts.token_price_source}
           </div>
         {/if}


### PR DESCRIPTION
# Motivation

For the second time in 2 days I ran into issues with whitespace caused by `prettier` reformatting.
Yesterday I had to add `prettier-ignore` in https://github.com/dfinity/nns-dapp/pull/5974 to avoid test breakage.
Today I need to fix a tooltip padding issue caused by whitespace introduced by `prettier`.

Bad:
<img width="276" alt="image" src="https://github.com/user-attachments/assets/78432a9c-445a-4789-a05c-eb2380d7a6e1">

Good:
<img width="272" alt="image" src="https://github.com/user-attachments/assets/d2de4ace-e536-40ca-9d16-3302ecb7eee1">

Instead of keep adding `prettier-ignore` I decided to change the `prettier` configuration to be strict about whitespace in HTML.

# Changes

1. Set `"htmlWhitespaceSensitivity": "strict"` in `frontend/.prettierrc`.
2. Remove `<!-- prettier-ignore -->` added in https://github.com/dfinity/nns-dapp/pull/5974
3. Remove whitespace that caused bad tooltip padding.

# Tests

1. Ran `npm run format` manually. Also changed some incorrect indentation to check that that is still formatted nicely.
2. Checked manually that the tooltip looks better.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary