### PR TITLE
FOLLOW-244: Remove MultiPartTransactionToBeProcessed::TopUpCanisterV2

### DIFF
--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -1,5 +1,5 @@
 use candid::CandidType;
-use ic_base_types::{CanisterId, PrincipalId};
+use ic_base_types::PrincipalId;
 use icp_ledger::BlockIndex;
 use serde::Deserialize;
 use std::collections::VecDeque;
@@ -12,10 +12,6 @@ pub struct MultiPartTransactionsProcessor {
 #[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub enum MultiPartTransactionToBeProcessed {
     CreateCanisterV2(PrincipalId),
-    // TODO: Remove TopUpCanisterV2 after a version has been released that does
-    //       not add TopUpCanisterV2 to the multi-part transaction queue
-    //       anymore.
-    TopUpCanisterV2(PrincipalId, CanisterId),
 }
 
 impl MultiPartTransactionsProcessor {

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -51,9 +51,8 @@ mod tests {
         for i in 0..10 {
             let (block_height, to_be_processed) = processor.take_next().unwrap();
             assert_eq!(block_height, i);
-            if let MultiPartTransactionToBeProcessed::CreateCanisterV2(p) = to_be_processed {
-                assert_eq!(p, principal);
-            }
+            let MultiPartTransactionToBeProcessed::CreateCanisterV2(p) = to_be_processed;
+            assert_eq!(p, principal);
         }
 
         assert!(processor.take_next().is_none());

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -19,10 +19,6 @@ pub async fn run_periodic_tasks() {
             MultiPartTransactionToBeProcessed::CreateCanisterV2(controller) => {
                 handle_create_canister_v2(block_height, controller).await;
             }
-            // TODO: Remove TopUpCanisterV2 after a version has been released
-            //       that does not add TopUpCanisterV2 to the multi-part
-            //       transaction queue anymore.
-            MultiPartTransactionToBeProcessed::TopUpCanisterV2(_principal, _canister_id) => {}
         }
     }
 }


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/5862 removed the canister top-up functionality from the backend canister.
It left some TODOs to do after the next release.
There has now been a release so we can remove `MultiPartTransactionToBeProcessed::TopUpCanisterV2` now.

# Changes

Remove `MultiPartTransactionToBeProcessed::TopUpCanisterV2`.

# Tests

CI passes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary