### PR TITLE
refactor: UiTransactionsList rendering logic

### DIFF
--- a/frontend/src/lib/components/accounts/UiTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/UiTransactionsList.svelte
@@ -10,22 +10,28 @@
   export let transactions: UiTransaction[];
   export let loading: boolean;
   export let completed = false;
+
+  $: isEmpty = transactions.length === 0;
+
+  $: showSkeleton = loading && isEmpty;
+  $: showNoTransactions = !loading && isEmpty;
+  $: disabledInifiteScroll = loading || completed;
 </script>
 
 <div data-tid="transactions-list" class="container">
-  {#if transactions.length === 0 && !loading}
+  {#if showSkeleton}
+    <SkeletonCard cardType="info" />
+  {:else if showNoTransactions}
     <NoTransactions />
-  {:else if transactions.length === 0 && loading}
-    <SkeletonCard cardType="info" />
-    <SkeletonCard cardType="info" />
   {:else}
-    <InfiniteScroll on:nnsIntersect disabled={loading || completed}>
+    <InfiniteScroll on:nnsIntersect disabled={disabledInifiteScroll}>
       {#each transactions as transaction (transaction.domKey)}
         <div animate:flip={{ duration: 250 }}>
           <TransactionCard {transaction} />
         </div>
       {/each}
     </InfiniteScroll>
+
     {#if loading}
       <Spinner inline />
     {/if}

--- a/frontend/src/lib/components/accounts/UiTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/UiTransactionsList.svelte
@@ -13,8 +13,8 @@
 
   $: isEmpty = transactions.length === 0;
 
-  $: showSkeleton = loading && isEmpty;
-  $: showNoTransactions = !loading && isEmpty;
+  $: showSkeleton = isEmpty && loading;
+  $: showNoTransactions = isEmpty && !loading;
   $: disabledInifiteScroll = loading || completed;
 </script>
 

--- a/frontend/src/lib/components/accounts/UiTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/UiTransactionsList.svelte
@@ -21,6 +21,7 @@
 <div data-tid="transactions-list" class="container">
   {#if showSkeleton}
     <SkeletonCard cardType="info" />
+    <SkeletonCard cardType="info" />
   {:else if showNoTransactions}
     <NoTransactions />
   {:else}

--- a/frontend/src/tests/lib/components/accounts/UiTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/UiTransactionsList.spec.ts
@@ -37,7 +37,9 @@ describe("UiTransactionsList", () => {
       loading: true,
     });
 
-    expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
+    expect(await po.hasSkeleton()).toBe(true);
+    expect(await po.hasNoTransactions()).toBe(false);
+    expect(await po.hasSpinner()).toBe(false);
   });
 
   it("should display no-transactions message", async () => {
@@ -51,7 +53,9 @@ describe("UiTransactionsList", () => {
       completed: true,
     });
 
+    expect(await po.hasSkeleton()).toBe(false);
     expect(await po.hasNoTransactions()).toBe(true);
+    expect(await po.hasSpinner()).toBe(false);
   });
 
   it("should render transactions", async () => {
@@ -64,7 +68,24 @@ describe("UiTransactionsList", () => {
       completed: true,
     });
 
-    expect(await po.getTransactionCardPos()).toHaveLength(2);
+    expect(await po.hasSkeleton()).toBe(false);
     expect(await po.hasNoTransactions()).toBe(false);
+    expect(await po.hasSpinner()).toBe(false);
+    expect(await po.getTransactionCardPos()).toHaveLength(2);
+  });
+
+  it("should render spinner", async () => {
+    const po = renderComponent({
+      transactions: [
+        createMockUiTransaction({ domKey: "1-1" }),
+        createMockUiTransaction({ domKey: "2-1" }),
+      ],
+      loading: true,
+      completed: true,
+    });
+
+    expect(await po.hasSkeleton()).toBe(false);
+    expect(await po.hasNoTransactions()).toBe(false);
+    expect(await po.hasSpinner()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/UiTransactionsList.page-object.ts
+++ b/frontend/src/tests/page-objects/UiTransactionsList.page-object.ts
@@ -18,8 +18,16 @@ export class UiTransactionsListPo extends BasePageObject {
     return TransactionCardPo.allUnder(this.root);
   }
 
+  hasSkeleton(): Promise<boolean> {
+    return this.getSkeletonCardPo().isPresent();
+  }
+
   hasNoTransactions(): Promise<boolean> {
     return this.isPresent("no-transactions-component");
+  }
+
+  hasSpinner() {
+    return this.isPresent("spinner");
   }
 
   async waitForLoaded(): Promise<void> {


### PR DESCRIPTION
# Motivation

We fixed a minor bug in https://github.com/dfinity/nns-dapp/pull/5874 that prevented the `completed` property from being set to `true` for empty transactions. The `UiTransactionsList` uses this property to disable the list once we have fetched all the items. However, it renders an Empty component when there are no transactions, which obscured the bug.

This PR aims to simplify the logic and enhance readability.

# Changes

* Refactor code to simplify the logic deciding what to render in the `UiTransactionsList`

# Tests

- Added a new test to check the `Spinner`.  
- Added checks to existing tests for UI elements.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary