### PR TITLE
fix: <span> cannot be a child of <option>

### DIFF
--- a/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
@@ -59,7 +59,7 @@
   testId="select-network-dropdown"
 >
   <option disabled selected value={undefined} class="hidden"
-    ><span class="description">{$i18n.accounts.select_network}</span></option
+    >{$i18n.accounts.select_network}</option
   >
   <DropdownItem value={TransactionNetwork.ICP}
     >{$i18n.accounts.network_icp}</DropdownItem


### PR DESCRIPTION
# Motivation

Fix warning which becomes an error with Svelte v5 tooling (PR #6020).

```
/Users/daviddalbusco/projects/dfinity/nns-dapp/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
  62:6  error  `<span>` cannot be a child of `<option>`. `<option>` only allows these children: `<#text>`. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components.
https://svelte.dev/e/node_invalid_placement(node_invalid_placement)  svelte/valid-compile
```

# Changes

- Remove `span` in `option`.
