### PR TITLE
Load ICPSwap ticker on neurons tabel page

### DIFF
--- a/frontend/src/lib/routes/Neurons.svelte
+++ b/frontend/src/lib/routes/Neurons.svelte
@@ -7,7 +7,13 @@
   import { snsCommittedProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
   import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { nonNullish } from "@dfinity/utils";
+
+  $: if ($ENABLE_USD_VALUES_FOR_NEURONS) {
+    loadIcpSwapTickers();
+  }
 </script>
 
 <TestIdWrapper testId="neurons-component">

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -1,24 +1,31 @@
 import * as agent from "$lib/api/agent.api";
+import * as icpSwapApi from "$lib/api/icp-swap.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Neurons from "$lib/routes/Neurons.svelte";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
 import * as fakeSnsAggregatorApi from "$tests/fakes/sns-aggregator-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
 import { mock } from "vitest-mock-extended";
 
 vi.mock("$lib/api/icrc-ledger.api");
@@ -127,5 +134,69 @@ describe("Neurons", () => {
 
     expect(await po.hasNnsNeuronsPo()).toBe(false);
     expect(await po.hasSnsNeuronsPo()).toBe(false);
+  });
+
+  it("should load ICP Swap tickers", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", true);
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Neurons,
+    });
+
+    const tickers = [
+      {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+        last_price: "10.00",
+      },
+    ];
+    vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue(tickers);
+
+    expect(get(icpSwapTickersStore)).toBeUndefined();
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(0);
+
+    const { container } = render(Neurons);
+    const po = NeuronsPo.under(new JestPageObjectElement(container));
+    await runResolvedPromises();
+
+    expect(get(icpSwapTickersStore)).toEqual(tickers);
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
+
+    const rows = await po
+      .getNnsNeuronsPo()
+      .getNeuronsTablePo()
+      .getNeuronsTableRowPos();
+    expect(rows).toHaveLength(1);
+    // The exact value doesn't matter (because it's tested in other tests),
+    // just that it's a number.
+    expect(await rows[0].getStakeInUsd()).toBe("$300.00");
+  });
+
+  it("should not load ICP Swap tickers without feature flag", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", false);
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Neurons,
+    });
+
+    vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue([]);
+
+    expect(get(icpSwapTickersStore)).toBeUndefined();
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(0);
+
+    const { container } = render(Neurons);
+    const po = NeuronsPo.under(new JestPageObjectElement(container));
+    await runResolvedPromises();
+
+    expect(get(icpSwapTickersStore)).toBeUndefined();
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(0);
+
+    const rows = await po
+      .getNnsNeuronsPo()
+      .getNeuronsTablePo()
+      .getNeuronsTableRowPos();
+    expect(rows).toHaveLength(1);
+    expect(await rows[0].hasStakeInUsd()).toBe(false);
   });
 });


### PR DESCRIPTION
# Motivation

If the user deep links to the neurons table page, the ICPSwap tickers will not have been loaded yet.

# Changes

1. Call `loadIcpSwapTickers` from `Neurons` route if `ENABLE_USD_VALUES_FOR_NEURONS` is enabled.

# Tests

1. Unit tests added.
2. Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet