### PR TITLE
NNS1-3486: adds ReportingDateRangeSelector 

### DIFF
--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -43,7 +43,7 @@
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   fieldset {
-    all: unset; // Reset all styles
+    all: unset;
 
     .wrapper {
       display: flex;
@@ -51,7 +51,7 @@
       gap: var(--padding-2x);
       border: none;
       padding: 0;
-      margin: 0; /* Add this to remove default margin */
+      margin: 0;
 
       legend {
         @include fonts.h5;

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -19,61 +19,73 @@
 </script>
 
 <fieldset data-tid="reporting-data-range-selector-component">
-  <legend>{$i18n.reporting.range_filter_title}</legend>
-  <div role="radiogroup">
-    {#each options as option}
-      <label class="radio-option">
-        <input
-          type="radio"
-          name="dateRange"
-          value={option.value}
-          checked={selectedRange === option.value}
-          aria-checked={selectedRange === option.value}
-          on:change={() => handleChange(option.value)}
-        />
-        <span class="label">{option.label}</span>
-      </label>
-    {/each}
-  </div>
+  <div class="wrapper">
+    <legend>{$i18n.reporting.range_filter_title}</legend>
+    <div role="radiogroup">
+      {#each options as option}
+        <label class="radio-option">
+          <input
+            type="radio"
+            name="dateRange"
+            value={option.value}
+            checked={selectedRange === option.value}
+            aria-checked={selectedRange === option.value}
+            on:change={() => handleChange(option.value)}
+          />
+          <span class="label">{option.label}</span>
+        </label>
+      {/each}
+    </div></div
+  >
 </fieldset>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
   fieldset {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding-2x);
+    all: unset; // Reset all styles
 
-    legend {
-    }
-
-    div {
+    .wrapper {
       display: flex;
-      gap: var(--padding-3x);
+      flex-direction: column;
+      gap: var(--padding-2x);
+      border: none;
+      padding: 0;
+      margin: 0; /* Add this to remove default margin */
 
-      .radio-option {
+      legend {
+        @include fonts.h5;
+      }
+
+      div {
         display: flex;
-        align-items: center;
-        gap: var(--padding);
-        cursor: pointer;
+        gap: var(--padding-3x);
 
-        .label {
-          color: var(--text-primary);
-          font-size: var(--font-size-body);
-        }
-
-        input[type="radio"] {
-          appearance: none;
-          width: 18px;
-          height: 18px;
-          border: 2px solid var(--primary);
-          border-radius: 50%;
-          margin: 0;
+        .radio-option {
+          display: flex;
+          align-items: center;
+          gap: var(--padding);
           cursor: pointer;
-          position: relative;
-          background: transparent;
 
-          &:checked {
-            border: 5px solid var(--primary, #666);
+          .label {
+            color: var(--text-description);
+            font-size: var(--font-size-body);
+          }
+
+          input[type="radio"] {
+            appearance: none;
+            width: 18px;
+            height: 18px;
+            border: 2px solid var(--primary);
+            border-radius: 50%;
+            margin: 0;
+            cursor: pointer;
+            position: relative;
+            background: transparent;
+
+            &:checked {
+              border: 5px solid var(--primary, #666);
+            }
           }
         }
       }

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import type { ReportingDateRange } from "$lib/types/reporting";
+
+  let selectedRange: ReportingDateRange = "all";
+
+  const options: Array<{
+    value: ReportingDateRange;
+    label: string;
+  }> = [
+    { value: "all", label: $i18n.reporting.range_filter_all },
+    { value: "last-year", label: $i18n.reporting.range_last_year },
+    { value: "year-to-date", label: $i18n.reporting.range_year_to_date },
+  ];
+
+  function handleChange(value: ReportingDateRange) {
+    selectedRange = value;
+  }
+</script>
+
+<fieldset data-tid="reporting-data-range-selector-component">
+  <legend>{$i18n.reporting.range_filter_title}</legend>
+  <div role="radiogroup">
+    {#each options as option}
+      <label class="radio-option">
+        <input
+          type="radio"
+          name="dateRange"
+          value={option.value}
+          checked={selectedRange === option.value}
+          aria-checked={selectedRange === option.value}
+          on:change={() => handleChange(option.value)}
+        />
+        <span class="label">{option.label}</span>
+      </label>
+    {/each}
+  </div>
+</fieldset>
+
+<style lang="scss">
+  fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+
+    legend {
+    }
+
+    div {
+      display: flex;
+      gap: var(--padding-3x);
+
+      .radio-option {
+        display: flex;
+        align-items: center;
+        gap: var(--padding);
+        cursor: pointer;
+
+        .label {
+          color: var(--text-primary);
+          font-size: var(--font-size-body);
+        }
+
+        input[type="radio"] {
+          appearance: none;
+          width: 18px;
+          height: 18px;
+          border: 2px solid var(--primary);
+          border-radius: 50%;
+          margin: 0;
+          cursor: pointer;
+          position: relative;
+          background: transparent;
+
+          &:checked {
+            border: 5px solid var(--primary, #666);
+          }
+        }
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -192,7 +192,11 @@
     "error_csv_generation": "Failed to generate CSV file",
     "error_file_system_access": "Unable to save file. Please check your permissions.",
     "error_neurons": "There was an error exporting the neurons. Please try again.",
-    "error_transactions": "There was an error exporting the transactions. Please try again."
+    "error_transactions": "There was an error exporting the transactions. Please try again.",
+    "range_filter_title": "Reporting Date Range",
+    "range_filter_all": "All transactions",
+    "range_last_year": "Last year",
+    "range_year_to_date": "Year to date"
   },
   "auth": {
     "login": "Sign in with Internet Identity",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -201,6 +201,10 @@ interface I18nReporting {
   error_file_system_access: string;
   error_neurons: string;
   error_transactions: string;
+  range_filter_title: string;
+  range_filter_all: string;
+  range_last_year: string;
+  range_year_to_date: string;
 }
 
 interface I18nAuth {

--- a/frontend/src/lib/types/reporting.ts
+++ b/frontend/src/lib/types/reporting.ts
@@ -1,0 +1,1 @@
+export type ReportingDateRange = "all" | "last-year" | "year-to-date";

--- a/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.spec.ts
@@ -1,0 +1,50 @@
+import ReportingDateRangeSelector from "$lib/components/reporting/ReportingDateRangeSelector.svelte";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ReportingDateRangeSelectorPo } from "$tests/page-objects/ReportingDateRangeSelector.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("ReportingDateRangeSelector", () => {
+  const renderComponent = () => {
+    const { container } = render(ReportingDateRangeSelector);
+    const po = ReportingDateRangeSelectorPo.under({
+      element: new JestPageObjectElement(container),
+    });
+
+    return po;
+  };
+
+  it("should render a title", async () => {
+    const po = renderComponent();
+    const title = await po.getLegend();
+    expect(title).toBeDefined();
+  });
+
+  it("should render three options", async () => {
+    const po = renderComponent();
+
+    expect(await po.getAllOptions()).toHaveLength(3);
+  });
+
+  it("should select 'all' option by default", async () => {
+    const po = renderComponent();
+
+    const selectedOption = po.getSelectedOption();
+    expect(await selectedOption.getValue()).toBe("all");
+  });
+
+  it("should change the option when interacting with a new element", async () => {
+    const po = renderComponent();
+    const allOptions = await po.getAllOptions();
+    const firstOptionValue = await allOptions[0].getValue();
+    const secondOption = allOptions[1];
+
+    let currentOption = po.getSelectedOption();
+
+    expect(await currentOption.getValue()).toEqual(firstOptionValue);
+
+    await secondOption.click();
+    currentOption = po.getSelectedOption();
+
+    expect(await currentOption.getValue()).toBe(await secondOption.getValue());
+  });
+});

--- a/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.spec.ts
@@ -13,12 +13,6 @@ describe("ReportingDateRangeSelector", () => {
     return po;
   };
 
-  it("should render a title", async () => {
-    const po = renderComponent();
-    const title = await po.getLegend();
-    expect(title).toBeDefined();
-  });
-
   it("should render three options", async () => {
     const po = renderComponent();
 

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -14,10 +14,6 @@ export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
     );
   }
 
-  getLegend() {
-    return this.getElement().querySelector("legend").getText();
-  }
-
   getAllOptions() {
     return this.getElement().querySelectorAll('input[type="radio"]');
   }

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -1,0 +1,28 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SimpleBasePageObject } from "./simple-base.page-object";
+
+export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
+  static readonly TID = "reporting-data-range-selector-component";
+
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): ReportingDateRangeSelectorPo {
+    return new ReportingDateRangeSelectorPo(
+      element.byTestId(ReportingDateRangeSelectorPo.TID)
+    );
+  }
+
+  getLegend() {
+    return this.getElement().querySelector("legend").getText();
+  }
+
+  getAllOptions() {
+    return this.getElement().querySelectorAll('input[type="radio"]');
+  }
+
+  getSelectedOption() {
+    return this.getElement().querySelector('input[type="radio"]:checked');
+  }
+}


### PR DESCRIPTION
# Motivation

Users can filter their export by choosing one of three options: all, this year, or last year.
<img width="793" alt="Screenshot 2024-12-16 at 22 16 48" src="https://github.com/user-attachments/assets/7ff41787-3c66-4d04-81e2-e89b9c9cf2f9" />

A follow up PR will introduce a new component `ReportingDateRangeSelector` that will onrchestrate the `dateRange` filter by passing it down to both, the `ReportingDateRangeSelector` and to `ReportingTransactionsButton`.

# Changes

- Adds a new component called `ReportingDateRangeSelector` to change the value of the date range filter.

# Tests

- Unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary