### PR TITLE
Add stakeInUsd to TableProject

### DIFF
--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -11,6 +11,7 @@ export type TableProject = {
   tokenSymbol: string;
   neuronCount: number | undefined;
   stake: TokenAmountV2 | UnavailableTokenAmount;
+  stakeInUsd: number | undefined;
   availableMaturity: bigint | undefined;
   stakedMaturity: bigint | undefined;
 };

--- a/frontend/src/tests/mocks/staking.mock.ts
+++ b/frontend/src/tests/mocks/staking.mock.ts
@@ -14,6 +14,7 @@ export const mockTableProject: TableProject = {
     amount: 100_000_000n,
     token: ICPToken,
   }),
+  stakeInUsd: 10.0,
   tokenSymbol: ICPToken.symbol,
   availableMaturity: 0n,
   stakedMaturity: 0n,


### PR DESCRIPTION
# Motivation

We want to show USD values for neuron stakes in the projects table.

In this PR we just provide the values but don't render them yet.

# Changes

1. Add `stakeInUsd` field to `TableProject` type.
2. Populate `stakeInUsd` in `getTableProjects` if `icpSwapUsdPrices` is passed and a price it available for the relevant projects.

# Tests

1. Unit tests added.
2. Tested manually in another branch with more changes.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet