### PR TITLE
NNS1-3485: fixes translations for the operations mint and burn

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -538,8 +538,8 @@
   "transaction_names": {
     "receive": "Received",
     "send": "Sent",
-    "mint": "Received",
-    "burn": "Sent",
+    "mint": "Mint",
+    "burn": "Burn",
     "stakeNeuron": "Staked",
     "stakeNeuronNotification": "Stake Neuron (Part 2 of 2)",
     "topUpNeuron": "Top-up Neuron",

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -673,7 +673,7 @@ describe("icp-transactions.utils", () => {
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
-        headline: "Sent",
+        headline: "Burn",
         tokenAmount: TokenAmountV2.fromUlps({
           amount,
           token: ICPToken,
@@ -704,7 +704,7 @@ describe("icp-transactions.utils", () => {
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
-        headline: "Received",
+        headline: "Mint",
         isIncoming: true,
         tokenAmount: TokenAmountV2.fromUlps({
           amount,

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -372,7 +372,7 @@ describe("icrc-transaction utils", () => {
       });
       expect(data).toEqual({
         domKey: "1234-1",
-        headline: "Sent",
+        headline: "Burn",
         isIncoming: false,
         isPending: false,
         otherParty: undefined,


### PR DESCRIPTION
# Motivation

Translations for the operations `Mint` and `Burn` were incorrectly labeled as `Receive` and `Send`. They have been changed to `Mint` and `Burn`.

# Changes

- Changes translations

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
