### PR TITLE
Refresh voting power from details

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -16,6 +16,7 @@
   import { secondsToDuration } from "@dfinity/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import FollowNeuronsButton from "./actions/FollowNeuronsButton.svelte";
+  import ConfirmFollowingButton from "./actions/ConfirmFollowingButton.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -90,8 +91,9 @@
 
   {#if isFollowingReset}
     <FollowNeuronsButton />
+  {:else}
+    <ConfirmFollowingButton neuronIds={[neuron.neuronId]} />
   {/if}
-  <!-- TODO(mstr): Add a button to confirm a single following. -->
 </CommonItemAction>
 
 <style lang="scss">

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
@@ -1,12 +1,16 @@
+import * as governanceApi from "$lib/api/governance.api";
 import {
   SECONDS_IN_DAY,
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
+import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import NnsNeuronRewardStatusActionTest from "./NnsNeuronRewardStatusActionTest.svelte";
@@ -42,6 +46,7 @@ describe("NnsNeuronRewardStatusAction", () => {
     expect(await po.getDescription()).toBe(
       "182 days, 15 hours to confirm following"
     );
+    expect(await po.getConfirmFollowingButtonPo().isPresent()).toBe(true);
     expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(false);
   });
 
@@ -62,6 +67,7 @@ describe("NnsNeuronRewardStatusAction", () => {
     expect(await po.getDescription()).toBe(
       `${tenDays} days to confirm following`
     );
+    expect(await po.getConfirmFollowingButtonPo().isPresent()).toBe(true);
     expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(false);
   });
 
@@ -81,6 +87,7 @@ describe("NnsNeuronRewardStatusAction", () => {
     expect(await po.getDescription()).toBe(
       "Confirm following or vote manually to continue receiving rewards"
     );
+    expect(await po.getConfirmFollowingButtonPo().isPresent()).toBe(true);
     expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(false);
   });
 
@@ -92,6 +99,7 @@ describe("NnsNeuronRewardStatusAction", () => {
         votingPowerRefreshedTimestampSeconds: BigInt(
           nowInSeconds() - SECONDS_IN_HALF_YEAR - SECONDS_IN_MONTH
         ),
+        controller: mockIdentity.getPrincipal().toText(),
       },
     };
     const po = renderComponent(testNeuron);
@@ -100,6 +108,44 @@ describe("NnsNeuronRewardStatusAction", () => {
     expect(await po.getDescription()).toBe(
       "Following has been reset. Confirm following or vote manually to continue receiving rewards"
     );
+    expect(await po.getConfirmFollowingButtonPo().isPresent()).toBe(false);
     expect(await po.getFollowNeuronsButtonPo().isPresent()).toBe(true);
+  });
+
+  it("should refresh voting power", async () => {
+    const testNeuron = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        votingPowerRefreshedTimestampSeconds: BigInt(
+          nowInSeconds() - SECONDS_IN_HALF_YEAR + 10 * SECONDS_IN_DAY
+        ),
+        controller: mockIdentity.getPrincipal().toText(),
+      },
+    };
+    resetIdentity();
+    neuronsStore.setNeurons({
+      neurons: [testNeuron],
+      certified: true,
+    });
+    vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue([testNeuron]);
+    const spyRefreshVotingPower = vi
+      .spyOn(governanceApi, "refreshVotingPower")
+      .mockResolvedValue();
+    vi.spyOn(governanceApi, "queryKnownNeurons").mockResolvedValue([]);
+
+    const po = renderComponent(testNeuron);
+
+    expect(spyRefreshVotingPower).toHaveBeenCalledTimes(0);
+
+    expect(await po.getConfirmFollowingButtonPo().isPresent()).toBe(true);
+    await po.getConfirmFollowingButtonPo().click();
+    await runResolvedPromises();
+
+    expect(spyRefreshVotingPower).toHaveBeenCalledTimes(1);
+    expect(spyRefreshVotingPower).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      neuronId: testNeuron.neuronId,
+    });
   });
 });

--- a/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ConfirmFollowingButtonPo } from "./ConfirmFollowingButton.page-object";
 import { FollowNeuronsButtonPo } from "./FollowNeuronsButton.page-object";
 
 export class NnsNeuronRewardStatusActionPo extends BasePageObject {
@@ -17,6 +18,10 @@ export class NnsNeuronRewardStatusActionPo extends BasePageObject {
 
   getDescription(): Promise<string> {
     return this.getText("state-description");
+  }
+
+  getConfirmFollowingButtonPo(): ConfirmFollowingButtonPo {
+    return ConfirmFollowingButtonPo.under(this.root);
   }
 
   getFollowNeuronsButtonPo(): FollowNeuronsButtonPo {


### PR DESCRIPTION
# Motivation

If there are inactive neurons, the user should be able to reset their voting-power-refreshed timestamp from the neuron details page. In this PR, we add a ["Confirm Following" button](https://github.com/dfinity/nns-dapp/pull/5990) to the neuron status field. It should be shown for all statuses except when the followings of a neuron have already been reset.

# Changes

- Add the `ConfirmFollowingButton` to the `NnsNeuronRewardStatusAction` component.

# Tests

- Updated.
- Tested locally:

https://github.com/user-attachments/assets/70d159fc-ee22-408e-b013-097f16a36e54


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.