### PR TITLE
Upgrade ic-js next version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -298,9 +298,10 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.4-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.4-next-2024-12-10.tgz",
-      "integrity": "sha512-zSv418sYALn8P+lNJ8WVc5auw9+bFPjPpyfGDG80SZpPfb9LaYfbTT9vXCNCTLPEYGI37RRKkkSdJFCEFDX9QA==",
+      "version": "3.1.4-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.4-next-2024-12-19.tgz",
+      "integrity": "sha512-fjFT6BOITu7yz0Zpy2qIv1LBVgEseMb5Dcfo/1Im2sht0yuAot8TxVKT+XUpZlL15TnhG3hwO9NSBfqTkX1r8g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -314,9 +315,10 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "4.0.2-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-10.tgz",
-      "integrity": "sha512-Fx2mQAhPdnUA9peL2xfYhugCwKg2nJe9cDUC26irR1BE0XffZeZVU/zqAphL4HlyxTCyvHiQSP4n2F4ZSHiDHA==",
+      "version": "4.0.2-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-19.tgz",
+      "integrity": "sha512-s+0ZoDxsfRK1KD5Bc2MrFZDwhb7JLVI1kpksOiZaqP2kA+ETFyllDCjYA92vRJ5xYq6UgQI4KxlZg1WCdHImvw==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +343,10 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "6.0.1-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.1-next-2024-12-10.tgz",
-      "integrity": "sha512-iPO5PaQj77LEJrp8rrgPVE9KQU3tcKKIYqTjunwFCfOYS7DC+CKIuA0R9xxurtPAy0Up92c6KP37hP591X5i+g==",
+      "version": "6.0.1-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.1-next-2024-12-19.tgz",
+      "integrity": "sha512-0B4vSbGTwQYaX0UQu3XRZErV2HMbsyuO7CcI07NVi8JIKgyVYRLOukf6IABydiUkiWz+7tMCvgzt57Pku9TKKw==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -367,9 +370,10 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.6.4-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.4-next-2024-12-10.tgz",
-      "integrity": "sha512-a9aVFEOA+IwKvmu0D022jZ6nEnO/xn61cN+eLGssiGhZ7ixPO5oWqW2gcH6IalDokN2RfzIvDK0ucT9mYUHqgw==",
+      "version": "2.6.4-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.4-next-2024-12-19.tgz",
+      "integrity": "sha512-Q8KPU1HXKkQ40tr/DyY3SKcUO4T5xAmC92ObA+vYcqSK9XTzmiFQohsU3VijhhYNFyQ1UOxe8wzJSdFR/xfENw==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -378,9 +382,10 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.6.4-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.4-next-2024-12-10.tgz",
-      "integrity": "sha512-9we7lwJjho/lUk8eaibRuxW01RSDJXT6hz9ao7kuls6WEMypkkzN2GYp1jzk8e+4h4HzLKJ0XuFWKNVLtx08sA==",
+      "version": "2.6.4-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.4-next-2024-12-19.tgz",
+      "integrity": "sha512-dzHQJJA9fX1wEP8XQnSQaTzc/j3+5J5pzLIDl+YbQVnGP+lNjoqwel6AyM7kcMOiqY3lcZeBaZVMK2hWhiZ1Eg==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -389,9 +394,10 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "8.0.1-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.1-next-2024-12-10.tgz",
-      "integrity": "sha512-7aMEWDJoppeYkSp3+Eq8SmOe6PTtmdI75OAnU9e2nAUrbAVVTKNY06oEf4e0mdQZQsY4okjrNq/W5UclWcUAnw==",
+      "version": "8.0.1-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.1-next-2024-12-19.tgz",
+      "integrity": "sha512-40x3UM4OiGOW3P5QgRfQbXFQtxRexaiawaf7o14PrWCL04irbnJ+rUS7GJ2yNR/PNmdS7F8Il7ltX33ruqkagA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -413,9 +419,10 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.2.5-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.5-next-2024-12-10.tgz",
-      "integrity": "sha512-GsNHQ7nVDySR1bBdy6kTq0rwS0i4QltkCJQUh3Jpe51SQCzhyfazPXh2Q3reefc17TuGNrqyUADDsia91EkCrA==",
+      "version": "3.2.5-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.5-next-2024-12-19.tgz",
+      "integrity": "sha512-MAb1/9XMywR9YcsnHJefQyHKyr+reXnrh0CGUjx6/j2vqi22/27LB9KCmcRnwEGi1950o3Oz3hBwgCyRgFSfhA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -428,9 +435,10 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.7.1-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.1-next-2024-12-10.tgz",
-      "integrity": "sha512-j8YCW6DKm+vSdW0/uLWYv3Z4bi7egB/hHaq4ucdpv8aaKtRu7wpIziKnc75p+kSdDjrtdas0Z1BTfZKw05TR0g==",
+      "version": "2.7.1-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.1-next-2024-12-19.tgz",
+      "integrity": "sha512-ixmPkzZ/fGzgym1autSq/j0Gi8RfImFB1EEyc9HGeUirTKvvi9+WeplvnERhKZnw4JZWmQMYJXxnWmF6xYeCRQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -2243,6 +2251,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
       "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2277,7 +2286,8 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
@@ -4969,6 +4979,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -6678,9 +6689,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "3.1.4-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.4-next-2024-12-10.tgz",
-      "integrity": "sha512-zSv418sYALn8P+lNJ8WVc5auw9+bFPjPpyfGDG80SZpPfb9LaYfbTT9vXCNCTLPEYGI37RRKkkSdJFCEFDX9QA==",
+      "version": "3.1.4-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.4-next-2024-12-19.tgz",
+      "integrity": "sha512-fjFT6BOITu7yz0Zpy2qIv1LBVgEseMb5Dcfo/1Im2sht0yuAot8TxVKT+XUpZlL15TnhG3hwO9NSBfqTkX1r8g==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -6688,9 +6699,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "4.0.2-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-10.tgz",
-      "integrity": "sha512-Fx2mQAhPdnUA9peL2xfYhugCwKg2nJe9cDUC26irR1BE0XffZeZVU/zqAphL4HlyxTCyvHiQSP4n2F4ZSHiDHA==",
+      "version": "4.0.2-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-19.tgz",
+      "integrity": "sha512-s+0ZoDxsfRK1KD5Bc2MrFZDwhb7JLVI1kpksOiZaqP2kA+ETFyllDCjYA92vRJ5xYq6UgQI4KxlZg1WCdHImvw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -6705,9 +6716,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "6.0.1-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.1-next-2024-12-10.tgz",
-      "integrity": "sha512-iPO5PaQj77LEJrp8rrgPVE9KQU3tcKKIYqTjunwFCfOYS7DC+CKIuA0R9xxurtPAy0Up92c6KP37hP591X5i+g==",
+      "version": "6.0.1-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.1-next-2024-12-19.tgz",
+      "integrity": "sha512-0B4vSbGTwQYaX0UQu3XRZErV2HMbsyuO7CcI07NVi8JIKgyVYRLOukf6IABydiUkiWz+7tMCvgzt57Pku9TKKw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -6721,21 +6732,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.6.4-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.4-next-2024-12-10.tgz",
-      "integrity": "sha512-a9aVFEOA+IwKvmu0D022jZ6nEnO/xn61cN+eLGssiGhZ7ixPO5oWqW2gcH6IalDokN2RfzIvDK0ucT9mYUHqgw==",
+      "version": "2.6.4-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.4-next-2024-12-19.tgz",
+      "integrity": "sha512-Q8KPU1HXKkQ40tr/DyY3SKcUO4T5xAmC92ObA+vYcqSK9XTzmiFQohsU3VijhhYNFyQ1UOxe8wzJSdFR/xfENw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.6.4-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.4-next-2024-12-10.tgz",
-      "integrity": "sha512-9we7lwJjho/lUk8eaibRuxW01RSDJXT6hz9ao7kuls6WEMypkkzN2GYp1jzk8e+4h4HzLKJ0XuFWKNVLtx08sA==",
+      "version": "2.6.4-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.4-next-2024-12-19.tgz",
+      "integrity": "sha512-dzHQJJA9fX1wEP8XQnSQaTzc/j3+5J5pzLIDl+YbQVnGP+lNjoqwel6AyM7kcMOiqY3lcZeBaZVMK2hWhiZ1Eg==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "8.0.1-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.1-next-2024-12-10.tgz",
-      "integrity": "sha512-7aMEWDJoppeYkSp3+Eq8SmOe6PTtmdI75OAnU9e2nAUrbAVVTKNY06oEf4e0mdQZQsY4okjrNq/W5UclWcUAnw==",
+      "version": "8.0.1-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.0.1-next-2024-12-19.tgz",
+      "integrity": "sha512-40x3UM4OiGOW3P5QgRfQbXFQtxRexaiawaf7o14PrWCL04irbnJ+rUS7GJ2yNR/PNmdS7F8Il7ltX33ruqkagA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -6750,17 +6761,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.2.5-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.5-next-2024-12-10.tgz",
-      "integrity": "sha512-GsNHQ7nVDySR1bBdy6kTq0rwS0i4QltkCJQUh3Jpe51SQCzhyfazPXh2Q3reefc17TuGNrqyUADDsia91EkCrA==",
+      "version": "3.2.5-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.5-next-2024-12-19.tgz",
+      "integrity": "sha512-MAb1/9XMywR9YcsnHJefQyHKyr+reXnrh0CGUjx6/j2vqi22/27LB9KCmcRnwEGi1950o3Oz3hBwgCyRgFSfhA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.7.1-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.1-next-2024-12-10.tgz",
-      "integrity": "sha512-j8YCW6DKm+vSdW0/uLWYv3Z4bi7egB/hHaq4ucdpv8aaKtRu7wpIziKnc75p+kSdDjrtdas0Z1BTfZKw05TR0g==",
+      "version": "2.7.1-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.1-next-2024-12-19.tgz",
+      "integrity": "sha512-ixmPkzZ/fGzgym1autSq/j0Gi8RfImFB1EEyc9HGeUirTKvvi9+WeplvnERhKZnw4JZWmQMYJXxnWmF6xYeCRQ==",
       "requires": {}
     },
     "@esbuild/aix-ppc64": {

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -44,6 +44,9 @@ export const createMockFullNeuron = (id: number | bigint) => {
 };
 
 export const mockNeuron: NeuronInfo = {
+  votingPowerRefreshedTimestampSeconds: 0n,
+  decidingVotingPower: 0n,
+  potentialVotingPower: 0n,
   neuronId: 1n,
   dissolveDelaySeconds: 11_111n,
   recentBallots: [],


### PR DESCRIPTION
# Motivation

To access the [new fields](https://github.com/dfinity/ic-js/pull/794) of the neuron info, we need to upgrade the ic-js version.

# Changes

- `npm run upgrade:next`

# Tests

- Added new fields to the mock NeuronInfo.
- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.