### PR TITLE
Move getUsdValue to utils

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -13,28 +13,11 @@ import type { Account, AccountType } from "$lib/types/account";
 import { UserTokenAction, type UserToken } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { buildWalletUrl } from "$lib/utils/navigation.utils";
-import { sortUserTokens } from "$lib/utils/token.utils";
+import { getUsdValue, sortUserTokens } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
 import { isNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { nnsUniverseStore } from "./nns-universe.derived";
-
-const getUsdValue = ({
-  balance,
-  icpPrice,
-}: {
-  balance: TokenAmountV2;
-  icpPrice?: number;
-}): number | undefined => {
-  const balanceE8s = Number(balance.toE8s());
-  if (balanceE8s === 0) {
-    return 0;
-  }
-  if (isNullish(icpPrice)) {
-    return undefined;
-  }
-  return (balanceE8s * icpPrice) / 100_000_000;
-};
 
 const convertAccountToUserTokenData = ({
   nnsUniverse,
@@ -85,8 +68,8 @@ const convertAccountToUserTokenData = ({
     subtitle: subtitleMap[account.type],
     balance,
     balanceInUsd: getUsdValue({
-      balance,
-      icpPrice,
+      amount: balance,
+      tokenPrice: icpPrice,
     }),
     logo: nnsUniverse.logo,
     token: NNS_TOKEN_DATA,

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -336,3 +336,20 @@ const getUsdBalance = (token: UserToken) => {
 
 export const getTotalBalanceInUsd = (tokens: UserToken[]): number =>
   tokens.reduce((acc, token) => acc + getUsdBalance(token), 0);
+
+export const getUsdValue = ({
+  amount,
+  tokenPrice,
+}: {
+  amount: TokenAmountV2;
+  tokenPrice?: number;
+}): number | undefined => {
+  const amountE8s = Number(amount.toE8s());
+  if (amountE8s === 0) {
+    return 0;
+  }
+  if (isNullish(tokenPrice)) {
+    return undefined;
+  }
+  return (amountE8s * tokenPrice) / 100_000_000;
+};

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -14,6 +14,7 @@ import {
   formattedTransactionFeeICP,
   getMaxTransactionAmount,
   getTotalBalanceInUsd,
+  getUsdValue,
   numberToE8s,
   numberToUlps,
   sortUserTokens,
@@ -914,6 +915,35 @@ describe("token-utils", () => {
       });
 
       expect(getTotalBalanceInUsd([token1, token2, token3])).toBe(8);
+    });
+  });
+
+  describe("getUsdValue", () => {
+    it("should multiply the amount with the price", () => {
+      const amount = TokenAmountV2.fromNumber({
+        amount: 2,
+        token: ICPToken,
+      });
+      const tokenPrice = 3;
+      expect(getUsdValue({ amount, tokenPrice })).toBe(6);
+    });
+
+    it("should return undefined if tokenPrice is undefined", () => {
+      const amount = TokenAmountV2.fromNumber({
+        amount: 2,
+        token: ICPToken,
+      });
+      const tokenPrice = undefined;
+      expect(getUsdValue({ amount, tokenPrice })).toBe(undefined);
+    });
+
+    it("should return 0 if amount is 0, even if tokenPrice is undefined", () => {
+      const amount = TokenAmountV2.fromNumber({
+        amount: 0,
+        token: ICPToken,
+      });
+      const tokenPrice = undefined;
+      expect(getUsdValue({ amount, tokenPrice })).toBe(0);
     });
   });
 });


### PR DESCRIPTION
# Motivation

The function `getUsdValue` defined in `frontend/src/lib/derived/icp-tokens-list-user.derived.ts` would be useful to reuse to display neuron stake in USD.

# Changes

Move `getUsdValue` to `frontend/src/lib/utils/token.utils.ts`.

# Tests

Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary