### PR TITLE
Move getLedgerCanisterIdFromUniverse to utils

### DIFF
--- a/frontend/src/lib/derived/tokens-list-base.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-base.derived.ts
@@ -1,23 +1,9 @@
-import {
-  LEDGER_CANISTER_ID,
-  OWN_CANISTER_ID_TEXT,
-} from "$lib/constants/canister-ids.constants";
 import type { UserTokenBase } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
+import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
 import { Principal } from "@dfinity/principal";
-import { nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
-
-const getLedgerCanisterIdFromUniverse = (universe: Universe): Principal => {
-  if (universe.canisterId === OWN_CANISTER_ID_TEXT) {
-    return LEDGER_CANISTER_ID;
-  }
-  if (nonNullish(universe.summary)) {
-    return universe.summary.ledgerCanisterId;
-  }
-  return Principal.fromText(universe.canisterId);
-};
 
 const convertUniverseToBaseTokenData = (universe: Universe): UserTokenBase => ({
   universeId: Principal.fromText(universe.canisterId),

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -1,4 +1,8 @@
-import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import {
+  LEDGER_CANISTER_ID,
+  OWN_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
@@ -11,7 +15,7 @@ import type { SnsSummary } from "$lib/types/sns";
 import type { Universe } from "$lib/types/universe";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
-import type { Principal } from "@dfinity/principal";
+import { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -83,3 +87,15 @@ export const createUniverse = (summary: SnsSummary): Universe => ({
   title: summary.metadata.name,
   logo: summary.metadata.logo,
 });
+
+export const getLedgerCanisterIdFromUniverse = (
+  universe: Universe
+): Principal => {
+  if (universe.canisterId === OWN_CANISTER_ID_TEXT) {
+    return LEDGER_CANISTER_ID;
+  }
+  if (nonNullish(universe.summary)) {
+    return universe.summary.ledgerCanisterId;
+  }
+  return Principal.fromText(universe.canisterId);
+};

--- a/frontend/src/tests/lib/utils/universe.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universe.utils.spec.ts
@@ -1,0 +1,48 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { nnsUniverseStore } from "$lib/derived//nns-universe.derived";
+import { ckBTCUniverseStore } from "$lib/derived/ckbtc-universe.derived";
+import { snsSummariesStore } from "$lib/stores/sns.store";
+import {
+  createUniverse,
+  getLedgerCanisterIdFromUniverse,
+} from "$lib/utils/universe.utils";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { get } from "svelte/store";
+
+describe("universe.utils", () => {
+  describe("getLedgerCanisterIdFromUniverse", () => {
+    const nnsUniverse = get(nnsUniverseStore);
+    const ckBtcUniverse = get(ckBTCUniverseStore);
+
+    it("should return the ledger canister ID for the NNS universe", () => {
+      expect(getLedgerCanisterIdFromUniverse(nnsUniverse)).toBe(
+        LEDGER_CANISTER_ID
+      );
+    });
+
+    it("should return the ledger canister ID for the ckBTC universe", () => {
+      expect(getLedgerCanisterIdFromUniverse(ckBtcUniverse).toText()).toBe(
+        CKBTC_LEDGER_CANISTER_ID.toText()
+      );
+    });
+
+    it("should return the ledger canister ID for an SNS universe", () => {
+      const rootCanisterId = principal(0);
+      const ledgerCanisterId = principal(1);
+      setSnsProjects([
+        {
+          rootCanisterId,
+          ledgerCanisterId,
+        },
+      ]);
+      const snsSummaries = get(snsSummariesStore);
+      expect(snsSummaries).toHaveLength(1);
+      const snsUniverse = createUniverse(snsSummaries[0]);
+      expect(getLedgerCanisterIdFromUniverse(snsUniverse).toText()).toBe(
+        ledgerCanisterId.toText()
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Token prices in USD are looked up based on the ledger canister ID.
`frontend/src/lib/derived/tokens-list-base.derived.ts` has a function `getLedgerCanisterIdFromUniverse` to get the ledger canister ID of a universe.
This will be useful for the USD values of neuron stakes as well.

# Changes

Move `getLedgerCanisterIdFromUniverse` form `frontend/src/lib/derived/tokens-list-base.derived.ts` to `frontend/src/lib/utils/universe.utils.ts`.

# Tests

1. Unit tests added.
2. Existing tests continue to pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary