### PR TITLE
Add HW support to refreshVotingPower

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -703,11 +703,11 @@ const refreshVotingPower = async (neuronId: NeuronId): Promise<void> => {
   });
 
   if (isHWControlled) {
-    // This is a workaround for the Ledger device, because it does not support
+    // This is a workaround for the Ledger device, because currently it does not support
     // the governance canister version required for the `refreshVotingPower` call.
     const identity: Identity = await getAuthenticatedIdentity();
     // It doesn't matter which topic to use to confirm the current state of the neuron
-    // except NeuronManagement, which can only be handled by controllers.
+    // (except NeuronManagement, which can only be handled by controllers).
     const topic = Topic.Governance;
     const followees =
       followeesByTopic({


### PR DESCRIPTION
# Motivation

Users should be able to refresh the voting power timestamp of a neuron to avoid missing voting rewards. A new API, `RefreshVotingPower`, is designed for this purpose. However, currently, the Ledger API does not support this type of transaction. This PR addresses the issue and provides a workaround. The `setFollowees` API is used for hardware HW neurons, as updating following and voting resets the voting power timestamp in the same way as the `RefreshVotingPower` call.

**Note:** The topic used to confirm the current state of the neuron does not matter, except for NeuronManagement, which can only be handled by controllers.

# Changes

- Update `refreshVotingPowerForNeurons` service to call `setFollowees` with the current value for HW neurons.

# Tests

- Added.
- Tested locally to confirm that it is possible to reset the timestamp for HW neurons.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.