### PR TITLE
Fix: Show error in USD banner on projects page

### DIFF
--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -88,6 +88,11 @@
   let sortedTableProjects: TableProject[];
   $: sortedTableProjects = sortTableProjects(tableProjects);
 
+  let hasAnyNeurons: boolean;
+  $: hasAnyNeurons = tableProjects.some(
+    (project) => project.neuronCount ?? 0 > 0
+  );
+
   let totalStakeInUsd: number;
   $: totalStakeInUsd = getTotalStakeInUsd(tableProjects);
 
@@ -113,7 +118,7 @@
 </script>
 
 <div class="wrapper" data-tid="projects-table-component">
-  {#if $authSignedInStore && $ENABLE_USD_VALUES_FOR_NEURONS && totalStakeInUsd > 0}
+  {#if $authSignedInStore && $ENABLE_USD_VALUES_FOR_NEURONS && hasAnyNeurons}
     <UsdValueBanner usdAmount={totalStakeInUsd} {hasUnpricedTokens}>
       <IconNeuronsPage slot="icon" />
     </UsdValueBanner>


### PR DESCRIPTION
# Motivation

On the projects table page, if you don't have any neurons, we show a banner inviting you to stake a neuron.
For this reason, and because your total stake with 0 neurons is always $0, we hide the total USD value banner on the projects table page if we show the other banner.

The problem is that the logic used for this just checked if the total USD value of neurons was 0. But if there is an error loading ICP Swap tickers, we calculate your total stake in USD as 0 as well, but we do want to show the banner in an error state.

So we need to check the actual number of neurons instead of using the total value as a shortcut for not having neurons.

# Changes

1. Check if the user has any neurons to decide on showing the USD value banner.

# Tests

1. Add a unit test testing the error state of the banner.
2. Tested manually by changing `queryIcpSwapTickers` to return an error.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary