### PR TITLE
Confirm following banner

### DIFF
--- a/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { IconErrorOutline } from "@dfinity/gix-components";
+  import Banner from "$lib/components/ui/Banner.svelte";
+  import BannerIcon from "$lib/components/ui/BannerIcon.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
+  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+
+  let title: string;
+  $: title = $i18n.losing_rewards_banner.confirm_title;
+
+  const text = replacePlaceholders($i18n.losing_rewards.description, {
+    $period: secondsToDissolveDelayDuration(
+      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS)
+    ),
+  });
+</script>
+
+<Banner testId="confirm-following-banner-component" {title} {text}>
+  <BannerIcon slot="icon" status="error">
+    <IconErrorOutline />
+  </BannerIcon>
+</Banner>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -395,6 +395,7 @@
     "confirm": "Confirm Following"
   },
   "losing_rewards_banner": {
+    "confirm_title": "Confirm following or vote manually to avoid missing rewards",
     "days_left_title": "$timeLeft left to confirm your neuron following",
     "rewards_missing_title": "One or more of your neurons are missing voting rewards"
   },

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -38,12 +38,15 @@
     getNeuronById,
     isSpawning,
     neuronVoting,
+    shouldDisplayRewardLossNotification,
   } from "$lib/utils/neuron.utils";
   import { Island } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
   import { onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
+  import ConfirmFollowingBanner from "$lib/components/neuron-detail/ConfirmFollowingBanner.svelte";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
 
   export let neuronIdText: string | undefined | null;
 
@@ -147,6 +150,12 @@
   $: if (nonNullish(neuron)) {
     refreshNeuronIfNeeded(neuron);
   }
+
+  let isConfirmFollowingVisible = false;
+  $: isConfirmFollowingVisible =
+    $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION &&
+    nonNullish(neuron) &&
+    shouldDisplayRewardLossNotification(neuron);
 </script>
 
 <TestIdWrapper testId="nns-neuron-detail-component">
@@ -156,6 +165,11 @@
         {#if neuron && !inVotingProcess}
           <NnsNeuronPageHeader {neuron} />
           <NnsNeuronPageHeading {neuron} />
+
+          {#if isConfirmFollowingVisible}
+            <ConfirmFollowingBanner />
+          {/if}
+
           <Separator spacing="none" />
           <NnsNeuronVotingPowerSection {neuron} />
           <Separator spacing="none" />

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -410,6 +410,7 @@ interface I18nLosing_rewards {
 }
 
 interface I18nLosing_rewards_banner {
+  confirm_title: string;
   days_left_title: string;
   rewards_missing_title: string;
 }

--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -4,6 +4,7 @@ import type {
   ApiQueryParams,
 } from "$lib/api/governance.api";
 import { queryAccountBalance } from "$lib/api/icp-ledger.api";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
@@ -200,7 +201,11 @@ export const addNeuronWith = ({
   neuronType,
   controller,
   stake,
-}: { identity?: Identity } & Partial<FakeNeuronParams>) => {
+  votingPowerRefreshedTimestampSeconds = nowInSeconds(),
+}: {
+  identity?: Identity;
+  votingPowerRefreshedTimestampSeconds?: bigint | number;
+} & Partial<FakeNeuronParams>) => {
   const neuron = { ...mockNeuron, fullNeuron: { ...mockNeuron.fullNeuron } };
   if (neuronId) {
     neuron.neuronId = neuronId;
@@ -215,6 +220,11 @@ export const addNeuronWith = ({
   }
   if (controller) {
     neuron.fullNeuron.controller = controller;
+  }
+  if (nonNullish(votingPowerRefreshedTimestampSeconds)) {
+    neuron.fullNeuron.votingPowerRefreshedTimestampSeconds = BigInt(
+      votingPowerRefreshedTimestampSeconds
+    );
   }
   if (nonNullish(getNeuron({ identity, neuronId: neuron.neuronId }))) {
     throw new Error(`A neuron with id ${neuron.neuronId} already exists`);

--- a/frontend/src/tests/page-objects/ConfirmFollowingBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmFollowingBanner.page-object.ts
@@ -1,0 +1,12 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BasePageObject } from "./base.page-object";
+
+export class ConfirmFollowingBannerPo extends BasePageObject {
+  private static readonly TID = "confirm-following-banner-component";
+
+  static under(element: PageObjectElement): ConfirmFollowingBannerPo {
+    return new ConfirmFollowingBannerPo(
+      element.byTestId(ConfirmFollowingBannerPo.TID)
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -7,6 +7,7 @@ import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVoti
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ConfirmFollowingBannerPo } from "./ConfirmFollowingBanner.page-object";
 import { NnsNeuronPageHeaderPo } from "./NnsNeuronPageHeader.page-object";
 
 export class NnsNeuronDetailPo extends BasePageObject {
@@ -67,6 +68,10 @@ export class NnsNeuronDetailPo extends BasePageObject {
 
   getUniverse(): Promise<string> {
     return this.getPageHeaderPo().getUniverse();
+  }
+
+  getConfirmFollowingBannerPo(): ConfirmFollowingBannerPo {
+    return ConfirmFollowingBannerPo.under(this.root);
   }
 
   getVotingPowerSectionPo(): NnsNeuronVotingPowerSectionPo {


### PR DESCRIPTION
# Motivation

If a neuron is inactive, users should be notified to prevent rewards missing . This PR adds a banner with a description to the neuron details page to inform users about the neuron’s inactive status.

# Changes

- Added `ConfirmFollowingBanner` component.
- Show `ConfirmFollowingBanner` on neuron details page.

# Tests

- Added.

<img width="388" alt="image" src="https://github.com/user-attachments/assets/c5c03a32-c149-42c4-ad21-6708d5cbe2f7" />

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary