### PR TITLE
refactor(ui): replace portfolio icon with IconHome

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -15,6 +15,7 @@
   } from "$lib/utils/navigation.utils";
   import SourceCodeButton from "./SourceCodeButton.svelte";
   import {
+    IconHome,
     IconNeurons,
     IconRocketLaunch,
     IconVote,
@@ -50,8 +51,7 @@
               paths: [AppPath.Portfolio],
             }),
             title: $i18n.navigation.portfolio,
-            // TODO: Fix this once we have new version of GIX
-            icon: IconWallet,
+            icon: IconHome,
           },
         ]
       : []),


### PR DESCRIPTION
# Motivation

Follow up on this [one](https://github.com/dfinity/nns-dapp/pull/6046/files#diff-4f5601a1438e042ad0712ce95604c71e170f9e38b927559aa2f438928b909f69R53)

Ticket: [NNS1-3510](https://dfinity.atlassian.net/browse/NNS1-3510)

<img width="1004" alt="Screenshot 2024-12-20 at 10 05 27" src="https://github.com/user-attachments/assets/13ee3782-cd3d-40d2-b26e-280531f70489" />

# Changes

- Replaces the `Portfolio` page icon with the `IconHome` icon.

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3510]: https://dfinity.atlassian.net/browse/NNS1-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ