### PR TITLE
chore: unrecognized attribute xmlns:svelte

### DIFF
--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" xmlns:svelte="http://www.w3.org/1999/html">
+<script lang="ts">
   import CurrentBalance from "$lib/components/accounts/CurrentBalance.svelte";
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";


### PR DESCRIPTION
# Motivation

Fix warning which becomes an error with Svelte v5 tooling (PR #6020).

```
/Users/daviddalbusco/projects/dfinity/nns-dapp/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
  1:19  error  Unrecognized attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it
https://svelte.dev/e/script_unknown_attribute(script_unknown_attribute)  svelte/valid-compile
```

