### PR TITLE
Confirm following from banner

### DIFF
--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -12,16 +12,23 @@
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import type { NeuronInfo } from "@dfinity/nns";
+  import ConfirmFollowingButton from "../../components/neuron-detail/actions/ConfirmFollowingButton.svelte";
 
   const dispatcher = createEventDispatcher<{ nnsClose: void }>();
 
   // Load KnownNeurons which are used in the FollowNnsTopicSections
   onMount(() => listKnownNeurons());
 
-  const confirm = () => {
-    // TBD
-  };
   const close = () => dispatcher("nnsClose");
+  const onConfirmed = ({
+    detail: { successCount, totalCount },
+  }: {
+    detail: { successCount: number; totalCount: number };
+  }) => {
+    if (successCount === totalCount) {
+      close();
+    }
+  };
 
   const navigateToNeuronDetail = async (neuron: NeuronInfo) => {
     close();
@@ -32,6 +39,9 @@
       })
     );
   };
+
+  let neuronIds: bigint[];
+  $: neuronIds = $soonLosingRewardNeuronsStore.map((neuron) => neuron.neuronId);
 </script>
 
 <Modal on:nnsClose testId="losing-reward-neurons-modal-component">
@@ -63,9 +73,7 @@
       <button on:click={close} class="secondary" data-tid="cancel-button"
         >{$i18n.core.cancel}</button
       >
-      <button on:click={confirm} class="primary" data-tid="confirm-button"
-        >{$i18n.losing_rewards.confirm}</button
-      >
+      <ConfirmFollowingButton {neuronIds} on:nnsComplete={onConfirmed} />
     </div>
   </div>
 </Modal>

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -12,7 +12,7 @@
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import type { NeuronInfo } from "@dfinity/nns";
-  import ConfirmFollowingButton from "../../components/neuron-detail/actions/ConfirmFollowingButton.svelte";
+  import ConfirmFollowingButton from "$lib/components/neuron-detail/actions/ConfirmFollowingButton.svelte";
 
   const dispatcher = createEventDispatcher<{ nnsClose: void }>();
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/ConfirmFollowingButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/ConfirmFollowingButton.spec.ts
@@ -5,7 +5,6 @@ import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { ConfirmFollowingButtonPo } from "$tests/page-objects/ConfirmFollowingButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore } from "@dfinity/gix-components";
 import { nonNullish } from "@dfinity/utils";
@@ -30,7 +29,6 @@ describe("ConfirmFollowingButton", () => {
 
   beforeEach(() => {
     resetIdentity();
-    allowLoggingInOneTestForDebugging();
 
     neuronsStore.pushNeurons({ neurons, certified: true });
     spyQueryNeurons = vi.spyOn(api, "queryNeurons").mockResolvedValue(neurons);

--- a/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
@@ -1,39 +1,60 @@
+import * as governanceApi from "$lib/api/governance.api";
 import LosingRewardsBanner from "$lib/components/neurons/LosingRewardsBanner.svelte";
 import { SECONDS_IN_DAY, SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { LosingRewardsBannerPo } from "$tests/page-objects/LosingRewardsBanner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 
 describe("LosingRewardsBanner", () => {
   const nowSeconds = nowInSeconds();
   const activeNeuron = {
     ...mockNeuron,
+    neuronId: 0n,
     fullNeuron: {
       ...mockFullNeuron,
       votingPowerRefreshedTimestampSeconds: BigInt(nowSeconds),
+      controller: mockIdentity.getPrincipal().toText(),
     },
   };
   const in10DaysLosingRewardsNeuron = {
     ...mockNeuron,
+    neuronId: 1n,
     fullNeuron: {
       ...mockFullNeuron,
       votingPowerRefreshedTimestampSeconds: BigInt(
         nowSeconds - SECONDS_IN_HALF_YEAR + 10 * SECONDS_IN_DAY
       ),
+      controller: mockIdentity.getPrincipal().toText(),
     },
   };
   const losingRewardsNeuron = {
     ...mockNeuron,
+    neuronId: 2n,
     fullNeuron: {
       ...mockFullNeuron,
       votingPowerRefreshedTimestampSeconds: BigInt(
         nowSeconds - SECONDS_IN_HALF_YEAR
       ),
+      controller: mockIdentity.getPrincipal().toText(),
     },
   };
+  const neurons = [
+    activeNeuron,
+    in10DaysLosingRewardsNeuron,
+    losingRewardsNeuron,
+  ];
+  const refreshedNeurons = neurons.map((neuron) => ({
+    ...neuron,
+    fullNeuron: {
+      ...neuron.fullNeuron,
+      votingPowerRefreshedTimestampSeconds: BigInt(nowSeconds),
+    },
+  }));
 
   const renderComponent = () => {
     const { container } = render(LosingRewardsBanner);
@@ -41,9 +62,14 @@ describe("LosingRewardsBanner", () => {
   };
 
   beforeEach(() => {
+    resetIdentity();
     vi.useFakeTimers({
       now: nowSeconds * 1000,
     });
+
+    vi.spyOn(governanceApi, "queryKnownNeurons").mockResolvedValue([]);
+    vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue(refreshedNeurons);
+    vi.spyOn(governanceApi, "refreshVotingPower").mockResolvedValue();
   });
 
   it("should not display banner when all neurons are active", async () => {
@@ -77,7 +103,7 @@ describe("LosingRewardsBanner", () => {
 
   it("displays losing rewards title ", async () => {
     neuronsStore.setNeurons({
-      neurons: [activeNeuron, in10DaysLosingRewardsNeuron, losingRewardsNeuron],
+      neurons,
       certified: true,
     });
     const po = await renderComponent();
@@ -107,6 +133,50 @@ describe("LosingRewardsBanner", () => {
 
     expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(false);
     await po.clickConfirm();
+    expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(true);
+  });
+
+  it("should close modal when all refreshed", async () => {
+    const spyRefreshVotingPower = vi
+      .spyOn(governanceApi, "refreshVotingPower")
+      .mockResolvedValue();
+    neuronsStore.setNeurons({
+      neurons: [losingRewardsNeuron],
+      certified: true,
+    });
+    const po = await renderComponent();
+
+    expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(false);
+    await po.clickConfirm();
+    expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(true);
+
+    await po.getLosingRewardNeuronsModalPo().clickConfirmFollowing();
+    await runResolvedPromises();
+
+    vi.advanceTimersToNextFrame();
+    expect(spyRefreshVotingPower).toBeCalledTimes(1);
+    expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(false);
+  });
+
+  it("should not close the modal on error", async () => {
+    const spyConsoleError = vi.spyOn(console, "error").mockReturnValue();
+    const spyRefreshVotingPower = vi
+      .spyOn(governanceApi, "refreshVotingPower")
+      .mockRejectedValueOnce(new Error());
+
+    neuronsStore.setNeurons({
+      neurons: [losingRewardsNeuron],
+      certified: true,
+    });
+    const po = await renderComponent();
+
+    await po.clickConfirm();
+    await runResolvedPromises();
+    await po.getLosingRewardNeuronsModalPo().clickConfirmFollowing();
+    await runResolvedPromises();
+
+    expect(spyRefreshVotingPower).toBeCalledTimes(1);
+    expect(spyConsoleError).toBeCalledTimes(1);
     expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(true);
   });
 });

--- a/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
@@ -174,6 +174,7 @@ describe("LosingRewardsBanner", () => {
     await runResolvedPromises();
     await po.getLosingRewardNeuronsModalPo().clickConfirmFollowing();
     await runResolvedPromises();
+    vi.advanceTimersToNextFrame();
 
     expect(spyRefreshVotingPower).toBeCalledTimes(1);
     expect(spyConsoleError).toBeCalledTimes(1);

--- a/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
@@ -1,5 +1,6 @@
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ConfirmFollowingButtonPo } from "./ConfirmFollowingButton.page-object";
 import { NnsLosingRewardsNeuronCardPo } from "./NnsLosingRewardsNeuronCard.page-object";
 
 export class LosingRewardNeuronsModalPo extends ModalPo {
@@ -13,6 +14,14 @@ export class LosingRewardNeuronsModalPo extends ModalPo {
 
   getNnsLosingRewardsNeuronCardPos(): Promise<NnsLosingRewardsNeuronCardPo[]> {
     return NnsLosingRewardsNeuronCardPo.allUnder(this.root);
+  }
+
+  getConfirmFollowingButtonPo(): ConfirmFollowingButtonPo {
+    return ConfirmFollowingButtonPo.under(this.root);
+  }
+
+  async clickConfirmFollowing(): Promise<void> {
+    return this.getConfirmFollowingButtonPo().click();
   }
 
   async clickCancel(): Promise<void> {


### PR DESCRIPTION
# Motivation

If there are inactive neurons, the user should be able to reset their voting-power-refreshed timestamp. In this PR, we add a ["Confirm Following" button](https://github.com/dfinity/nns-dapp/pull/5990) to the modal that displays the user’s inactive neurons.

# Changes

- Add the `ConfirmFollowingButton` to the modal.
- Close the modal when all inactive neurons are refreshed.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.