### PR TITLE
Show total stake in USD banner on projects page

### DIFF
--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -113,7 +113,7 @@
 </script>
 
 <div class="wrapper" data-tid="projects-table-component">
-  {#if $authSignedInStore && $ENABLE_USD_VALUES_FOR_NEURONS}
+  {#if $authSignedInStore && $ENABLE_USD_VALUES_FOR_NEURONS && totalStakeInUsd > 0}
     <UsdValueBanner usdAmount={totalStakeInUsd} {hasUnpricedTokens}>
       <IconNeuronsPage slot="icon" />
     </UsdValueBanner>

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -218,3 +218,13 @@ export const sortTableProjects = (projects: TableProject[]): TableProject[] => {
     ])
   );
 };
+
+const getUsdStake = (project: TableProject) => {
+  if (!("stakeInUsd" in project) || isNullish(project.stakeInUsd)) {
+    return 0;
+  }
+  return project.stakeInUsd;
+};
+
+export const getTotalStakeInUsd = (projects: TableProject[]): number =>
+  projects.reduce((acc, project) => acc + getUsdStake(project), 0);

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -542,6 +542,15 @@ describe("ProjectsTable", () => {
       expect(await po.getUsdValueBannerPo().isPresent()).toBe(false);
     });
 
+    it("should not show total USD value banner when not logged in", async () => {
+      setNoIdentity();
+      overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", true);
+
+      const po = renderComponent();
+
+      expect(await po.getUsdValueBannerPo().isPresent()).toBe(false);
+    });
+
     it("should show total USD value banner when feature flag is enabled", async () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", true);
 

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -4,7 +4,11 @@ import {
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
 import type { Universe } from "$lib/types/universe";
-import { getTableProjects, sortTableProjects } from "$lib/utils/staking.utils";
+import {
+  getTableProjects,
+  getTotalStakeInUsd,
+  sortTableProjects,
+} from "$lib/utils/staking.utils";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
@@ -731,6 +735,38 @@ describe("staking.utils", () => {
         snsC,
         snsD,
       ]);
+    });
+  });
+
+  describe("getTotalStakeInUsd", () => {
+    it("should add up USD stakes", () => {
+      const project1 = {
+        ...mockTableProject,
+        stakeInUsd: 2,
+      };
+      const project2 = {
+        ...mockTableProject,
+        stakeInUsd: 3,
+      };
+
+      expect(getTotalStakeInUsd([project1, project2])).toBe(5);
+    });
+
+    it("should ignore tokens with unknown stake in USD when adding up the total", () => {
+      const project1 = {
+        ...mockTableProject,
+        stakeInUsd: 3,
+      };
+      const project2 = {
+        ...mockTableProject,
+        stakeInUsd: undefined,
+      };
+      const project3 = {
+        ...mockTableProject,
+        stakeInUsd: 5,
+      };
+
+      expect(getTotalStakeInUsd([project1, project2, project3])).toBe(8);
     });
   });
 });

--- a/frontend/src/tests/page-objects/ProjectsTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTable.page-object.ts
@@ -1,5 +1,6 @@
 import { ProjectsTableRowPo } from "$tests/page-objects/ProjectsTableRow.page-object";
 import { ResponsiveTablePo } from "$tests/page-objects/ResponsiveTable.page-object";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ProjectsTablePo extends ResponsiveTablePo {
@@ -7,6 +8,10 @@ export class ProjectsTablePo extends ResponsiveTablePo {
 
   static under(element: PageObjectElement): ProjectsTablePo {
     return new ProjectsTablePo(element.byTestId(ProjectsTablePo.TID));
+  }
+
+  getUsdValueBannerPo(): UsdValueBannerPo {
+    return UsdValueBannerPo.under(this.root);
   }
 
   getProjectsTableRowPos(): Promise<ProjectsTableRowPo[]> {


### PR DESCRIPTION
# Motivation

Similar to the tokens page, we want to show a banner with total stake in USD on the staking page.

# Changes

1. Add utility function to add of `stakeInUsd` ignoring undefined stakes. Analogous to [getTotalBalanceInUsd](https://github.com/dfinity/nns-dapp/blob/5152fa635d0080fa3ed59ed53daf6afb4660412f/frontend/src/lib/utils/token.utils.ts#L337).
2. Add `UsdValueBanner` to `ProjectsTable` component when `ENABLE_USD_VALUES_FOR_NEURONS` is enabled and the user has some stake.

# Tests

1. Unit tests added for `getTotalStakeInUsd`.
2. Unit tests added for `ProjectsTable`.
3. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet