### PR TITLE
 Load ICPSwap ticker on neuron details page

### DIFF
--- a/frontend/src/lib/routes/NeuronDetail.svelte
+++ b/frontend/src/lib/routes/NeuronDetail.svelte
@@ -4,11 +4,17 @@
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import NnsNeuronDetail from "$lib/pages/NnsNeuronDetail.svelte";
   import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import { nonNullish } from "@dfinity/utils";
 
   export let neuronId: string | null | undefined;
+
+  $: if ($ENABLE_USD_VALUES_FOR_NEURONS) {
+    loadIcpSwapTickers();
+  }
 
   layoutTitleStore.set({
     title: $i18n.neuron_detail.title,

--- a/frontend/src/tests/fakes/sns-aggregator-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-aggregator-api.fake.ts
@@ -32,12 +32,18 @@ const reset = () => {
 
 export const addProjectWith = ({
   rootCanisterId,
+  ledgerCanisterId,
   lifecycle,
 }: {
   rootCanisterId: string;
+  ledgerCanisterId?: string;
   lifecycle: SnsSwapLifecycle;
 }): CachedSnsDto => {
-  const project = aggregatorSnsMockWith({ rootCanisterId, lifecycle });
+  const project = aggregatorSnsMockWith({
+    rootCanisterId,
+    ledgerCanisterId,
+    lifecycle,
+  });
   projects.push(project);
   return project;
 };

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -6,6 +6,7 @@ import { SnsNeuronFollowingCardPo } from "$tests/page-objects/SnsNeuronFollowing
 import { SnsNeuronHotkeysCardPo } from "$tests/page-objects/SnsNeuronHotkeysCard.page-object";
 import { SnsNeuronMaturitySectionPo } from "$tests/page-objects/SnsNeuronMaturitySection.page-object";
 import { SnsNeuronPageHeaderPo } from "$tests/page-objects/SnsNeuronPageHeader.page-object";
+import { SnsNeuronPageHeadingPo } from "$tests/page-objects/SnsNeuronPageHeading.page-object";
 import { SnsNeuronVotingPowerSectionPo } from "$tests/page-objects/SnsNeuronVotingPowerSection.page-object";
 import { SummaryPo } from "$tests/page-objects/Summary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -16,6 +17,10 @@ export class SnsNeuronDetailPo extends BasePageObject {
 
   static under(element: PageObjectElement): SnsNeuronDetailPo {
     return new SnsNeuronDetailPo(element.byTestId(SnsNeuronDetailPo.TID));
+  }
+
+  getSnsNeuronPageHeadingPo(): SnsNeuronPageHeadingPo {
+    return SnsNeuronPageHeadingPo.under(this.root);
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {


### PR DESCRIPTION
# Motivation

If the user deep links to the neuron details page, the ICPSwap tickers will not have been loaded yet.

# Changes

1. Call `loadIcpSwapTickers` from `NeuronDetail.svelte` if `ENABLE_USD_VALUES_FOR_NEURONS` is enabled.

# Tests

1. Unit tests added.
2. Support setting `ledgerCanisterId` in fake SNS aggregator API.
3. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neuron/?u=bd3sg-teaaa-aaaaa-qaaba-cai&neuron=d09433a0369029e7b1114df00138c0cf5bbbef6d0d150c0aa6dd0fd67a75f985

# Todos

- [ ] Add entry to changelog (if necessary).
not yet