### PR TITLE
Add USD banner on NNS neurons page

### DIFF
--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -4,16 +4,20 @@
   import MakeNeuronsPublicBanner from "$lib/components/neurons/MakeNeuronsPublicBanner.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
+  import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
   import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
+  import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import { tableNeuronsFromNeuronInfos } from "$lib/utils/neurons-table.utils";
+  import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
+  import { IconNeuronsPage } from "@dfinity/gix-components";
   import { Spinner } from "@dfinity/gix-components";
   import { onMount } from "svelte";
 
@@ -32,6 +36,9 @@
     neuronInfos: $definedNeuronsStore,
     icpSwapUsdPrices: $icpSwapUsdPricesStore,
   });
+
+  let totalStakeInUsd: number;
+  $: totalStakeInUsd = getTotalStakeInUsd(tableNeurons);
 </script>
 
 <TestIdWrapper testId="nns-neurons-component">
@@ -43,6 +50,11 @@
         <LosingRewardsBanner />
       {/if}
       <MakeNeuronsPublicBanner />
+      {#if $ENABLE_USD_VALUES_FOR_NEURONS}
+        <UsdValueBanner usdAmount={totalStakeInUsd} hasUnpricedTokens={false}>
+          <IconNeuronsPage slot="icon" />
+        </UsdValueBanner>
+      {/if}
       <NeuronsTable neurons={tableNeurons} />
     </div>
   {:else}

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -1,5 +1,6 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { type IcpSwapUsdPricesStoreData } from "$lib/derived/icp-swap.derived";
+import type { TableNeuron } from "$lib/types/neurons-table";
 import type { TableProject } from "$lib/types/staking";
 import type { Universe } from "$lib/types/universe";
 import { buildNeuronsUrl } from "$lib/utils/navigation.utils";
@@ -219,12 +220,13 @@ export const sortTableProjects = (projects: TableProject[]): TableProject[] => {
   );
 };
 
-const getUsdStake = (project: TableProject) => {
+const getUsdStake = (project: TableProject | TableNeuron) => {
   if (!("stakeInUsd" in project) || isNullish(project.stakeInUsd)) {
     return 0;
   }
   return project.stakeInUsd;
 };
 
-export const getTotalStakeInUsd = (projects: TableProject[]): number =>
-  projects.reduce((acc, project) => acc + getUsdStake(project), 0);
+export const getTotalStakeInUsd = (
+  projects: Array<TableProject | TableNeuron>
+): number => projects.reduce((acc, project) => acc + getUsdStake(project), 0);

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -139,6 +139,52 @@ describe("NnsNeurons", () => {
       const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
       expect(await rows[0].getStakeInUsd()).toBe("$33.00");
     });
+
+    it("should not show total USD value banner when feature flag is disabled", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", false);
+
+      const po = await renderComponent();
+
+      expect(await po.getUsdValueBannerPo().isPresent()).toBe(false);
+    });
+
+    it("should show total USD value banner when feature flag is enabled", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", true);
+
+      const po = await renderComponent();
+
+      expect(await po.getUsdValueBannerPo().isPresent()).toBe(true);
+    });
+
+    it("should show total stake in USD", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_USD_VALUES_FOR_NEURONS", true);
+
+      vi.spyOn(api, "queryNeurons").mockResolvedValue([
+        {
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockFullNeuron,
+            cachedNeuronStake: 300_000_000n,
+          },
+        },
+      ]);
+
+      icpSwapTickersStore.set([
+        {
+          ...mockIcpSwapTicker,
+          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+          last_price: "11.00",
+        },
+      ]);
+
+      const po = await renderComponent();
+
+      expect(await po.getUsdValueBannerPo().isPresent()).toBe(true);
+      expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$33.00");
+      expect(
+        await po.getUsdValueBannerPo().getTotalsTooltipIconPo().isPresent()
+      ).toBe(false);
+    });
   });
 
   describe("LosingRewardsBanner", () => {

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -1,4 +1,5 @@
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { LosingRewardsBannerPo } from "./LosingRewardsBanner.page-object";
@@ -9,6 +10,10 @@ export class NnsNeuronsPo extends BasePageObject {
 
   static under(element: PageObjectElement): NnsNeuronsPo {
     return new NnsNeuronsPo(element.byTestId(NnsNeuronsPo.TID));
+  }
+
+  getUsdValueBannerPo(): UsdValueBannerPo {
+    return UsdValueBannerPo.under(this.root);
   }
 
   getNeuronsTablePo(): NeuronsTablePo {


### PR DESCRIPTION
# Motivation

We want to show people the total value for their NNS neuron in USD and ICP.

# Changes

1. Add `UsdValueBanner` on `NnsNeurons` if `ENABLE_USD_VALUES_FOR_NEURONS` is enabled.
2. Support `TableNeuron` in `getTotalStakeInUsd` as the code would be identical as for `TableProject`.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet