### PR TITLE
Simplify attach_canister with early returns

### DIFF
--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -234,6 +234,23 @@ fn attach_canister_name_too_long() {
 }
 
 #[test]
+fn attach_canister_account_not_found() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_3).unwrap();
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    let result = store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "".to_string(),
+            canister_id,
+        },
+    );
+
+    assert!(matches!(result, AttachCanisterResponse::AccountNotFound));
+}
+
+#[test]
 fn attach_canister_canister_already_attached() {
     let mut store = setup_test_store();
     let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();


### PR DESCRIPTION
# Motivation

The `attach_canister` function in the backend is unnecessarily much indented.
This can be avoided by inverting 2 `if`s and using early returns.

Make sure to enable "ignore whitespace" when reviewing.

# Changes

1. Change
```
if Self::validate_canister_name(&request.name) {
    ...
} else {
    AttachCanisterResponse::NameTooLong
}
```
to
```
if !Self::validate_canister_name(&request.name) {
    return AttachCanisterResponse::NameTooLong;
}
...
```
2. Change
```
if let Some(mut account) = self.accounts_db.db_get_account(&account_identifier) {
    ...
} else {
    AttachCanisterResponse::AccountNotFound
}
```
to
```
let Some(mut account) = self.accounts_db.db_get_account(&account_identifier) else {
    return AttachCanisterResponse::AccountNotFound;
};
...
```


# Tests

Added a missing test for `AttachCanisterResponse::AccountNotFound`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary