### PR TITLE
fix: <div> cannot be a child of <p>

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCInfoCard.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCInfoCard.svelte
@@ -66,7 +66,7 @@
       {$i18n.ckbtc.receive_btc_title}
     </h4>
     <div class="content-cell-details info-section">
-      <p class="description">
+      <div class="description">
         {$i18n.ckbtc.ckbtc_buzz_words}
         {#if nonNullish(account)}
           <Html
@@ -88,7 +88,7 @@
             {/if}
           </a>.
         {/if}
-      </p>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/lib/routes/Settings.svelte
+++ b/frontend/src/lib/routes/Settings.svelte
@@ -53,7 +53,7 @@
 
         <KeyValuePairInfo>
           <p slot="key" class="label">{$i18n.settings.your_session}</p>
-          <p slot="value" class="value session" data-tid="session-duration">
+          <div slot="value" class="value session" data-tid="session-duration">
             {#if nonNullish(remainingTimeMilliseconds)}
               {remainingTimeMilliseconds <= 0
                 ? "0"
@@ -64,7 +64,7 @@
             {:else}
               <div class="skeleton"><SkeletonText /></div>
             {/if}
-          </p>
+          </div>
 
           <svelte:fragment slot="info">
             {$i18n.settings.your_session_description}


### PR DESCRIPTION
# Motivation

Fix warning which becomes an error with Svelte v5 tooling (PR #6020).

```
/Users/daviddalbusco/projects/dfinity/nns-dapp/frontend/src/lib/components/accounts/CkBTCInfoCard.svelte
  85:15  error  `<div>` cannot be a descendant of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning
https://svelte.dev/e/node_invalid_placement_ssr(node_invalid_placement_ssr)  svelte/valid-compile
```

# Changes

- Transform container `p` into a `div`.
