### PR TITLE
Add BOT_APPROVED_FILES

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,26 @@
+# List of approved files that can be changed by a bot via an automated PR
+# This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
+
+Cargo.lock
+declarations/used_by_proposals/nns_governance/nns_governance.did
+declarations/used_by_proposals/nns_registry/nns_registry.did
+declarations/used_by_proposals/sns_wasm/sns_wasm.did
+declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
+declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
+declarations/used_by_sns_aggregator/sns_root/sns_root.did
+declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
+declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
+dfx.json
+frontend/package-lock.json
+frontend/src/tests/workflows/Launchpad/sns-agg-page-0.json
+frontend/src/tests/workflows/Launchpad/sns-agg-page-1.json
+frontend/src/tests/workflows/Launchpad/sns-agg-page-2.json
+frontend/src/tests/workflows/Launchpad/sns-agg-page-3.json
+rs/proposals/src/canisters/nns_governance/api.rs
+rs/proposals/src/canisters/nns_registry/api.rs
+rs/proposals/src/canisters/sns_wasm/api.rs
+rs/sns_aggregator/src/types/ic_sns_governance.rs
+rs/sns_aggregator/src/types/ic_sns_ledger.rs
+rs/sns_aggregator/src/types/ic_sns_root.rs
+rs/sns_aggregator/src/types/ic_sns_swap.rs
+rs/sns_aggregator/src/types/ic_sns_wasm.rs


### PR DESCRIPTION
# Motivation

According to this [slack thread](https://dfinity.slack.com/archives/CH4CADCJX/p1733844276935979), files changed by bots must be listed in `.github/repo_policies/BOT_APPROVED_FILES`.
This is supposed to be enforced starting 2025 but [this workflow](https://github.com/dfinity/nns-dapp/actions/runs/12405804323/job/34633261245?pr=6040) just failed because of it.

# Changes

I looked at recent PRs made by bots and added the files changed by them to `.github/repo_policies/BOT_APPROVED_FILES`.

# Tests

No idea how to test this without merging first and then running the bots.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary