### PR TITLE
Add AmountWithUsd component

### DIFF
--- a/frontend/src/lib/components/ic/AmountWithUsd.svelte
+++ b/frontend/src/lib/components/ic/AmountWithUsd.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+  import { TokenAmountV2 } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
+
+  export let amount: TokenAmountV2 | UnavailableTokenAmount;
+  export let amountInUsd: number | undefined;
+</script>
+
+<div class="values" data-tid="amount-with-usd-component">
+  <AmountDisplay singleLine {amount} />
+  <span data-tid="usd-value" class="usd-value">
+    {#if nonNullish(amountInUsd)}
+      ${formatNumber(amountInUsd)}
+    {:else}
+      $-/-
+    {/if}
+  </span>
+</div>
+
+<style lang="scss">
+  .values {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-0_5x);
+    align-items: flex-end;
+
+    .usd-value {
+      color: var(--text-description);
+      font-size: var(--font-size-small);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import AmountWithUsd from "$lib/components/ic/AmountWithUsd.svelte";
   import { ENABLE_USD_VALUES } from "$lib/stores/feature-flags.store";
   import type {
     UserTokenData,
     UserTokenFailed,
     UserTokenLoading,
   } from "$lib/types/tokens-page";
-  import { formatNumber } from "$lib/utils/format.utils";
   import {
     isUserTokenData,
     isUserTokenLoading,
   } from "$lib/utils/user-token.utils";
   import { Spinner } from "@dfinity/gix-components";
-  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 </script>
@@ -22,18 +21,12 @@
     ><Spinner inline size="tiny" /></span
   >
 {:else if isUserTokenData(rowData)}
-  <div class="values">
+  {#if $ENABLE_USD_VALUES}
+    <AmountWithUsd amount={rowData.balance} amountInUsd={rowData.balanceInUsd}
+    ></AmountWithUsd>
+  {:else}
     <AmountDisplay singleLine amount={rowData.balance} />
-    {#if $ENABLE_USD_VALUES}
-      <span data-tid="usd-value" class="usd-value">
-        {#if nonNullish(rowData.balanceInUsd)}
-          ${formatNumber(rowData.balanceInUsd)}
-        {:else}
-          $-/-
-        {/if}
-      </span>
-    {/if}
-  </div>
+  {/if}
 {:else}
   <span data-tid="unavailable-balance" class="value">-/-</span>
 {/if}
@@ -42,17 +35,5 @@
   .balance-spinner {
     display: flex;
     align-items: center;
-  }
-
-  .values {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding-0_5x);
-    align-items: flex-end;
-
-    .usd-value {
-      color: var(--text-description);
-      font-size: var(--font-size-small);
-    }
   }
 </style>

--- a/frontend/src/tests/lib/components/ic/AmountWithUsd.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountWithUsd.spec.ts
@@ -1,0 +1,47 @@
+import AmountWithUsd from "$lib/components/ic/AmountWithUsd.svelte";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { AmountWithUsdPo } from "$tests/page-objects/AmountWithUsd.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ICPToken, TokenAmount } from "@dfinity/utils";
+import { render } from "@testing-library/svelte";
+
+describe("AmountWithUsd", () => {
+  const tokenAmount = TokenAmount.fromE8s({
+    amount: 123_456_789_010_000n,
+    token: ICPToken,
+  });
+
+  const renderComponent = (props) => {
+    const { container } = render(AmountWithUsd, props);
+    return AmountWithUsdPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render a token amount", async () => {
+    const po = renderComponent({ amount: tokenAmount, amountInUsd: undefined });
+    expect(await po.getAmountDisplayPo().getText()).toEqual("1'234'567.89 ICP");
+  });
+
+  it("should render an unavailable token amount", async () => {
+    const po = renderComponent({
+      amount: new UnavailableTokenAmount(ICPToken),
+      amountInUsd: undefined,
+    });
+    expect(await po.getAmountDisplayPo().getText()).toEqual("-/- ICP");
+  });
+
+  it("should render an amount in USD", async () => {
+    const po = renderComponent({
+      amount: tokenAmount,
+      amountInUsd: "12345.678",
+    });
+    expect(await po.getAmountInUsd()).toEqual("$12’345.68");
+  });
+
+  it("should render an absent amount in USD", async () => {
+    const po = renderComponent({
+      amount: tokenAmount,
+      amountInUsd: undefined,
+    });
+    expect(await po.getAmountInUsd()).toEqual("$-/-");
+  });
+});

--- a/frontend/src/tests/page-objects/AmountWithUsd.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountWithUsd.page-object.ts
@@ -1,0 +1,23 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AmountDisplayPo } from "./AmountDisplay.page-object";
+
+export class AmountWithUsdPo extends BasePageObject {
+  private static readonly TID = "amount-with-usd-component";
+
+  static under(element: PageObjectElement): AmountWithUsdPo {
+    return new AmountWithUsdPo(element.byTestId(AmountWithUsdPo.TID));
+  }
+
+  getAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
+  }
+
+  async getAmount(): Promise<string> {
+    return this.getAmountDisplayPo().getAmount();
+  }
+
+  async getAmountInUsd(): Promise<string> {
+    return this.getText("usd-value");
+  }
+}


### PR DESCRIPTION
# Motivation

In the tokens table we display token amounts with amount in USD.
We want to do the same, using the same style, for stake in the projects table and neurons table.

This PR factors out a component to display the 2 amounts to be reused in other tables.

# Changes

1. Add `AmountWithUsd` based on `TokenBalanceCell`.
2. Use `AmountWithUsd` in `TokenBalanceCell`.

# Tests

1. Unit tests added.
2. Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary