### PR TITLE
NNS1-3486: new util function to convert from period to dateRange

### DIFF
--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -94,7 +94,7 @@ export const getAccountTransactionsConcurrently = async ({
   return entitiesAndTransactions;
 };
 
-type DateRange = {
+export type TransactionsDateRange = {
   from?: bigint;
   to?: bigint;
 };
@@ -112,7 +112,7 @@ export const getAllTransactionsFromAccountAndIdentity = async ({
   lastTransactionId?: bigint;
   allTransactions?: TransactionWithId[];
   currentPageIndex?: number;
-  range?: DateRange;
+  range?: TransactionsDateRange;
 }): Promise<TransactionWithId[] | undefined> => {
   // Based on
   //   https://github.com/dfinity/ic/blob/master/rs/ledger_suite/icp/index/src/lib.rs#L31

--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -178,7 +178,7 @@ export const getAllTransactionsFromAccountAndIdentity = async ({
 // Helper function to filter transactions by date range
 const filterTransactionsByRange = (
   transactions: TransactionWithId[],
-  range?: DateRange
+  range?: TransactionsDateRange
 ): TransactionWithId[] => {
   if (isNullish(range)) return transactions;
   return transactions.filter((tx) => {

--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -1,5 +1,6 @@
 import { getTransactions } from "$lib/api/icp-index.api";
 import type { Account } from "$lib/types/account";
+import type { TransactionsDateRange } from "$lib/types/reporting";
 import { neuronStake } from "$lib/utils/neuron.utils";
 import { SignIdentity } from "@dfinity/agent";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
@@ -92,11 +93,6 @@ export const getAccountTransactionsConcurrently = async ({
   });
 
   return entitiesAndTransactions;
-};
-
-export type TransactionsDateRange = {
-  from?: bigint;
-  to?: bigint;
 };
 
 export const getAllTransactionsFromAccountAndIdentity = async ({

--- a/frontend/src/lib/types/reporting.ts
+++ b/frontend/src/lib/types/reporting.ts
@@ -1,1 +1,6 @@
 export type ReportingDateRange = "all" | "last-year" | "year-to-date";
+
+export type TransactionsDateRange = {
+  from?: bigint;
+  to?: bigint;
+};

--- a/frontend/src/lib/types/reporting.ts
+++ b/frontend/src/lib/types/reporting.ts
@@ -1,6 +1,8 @@
 export type ReportingDateRange = "all" | "last-year" | "year-to-date";
 
 export type TransactionsDateRange = {
+  /** Start of the date range (inclusive) - timestamp in nanoseconds */
   from?: bigint;
+  /** End of the date range (exclusive) - timestamp in nanoseconds */
   to?: bigint;
 };

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -1,8 +1,8 @@
+import type { TransactionResults } from "$lib/services/reporting.services";
 import type {
-  TransactionResults,
+  ReportingDateRange,
   TransactionsDateRange,
-} from "$lib/services/reporting.services";
-import type { ReportingDateRange } from "$lib/types/reporting";
+} from "$lib/types/reporting";
 import {
   getFutureDateFromDelayInSeconds,
   nanoSecondsToDateTime,
@@ -467,23 +467,22 @@ export const buildNeuronsDatasets = ({
 export const periodToDateRangeTimestampts = (
   period: ReportingDateRange
 ): TransactionsDateRange => {
-  if (period === "all") return {};
-
   const now = new Date();
   const currentYear = now.getFullYear();
 
-  if (period === "last-year") {
-    return {
-      from: BigInt(new Date(currentYear - 1, 0, 1).getTime()),
-      to: BigInt(new Date(currentYear - 1, 11, 31, 23, 59, 59, 999).getTime()),
-    };
-  }
+  switch (period) {
+    case "all":
+      return {};
 
-  if (period === "year-to-date") {
-    return {
-      from: BigInt(new Date(currentYear, 0, 1).getTime()),
-    };
-  }
+    case "last-year":
+      return {
+        from: BigInt(new Date(currentYear - 1, 0, 1).getTime()),
+        to: BigInt(new Date(currentYear, 0, 1).getTime()),
+      };
 
-  throw new Error(`Invalid period: ${period}`);
+    case "year-to-date":
+      return {
+        from: BigInt(new Date(currentYear, 0, 1).getTime()),
+      };
+  }
 };

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -469,6 +469,8 @@ export const periodToDateRangeTimestampts = (
 ): TransactionsDateRange => {
   const now = new Date();
   const currentYear = now.getFullYear();
+  const toNanoseconds = (milliseconds: number): bigint =>
+    BigInt(milliseconds) * BigInt(1_000_000);
 
   switch (period) {
     case "all":
@@ -476,13 +478,13 @@ export const periodToDateRangeTimestampts = (
 
     case "last-year":
       return {
-        from: BigInt(new Date(currentYear - 1, 0, 1).getTime()),
-        to: BigInt(new Date(currentYear, 0, 1).getTime()),
+        from: toNanoseconds(new Date(currentYear - 1, 0, 1).getTime()),
+        to: toNanoseconds(new Date(currentYear, 0, 1).getTime()),
       };
 
     case "year-to-date":
       return {
-        from: BigInt(new Date(currentYear, 0, 1).getTime()),
+        from: toNanoseconds(new Date(currentYear, 0, 1).getTime()),
       };
   }
 };

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -1,4 +1,8 @@
-import type { TransactionResults } from "$lib/services/reporting.services";
+import type {
+  TransactionResults,
+  TransactionsDateRange,
+} from "$lib/services/reporting.services";
+import type { ReportingDateRange } from "$lib/types/reporting";
 import {
   getFutureDateFromDelayInSeconds,
   nanoSecondsToDateTime,
@@ -458,4 +462,28 @@ export const buildNeuronsDatasets = ({
   });
 
   return [{ metadata, data }];
+};
+
+export const periodToDateRangeTimestampts = (
+  period: ReportingDateRange
+): TransactionsDateRange => {
+  if (period === "all") return {};
+
+  const now = new Date();
+  const currentYear = now.getFullYear();
+
+  if (period === "last-year") {
+    return {
+      from: BigInt(new Date(currentYear - 1, 0, 1).getTime()),
+      to: BigInt(new Date(currentYear - 1, 11, 31, 23, 59, 59, 999).getTime()),
+    };
+  }
+
+  if (period === "year-to-date") {
+    return {
+      from: BigInt(new Date(currentYear, 0, 1).getTime()),
+    };
+  }
+
+  throw new Error(`Invalid period: ${period}`);
 };

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -464,7 +464,7 @@ export const buildNeuronsDatasets = ({
   return [{ metadata, data }];
 };
 
-export const periodToDateRangeTimestamps = (
+export const convertPeriodToNanosecondRange = (
   period: ReportingDateRange
 ): TransactionsDateRange => {
   const now = new Date();

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -464,7 +464,7 @@ export const buildNeuronsDatasets = ({
   return [{ metadata, data }];
 };
 
-export const periodToDateRangeTimestampts = (
+export const periodToDateRangeTimestamps = (
   period: ReportingDateRange
 ): TransactionsDateRange => {
   const now = new Date();

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -5,6 +5,7 @@ import {
   combineDatasetsToCsv,
   convertToCsv,
   generateCsvFileToSave,
+  periodToDateRangeTimestampts,
   type CsvHeader,
 } from "$lib/utils/reporting.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -552,6 +553,45 @@ describe("reporting utils", () => {
           metadata: expectedMetadata,
         },
       ]);
+    });
+  });
+
+  describe("periodToDateRangeTimestampts", () => {
+    const mockDate = new Date("2024-03-15T12:00:00Z");
+
+    beforeEach(() => {
+      vi.clearAllTimers();
+      vi.useFakeTimers();
+      vi.setSystemTime(mockDate);
+    });
+
+    it('returns empty object for "all" period', () => {
+      const result = periodToDateRangeTimestampts("all");
+      expect(result).toEqual({});
+    });
+
+    it('returns correct range for "last-year"', () => {
+      const result = periodToDateRangeTimestampts("last-year");
+
+      expect(result).toEqual({
+        from: BigInt(new Date("2023-01-01T00:00:00Z").getTime()),
+        to: BigInt(new Date("2023-12-31T23:59:59.999Z").getTime()),
+      });
+    });
+
+    it('returns correct range for "year-to-date"', () => {
+      const result = periodToDateRangeTimestampts("year-to-date");
+
+      expect(result).toEqual({
+        from: BigInt(new Date("2024-01-01T00:00:00Z").getTime()),
+      });
+    });
+
+    it("throws error for invalid period", () => {
+      // @ts-expect-error Testing invalid input
+      expect(() => periodToDateRangeTimestampts("invalid-period")).toThrow(
+        "Invalid period: invalid-period"
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -575,7 +575,7 @@ describe("reporting utils", () => {
 
       expect(result).toEqual({
         from: BigInt(new Date("2023-01-01T00:00:00Z").getTime()),
-        to: BigInt(new Date("2023-12-31T23:59:59.999Z").getTime()),
+        to: BigInt(new Date("2024-01-01T00:00:00Z").getTime()),
       });
     });
 
@@ -585,13 +585,6 @@ describe("reporting utils", () => {
       expect(result).toEqual({
         from: BigInt(new Date("2024-01-01T00:00:00Z").getTime()),
       });
-    });
-
-    it("throws error for invalid period", () => {
-      // @ts-expect-error Testing invalid input
-      expect(() => periodToDateRangeTimestampts("invalid-period")).toThrow(
-        "Invalid period: invalid-period"
-      );
     });
   });
 });

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -3,9 +3,9 @@ import {
   buildNeuronsDatasets,
   buildTransactionsDatasets,
   combineDatasetsToCsv,
+  convertPeriodToNanosecondRange,
   convertToCsv,
   generateCsvFileToSave,
-  periodToDateRangeTimestamps,
   type CsvHeader,
 } from "$lib/utils/reporting.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -556,7 +556,7 @@ describe("reporting utils", () => {
     });
   });
 
-  describe("periodToDateRangeTimestamps", () => {
+  describe("convertPeriodToNanosecondRange", () => {
     const mockDate = new Date("2024-03-15T12:00:00Z");
     const NANOS_IN_MS = BigInt(1_000_000);
 
@@ -567,12 +567,12 @@ describe("reporting utils", () => {
     });
 
     it('returns empty object for "all" period', () => {
-      const result = periodToDateRangeTimestamps("all");
+      const result = convertPeriodToNanosecondRange("all");
       expect(result).toEqual({});
     });
 
     it('returns correct range for "last-year"', () => {
-      const result = periodToDateRangeTimestamps("last-year");
+      const result = convertPeriodToNanosecondRange("last-year");
 
       expect(result).toEqual({
         from: BigInt(new Date("2023-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,
@@ -581,7 +581,7 @@ describe("reporting utils", () => {
     });
 
     it('returns correct range for "year-to-date"', () => {
-      const result = periodToDateRangeTimestamps("year-to-date");
+      const result = convertPeriodToNanosecondRange("year-to-date");
 
       expect(result).toEqual({
         from: BigInt(new Date("2024-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -5,7 +5,7 @@ import {
   combineDatasetsToCsv,
   convertToCsv,
   generateCsvFileToSave,
-  periodToDateRangeTimestampts,
+  periodToDateRangeTimestamps,
   type CsvHeader,
 } from "$lib/utils/reporting.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -556,7 +556,7 @@ describe("reporting utils", () => {
     });
   });
 
-  describe("periodToDateRangeTimestampts", () => {
+  describe("periodToDateRangeTimestamps", () => {
     const mockDate = new Date("2024-03-15T12:00:00Z");
     const NANOS_IN_MS = BigInt(1_000_000);
 
@@ -567,12 +567,12 @@ describe("reporting utils", () => {
     });
 
     it('returns empty object for "all" period', () => {
-      const result = periodToDateRangeTimestampts("all");
+      const result = periodToDateRangeTimestamps("all");
       expect(result).toEqual({});
     });
 
     it('returns correct range for "last-year"', () => {
-      const result = periodToDateRangeTimestampts("last-year");
+      const result = periodToDateRangeTimestamps("last-year");
 
       expect(result).toEqual({
         from: BigInt(new Date("2023-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,
@@ -581,7 +581,7 @@ describe("reporting utils", () => {
     });
 
     it('returns correct range for "year-to-date"', () => {
-      const result = periodToDateRangeTimestampts("year-to-date");
+      const result = periodToDateRangeTimestamps("year-to-date");
 
       expect(result).toEqual({
         from: BigInt(new Date("2024-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -558,6 +558,7 @@ describe("reporting utils", () => {
 
   describe("periodToDateRangeTimestampts", () => {
     const mockDate = new Date("2024-03-15T12:00:00Z");
+    const NANOS_IN_MS = BigInt(1_000_000);
 
     beforeEach(() => {
       vi.clearAllTimers();
@@ -574,8 +575,8 @@ describe("reporting utils", () => {
       const result = periodToDateRangeTimestampts("last-year");
 
       expect(result).toEqual({
-        from: BigInt(new Date("2023-01-01T00:00:00Z").getTime()),
-        to: BigInt(new Date("2024-01-01T00:00:00Z").getTime()),
+        from: BigInt(new Date("2023-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,
+        to: BigInt(new Date("2024-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,
       });
     });
 
@@ -583,7 +584,7 @@ describe("reporting utils", () => {
       const result = periodToDateRangeTimestampts("year-to-date");
 
       expect(result).toEqual({
-        from: BigInt(new Date("2024-01-01T00:00:00Z").getTime()),
+        from: BigInt(new Date("2024-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,
       });
     });
   });


### PR DESCRIPTION
# Motivation

We want to convert the selected radio value into a `DateRange` object that can be used when fetching the translations.

# Changes

- New utility `convertPeriodToNanosecondRange` to convert a reporting period into a transaction date range.

# Tests

- Unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary