### PR TITLE
Reset following neuron state

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -91,6 +91,7 @@
   {#if isFollowingReset}
     <FollowNeuronsButton />
   {/if}
+  <!-- TODO(mstr): Add a button to confirm a single following. -->
 </CommonItemAction>
 
 <style lang="scss">

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import {
+    isNeuronFollowingReset,
     isNeuronLosingRewards,
     secondsUntilLosingRewards,
     shouldDisplayRewardLossNotification,
@@ -14,8 +15,12 @@
   import { type NeuronInfo } from "@dfinity/nns";
   import { secondsToDuration } from "@dfinity/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import FollowNeuronsButton from "./actions/FollowNeuronsButton.svelte";
 
   export let neuron: NeuronInfo;
+
+  let isFollowingReset = false;
+  $: isFollowingReset = isNeuronFollowingReset(neuron);
 
   let isLosingRewards = false;
   $: isLosingRewards = isNeuronLosingRewards(neuron);
@@ -25,32 +30,40 @@
     !isLosingRewards && shouldDisplayRewardLossNotification(neuron);
 
   let icon: typeof IconError | typeof IconWarning | typeof IconCheckCircle;
-  $: icon = isLosingRewards
-    ? IconError
-    : isLosingRewardsSoon
-      ? IconWarning
-      : // TODO(mstr): Replace with the filled version.
-        IconCheckCircle;
+  $: icon =
+    isFollowingReset || isLosingRewards
+      ? IconError
+      : isLosingRewardsSoon
+        ? IconWarning
+        : // TODO(mstr): Replace with the filled version.
+          IconCheckCircle;
 
   let title: string;
-  $: title = isLosingRewards
-    ? $i18n.neuron_detail.reward_status_inactive
-    : isLosingRewardsSoon
-      ? $i18n.neuron_detail.reward_status_losing_soon
-      : $i18n.neuron_detail.reward_status_active;
+  $: title =
+    isFollowingReset || isLosingRewards
+      ? $i18n.neuron_detail.reward_status_inactive
+      : isLosingRewardsSoon
+        ? $i18n.neuron_detail.reward_status_losing_soon
+        : $i18n.neuron_detail.reward_status_active;
 
-  const getDescription = (neuron: NeuronInfo): string =>
-    isLosingRewards
-      ? $i18n.neuron_detail.reward_status_inactive_description
-      : replacePlaceholders(
-          $i18n.neuron_detail.reward_status_losing_soon_description,
-          {
-            $time: secondsToDuration({
-              seconds: BigInt(secondsUntilLosingRewards(neuron)),
-              i18n: $i18n.time,
-            }),
-          }
-        );
+  const getDescription = (neuron: NeuronInfo): string => {
+    if (isFollowingReset)
+      return $i18n.neuron_detail.reward_status_inactive_reset_description;
+
+    if (isLosingRewards)
+      return $i18n.neuron_detail.reward_status_inactive_description;
+
+    const timeUntilLoss = secondsToDuration({
+      seconds: BigInt(secondsUntilLosingRewards(neuron)),
+      i18n: $i18n.time,
+    });
+    return replacePlaceholders(
+      $i18n.neuron_detail.reward_status_losing_soon_description,
+      {
+        $time: timeUntilLoss,
+      }
+    );
+  };
 </script>
 
 <CommonItemAction testId="nns-neuron-reward-status-action-component">
@@ -75,7 +88,9 @@
     {getDescription(neuron)}
   </span>
 
-  <!-- TODO(mstr): Add a button to confirm a single following. -->
+  {#if isFollowingReset}
+    <FollowNeuronsButton />
+  {/if}
 </CommonItemAction>
 
 <style lang="scss">

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -1,6 +1,7 @@
 import {
   SECONDS_IN_7_DAYS,
   SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
 import { enumValues } from "$lib/utils/enum.utils";
 import { Topic } from "@dfinity/nns";
@@ -41,6 +42,13 @@ export const TOPICS_TO_FOLLOW_NNS = [
 // Draft ic pr: https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L582)
 // TODO(mstr): replace with the actual ic link.
 export const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
+
+// After a neuron has experienced voting power reduction for this amount of time,
+// a couple of things happen:
+// 1. Deciding voting power reaches 0.
+// 2. Its following on topics other than NeuronManagement are cleared.
+// https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L584
+export const CLEAR_FOLLOWING_AFTER_SECONDS = SECONDS_IN_MONTH;
 
 // To notify users that their rewards will start decreasing in 30 days.
 export const NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS = 30;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -773,6 +773,7 @@
     "reward_status_losing_soon_description": "$time to confirm following",
     "reward_status_inactive": "Inactive neuron",
     "reward_status_inactive_description": "Confirm following or vote manually to continue receiving rewards",
+    "reward_status_inactive_reset_description": "Following has been reset. Confirm following or vote manually to continue receiving rewards",
     "neuron_state_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account.",
     "dissolve_delay_tooltip": "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and $token to be available again. If your neuron is dissolving, your $token will be available in $duration.",
     "neuron_stake_refreshed": "Your neuron's stake was refreshed successfully.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -805,6 +805,7 @@ interface I18nNeuron_detail {
   reward_status_losing_soon_description: string;
   reward_status_inactive: string;
   reward_status_inactive_description: string;
+  reward_status_inactive_reset_description: string;
   neuron_state_tooltip: string;
   dissolve_delay_tooltip: string;
   neuron_stake_refreshed: string;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -10,6 +10,7 @@ import {
   E8S_PER_ICP,
 } from "$lib/constants/icp.constants";
 import {
+  CLEAR_FOLLOWING_AFTER_SECONDS,
   MATURITY_MODULATION_VARIANCE_PERCENTAGE,
   MAX_AGE_BONUS,
   MAX_DISSOLVE_DELAY_BONUS,
@@ -1215,6 +1216,14 @@ export const secondsUntilLosingRewards = (neuron: NeuronInfo): number => {
     Number(getVotingPowerRefreshedTimestampSeconds(neuron)) +
     START_REDUCING_VOTING_POWER_AFTER_SECONDS;
   return rewardLossStart - nowInSeconds();
+};
+
+export const isNeuronFollowingReset = (neuron: NeuronInfo): boolean => {
+  const neuronFollowingResetTimestampSeconds =
+    Number(getVotingPowerRefreshedTimestampSeconds(neuron)) +
+    START_REDUCING_VOTING_POWER_AFTER_SECONDS +
+    CLEAR_FOLLOWING_AFTER_SECONDS;
+  return nowInSeconds() >= neuronFollowingResetTimestampSeconds;
 };
 
 export const isNeuronLosingRewards = (neuron: NeuronInfo): boolean =>

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
@@ -1,15 +1,19 @@
-import NnsNeuronRewardStatusAction from "$lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte";
-import { SECONDS_IN_DAY, SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
+import {
+  SECONDS_IN_DAY,
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_MONTH,
+} from "$lib/constants/constants";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
+import NnsNeuronRewardStatusActionTest from "./NnsNeuronRewardStatusActionTest.svelte";
 
 describe("NnsNeuronRewardStatusAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {
-    const { container } = render(NnsNeuronRewardStatusAction, {
+    const { container } = render(NnsNeuronRewardStatusActionTest, {
       props: {
         neuron,
       },
@@ -38,6 +42,7 @@ describe("NnsNeuronRewardStatusAction", () => {
     expect(await po.getDescription()).toBe(
       "182 days, 15 hours to confirm following"
     );
+    expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(false);
   });
 
   it("should render losing soon neuron state", async () => {
@@ -57,9 +62,10 @@ describe("NnsNeuronRewardStatusAction", () => {
     expect(await po.getDescription()).toBe(
       `${tenDays} days to confirm following`
     );
+    expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(false);
   });
 
-  it("should render active neuron reward state", async () => {
+  it("should render inactive neuron reward state", async () => {
     const testNeuron = {
       ...mockNeuron,
       fullNeuron: {
@@ -75,5 +81,25 @@ describe("NnsNeuronRewardStatusAction", () => {
     expect(await po.getDescription()).toBe(
       "Confirm following or vote manually to continue receiving rewards"
     );
+    expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(false);
+  });
+
+  it("should render inactive/reset following neuron reward state", async () => {
+    const testNeuron = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        votingPowerRefreshedTimestampSeconds: BigInt(
+          nowInSeconds() - SECONDS_IN_HALF_YEAR - SECONDS_IN_MONTH
+        ),
+      },
+    };
+    const po = renderComponent(testNeuron);
+
+    expect(await po.getTitle()).toBe("Inactive neuron");
+    expect(await po.getDescription()).toBe(
+      "Following has been reset. Confirm following or vote manually to continue receiving rewards"
+    );
+    expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusActionTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusActionTest.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
   import type {
     NnsNeuronContext,
     NnsNeuronStore,

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusActionTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusActionTest.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
+  import type {
+    NnsNeuronContext,
+    NnsNeuronStore,
+  } from "$lib/types/nns-neuron-detail.context";
+  import { NNS_NEURON_CONTEXT_KEY } from "$lib/types/nns-neuron-detail.context";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+  import NnsNeuronRewardStatusAction from "$lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte";
+
+  export let neuron: NeuronInfo;
+
+  export const neuronStore = writable<NnsNeuronStore>({
+    neuron,
+  });
+
+  setContext<NnsNeuronContext>(NNS_NEURON_CONTEXT_KEY, {
+    store: neuronStore,
+  });
+</script>
+
+<NnsNeuronRewardStatusAction {neuron} />

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -4,6 +4,7 @@ import {
   SECONDS_IN_FOUR_YEARS,
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_HOUR,
+  SECONDS_IN_MONTH,
   SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
@@ -51,6 +52,7 @@ import {
   isNeuronControllable,
   isNeuronControllableByUser,
   isNeuronControlledByHardwareWallet,
+  isNeuronFollowingReset,
   isNeuronLosingRewards,
   isPublicNeuron,
   isSpawning,
@@ -3455,6 +3457,47 @@ describe("neuron-utils", () => {
           isNeuronLosingRewards(
             neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod - 1,
+            })
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe("isNeuronFollowingReset", () => {
+      it("should return false by default", () => {
+        expect(
+          isNeuronFollowingReset({
+            ...mockNeuron,
+            fullNeuron: undefined,
+          })
+        ).toBe(false);
+      });
+
+      it("should return true after the followings have been reset", () => {
+        expect(
+          isNeuronFollowingReset(
+            neuronWithRefreshedTimestamp({
+              votingPowerRefreshedTimestampAgeSecs:
+                losingRewardsPeriod + SECONDS_IN_MONTH,
+            })
+          )
+        ).toBe(true);
+        expect(
+          isNeuronFollowingReset(
+            neuronWithRefreshedTimestamp({
+              votingPowerRefreshedTimestampAgeSecs:
+                losingRewardsPeriod + 2 * SECONDS_IN_MONTH,
+            })
+          )
+        ).toBe(true);
+      });
+
+      it("should return false", () => {
+        expect(
+          isNeuronFollowingReset(
+            neuronWithRefreshedTimestamp({
+              votingPowerRefreshedTimestampAgeSecs:
+                losingRewardsPeriod + SECONDS_IN_MONTH - 1,
             })
           )
         ).toBe(false);

--- a/frontend/src/tests/page-objects/FollowNeuronsButton.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowNeuronsButton.page-object.ts
@@ -1,0 +1,16 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class FollowNeuronsButtonPo extends ButtonPo {
+  private static readonly TID = "follow-neurons-button-component";
+
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): FollowNeuronsButtonPo {
+    return new FollowNeuronsButtonPo(
+      element.byTestId(FollowNeuronsButtonPo.TID)
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { FollowNeuronsButtonPo } from "./FollowNeuronsButton.page-object";
 
 export class NnsNeuronRewardStatusActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-reward-status-action-component";
@@ -16,5 +17,11 @@ export class NnsNeuronRewardStatusActionPo extends BasePageObject {
 
   getDescription(): Promise<string> {
     return this.getText("state-description");
+  }
+
+  getFollowNeuronsButtonPo(): FollowNeuronsButtonPo {
+    return FollowNeuronsButtonPo.under({
+      element: this.root,
+    });
   }
 }


### PR DESCRIPTION
# Motivation

In the case where a neuron hasn't been used for a long period of time (currently defined as 6 + 1 months), its followings are reset. To avoid confusion, it was decided to display a special type of inactive status with additional information in the description and a "Set Following" button, instead of "Confirm Following"

**Note:** Currently, the component looks suboptimal with such a long description. This issue will be addressed in a separate PR.

# Changes

- New `isNeuronFollowingReset` util.
- Display additional Neuron reward state.

# Tests

- Updated unit tests.
- Tested manually:
<img width="717" alt="image" src="https://github.com/user-attachments/assets/3d345d8c-2359-4b5c-bbfa-461fe141e7ff" />


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.