### PR TITLE
feat: filters icp ledger transactions based on range if provided

### DIFF
--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -147,10 +147,7 @@ export const getAllTransactionsFromAccountAndIdentity = async ({
     const to = range?.to;
     if (nonNullish(to) && nonNullish(oldestTransactionInPageTimestamp)) {
       if (oldestTransactionInPageTimestamp < to) {
-        return filterTransactionsByRange(
-          [...allTransactions, ...transactions],
-          range
-        );
+        return filterTransactionsByRange(updatedTransactions, range);
       }
     }
 

--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -144,9 +144,9 @@ export const getAllTransactionsFromAccountAndIdentity = async ({
     const oldestTransactionInPageTimestamp = getTimestampFromTransaction(
       transactions[transactions.length - 1]
     );
-    const to = range?.to;
-    if (nonNullish(to) && nonNullish(oldestTransactionInPageTimestamp)) {
-      if (oldestTransactionInPageTimestamp < to) {
+    const from = range?.from;
+    if (nonNullish(from) && nonNullish(oldestTransactionInPageTimestamp)) {
+      if (oldestTransactionInPageTimestamp < from) {
         return filterTransactionsByRange(updatedTransactions, range);
       }
     }
@@ -186,12 +186,12 @@ const filterTransactionsByRange = (
     if (isNullish(timestamp)) return false;
 
     const from = range.from;
-    if (nonNullish(from) && timestamp > from) {
+    if (nonNullish(from) && timestamp < from) {
       return false;
     }
 
     const to = range.to;
-    if (nonNullish(to) && timestamp < to) {
+    if (nonNullish(to) && timestamp > to) {
       return false;
     }
 

--- a/frontend/src/tests/lib/services/reporting.services.spec.ts
+++ b/frontend/src/tests/lib/services/reporting.services.spec.ts
@@ -116,15 +116,15 @@ describe("reporting service", () => {
     });
 
     it("should handle errors and return accumulated transactions", async () => {
-      const allTransactions = [
-        createTransactionWithId({ id: 1n }),
+      const firstBatch = [
+        createTransactionWithId({ id: 3n }),
         createTransactionWithId({ id: 2n }),
       ];
 
       spyGetTransactions
         .mockResolvedValueOnce({
-          transactions: allTransactions,
-          oldestTxId: 2000n,
+          transactions: firstBatch,
+          oldestTxId: 1n,
         })
         .mockRejectedValueOnce(new Error("API Error"));
 
@@ -133,7 +133,7 @@ describe("reporting service", () => {
         identity: mockSignInIdentity,
       });
 
-      expect(result).toEqual(allTransactions);
+      expect(result).toEqual(firstBatch);
       expect(spyGetTransactions).toHaveBeenCalledTimes(2);
     });
 
@@ -167,7 +167,7 @@ describe("reporting service", () => {
       });
 
       expect(result).toHaveLength(2);
-      expect(result).toEqual(allTransactions.slice(1, 3));
+      expect(result).toEqual(allTransactions.slice(1));
       expect(spyGetTransactions).toHaveBeenCalledTimes(1);
     });
 
@@ -209,15 +209,15 @@ describe("reporting service", () => {
       const allTransactions = [
         createTransactionWithId({
           id: 3n,
-          timestamp: new Date("2023-01-01T00:00:00.000Z"),
+          timestamp: new Date("2023-01-02T00:00:00.000Z"),
         }),
         createTransactionWithId({
           id: 2n,
-          timestamp: new Date("2022-12-31T00:00:00.000Z"),
+          timestamp: new Date("2022-12-30T00:00:00.000Z"),
         }),
         createTransactionWithId({
           id: 1n,
-          timestamp: new Date("2023-01-02T00:00:00.000Z"),
+          timestamp: new Date("2022-12-29T00:00:00.000Z"),
         }),
       ];
 
@@ -230,8 +230,8 @@ describe("reporting service", () => {
         accountId: mockAccountId,
         identity: mockSignInIdentity,
         range: {
-          from: dateToNanoSeconds(new Date("2022-12-31T10:00:00.000Z")),
-          to: dateToNanoSeconds(new Date("2022-12-31T23:00:00.000Z")),
+          from: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
+          to: dateToNanoSeconds(new Date("2022-12-31T00:00:00.000Z")),
         },
       });
 
@@ -242,7 +242,7 @@ describe("reporting service", () => {
     it('should return early if the last transaction is in the current page is older than "to" date', async () => {
       const allTransactions = [
         createTransactionWithId({
-          id: 1n,
+          id: 3n,
           timestamp: new Date("2023-01-02T00:00:00.000Z"),
         }),
         createTransactionWithId({
@@ -250,12 +250,12 @@ describe("reporting service", () => {
           timestamp: new Date("2022-12-31T00:00:00.000Z"),
         }),
         createTransactionWithId({
-          id: 3n,
+          id: 1n,
           timestamp: new Date("2022-12-30T00:00:00.000Z"),
         }),
       ];
       const firstBatchOfMockTransactions = allTransactions.slice(0, 2);
-      const secondBatchOfMockTransactions = allTransactions.slice(3);
+      const secondBatchOfMockTransactions = allTransactions.slice(2);
 
       spyGetTransactions
         .mockResolvedValueOnce({
@@ -276,7 +276,7 @@ describe("reporting service", () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result).toEqual([firstBatchOfMockTransactions[0]]);
+      expect(result).toEqual(allTransactions.slice(0, 1));
       expect(spyGetTransactions).toHaveBeenCalledTimes(1);
     });
 

--- a/frontend/src/tests/lib/services/reporting.services.spec.ts
+++ b/frontend/src/tests/lib/services/reporting.services.spec.ts
@@ -137,40 +137,6 @@ describe("reporting service", () => {
       expect(spyGetTransactions).toHaveBeenCalledTimes(2);
     });
 
-    it('should filter "from" the provided date', async () => {
-      const allTransactions = [
-        createTransactionWithId({
-          id: 3n,
-          timestamp: new Date("2023-01-02T00:00:00.000Z"),
-        }),
-        createTransactionWithId({
-          id: 2n,
-          timestamp: new Date("2023-01-01T00:00:00.000Z"),
-        }),
-        createTransactionWithId({
-          id: 1n,
-          timestamp: new Date("2022-12-31T00:00:00.000Z"),
-        }),
-      ];
-
-      spyGetTransactions.mockResolvedValue({
-        transactions: allTransactions,
-        oldestTxId: 1n,
-      });
-
-      const result = await getAllTransactionsFromAccountAndIdentity({
-        accountId: mockAccountId,
-        identity: mockSignInIdentity,
-        range: {
-          from: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
-        },
-      });
-
-      expect(result).toHaveLength(2);
-      expect(result).toEqual(allTransactions.slice(1));
-      expect(spyGetTransactions).toHaveBeenCalledTimes(1);
-    });
-
     it('should filter "to" the provided date', async () => {
       const allTransactions = [
         createTransactionWithId({
@@ -197,6 +163,40 @@ describe("reporting service", () => {
         identity: mockSignInIdentity,
         range: {
           to: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
+        },
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(allTransactions.slice(1));
+      expect(spyGetTransactions).toHaveBeenCalledTimes(1);
+    });
+
+    it('should filter "from" the provided date', async () => {
+      const allTransactions = [
+        createTransactionWithId({
+          id: 3n,
+          timestamp: new Date("2023-01-02T00:00:00.000Z"),
+        }),
+        createTransactionWithId({
+          id: 2n,
+          timestamp: new Date("2023-01-01T00:00:00.000Z"),
+        }),
+        createTransactionWithId({
+          id: 1n,
+          timestamp: new Date("2022-12-31T00:00:00.000Z"),
+        }),
+      ];
+
+      spyGetTransactions.mockResolvedValue({
+        transactions: allTransactions,
+        oldestTxId: 1n,
+      });
+
+      const result = await getAllTransactionsFromAccountAndIdentity({
+        accountId: mockAccountId,
+        identity: mockSignInIdentity,
+        range: {
+          from: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
         },
       });
 
@@ -230,8 +230,8 @@ describe("reporting service", () => {
         accountId: mockAccountId,
         identity: mockSignInIdentity,
         range: {
-          from: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
-          to: dateToNanoSeconds(new Date("2022-12-31T00:00:00.000Z")),
+          to: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
+          from: dateToNanoSeconds(new Date("2022-12-31T00:00:00.000Z")),
         },
       });
 
@@ -239,7 +239,7 @@ describe("reporting service", () => {
       expect(spyGetTransactions).toHaveBeenCalledTimes(1);
     });
 
-    it('should return early if the last transaction is in the current page is older than "to" date', async () => {
+    it('should return early if the last transaction is in the current page is older than "from" date', async () => {
       const allTransactions = [
         createTransactionWithId({
           id: 3n,
@@ -271,7 +271,7 @@ describe("reporting service", () => {
         accountId: mockAccountId,
         identity: mockSignInIdentity,
         range: {
-          to: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
+          from: dateToNanoSeconds(new Date("2023-01-01T00:00:00.000Z")),
         },
       });
 
@@ -324,8 +324,8 @@ describe("reporting service", () => {
         accountId: mockAccountId,
         identity: mockSignInIdentity,
         range: {
-          from: dateToNanoSeconds(new Date("2023-01-02T00:00:00.000Z")),
-          to: dateToNanoSeconds(new Date("2022-11-30T00:00:00.000Z")),
+          to: dateToNanoSeconds(new Date("2023-01-02T00:00:00.000Z")),
+          from: dateToNanoSeconds(new Date("2022-11-30T00:00:00.000Z")),
         },
       });
       expect(result).toHaveLength(4);
@@ -358,8 +358,8 @@ describe("reporting service", () => {
         accountId: mockAccountId,
         identity: mockSignInIdentity,
         range: {
-          from: dateToNanoSeconds(new Date("2023-01-02T00:00:00.000Z")),
-          to: dateToNanoSeconds(new Date("2022-11-30T00:00:00.000Z")),
+          to: dateToNanoSeconds(new Date("2023-01-02T00:00:00.000Z")),
+          from: dateToNanoSeconds(new Date("2022-11-30T00:00:00.000Z")),
         },
       });
       expect(result).toHaveLength(2);

--- a/frontend/src/tests/mocks/icp-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icp-transactions.mock.ts
@@ -22,6 +22,10 @@ export const mockTransactionTransfer: Transaction = {
   timestamp: [{ timestamp_nanos: 235n }],
 };
 
+export const dateToNanoSeconds = (date: Date): bigint => {
+  return BigInt(date.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND);
+};
+
 const defaultTimestamp = new Date("2023-01-01T00:00:00.000Z");
 export const createTransactionWithId = ({
   memo,
@@ -35,8 +39,7 @@ export const createTransactionWithId = ({
   id?: bigint;
 }): TransactionWithId => {
   const timestampNanos = {
-    timestamp_nanos:
-      BigInt(timestamp.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND),
+    timestamp_nanos: dateToNanoSeconds(timestamp),
   };
   return {
     id,


### PR DESCRIPTION
# Motivation

Users can select a date range before generating a report. We need to filter the results in the front end and stop fetching pages if we exceed the `from` date.

The ledger canister returns transactions sorted by date, with the newest transaction listed first and the oldest transaction listed last.

```
Present                                                                     Past
(now)                                                                      (t)
0-----------------------[TO]-----------------[FROM]--------------------------->t
|                        |                     |                            |
|                        |                     |                            |
Current time        Newer limit            Older limit                   Earliest
                                                                        transaction

- Transactions BETWEEN 'from' and 'to' are included
- Transactions NEWER than 'from' are excluded
- Transactions OLDER than 'to' are excluded

```

# Changes

- Extends `getAllTransactionsFromAccountAndIdentity` to accept a date range for filtering results and to stop fetching.

# Tests

- Unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary