### PR TITLE
Refresh voting power service

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -130,7 +130,7 @@
     "qrcode_token_incompatible": "The payment token you are attempting to use is not compatible with this transaction.",
     "invalid_ledger_index_pair": "The provided index canister ID does not match the associated ledger canister ID.",
     "index_canister_validation": "An error occurred while validating the index canister ID. It appears that $indexCanister might not be a valid index canister ID.",
-    "refresh_voting_power": "An error occurred while confirming the following."
+    "refresh_voting_power": "An error occurred while confirming following."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -129,7 +129,8 @@
     "qrcode_camera_error": "An error occurred while initializing the camera to read the QR code.",
     "qrcode_token_incompatible": "The payment token you are attempting to use is not compatible with this transaction.",
     "invalid_ledger_index_pair": "The provided index canister ID does not match the associated ledger canister ID.",
-    "index_canister_validation": "An error occurred while validating the index canister ID. It appears that $indexCanister might not be a valid index canister ID."
+    "index_canister_validation": "An error occurred while validating the index canister ID. It appears that $indexCanister might not be a valid index canister ID.",
+    "refresh_voting_power": "An error occurred while confirming the following."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -134,6 +134,7 @@ interface I18nError {
   qrcode_token_incompatible: string;
   invalid_ledger_index_pair: string;
   index_canister_validation: string;
+  refresh_voting_power: string;
 }
 
 interface I18nWarning {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -880,6 +880,28 @@ describe("neurons-services", () => {
       expect(spyQueryNeurons).toBeCalledTimes(2);
     });
 
+    it("should skip reloading the neurons when all of them fail.", async () => {
+      const neurons = [neuron1, neuron2];
+      neuronsStore.pushNeurons({ neurons, certified: true });
+
+      // All neurons fail
+      const spyRefreshVotingPower = vi
+        .spyOn(api, "refreshVotingPower")
+        .mockRejectedValue(undefined);
+      // ignore console errors
+      vi.spyOn(console, "error").mockReturnValue();
+      const spyQueryNeurons = vi
+        .spyOn(api, "queryNeurons")
+        .mockResolvedValue(neurons);
+
+      await services.refreshVotingPowerForNeurons({
+        neuronIds: [neuron1.neuronId, neuron2.neuronId],
+      });
+
+      expect(spyRefreshVotingPower).toBeCalledTimes(2);
+      expect(spyQueryNeurons).toBeCalledTimes(0);
+    });
+
     it("should handle errors", async () => {
       const testError = new Error("Test error");
       const neurons = [neuron1, neuron2];


### PR DESCRIPTION
# Motivation

In case there are inactive neurons, the user should be able to reset their voting-power-refreshed timestamp. In this PR, we add the service that performs this action.

# Changes

- Added `refreshVotingPowerForNeurons` service.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.