### PR TITLE
Show total USD stake banner on SNS neurons page

### DIFF
--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
+  import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { pageStore } from "$lib/derived/page.derived";
   import {
@@ -13,12 +13,15 @@
   import { claimNextNeuronIfNeeded } from "$lib/services/sns-neurons-check-balances.services";
   import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
   import { authStore } from "$lib/stores/auth.store";
+  import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import type { SnsSummary } from "$lib/types/sns";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { tableNeuronsFromSnsNeurons } from "$lib/utils/neurons-table.utils";
+  import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
+  import { IconNeuronsPage } from "@dfinity/gix-components";
   import { Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { nonNullish } from "@dfinity/utils";
@@ -56,6 +59,18 @@
       })
     : [];
 
+  let isTokenPriceKnown: boolean;
+  $: isTokenPriceKnown =
+    nonNullish($icpSwapUsdPricesStore) &&
+    $icpSwapUsdPricesStore !== "error" &&
+    nonNullish(summary) &&
+    summary.ledgerCanisterId.toText() in $icpSwapUsdPricesStore;
+
+  let totalStakeInUsd: number | undefined;
+  $: totalStakeInUsd = isTokenPriceKnown
+    ? getTotalStakeInUsd(tableNeurons)
+    : undefined;
+
   $: claimNextNeuronIfNeeded({
     rootCanisterId: $snsOnlyProjectStore,
     neurons:
@@ -64,10 +79,18 @@
   });
 </script>
 
-<TestIdWrapper testId="sns-neurons-component">
+<div class="wrapper" data-tid="sns-neurons-component">
   {#if loading}
     <Spinner />
   {:else if tableNeurons.length > 0}
+    {#if $ENABLE_USD_VALUES_FOR_NEURONS}
+      <UsdValueBanner
+        usdAmount={totalStakeInUsd}
+        hasUnpricedTokens={!isTokenPriceKnown}
+      >
+        <IconNeuronsPage slot="icon" />
+      </UsdValueBanner>
+    {/if}
     <NeuronsTable neurons={tableNeurons} />
   {:else if nonNullish(summary)}
     <EmptyMessage
@@ -77,4 +100,12 @@
       })}</EmptyMessage
     >
   {/if}
-</TestIdWrapper>
+</div>
+
+<style lang="scss">
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+  }
+</style>

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -1,4 +1,5 @@
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -7,6 +8,10 @@ export class SnsNeuronsPo extends BasePageObject {
 
   static under(element: PageObjectElement): SnsNeuronsPo {
     return new SnsNeuronsPo(element.byTestId(SnsNeuronsPo.TID));
+  }
+
+  getUsdValueBannerPo(): UsdValueBannerPo {
+    return UsdValueBannerPo.under(this.root);
   }
 
   getNeuronsTablePo(): NeuronsTablePo {


### PR DESCRIPTION
# Motivation

We want to show people the total value for their SNS neurons in USD and ICP.

Analogous to https://github.com/dfinity/nns-dapp/pull/6038

# Changes

1. Add `UsdValueBanner` on `SnsNeurons` if `ENABLE_USD_VALUES_FOR_NEURONS` is enabled.
2. Show `-/-` instead of `0.00` if the token price for this SNS is not known.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=bd3sg-teaaa-aaaaa-qaaba-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet