### PR TITLE
refactor: types toast messages 

### DIFF
--- a/frontend/src/lib/stores/toasts.store.ts
+++ b/frontend/src/lib/stores/toasts.store.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { DEFAULT_TOAST_DURATION_MILLIS } from "$lib/constants/constants";
-import type { ToastMsg } from "$lib/types/toast";
+import type { ToastLabelKey, ToastMsg } from "$lib/types/toast";
 import { errorToString } from "$lib/utils/error.utils";
 import type { I18nSubstitutions } from "$lib/utils/i18n.utils";
 import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
@@ -48,7 +48,7 @@ export const toastsError = ({
   substitutions,
   renderAsHtml,
 }: {
-  labelKey: string;
+  labelKey: ToastLabelKey;
   err?: unknown;
   substitutions?: I18nSubstitutions;
   renderAsHtml?: boolean;

--- a/frontend/src/lib/types/toast.ts
+++ b/frontend/src/lib/types/toast.ts
@@ -1,6 +1,9 @@
 import type { I18nKeys, I18nSubstitutions } from "$lib/utils/i18n.utils";
 import type { ToastMsg as ToastMsgUI } from "@dfinity/gix-components";
 
+// We use empty object intersection (string & {}) instead of plain string
+// to prevent TS from widening the type to just 'string', which would lose
+// autocomplete suggestions from I18nKeys
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type ToastLabelKey = I18nKeys | (string & {});
 

--- a/frontend/src/lib/types/toast.ts
+++ b/frontend/src/lib/types/toast.ts
@@ -1,6 +1,7 @@
 import type { I18nKeys, I18nSubstitutions } from "$lib/utils/i18n.utils";
 import type { ToastMsg as ToastMsgUI } from "@dfinity/gix-components";
 
+// Note: This is a "hack"/"bug" supported by the TS team
 // We use empty object intersection (string & {}) instead of plain string
 // to prevent TS from widening the type to just 'string', which would lose
 // autocomplete suggestions from I18nKeys

--- a/frontend/src/lib/types/toast.ts
+++ b/frontend/src/lib/types/toast.ts
@@ -1,9 +1,12 @@
-import type { I18nSubstitutions } from "$lib/utils/i18n.utils";
+import type { I18nKeys, I18nSubstitutions } from "$lib/utils/i18n.utils";
 import type { ToastMsg as ToastMsgUI } from "@dfinity/gix-components";
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type ToastLabelKey = I18nKeys | (string & {});
 
 export interface ToastMsg extends Omit<ToastMsgUI, "text" | "id"> {
   id?: symbol;
-  labelKey: string;
+  labelKey: ToastLabelKey;
   detail?: string;
   substitutions?: I18nSubstitutions;
 }

--- a/frontend/src/lib/utils/i18n.utils.ts
+++ b/frontend/src/lib/utils/i18n.utils.ts
@@ -76,8 +76,18 @@ export const joinWithOr = (text: string[]): string =>
     ? `${text.slice(0, -1).join(", ")} ${get(i18n).core.or} ${text.slice(-1)}`
     : text.join(", ");
 
+// Creates a dot-prefixed string type unless empty
 type DotPrefix<T extends string> = T extends "" ? "" : `.${T}`;
 
+// Recursively builds a union type of all possible object paths in dot notation:
+// 1. For each object level, takes all keys (excluding symbols)
+// 2. For each key, creates a string literal combining:
+//    - Current key name
+//    - Dot prefix
+//    - Recursively processes nested properties
+// Example:
+// { user: { name: string, settings: { theme: string } } }
+// Generates: "user" | "user.name" | "user.settings" | "user.settings.theme"
 type DotNestedKeys<T> = (
   T extends object
     ? {
@@ -91,5 +101,5 @@ type DotNestedKeys<T> = (
   ? Extract<D, string>
   : never;
 
-// Get all possible keys from I18n interface
+// Type containing all possible i18n keys in dot notation (e.g., "reporting.error_csv_generation")
 export type I18nKeys = DotNestedKeys<I18n>;

--- a/frontend/src/lib/utils/i18n.utils.ts
+++ b/frontend/src/lib/utils/i18n.utils.ts
@@ -91,7 +91,8 @@ type StringKeyOf<T> = Extract<keyof T, string>;
 //    - Extract only string literals from it
 //    - Filter out any non-string types
 // Example: { user: { name: string, settings: { theme: string } } }
-// Generates: "user.name" | "user.settings" | "user.settings.theme"
+// Allows: "user.name" | "user.settings.theme"
+// Excludes: "user" | "user.settings"
 type DotNestedKeys<T> = (
   T extends object
     ? {

--- a/frontend/src/lib/utils/i18n.utils.ts
+++ b/frontend/src/lib/utils/i18n.utils.ts
@@ -75,3 +75,21 @@ export const joinWithOr = (text: string[]): string =>
   text.length > 1
     ? `${text.slice(0, -1).join(", ")} ${get(i18n).core.or} ${text.slice(-1)}`
     : text.join(", ");
+
+type DotPrefix<T extends string> = T extends "" ? "" : `.${T}`;
+
+type DotNestedKeys<T> = (
+  T extends object
+    ? {
+        [K in Exclude<
+          keyof T,
+          symbol
+        >]: `${K}${DotPrefix<DotNestedKeys<T[K]>>}`;
+      }[Exclude<keyof T, symbol>]
+    : ""
+) extends infer D
+  ? Extract<D, string>
+  : never;
+
+// Get all possible keys from I18n interface
+export type I18nKeys = DotNestedKeys<I18n>;


### PR DESCRIPTION
# Motivation

We want to define the types of potential messages that can be passed to the `toast` store. We can extract this list of potential messages from `I18n`.

https://github.com/user-attachments/assets/17c7d582-bf7b-42f4-b873-8aee9c2919a5

We can't enforce just `I18n` keys as we have some places were we programmatically pass the value and we don't have control on the type.

# Changes

- Types `labelKey` based on `I18n` nested keys.

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary