### PR TITLE
feat(nav): set AccountsPortfolio as default menu page

### DIFF
--- a/frontend/src/lib/utils/page.utils.ts
+++ b/frontend/src/lib/utils/page.utils.ts
@@ -1,6 +1,8 @@
 import { AppPath, ROUTE_ID_GROUPS } from "$lib/constants/routes.constants";
+import { ENABLE_PORTFOLIO_PAGE } from "$lib/stores/feature-flags.store";
 import { isNullish } from "@dfinity/utils";
 import type { AfterNavigate } from "@sveltejs/kit";
+import { get } from "svelte/store";
 
 /**
  * Returns an AppPath for a given path.
@@ -12,8 +14,12 @@ import type { AfterNavigate } from "@sveltejs/kit";
  * @returns {AppPath}
  */
 export const pathForRouteId = (routeId: string | null | undefined): AppPath => {
+  const defaultPath = get(ENABLE_PORTFOLIO_PAGE)
+    ? AppPath.Portfolio
+    : AppPath.Accounts;
+
   if (isNullish(routeId)) {
-    return AppPath.Accounts;
+    return defaultPath;
   }
 
   const routeIdWithoutGroups = (routeId: string): string =>
@@ -33,7 +39,7 @@ export const pathForRouteId = (routeId: string | null | undefined): AppPath => {
   // TODO: solve eslint type checking
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore-line
-  return AppPath[key as keyof AppPath] ?? AppPath.Accounts;
+  return AppPath[key as keyof AppPath] ?? defaultPath;
 };
 
 export const referrerPathForNav = ({

--- a/frontend/src/routes/(app)/(home)/+layout.svelte
+++ b/frontend/src/routes/(app)/(home)/+layout.svelte
@@ -3,10 +3,15 @@
   import IslandWidthMain from "$lib/components/layout/IslandWidthMain.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import { ENABLE_PORTFOLIO_PAGE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
+
+  const title = $ENABLE_PORTFOLIO_PAGE
+    ? $i18n.navigation.portfolio
+    : $i18n.navigation.tokens;
 </script>
 
-<LayoutList title={$i18n.navigation.tokens}>
+<LayoutList {title}>
   <Layout>
     <Content>
       <IslandWidthMain>

--- a/frontend/src/routes/(app)/(home)/+page.svelte
+++ b/frontend/src/routes/(app)/(home)/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
+  import { ENABLE_PORTFOLIO_PAGE } from "$lib/stores/feature-flags.store";
   import TokensRoute from "../(nns)/tokens/+page.svelte";
+  import PortfolioRoute from "../(nns)/portfolio/+page.svelte";
 </script>
 
-<TokensRoute />
+{#if $ENABLE_PORTFOLIO_PAGE}
+  <PortfolioRoute />
+{:else}
+  <TokensRoute />
+{/if}

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -1,2 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 </script>
+
+<TestIdWrapper testId="portfolio-route-component"></TestIdWrapper>

--- a/frontend/src/tests/lib/utils/page.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/page.utils.spec.ts
@@ -1,4 +1,5 @@
 import { AppPath, ROUTE_ID_GROUP_APP } from "$lib/constants/routes.constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { pathForRouteId } from "$lib/utils/page.utils";
 
 describe("page.utils", () => {
@@ -18,5 +19,14 @@ describe("page.utils", () => {
     expect(pathForRouteId(`${ROUTE_ID_GROUP_APP}${AppPath.Accounts}`)).toEqual(
       AppPath.Accounts
     );
+  });
+
+  describe("ENABLE_PORTFOLIO_PAGE feature flag is one", () => {
+    it("should find no path and fallback to accounts path", () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
+      expect(pathForRouteId(undefined)).toEqual(AppPath.Portfolio);
+      expect(pathForRouteId(null)).toEqual(AppPath.Portfolio);
+      expect(pathForRouteId("yolo")).toEqual(AppPath.Portfolio);
+    });
   });
 });

--- a/frontend/src/tests/routes/app/home/layout.spec.ts
+++ b/frontend/src/tests/routes/app/home/layout.spec.ts
@@ -2,7 +2,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import { page } from "$mocks/$app/stores";
-import AccountsLayout from "$routes/(app)/(home)/+layout.svelte";
+import HomeLayout from "$routes/(app)/(home)/+layout.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -19,7 +19,7 @@ describe("Home layout", () => {
   });
 
   it("should set title and header layout to 'Tokens'", () => {
-    render(AccountsLayout);
+    render(HomeLayout);
 
     expect(get(layoutTitleStore)).toEqual({
       title: en.navigation.tokens,
@@ -28,13 +28,13 @@ describe("Home layout", () => {
   });
 
   it("should not show the split content navigation", () => {
-    const { queryByTestId } = render(AccountsLayout);
+    const { queryByTestId } = render(HomeLayout);
 
     expect(queryByTestId("select-universe-nav-title")).not.toBeInTheDocument();
   });
 
   it("should render menu toggle button", () => {
-    const { queryByTestId } = render(AccountsLayout);
+    const { queryByTestId } = render(HomeLayout);
 
     expect(queryByTestId("menu-toggle")).toBeInTheDocument();
   });
@@ -43,7 +43,7 @@ describe("Home layout", () => {
     it("should show the Portfolio title", () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
 
-      render(AccountsLayout);
+      render(HomeLayout);
 
       expect(get(layoutTitleStore)).toEqual({
         title: en.navigation.portfolio,

--- a/frontend/src/tests/routes/app/home/layout.spec.ts
+++ b/frontend/src/tests/routes/app/home/layout.spec.ts
@@ -1,7 +1,9 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import { page } from "$mocks/$app/stores";
 import AccountsLayout from "$routes/(app)/(home)/+layout.svelte";
+import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -16,28 +18,37 @@ describe("Home layout", () => {
     });
   });
 
-  describe("when tokens flag is enabled", () => {
-    it("should set title and header layout to 'Tokens'", () => {
+  it("should set title and header layout to 'Tokens'", () => {
+    render(AccountsLayout);
+
+    expect(get(layoutTitleStore)).toEqual({
+      title: en.navigation.tokens,
+      header: en.navigation.tokens,
+    });
+  });
+
+  it("should not show the split content navigation", () => {
+    const { queryByTestId } = render(AccountsLayout);
+
+    expect(queryByTestId("select-universe-nav-title")).not.toBeInTheDocument();
+  });
+
+  it("should render menu toggle button", () => {
+    const { queryByTestId } = render(AccountsLayout);
+
+    expect(queryByTestId("menu-toggle")).toBeInTheDocument();
+  });
+
+  describe("when ENABLE_PORTFOLIO_PAGE feature flag is one", () => {
+    it("should show the Portfolio title", () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
+
       render(AccountsLayout);
 
       expect(get(layoutTitleStore)).toEqual({
-        title: "Tokens",
-        header: "Tokens",
+        title: en.navigation.portfolio,
+        header: en.navigation.portfolio,
       });
-    });
-
-    it("should not show the split content navigation", () => {
-      const { queryByTestId } = render(AccountsLayout);
-
-      expect(
-        queryByTestId("select-universe-nav-title")
-      ).not.toBeInTheDocument();
-    });
-
-    it("should render menu toggle button", () => {
-      const { queryByTestId } = render(AccountsLayout);
-
-      expect(queryByTestId("menu-toggle")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/routes/app/home/page.spec.ts
+++ b/frontend/src/tests/routes/app/home/page.spec.ts
@@ -1,15 +1,33 @@
-import CanistersPage from "$routes/(app)/(nns)/canisters/+page.svelte";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import HomeRoute from "$routes/(app)/(home)/+page.svelte";
 import { setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
 
-describe("Canisters page", () => {
+describe("Home page", () => {
   beforeEach(() => {
     setNoIdentity();
   });
 
-  it("should render sign-in if not logged in", () => {
-    const { getByTestId } = render(CanistersPage);
+  it("should render sign-in button", () => {
+    const { getByTestId } = render(HomeRoute);
 
     expect(getByTestId("login-button")).not.toBeNull();
+  });
+
+  it("should render tokens pages", () => {
+    const { getByTestId } = render(HomeRoute);
+
+    expect(getByTestId("tokens-route-component")).not.toBeNull();
+  });
+
+  describe("when ENABLE_PORTFOLIO_PAGE feature flag is one", () => {
+    it("should show the Portfolio page", () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
+
+      const { queryByTestId } = render(HomeRoute);
+
+      expect(queryByTestId("portfolio-route-component")).not.toBeNull();
+      expect(queryByTestId("tokens-route-component")).toBeNull();
+    });
   });
 });

--- a/frontend/src/tests/routes/app/home/page.spec.ts
+++ b/frontend/src/tests/routes/app/home/page.spec.ts
@@ -1,0 +1,15 @@
+import CanistersPage from "$routes/(app)/(nns)/canisters/+page.svelte";
+import { setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { render } from "@testing-library/svelte";
+
+describe("Canisters page", () => {
+  beforeEach(() => {
+    setNoIdentity();
+  });
+
+  it("should render sign-in if not logged in", () => {
+    const { getByTestId } = render(CanistersPage);
+
+    expect(getByTestId("login-button")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# Motivation

The new portfolio page will be the default landing page for users in the nns-dapp.  
Ticket: [NNS1-3510](https://dfinity.atlassian.net/browse/NNS1-3510)

# Changes

- The `home` route will render the `Portfolio` page if the feature flag is enabled.
- Set route utilities to default to the `/portfolio` route if there is no match with the current path.

# Tests

- Unit test the behavior of the utils function when `ENABLE_PORTFOLIO_PAGE` is enabled.
- Unit test the behavior of the home route when `ENABLE_PORTFOLIO_PAGE` is enabled.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3510]: https://dfinity.atlassian.net/browse/NNS1-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ