### PR TITLE
Update snsdemo to release-2024-12-11

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.24.2",
+  "dfx": "0.24.3",
   "canisters": {
     "nns-governance": {
       "type": "custom",
@@ -441,7 +441,7 @@
         "DIDC_VERSION": "didc 0.4.0",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-12-04",
+        "SNSDEMO_RELEASE": "release-2024-12-11",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-12-06_03-16-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-12-06_03-16-base"
       },

--- a/frontend/src/tests/e2e/ckbtc.spec.ts
+++ b/frontend/src/tests/e2e/ckbtc.spec.ts
@@ -44,5 +44,5 @@ test("Test accounts requirements", async ({ page, context }) => {
 
   expect(await transaction.getIdentifier()).toBe("From: BTC Network");
   // 20 minus fees.
-  expect(await transaction.getAmount()).toBe("+19.99986667");
+  expect(await transaction.getAmount()).toBe("+19.99999");
 });


### PR DESCRIPTION
# Motivation

[The automatic update](https://github.com/dfinity/nns-dapp/pull/6009) had test failure.
It appears that the ckBTC checker, which replaces the KYT canister (see https://github.com/dfinity/snsdemo/pull/427 and https://github.com/dfinity/snsdemo/pull/435), has lower fees.

# Changes

1. Update the snsdemo release.
2. Update the end-to-end test that failed in the automatic update.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary