### PR TITLE
Add stakeInUsd field to TableNeuron

### DIFF
--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -50,6 +50,7 @@
         identity: $authStore.identity,
         i18n: $i18n,
         snsNeurons: $definedSnsNeuronStore,
+        ledgerCanisterId: summary.ledgerCanisterId,
       })
     : [];
 

--- a/frontend/src/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.ts
+++ b/frontend/src/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.ts
@@ -29,6 +29,7 @@ const snsTableNeuronsToSortStore = derived(
           identity: $authStore.identity,
           i18n: $i18n,
           snsNeurons: $definedSnsNeuronStore,
+          ledgerCanisterId: summary.ledgerCanisterId,
         })
       : [];
     return tableNeurons.sort(compareById);

--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -12,6 +12,7 @@ export type TableNeuron = {
   domKey: string;
   neuronId: string;
   stake: TokenAmountV2;
+  stakeInUsd: number | undefined;
   availableMaturity: bigint;
   stakedMaturity: bigint;
   dissolveDelaySeconds: bigint;

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -115,6 +115,7 @@ export const mockTableNeuron: TableNeuron = {
     amount: 1n,
     token: ICPToken,
   }),
+  stakeInUsd: 10,
   availableMaturity: 0n,
   stakedMaturity: 0n,
   dissolveDelaySeconds: 1n,


### PR DESCRIPTION
# Motivation

We want to show USD values in the neurons tables, similar to the tokens table and the projects table.

In this PR we just add the USD stake to the `TableNeuron` objects. It will be displayed in future PRs.

# Changes

1. Add `stakeInUsd` field to `TableNeuron` type.
2. Populate `stakeInUsd` in and `tableNeuronsFromNeuronInfos` and `tableNeuronsFromSnsNeurons`.
3. Make `icpSwapUsdPrices` temporarily an optional parameter until we pass it from all the components callers in future PRs. Then they will be tested too.

# Tests

1. Unit tests adapted.
2. Tested manually (including future changes) at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet