### PR TITLE
chore: bump gix-components to latest

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "5.0.0-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.0.0-next-2024-12-10.tgz",
-      "integrity": "sha512-rdKfTWSUnVYjr3XjtQbc3XwaG8RWAOAggeuAVmVH+Ds2D/+8O/bGVRdzt/nYVrntTULem221YalmWTU1FLZztg==",
+      "version": "5.0.0-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.0.0-next-2024-12-19.tgz",
+      "integrity": "sha512-tMIeXb+HRRajHOkTEIh9B8jnzBiFK4RAXmL3l7HrfkARq5T/zKy43Xgyse7NoLtvQxV2jOsJ4V0Koymnmag4BA==",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.1.6",
@@ -6705,9 +6705,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "5.0.0-next-2024-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.0.0-next-2024-12-10.tgz",
-      "integrity": "sha512-rdKfTWSUnVYjr3XjtQbc3XwaG8RWAOAggeuAVmVH+Ds2D/+8O/bGVRdzt/nYVrntTULem221YalmWTU1FLZztg==",
+      "version": "5.0.0-next-2024-12-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.0.0-next-2024-12-19.tgz",
+      "integrity": "sha512-tMIeXb+HRRajHOkTEIh9B8jnzBiFK4RAXmL3l7HrfkARq5T/zKy43Xgyse7NoLtvQxV2jOsJ4V0Koymnmag4BA==",
       "requires": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Motivation

We want to pull in the latest changes.

# Changes

* Ran `npm run update:gix` locally

# Tests

* CI should pass
* The pulled in changes should have been tested before being committed to their repositories.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary