### PR TITLE
Show stake in USD on SNS neuron details

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { selectedTokenStore } from "$lib/derived/selected-token.derived";
   import { authStore } from "$lib/stores/auth.store";
+  import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
@@ -10,14 +11,17 @@
     snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
   import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
+  import HeadingSubtitleWithUsdValue from "../common/HeadingSubtitleWithUsdValue.svelte";
   import PageHeading from "../common/PageHeading.svelte";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import { Tag } from "@dfinity/gix-components";
+  import type { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import { TokenAmountV2, nonNullish, type Token } from "@dfinity/utils";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
+  export let ledgerCanisterId: Principal | undefined;
 
   let token: Token | undefined;
   $: token = $selectedTokenStore;
@@ -47,15 +51,29 @@
       <AmountDisplay {amount} size="huge" singleLine detailed />
     {/if}
   </svelte:fragment>
-  <HeadingSubtitle slot="subtitle" testId="voting-power">
-    {#if votingPower > 0}
-      {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
-        $votingPower: formatVotingPower(votingPower),
-      })}
+  <svelte:fragment slot="subtitle">
+    {#if $ENABLE_USD_VALUES_FOR_NEURONS}
+      <HeadingSubtitleWithUsdValue {amount} {ledgerCanisterId}>
+        {#if votingPower > 0}
+          {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
+            $votingPower: formatVotingPower(votingPower),
+          })}
+        {:else}
+          {$i18n.neuron_detail.voting_power_zero_subtitle}
+        {/if}
+      </HeadingSubtitleWithUsdValue>
     {:else}
-      {$i18n.neuron_detail.voting_power_zero_subtitle}
+      <HeadingSubtitle testId="voting-power">
+        {#if votingPower > 0}
+          {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
+            $votingPower: formatVotingPower(votingPower),
+          })}
+        {:else}
+          {$i18n.neuron_detail.voting_power_zero_subtitle}
+        {/if}
+      </HeadingSubtitle>
     {/if}
-  </HeadingSubtitle>
+  </svelte:fragment>
   <svelte:fragment slot="tags">
     {#if isHotkey}
       <Tag size="large" testId="hotkey-tag">{$i18n.neurons.hotkey_control}</Tag>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -76,6 +76,9 @@
   let token: Token;
   $: token = $snsTokenSymbolSelectedStore as Token;
 
+  let ledgerCanisterId: Principal | undefined;
+  $: ledgerCanisterId = $selectedUniverseStore.summary?.ledgerCanisterId;
+
   let governanceCanisterId: Principal | undefined;
   $: governanceCanisterId =
     $selectedUniverseStore.summary?.governanceCanisterId;
@@ -193,6 +196,7 @@
           <SnsNeuronPageHeading
             {parameters}
             neuron={$selectedSnsNeuronStore.neuron}
+            {ledgerCanisterId}
           />
           <Separator spacing="none" />
           <SnsNeuronVotingPowerSection

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
@@ -1,6 +1,7 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { HeadingSubtitleWithUsdValuePo } from "./HeadingSubtitleWithUsdValue.page-object";
 
 export class SnsNeuronPageHeadingPo extends BasePageObject {
   private static readonly TID = "sns-neuron-page-heading-component";
@@ -9,6 +10,10 @@ export class SnsNeuronPageHeadingPo extends BasePageObject {
     return new SnsNeuronPageHeadingPo(
       element.byTestId(SnsNeuronPageHeadingPo.TID)
     );
+  }
+
+  getHeadingSubtitleWithUsdValuePo(): HeadingSubtitleWithUsdValuePo {
+    return HeadingSubtitleWithUsdValuePo.under(this.root);
   }
 
   getAmountDisplayPo(): AmountDisplayPo {
@@ -25,5 +30,13 @@ export class SnsNeuronPageHeadingPo extends BasePageObject {
 
   hasHotkeyTag(): Promise<boolean> {
     return this.root.byTestId("hotkey-tag").isPresent();
+  }
+
+  hasBalanceInUsd(): Promise<boolean> {
+    return this.getHeadingSubtitleWithUsdValuePo().hasAmountInUsd();
+  }
+
+  getBalanceInUsd(): Promise<string> {
+    return this.getHeadingSubtitleWithUsdValuePo().getAmountInUsd();
   }
 }


### PR DESCRIPTION
# Motivation

Want to show the stake in USD on the neuron details page similar to how we show the account balance on the wallet page.

https://github.com/dfinity/nns-dapp/pull/6039 did it for NNS neurons.
This PR does it for SNS neurons.
And a third PR will make sure token prices are loaded when the neuron page is deep linked.

# Changes

1. Use `HeadingSubtitleWithUsdValue` in `SnsNeuronPageHeading`. Some of the slot content is temporarily duplicate between with and without feature flag.
2. Pass the `ledgerCanisterId` from `SnsNeuronDetail` to `SnsNeuronPageHeading` as it's needed to find the token price.

# Tests

1. Unit tests added.
2. Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neuron/?u=bd3sg-teaaa-aaaaa-qaaba-cai&neuron=d09433a0369029e7b1114df00138c0cf5bbbef6d0d150c0aa6dd0fd67a75f985

# Todos

- [ ] Add entry to changelog (if necessary).
not yet