### PR TITLE
Neuron rewards status info

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -75,7 +75,11 @@
   });
 </script>
 
-<CommonItemAction testId="nns-neuron-reward-status-action-component">
+<CommonItemAction
+  testId="nns-neuron-reward-status-action-component"
+  {tooltipText}
+  tooltipId="neuron-reward-status-icon"
+>
   <span
     slot="icon"
     class="icon"
@@ -86,7 +90,6 @@
   </span>
   <span slot="title" data-tid="state-title">
     {title}
-    <TooltipIcon text={tooltipText} tooltipId="neuron-reward-status-tooltip" />
   </span>
 
   <span

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -18,7 +18,6 @@
   import FollowNeuronsButton from "./actions/FollowNeuronsButton.svelte";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
-  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -16,6 +16,9 @@
   import { secondsToDuration } from "@dfinity/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import FollowNeuronsButton from "./actions/FollowNeuronsButton.svelte";
+  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -64,6 +67,12 @@
       }
     );
   };
+
+  const tooltipText = replacePlaceholders($i18n.losing_rewards.description, {
+    $period: secondsToDissolveDelayDuration(
+      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS)
+    ),
+  });
 </script>
 
 <CommonItemAction testId="nns-neuron-reward-status-action-component">
@@ -77,6 +86,7 @@
   </span>
   <span slot="title" data-tid="state-title">
     {title}
+    <TooltipIcon text={tooltipText} tooltipId="neuron-reward-status-tooltip" />
   </span>
 
   <span


### PR DESCRIPTION
# Motivation

Currently, the meaning of the neuron rewards status might not be very clear. To improve this, we are adding an info icon with a description of this indicator.

# Changes

- Added description to the neuron rewards status action field 

# Tests

- Tested manually

<img width="420" alt="image" src="https://github.com/user-attachments/assets/d2b0606a-40ee-4fad-aea8-eaac759da1ac" />


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.