### PR TITLE
refactor: remove named parameters from Reporting page-objects

### DIFF
--- a/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.spec.ts
@@ -17,9 +17,9 @@ describe("ReportingDateRangeSelector", () => {
       period,
     });
 
-    const po = ReportingDateRangeSelectorPo.under({
-      element: new JestPageObjectElement(container),
-    });
+    const po = ReportingDateRangeSelectorPo.under(
+      new JestPageObjectElement(container)
+    );
 
     return { po, component };
   };

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactions.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactions.spec.ts
@@ -25,9 +25,9 @@ describe("ReportingTransactions", () => {
   const renderComponent = () => {
     const { container } = render(ReportingTransactions);
 
-    const po = ReportingTransactionsPo.under({
-      element: new JestPageObjectElement(container),
-    });
+    const po = ReportingTransactionsPo.under(
+      new JestPageObjectElement(container)
+    );
     return po;
   };
 

--- a/frontend/src/tests/lib/routes/Reporting.spec.ts
+++ b/frontend/src/tests/lib/routes/Reporting.spec.ts
@@ -14,9 +14,7 @@ describe("Reporting", () => {
 
   const renderComponent = () => {
     const { container } = render(ReportingPage);
-    const po = ReportingPagePo.under({
-      element: new JestPageObjectElement(container),
-    });
+    const po = ReportingPagePo.under(new JestPageObjectElement(container));
     return po;
   };
 

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -5,11 +5,7 @@ import { SimpleBasePageObject } from "./simple-base.page-object";
 export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
   static readonly TID = "reporting-data-range-selector-component";
 
-  static under({
-    element,
-  }: {
-    element: PageObjectElement;
-  }): ReportingDateRangeSelectorPo {
+  static under(element: PageObjectElement): ReportingDateRangeSelectorPo {
     return new ReportingDateRangeSelectorPo(
       element.byTestId(ReportingDateRangeSelectorPo.TID)
     );

--- a/frontend/src/tests/page-objects/ReportingPage.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingPage.page-object.ts
@@ -4,7 +4,7 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class ReportingPagePo extends BasePageObject {
   private static readonly TID = "reporting-page-component";
 
-  static under({ element }: { element: PageObjectElement }): ReportingPagePo {
+  static under(element: PageObjectElement): ReportingPagePo {
     return new ReportingPagePo(element.byTestId(ReportingPagePo.TID));
   }
 }

--- a/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
@@ -13,9 +13,7 @@ export class ReportingTransactionsPo extends BasePageObject {
   }
 
   getReportingDateRangeSelectorPo() {
-    return ReportingDateRangeSelectorPo.under({
-      element: this.root,
-    });
+    return ReportingDateRangeSelectorPo.under(this.root);
   }
 
   getReportingTransactionsButtonPo() {

--- a/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
@@ -6,11 +6,7 @@ import { BasePageObject } from "./base.page-object";
 export class ReportingTransactionsPo extends BasePageObject {
   static readonly TID = "reporting-transactions-component";
 
-  static under({
-    element,
-  }: {
-    element: PageObjectElement;
-  }): ReportingTransactionsPo {
+  static under(element: PageObjectElement): ReportingTransactionsPo {
     return new ReportingTransactionsPo(
       element.byTestId(ReportingTransactionsPo.TID)
     );


### PR DESCRIPTION
# Motivation

We want to be consistent and removed named parameters when not necessary.
Addresses this comment: https://github.com/dfinity/nns-dapp/pull/6032#discussion_r1890418487

# Changes

- removes named parameters from Reporting related page-objects

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary