### PR TITLE
feat: add Portfolio route

### DIFF
--- a/frontend/src/routes/(app)/(nns)/portfolio/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+layout.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Content from "$lib/components/layout/Content.svelte";
+  import Layout from "$lib/components/layout/Layout.svelte";
+  import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import { i18n } from "$lib/stores/i18n";
+</script>
+
+<LayoutList title={$i18n.navigation.portfolio}>
+  <Layout>
+    <Content>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutList>

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -1,0 +1,2 @@
+<script lang="ts">
+</script>

--- a/frontend/src/tests/routes/app/portfolio/layout.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/layout.spec.ts
@@ -1,0 +1,19 @@
+import { layoutTitleStore } from "$lib/stores/layout.store";
+import PortfolioLayout from "$routes/(app)/(nns)/portfolio/+layout.svelte";
+import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("Portfolio layout", () => {
+  beforeEach(() => {
+    layoutTitleStore.set({ title: "" });
+  });
+
+  it("should set title and header layout to 'Portfolio'", () => {
+    render(PortfolioLayout);
+
+    expect(get(layoutTitleStore)).toEqual({
+      title: "Portfolio",
+      header: "Portfolio",
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We need a new route to display the Portfolio page.

# Changes

- Creates a new route in the (nns) group for the portfolio page.

# Tests

- Unit test that the page renders with the appropriate title.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.