### PR TITLE
NNS1-3486: updates reporting transactions button to provide period to the service

### DIFF
--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -4,6 +4,7 @@
   import { ICPToken, nonNullish } from "@dfinity/utils";
   import {
     buildTransactionsDatasets,
+    convertPeriodToNanosecondRange,
     CsvGenerationError,
     FileSystemAccessError,
     generateCsvFileToSave,
@@ -24,6 +25,9 @@
   import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
   import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import type { ReportingPeriod } from "$lib/types/reporting";
+
+  export let period: ReportingPeriod = "all";
 
   let identity: Identity | null | undefined;
   let swapCanisterAccounts: Set<string>;
@@ -70,9 +74,11 @@
       );
 
       const entities = [...nnsAccounts, ...nnsNeurons];
+      const range = convertPeriodToNanosecondRange(period);
       const transactions = await getAccountTransactionsConcurrently({
         entities,
         identity: signIdentity,
+        range,
       });
       const datasets = buildTransactionsDatasets({
         transactions,

--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -43,7 +43,7 @@ export const getAccountTransactionsConcurrently = async ({
 }: {
   entities: (Account | NeuronInfo)[];
   identity: SignIdentity;
-  range: TransactionsDateRange;
+  range?: TransactionsDateRange;
 }): Promise<TransactionResults> => {
   const transactionEntities = entities.map(
     mapAccountOrNeuronToTransactionEntity

--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -39,9 +39,11 @@ export const mapAccountOrNeuronToTransactionEntity = (
 export const getAccountTransactionsConcurrently = async ({
   entities,
   identity,
+  range,
 }: {
   entities: (Account | NeuronInfo)[];
   identity: SignIdentity;
+  range: TransactionsDateRange;
 }): Promise<TransactionResults> => {
   const transactionEntities = entities.map(
     mapAccountOrNeuronToTransactionEntity
@@ -51,6 +53,7 @@ export const getAccountTransactionsConcurrently = async ({
     getAllTransactionsFromAccountAndIdentity({
       accountId: entity.identifier,
       identity,
+      range,
     })
   );
 
@@ -177,7 +180,7 @@ const filterTransactionsByRange = (
     }
 
     const to = range.to;
-    if (nonNullish(to) && timestamp > to) {
+    if (nonNullish(to) && timestamp >= to) {
       return false;
     }
 

--- a/frontend/src/tests/lib/services/reporting.services.spec.ts
+++ b/frontend/src/tests/lib/services/reporting.services.spec.ts
@@ -455,6 +455,46 @@ describe("reporting service", () => {
       expect(result[2].error).toBeUndefined();
     });
 
+    it("should fetch transactions for the specified period", async () => {
+      const allTransactions = [
+        createTransactionWithId({
+          id: 3n,
+          timestamp: new Date("2023-01-02T00:00:00.000Z"),
+        }),
+        createTransactionWithId({
+          id: 2n,
+          timestamp: new Date("2023-01-01T00:00:00.000Z"),
+        }),
+        createTransactionWithId({
+          id: 1n,
+          timestamp: new Date("2022-12-31T00:00:00.000Z"),
+        }),
+      ];
+      spyGetTransactions.mockResolvedValue({
+        transactions: allTransactions,
+        oldestTxId: 1n,
+      });
+
+      const beginningOfYear = dateToNanoSeconds(
+        new Date("2023-01-01T00:00:00.000Z")
+      );
+
+      const result = await getAccountTransactionsConcurrently({
+        entities: [mockMainAccount],
+        identity: mockIdentity,
+        range: {
+          from: beginningOfYear,
+        },
+      });
+
+      expect(result).toHaveLength(1);
+      expect(spyGetTransactions).toHaveBeenCalledTimes(1);
+
+      expect(result[0].entity).toEqual(mainAccountEntity);
+      expect(result[0].transactions).toEqual(allTransactions.slice(0, 2));
+      expect(result[0].error).toBeUndefined();
+    });
+
     // TODO: To be implemented once getAccountTransactionsConcurrently handles errors
     it.skip("should handle failed transactions fetch for some accounts", async () => {
       spyGetTransactions

--- a/frontend/src/tests/lib/services/reporting.services.spec.ts
+++ b/frontend/src/tests/lib/services/reporting.services.spec.ts
@@ -137,7 +137,7 @@ describe("reporting service", () => {
       expect(spyGetTransactions).toHaveBeenCalledTimes(2);
     });
 
-    it('should filter "to" the provided date', async () => {
+    it('should filter "to" the provided date excluding to', async () => {
       const allTransactions = [
         createTransactionWithId({
           id: 3n,
@@ -166,8 +166,8 @@ describe("reporting service", () => {
         },
       });
 
-      expect(result).toHaveLength(2);
-      expect(result).toEqual(allTransactions.slice(1));
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(allTransactions.slice(2));
       expect(spyGetTransactions).toHaveBeenCalledTimes(1);
     });
 

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -6,6 +6,7 @@ import {
   convertPeriodToNanosecondRange,
   convertToCsv,
   generateCsvFileToSave,
+  periodToDateRangeTimestampts,
   type CsvHeader,
 } from "$lib/utils/reporting.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -6,7 +6,6 @@ import {
   convertPeriodToNanosecondRange,
   convertToCsv,
   generateCsvFileToSave,
-  periodToDateRangeTimestampts,
   type CsvHeader,
 } from "$lib/utils/reporting.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";


### PR DESCRIPTION
# Motivation

We want to filter transactions by a specific period.
Follow up PR will hook the `PeriodDateRangeSelector` to the `PeriodTransactionsButton` so users selection will be propagated to the service.

# Changes

- Forwards the `period` property from the `ReportingTransactionsButton` to the service.
- Changes the utility `filterTransactionsByRange` to exclude dates that are equal to `to` this.https://github.com/dfinity/nns-dapp/blob/bc7b3b64cafd286bb76a5996ae29447849220163/frontend/src/lib/types/reporting.ts#L6

# Tests

- New unit tests for the component
- Updated test for the service

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary