### PR TITLE
feat(nav): add new navigation entry for Portfolio

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -7,6 +7,7 @@
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { pageStore } from "$lib/derived/page.derived";
   import { proposalsPathStore } from "$lib/derived/paths.derived";
+  import { ENABLE_PORTFOLIO_PAGE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import {
     ACTIONABLE_PROPOSALS_URL,
@@ -39,6 +40,21 @@
     statusIcon?: ComponentType;
   }[];
   $: routes = [
+    ...($ENABLE_PORTFOLIO_PAGE
+      ? [
+          {
+            context: "portfolio",
+            href: AppPath.Portfolio,
+            selected: isSelectedPath({
+              currentPath: $pageStore.path,
+              paths: [AppPath.Portfolio],
+            }),
+            title: $i18n.navigation.portfolio,
+            // TODO: Fix this once we have new version of GIX
+            icon: IconWallet,
+          },
+        ]
+      : []),
     {
       context: "accounts",
       href: AppPath.Tokens,

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -13,6 +13,7 @@ export enum AppPath {
   Settings = "/settings",
   Tokens = "/tokens",
   Reporting = "/reporting",
+  Portfolio = "/portfolio",
 }
 
 // SvelteKit uses the group defined in src/routes/(app)/ as part of the routeId. It also prefixes it with /.

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -148,7 +148,8 @@
     "manage_ii": "Manage Internet Identity",
     "source_code": "Source Code",
     "settings": "Settings",
-    "reporting": "Reporting"
+    "reporting": "Reporting",
+    "portfolio": "Portfolio"
   },
   "header": {
     "menu": "Open menu to access navigation options",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -155,6 +155,7 @@ interface I18nNavigation {
   source_code: string;
   settings: string;
   reporting: string;
+  portfolio: string;
 }
 
 interface I18nHeader {

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -271,17 +271,16 @@ describe("MenuItems", () => {
   });
 
   describe("portfolio", () => {
-    it("should not show the icon when the feature flag is off", () => {
+    it("should not show the icon when the feature flag is off", async () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", false);
-      const context = "portfolio";
-      const { queryByTestId } = render(MenuItems);
-      const link = queryByTestId(`menuitem-${context}`);
-      expect(link).not.toBeInTheDocument();
+      const po = renderComponent();
+      expect(await po.getPortfolioLinkPo().isPresent()).toBe(false);
     });
 
-    it("should show the icon when the feature flag is on", () => {
+    it("should show the icon when the feature flag is on", async () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
-      shouldRenderMenuItem({ context: "portfolio", labelKey: "portfolio" });
+      const po = renderComponent();
+      expect(await po.getPortfolioLinkPo().isPresent()).toBe(true);
     });
   });
 });

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -3,6 +3,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -266,6 +267,21 @@ describe("MenuItems", () => {
       expect(await menuItemsPo.getTotalValueLockedLinkPo().getHref()).toBe(
         "https://dashboard.internetcomputer.org/neurons"
       );
+    });
+  });
+
+  describe("portfolio", () => {
+    it("should not show the icon when the feature flag is off", () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", false);
+      const context = "portfolio";
+      const { queryByTestId } = render(MenuItems);
+      const link = queryByTestId(`menuitem-${context}`);
+      expect(link).not.toBeInTheDocument();
+    });
+
+    it("should show the icon when the feature flag is on", () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
+      shouldRenderMenuItem({ context: "portfolio", labelKey: "portfolio" });
     });
   });
 });

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -31,10 +31,6 @@ export class MenuItemsPo extends BasePageObject {
     return this.click("menuitem-launchpad");
   }
 
-  clickPortfolio(): Promise<void> {
-    return this.click("menuitem-portfolio");
-  }
-
   getSourceCodeButtonPo(): LinkPo {
     return LinkPo.under({ element: this.root, testId: "source-code-link" });
   }
@@ -48,6 +44,10 @@ export class MenuItemsPo extends BasePageObject {
 
   getGetTokensPo(): GetTokensPo {
     return GetTokensPo.under(this.root);
+  }
+
+  getPortfolioLinkPo(): LinkPo {
+    return LinkPo.under({ element: this.root, testId: "menuitem-portfolio" });
   }
 
   hasFooter(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -31,6 +31,10 @@ export class MenuItemsPo extends BasePageObject {
     return this.click("menuitem-launchpad");
   }
 
+  clickPortfolio(): Promise<void> {
+    return this.click("menuitem-portfolio");
+  }
+
   getSourceCodeButtonPo(): LinkPo {
     return LinkPo.under({ element: this.root, testId: "source-code-link" });
   }


### PR DESCRIPTION
# Motivation

We want to be able to navigate to the portfolio page by clicking an element in the navigation bar.
Follow up PR will introduce the new Route.

# Changes

- New entry in the navigation bar.

# Tests

- Unit test to check for the presence of the link base on the feature flag `ENABLE_PORTFOLIO_PAGE`

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary