### PR TITLE
Deprecate voting power

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -44,7 +44,7 @@
   <HeadingSubtitle slot="subtitle" testId="voting-power">
     {#if canVote}
       {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
-        $votingPower: formatVotingPower(neuron.votingPower),
+        $votingPower: formatVotingPower(neuron.decidingVotingPower ?? 0n),
       })}
     {:else}
       {$i18n.neuron_detail.voting_power_zero_subtitle}

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -52,7 +52,7 @@
       >
         {#if canVote}
           {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
-            $votingPower: formatVotingPower(neuron.decidingVotingPower),
+            $votingPower: formatVotingPower(neuron.decidingVotingPower ?? 0n),
           })}
         {:else}
           {$i18n.neuron_detail.voting_power_zero_subtitle}
@@ -62,7 +62,7 @@
       <HeadingSubtitle testId="voting-power">
         {#if canVote}
           {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
-            $votingPower: formatVotingPower(neuron.decidingVotingPower),
+            $votingPower: formatVotingPower(neuron.decidingVotingPower ?? 0n),
           })}
         {:else}
           {$i18n.neuron_detail.voting_power_zero_subtitle}

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -32,7 +32,7 @@
   <h3 slot="title">{$i18n.neurons.voting_power}</h3>
   <p slot="end" class="title-value" data-tid="voting-power">
     {#if canVote}
-      {formatVotingPower(neuron.votingPower)}
+      {formatVotingPower(neuron.decidingVotingPower ?? 0n)}
     {:else}
       {$i18n.neuron_detail.voting_power_zero}
     {/if}
@@ -68,7 +68,7 @@
               neuron.dissolveDelaySeconds
             ).toFixed(2),
             $activityMultiplier: activityMultiplier(neuron).toFixed(2),
-            $votingPower: formatVotingPower(neuron.votingPower),
+            $votingPower: formatVotingPower(neuron.decidingVotingPower ?? 0n),
           }
         )}
       </p>

--- a/frontend/src/lib/components/neurons/NnsNeuronAmount.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronAmount.svelte
@@ -23,7 +23,7 @@
     title
     label={$i18n.neurons.voting_power}
     amount={TokenAmountV2.fromUlps({
-      amount: neuron.votingPower,
+      amount: neuron.decidingVotingPower ?? 0n,
       token: ICPToken,
     })}
     detailed

--- a/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
@@ -56,7 +56,7 @@
   <KeyValuePair testId="voting-power">
     <span class="label" slot="key">{$i18n.neurons.voting_power}</span>
     <span class="value" slot="value"
-      >{formatVotingPower(neuron.votingPower)}</span
+      >{formatVotingPower(neuron.decidingVotingPower ?? 0n)}</span
     >
   </KeyValuePair>
   <KeyValuePair testId="maturity">

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -112,7 +112,7 @@ export const getStateInfo = (neuronState: NeuronState): StateInfo =>
 // TODO(mstr): Rename to neuronPotentialVotingPower
 /**
  * Calculation of the voting power of a neuron.
- * 
+ *
  * Note: this calculation ignores the neuron’s activity state (votingPowerRefreshedTimestampSeconds).
  *
  * If neuron's dissolve delay is less than 6 months, the voting power is 0.

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -168,7 +168,7 @@ interface VotingPowerParams {
 }
 
 // TODO(mstr): Rename to calculatePotentialNeuronVotingPower
-// Because it doesn't take into account the the NNS neuron's activity state.
+// Because it doesn't take into account the NNS neuron's activity state.
 /**
  * For now used only internally in this file.
  *

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -112,7 +112,8 @@ export const getStateInfo = (neuronState: NeuronState): StateInfo =>
 // TODO(mstr): Rename to neuronPotentialVotingPower
 /**
  * Calculation of the voting power of a neuron.
- * ! Ignores the neurons activity state (votingPowerRefreshedTimestampSeconds)
+ * 
+ * Note: this calculation ignores the neuron’s activity state (votingPowerRefreshedTimestampSeconds).
  *
  * If neuron's dissolve delay is less than 6 months, the voting power is 0.
  *

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -109,8 +109,10 @@ const stateInfoMapper: StateMapper = {
 export const getStateInfo = (neuronState: NeuronState): StateInfo =>
   stateInfoMapper[neuronState];
 
+// TODO(mstr): Rename to neuronPotentialVotingPower
 /**
  * Calculation of the voting power of a neuron.
+ * ! Ignores the neurons activity state (votingPowerRefreshedTimestampSeconds)
  *
  * If neuron's dissolve delay is less than 6 months, the voting power is 0.
  *
@@ -163,6 +165,9 @@ interface VotingPowerParams {
   maxDissolveDelaySeconds?: number;
   minDissolveDelaySeconds?: number;
 }
+
+// TODO(mstr): Rename to calculatePotentialNeuronVotingPower
+// Because it doesn't take into account the the NNS neuron's activity state.
 /**
  * For now used only internally in this file.
  *

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -221,6 +221,7 @@ export const ageMultiplier = (ageSeconds: bigint): number =>
   });
 
 export const activityMultiplier = ({ fullNeuron }: NeuronInfo) => {
+  // TODO(mstr): use properties from the NeuronInfo
   const { decidingVotingPower = 0n, potentialVotingPower = 0n } =
     fullNeuron ?? {};
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -113,7 +113,7 @@ export const getStateInfo = (neuronState: NeuronState): StateInfo =>
 /**
  * Calculation of the voting power of a neuron.
  *
- * Note: this calculation ignores the neuron’s activity state (votingPowerRefreshedTimestampSeconds).
+ * Note: This calculation ignores the case where the neuron starts missing voting rewards due to user inactivity (related to votingPowerRefreshedTimestampSeconds).
  *
  * If neuron's dissolve delay is less than 6 months, the voting power is 0.
  *

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -148,7 +148,9 @@ export const getVotingPower = ({
   getVotingBallot({
     neuronId,
     proposalInfo: proposal,
-  })?.votingPower ?? decidingVotingPower ?? 0n;
+  })?.votingPower ??
+  decidingVotingPower ??
+  0n;
 
 export const selectedNeuronsVotingPower = ({
   neurons,

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -139,7 +139,7 @@ export const getVotingBallot = ({
 // We first check the voting power of the ballot from the proposal. Which is the voting power that was used to vote.
 // In the edge case that the proposal voting power is not present, then we show the neuron voting power.
 export const getVotingPower = ({
-  neuron: { neuronId, votingPower },
+  neuron: { neuronId, decidingVotingPower },
   proposal,
 }: {
   neuron: NeuronInfo;
@@ -148,7 +148,7 @@ export const getVotingPower = ({
   getVotingBallot({
     neuronId,
     proposalInfo: proposal,
-  })?.votingPower ?? votingPower;
+  })?.votingPower ?? decidingVotingPower ?? 0n;
 
 export const selectedNeuronsVotingPower = ({
   neurons,

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -55,10 +55,10 @@ describe("NnsNeuronPageHeading", () => {
   });
 
   it("should render neuron's voting power", async () => {
-    const votingPower = 314_000_000n;
+    const decidingVotingPower = 314_000_000n;
     const po = renderComponent({
       ...mockNeuron,
-      votingPower,
+      decidingVotingPower,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
     });
 
@@ -66,10 +66,10 @@ describe("NnsNeuronPageHeading", () => {
   });
 
   it("should render no voting power if neuron can't vote", async () => {
-    const votingPower = 314_000_000n;
+    const decidingVotingPower = 314_000_000n;
     const po = renderComponent({
       ...mockNeuron,
-      votingPower,
+      decidingVotingPower,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE - 1),
     });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -25,7 +25,8 @@ describe("NnsStakeItemAction", () => {
   it("should render voting power", async () => {
     const neuron: NeuronInfo = {
       ...mockNeuron,
-      votingPower: 614000000n,
+      decidingVotingPower: 614000000n,
+      potentialVotingPower: 614000000n,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
     };
     const po = renderComponent(neuron);
@@ -36,7 +37,8 @@ describe("NnsStakeItemAction", () => {
   it("should render no voting power if neuron can't vote", async () => {
     const neuron: NeuronInfo = {
       ...mockNeuron,
-      votingPower: 614000000n,
+      decidingVotingPower: 614000000n,
+      potentialVotingPower: 614000000n,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE - 1),
     };
     const po = renderComponent(neuron);
@@ -47,7 +49,8 @@ describe("NnsStakeItemAction", () => {
   it("should render description with no voting power explanation", async () => {
     const neuron: NeuronInfo = {
       ...mockNeuron,
-      votingPower: 614000000n,
+      decidingVotingPower: 614000000n,
+      potentialVotingPower: 614000000n,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE - 1),
     };
     const po = renderComponent(neuron);
@@ -64,7 +67,8 @@ describe("NnsStakeItemAction", () => {
     );
     const neuron: NeuronInfo = {
       ...mockNeuron,
-      votingPower: 614000000n,
+      decidingVotingPower: 614000000n,
+      potentialVotingPower: 614000000n,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
     };
     const po = renderComponent(neuron);
@@ -81,7 +85,8 @@ describe("NnsStakeItemAction", () => {
     );
     const neuron: NeuronInfo = {
       ...mockNeuron,
-      votingPower: 614000000n,
+      decidingVotingPower: 614000000n,
+      potentialVotingPower: 614000000n,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
     };
     const po = renderComponent(neuron);
@@ -98,7 +103,8 @@ describe("NnsStakeItemAction", () => {
     );
     const neuron: NeuronInfo = {
       ...mockNeuron,
-      votingPower: 614000000n,
+      decidingVotingPower: 614000000n,
+      potentialVotingPower: 614000000n,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
     };
     const po = renderComponent(neuron);
@@ -115,8 +121,9 @@ describe("NnsStakeItemAction", () => {
     );
     const neuron: NeuronInfo = {
       ...mockNeuron,
-      votingPower: 614000000n,
       dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
+      decidingVotingPower: 307000000n,
+      potentialVotingPower: 614000000n,
       fullNeuron: {
         ...mockFullNeuron,
         decidingVotingPower: 307000000n,
@@ -126,7 +133,7 @@ describe("NnsStakeItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getDescription()).toBe(
-      "voting_power = (30.00 + 0) × 1.00 × 1.06 × 0.50 = 6.14"
+      "voting_power = (30.00 + 0) × 1.00 × 1.06 × 0.50 = 3.07"
     );
   });
 

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -252,14 +252,13 @@ describe("NnsNeuronCard", () => {
   it("renders voting power in `proposerNeuron` version", async () => {
     const { getByText } = render(NnsNeuronCard, {
       props: {
-        neuron: mockNeuron,
+        neuron: {
+          ...mockNeuron,
+          decidingVotingPower: 864_000_000n,
+        },
         proposerNeuron: true,
       },
     });
-    const votingValue = formatTokenE8s({
-      value: mockNeuron.votingPower,
-      detailed: true,
-    });
-    expect(getByText(votingValue)).toBeInTheDocument();
+    expect(getByText("8.64")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
@@ -56,7 +56,7 @@ describe("NnsNeuronDetailCard", () => {
   it("should render neuron voting power", async () => {
     const po = renderComponent({
       ...mockNeuron,
-      votingPower: 3_000_000_000n,
+      decidingVotingPower: 3_000_000_000n,
     });
 
     expect(await po.getVotingPower()).toBe("30.00");

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
@@ -19,7 +19,7 @@ describe("VotingNeuronListItem", () => {
       neuron: {
         ...mockNeuron,
         neuronId,
-        votingPower,
+        decidingVotingPower: votingPower,
       },
       proposal: mockProposalInfo,
     });

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -848,7 +848,7 @@ describe("proposals-utils", () => {
     });
 
     it("should return neuron voting power if no ballot", () => {
-      const decidingVotingPower= 123_000_000n;
+      const decidingVotingPower = 123_000_000n;
       const proposal = {
         ...mockProposalInfo,
         ballots: [],

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -848,16 +848,20 @@ describe("proposals-utils", () => {
     });
 
     it("should return neuron voting power if no ballot", () => {
+      const decidingVotingPower= 123_000_000n;
       const proposal = {
         ...mockProposalInfo,
         ballots: [],
       };
       expect(
         getVotingPower({
-          neuron: mockNeuron,
+          neuron: {
+            ...mockNeuron,
+            decidingVotingPower,
+          },
           proposal,
         })
-      ).toBe(mockNeuron.votingPower);
+      ).toBe(decidingVotingPower);
     });
   });
 

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -55,6 +55,7 @@ export const mockNeuron: NeuronInfo = {
   state: NeuronState.Locked,
   joinedCommunityFundTimestampSeconds: undefined,
   retrievedAtTimestampSeconds: 10n,
+  /** @deprecated */
   votingPower: 300_000_000n,
   ageSeconds: 100n,
   visibility: undefined,


### PR DESCRIPTION
# Motivation

New fields representing the voting power of a neuron have recently been introduced to the governance canister (https://github.com/dfinity/ic/blob/release-2024-12-06_03-16-base/rs/nns/governance/canister/governance.did#L741-L743), and the original votingPower field has been marked as [deprecated](https://github.com/dfinity/ic/blob/d9fe2076f677a08734bed90c67b1c3f4056ed621/rs/nns/governance/canister/governance.did#L740). With this PR, `votingPower` is replaced by `decidedVotingPower`, which more accurately reflects the current voting power state of a neuron.

**Note**: The new fields are marked as optional to maintain backward compatibility of the type, but they are expected to always be provided.

# Changes

- Replace `NeuronInfo.votingPower` with `NeuronInfo.decidingVotingPower`.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.