### PR TITLE
Pass icpSwapUsdPricesStore when constructing table neurons

### DIFF
--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -1,20 +1,21 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import LosingRewardsBanner from "$lib/components/neurons/LosingRewardsBanner.svelte";
   import MakeNeuronsPublicBanner from "$lib/components/neurons/MakeNeuronsPublicBanner.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
-  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import { tableNeuronsFromNeuronInfos } from "$lib/utils/neurons-table.utils";
   import { Spinner } from "@dfinity/gix-components";
   import { onMount } from "svelte";
-  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
-  import LosingRewardsBanner from "$lib/components/neurons/LosingRewardsBanner.svelte";
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;
@@ -29,6 +30,7 @@
     accounts: $icpAccountsStore,
     i18n: $i18n,
     neuronInfos: $definedNeuronsStore,
+    icpSwapUsdPrices: $icpSwapUsdPricesStore,
   });
 </script>
 

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -2,6 +2,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { pageStore } from "$lib/derived/page.derived";
   import {
     snsOnlyProjectStore,
@@ -50,6 +51,7 @@
         identity: $authStore.identity,
         i18n: $i18n,
         snsNeurons: $definedSnsNeuronStore,
+        icpSwapUsdPrices: $icpSwapUsdPricesStore,
         ledgerCanisterId: summary.ledgerCanisterId,
       })
     : [];

--- a/frontend/src/lib/stores/neurons-table-order-sorted-neuron-ids-store.ts
+++ b/frontend/src/lib/stores/neurons-table-order-sorted-neuron-ids-store.ts
@@ -1,4 +1,5 @@
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
 import { definedNeuronsStore } from "$lib/derived/neurons.derived";
 import { authStore } from "$lib/stores/auth.store";
 import { i18n } from "$lib/stores/i18n";
@@ -11,13 +12,26 @@ import {
 import { derived } from "svelte/store";
 
 const tableNeuronsToSortStore = derived(
-  [authStore, icpAccountsStore, i18n, definedNeuronsStore],
-  ([$authStore, $icpAccountsStore, $i18n, $definedNeuronsStore]) => {
+  [
+    authStore,
+    icpAccountsStore,
+    i18n,
+    definedNeuronsStore,
+    icpSwapUsdPricesStore,
+  ],
+  ([
+    $authStore,
+    $icpAccountsStore,
+    $i18n,
+    $definedNeuronsStore,
+    $icpSwapUsdPricesStore,
+  ]) => {
     const tableNeurons = tableNeuronsFromNeuronInfos({
       identity: $authStore.identity,
       accounts: $icpAccountsStore,
       i18n: $i18n,
       neuronInfos: $definedNeuronsStore,
+      icpSwapUsdPrices: $icpSwapUsdPricesStore,
     });
     return tableNeurons.sort(compareById);
   }

--- a/frontend/src/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.ts
+++ b/frontend/src/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.ts
@@ -1,3 +1,4 @@
+import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
 import { pageStore } from "$lib/derived/page.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import { definedSnsNeuronStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
@@ -13,13 +14,21 @@ import { derived } from "svelte/store";
 import { neuronsTableOrderStore } from "./neurons-table.store";
 
 const snsTableNeuronsToSortStore = derived(
-  [authStore, i18n, definedSnsNeuronStore, snsProjectSelectedStore, pageStore],
+  [
+    authStore,
+    i18n,
+    definedSnsNeuronStore,
+    snsProjectSelectedStore,
+    pageStore,
+    icpSwapUsdPricesStore,
+  ],
   ([
     $authStore,
     $i18n,
     $definedSnsNeuronStore,
     $snsProjectSelectedStore,
     $pageStore,
+    $icpSwapUsdPricesStore,
   ]) => {
     const summary = $snsProjectSelectedStore?.summary;
     const tableNeurons = nonNullish(summary)
@@ -29,6 +38,7 @@ const snsTableNeuronsToSortStore = derived(
           identity: $authStore.identity,
           i18n: $i18n,
           snsNeurons: $definedSnsNeuronStore,
+          icpSwapUsdPrices: $icpSwapUsdPricesStore,
           ledgerCanisterId: summary.ledgerCanisterId,
         })
       : [];

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -51,7 +51,7 @@ export const tableNeuronsFromNeuronInfos = ({
   neuronInfos: NeuronInfo[];
   identity?: Identity | undefined | null;
   accounts: IcpAccountsStoreData;
-  icpSwapUsdPrices?: IcpSwapUsdPricesStoreData;
+  icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
   i18n: I18n;
 }): TableNeuron[] => {
   return neuronInfos.map((neuronInfo) => {
@@ -110,7 +110,7 @@ export const tableNeuronsFromSnsNeurons = ({
   universe: UniverseCanisterIdText;
   token: Token;
   identity: Identity | undefined | null;
-  icpSwapUsdPrices?: IcpSwapUsdPricesStoreData;
+  icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
   ledgerCanisterId: Principal;
   i18n: I18n;
 }): TableNeuron[] => {

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -133,6 +133,9 @@ describe("NnsNeurons", () => {
 
       const po = await renderComponent();
 
+      // The neuron has a stake of 3 ICP.
+      // There are 11 USD in 1 ICP.
+      // So the stake is $33.
       const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
       expect(await rows[0].getStakeInUsd()).toBe("$33.00");
     });

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -1,12 +1,15 @@
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronsPo } from "$tests/page-objects/NnsNeurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -105,6 +108,33 @@ describe("NnsNeurons", () => {
       // Spawning neuron without stake comes last.
       expect(await rows[2].getStake()).toBe("0 ICP");
       expect(await rows[2].hasGoToDetailButton()).toBe(false);
+    });
+
+    it("should provide USD prices", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", true);
+
+      vi.spyOn(api, "queryNeurons").mockResolvedValue([
+        {
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockFullNeuron,
+            cachedNeuronStake: 300_000_000n,
+          },
+        },
+      ]);
+
+      icpSwapTickersStore.set([
+        {
+          ...mockIcpSwapTicker,
+          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+          last_price: "11.00",
+        },
+      ]);
+
+      const po = await renderComponent();
+
+      const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+      expect(await rows[0].getStakeInUsd()).toBe("$33.00");
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -1,17 +1,20 @@
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
 import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { enumValues } from "$lib/utils/enum.utils";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { rootCanisterIdMock, ledgerCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import {
+  ledgerCanisterIdMock,
+  rootCanisterIdMock,
+} from "$tests/mocks/sns.api.mock";
 import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -236,7 +236,7 @@ describe("SnsNeurons", () => {
       const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
       // We have a stake of 4 and 2 in the neurons.
       // There are 10 USD in 1 ICP and 100 SNS tokens in 1 ICP.
-      // So each token in $0.10.
+      // So each token is $0.10.
       expect(await rows[0].getStakeInUsd()).toBe("$0.40");
       expect(await rows[1].getStakeInUsd()).toBe("$0.20");
     });


### PR DESCRIPTION
# Motivation

In order to display neuron stakes in USD we need token price data to factor into the calculation.

# Changes

1. Make `icpSwapUsdPrices` non-optional parameter to `tableNeuronsFromNeuronInfos` and `tableNeuronsFromSnsNeurons`. It can still be `undefined` but should only be so when the ICPSwap data isn't loaded yet.
2. Pass `icpSwapUsdPrices` from `NnsNeurons` and `SnsNeurons` components to display in the tables.
3. Include `icpSwapUsdPrices` in `tableNeuronsToSortStore` and `snsTableNeuronsToSortStore`. This currently has no effect but might if we ever include `stakeInUsd` in the ordering logic. It's good to have for completeness.

# Tests

1. Unit tests added for `NnsNeurons` and `SnsNeurons`.
2. Since the USD price currently has no effect on ordering, there's nothing to test for `neuronsTableOrderSortedNeuronIdsStore` or `snsNeuronsTableOrderSortedNeuronIdsStore`.
3. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet