### PR TITLE
Ledger neuron hotkey warning

### DIFF
--- a/frontend/src/lib/components/accounts/LedgerNeuronHotkeyWarning.svelte
+++ b/frontend/src/lib/components/accounts/LedgerNeuronHotkeyWarning.svelte
@@ -11,7 +11,7 @@
   let isDismissed = browser
     ? Boolean(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? "false"))
     : false;
-  let isVisible: boolean = false;
+  let isVisible = false;
   $: isVisible = !isDismissed;
 
   function dismissBanner() {

--- a/frontend/src/lib/components/accounts/LedgerNeuronHotkeyWarning.svelte
+++ b/frontend/src/lib/components/accounts/LedgerNeuronHotkeyWarning.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import { i18n } from "$lib/stores/i18n";
+  import { IconInfo } from "@dfinity/gix-components";
+  import Banner from "../ui/Banner.svelte";
+  import BannerIcon from "../ui/BannerIcon.svelte";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
+
+  const LOCAL_STORAGE_KEY = "isLedgerNeuronHotkeyWarningDisabled";
+
+  let isDismissed = browser
+    ? Boolean(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? "false"))
+    : false;
+  let isVisible: boolean = false;
+  $: isVisible = !isDismissed;
+
+  function dismissBanner() {
+    isDismissed = true;
+    localStorage.setItem(LOCAL_STORAGE_KEY, "true");
+  }
+</script>
+
+<TestIdWrapper testId="ledger-neuron-hotkey-warning-component">
+  {#if isVisible}
+    <Banner
+      isClosable
+      on:nnsClose={dismissBanner}
+      htmlText={$i18n.losing_rewards.hw_hotkey_warning}
+    >
+      <BannerIcon slot="icon">
+        <IconInfo />
+      </BannerIcon>
+    </Banner>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -393,7 +393,8 @@
   "losing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",
     "confirming": "Confirming following. This may take a moment.",
-    "confirm": "Confirm Following"
+    "confirm": "Confirm Following",
+    "hw_hotkey_warning": "You may have neurons that are not added to the NNS dapp. If you want to view your neurons and get alerts in case they start missing voting rewards, you can add them by clicking <strong>Show Neurons > Add to NNS Dapp</strong>."
   },
   "losing_rewards_banner": {
     "confirm_title": "Confirm following or vote manually to avoid missing rewards",

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -76,6 +76,8 @@
   } from "@dfinity/utils";
   import { onDestroy, onMount, setContext } from "svelte";
   import { writable, type Readable } from "svelte/store";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
+  import LedgerNeuronHotkeyWarning from "$lib/components/accounts/LedgerNeuronHotkeyWarning.svelte";
 
   $: if ($authSignedInStore) {
     pollAccounts();
@@ -380,6 +382,10 @@
             {/if}
             <SignInGuard />
           </WalletPageHeading>
+
+          {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION && isHardwareWallet}
+            <LedgerNeuronHotkeyWarning />
+          {/if}
 
           <Separator spacing="none" />
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -408,6 +408,7 @@ interface I18nLosing_rewards {
   description: string;
   confirming: string;
   confirm: string;
+  hw_hotkey_warning: string;
 }
 
 interface I18nLosing_rewards_banner {

--- a/frontend/src/tests/lib/components/accounts/LedgerNeuronHotkeyWarning.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/LedgerNeuronHotkeyWarning.spec.ts
@@ -1,7 +1,7 @@
+import LedgerNeuronHotkeyWarning from "$lib/components/accounts/LedgerNeuronHotkeyWarning.svelte";
 import { LedgerNeuronHotkeyWarningPo } from "$tests/page-objects/LedgerNeuronHotkeyWarning.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
-import LedgerNeuronHotkeyWarning from "$lib/components/accounts/LedgerNeuronHotkeyWarning.svelte";
 
 describe("LedgerNeuronHotkeyWarning", () => {
   const localStorageKey = "isLedgerNeuronHotkeyWarningDisabled";
@@ -19,7 +19,7 @@ describe("LedgerNeuronHotkeyWarning", () => {
   it("should be shown when localStorageKey not set", async () => {
     const po = await renderComponent();
     expect(localStorage.getItem(localStorageKey)).toBeNull();
-    
+
     expect(await po.isBannerVisible()).toBe(true);
   });
 
@@ -29,7 +29,6 @@ describe("LedgerNeuronHotkeyWarning", () => {
 
     expect(await po.isBannerVisible()).toBe(false);
   });
-
 
   it("should be closable", async () => {
     const po = await renderComponent();
@@ -42,5 +41,4 @@ describe("LedgerNeuronHotkeyWarning", () => {
     expect(await po.isBannerVisible()).toBe(false);
     expect(localStorage.getItem(localStorageKey)).toEqual("true");
   });
-
 });

--- a/frontend/src/tests/lib/components/accounts/LedgerNeuronHotkeyWarning.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/LedgerNeuronHotkeyWarning.spec.ts
@@ -1,0 +1,46 @@
+import { LedgerNeuronHotkeyWarningPo } from "$tests/page-objects/LedgerNeuronHotkeyWarning.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+import LedgerNeuronHotkeyWarning from "$lib/components/accounts/LedgerNeuronHotkeyWarning.svelte";
+
+describe("LedgerNeuronHotkeyWarning", () => {
+  const localStorageKey = "isLedgerNeuronHotkeyWarningDisabled";
+  const renderComponent = () => {
+    const { container } = render(LedgerNeuronHotkeyWarning);
+    return LedgerNeuronHotkeyWarningPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("should be shown when localStorageKey not set", async () => {
+    const po = await renderComponent();
+    expect(localStorage.getItem(localStorageKey)).toBeNull();
+    
+    expect(await po.isBannerVisible()).toBe(true);
+  });
+
+  it("should not render when localStorageKey is set to true", async () => {
+    localStorage.setItem(localStorageKey, "true");
+    const po = await renderComponent();
+
+    expect(await po.isBannerVisible()).toBe(false);
+  });
+
+
+  it("should be closable", async () => {
+    const po = await renderComponent();
+
+    expect(await po.isBannerVisible()).toBe(true);
+    expect(localStorage.getItem(localStorageKey)).toBeNull();
+
+    await po.getBannerPo().clickClose();
+
+    expect(await po.isBannerVisible()).toBe(false);
+    expect(localStorage.getItem(localStorageKey)).toEqual("true");
+  });
+
+});

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -14,6 +14,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import NnsWallet from "$lib/pages/NnsWallet.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
@@ -58,7 +59,6 @@ import { memoToNeuronAccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import AccountsTest from "./AccountsTest.svelte";
 
 vi.mock("$lib/api/nns-dapp.api");

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -1026,7 +1026,6 @@ describe("NnsWallet", () => {
         true
       );
       const po = await renderWallet(props);
-      allowLoggingInOneTestForDebugging();
 
       expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(
         true

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -59,6 +59,8 @@ import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
 import AccountsTest from "./AccountsTest.svelte";
+import { overrideFeatureFlagsStore } from "../../../lib/stores/feature-flags.store";
+import { allowLoggingInOneTestForDebugging } from "../../utils/console.test-utils";
 
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/accounts.api");
@@ -406,6 +408,12 @@ describe("NnsWallet", () => {
       const po = await renderWallet(props);
 
       expect(await po.getWalletPageHeadingPo().getTitle()).toBe("4.32 ICP");
+    });
+
+    it("should not render Ledger neuron hotkey warning for not HW wallet", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PERIODIC_FOLLOWING_CONFIRMATION", true);
+      const po = await renderWallet(props);
+      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(false);
     });
 
     it("should reload balance on open", async () => {
@@ -1006,6 +1014,22 @@ describe("NnsWallet", () => {
       const po = await renderWallet(props);
       expect(await po.getListNeuronsButtonPo().isPresent()).toBe(true);
       expect(await po.getShowHardwareWalletButtonPo().isPresent()).toBe(true);
+    });
+
+    it("should display Ledger neuron hotkey warning", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PERIODIC_FOLLOWING_CONFIRMATION", true);
+      const po = await renderWallet(props);
+      allowLoggingInOneTestForDebugging();
+
+      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(true);
+    });
+
+    it("should not display Ledger neuron hotkey warning when feature flag off", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PERIODIC_FOLLOWING_CONFIRMATION", false);
+      const po = await renderWallet(props);
+      allowLoggingInOneTestForDebugging();
+
+      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(false);
     });
 
     describe("when there are staking transactions", () => {

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -58,9 +58,8 @@ import { memoToNeuronAccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import AccountsTest from "./AccountsTest.svelte";
-import { overrideFeatureFlagsStore } from "../../../lib/stores/feature-flags.store";
-import { allowLoggingInOneTestForDebugging } from "../../utils/console.test-utils";
 
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/accounts.api");
@@ -411,9 +410,14 @@ describe("NnsWallet", () => {
     });
 
     it("should not render Ledger neuron hotkey warning for not HW wallet", async () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_PERIODIC_FOLLOWING_CONFIRMATION", true);
+      overrideFeatureFlagsStore.setFlag(
+        "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+        true
+      );
       const po = await renderWallet(props);
-      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(false);
+      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(
+        false
+      );
     });
 
     it("should reload balance on open", async () => {
@@ -1017,19 +1021,28 @@ describe("NnsWallet", () => {
     });
 
     it("should display Ledger neuron hotkey warning", async () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_PERIODIC_FOLLOWING_CONFIRMATION", true);
+      overrideFeatureFlagsStore.setFlag(
+        "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+        true
+      );
       const po = await renderWallet(props);
       allowLoggingInOneTestForDebugging();
 
-      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(true);
+      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(
+        true
+      );
     });
 
     it("should not display Ledger neuron hotkey warning when feature flag off", async () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_PERIODIC_FOLLOWING_CONFIRMATION", false);
+      overrideFeatureFlagsStore.setFlag(
+        "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+        false
+      );
       const po = await renderWallet(props);
-      allowLoggingInOneTestForDebugging();
 
-      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(false);
+      expect(await po.getLedgerNeuronHotkeyWarningPo().isBannerVisible()).toBe(
+        false
+      );
     });
 
     describe("when there are staking transactions", () => {

--- a/frontend/src/tests/page-objects/LedgerNeuronHotkeyWarning.page-object.ts
+++ b/frontend/src/tests/page-objects/LedgerNeuronHotkeyWarning.page-object.ts
@@ -1,0 +1,21 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BannerPo } from "./Banner.page-object";
+
+export class LedgerNeuronHotkeyWarningPo extends BasePageObject {
+  private static readonly TID = "ledger-neuron-hotkey-warning-component";
+
+  static under(element: PageObjectElement): LedgerNeuronHotkeyWarningPo {
+    return new LedgerNeuronHotkeyWarningPo(
+      element.byTestId(LedgerNeuronHotkeyWarningPo.TID)
+    );
+  }
+
+  getBannerPo(): BannerPo {
+    return BannerPo.under(this.root);
+  }
+
+  async isBannerVisible(): Promise<boolean> {
+    return this.getBannerPo().isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -6,6 +6,7 @@ import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-ob
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { LedgerNeuronHotkeyWarningPo } from "./LedgerNeuronHotkeyWarning.page-object";
 import { UiTransactionsListPo } from "./UiTransactionsList.page-object";
 
 export class NnsWalletPo extends BasePageObject {
@@ -49,6 +50,10 @@ export class NnsWalletPo extends BasePageObject {
 
   getListNeuronsButtonPo(): ButtonPo {
     return this.getButton("ledger-list-button");
+  }
+
+  getLedgerNeuronHotkeyWarningPo(): LedgerNeuronHotkeyWarningPo {
+    return LedgerNeuronHotkeyWarningPo.under(this.root);
   }
 
   getShowHardwareWalletButtonPo(): ButtonPo {


### PR DESCRIPTION
# Motivation

To prevent missing rewards for ledger neurons, we display a warning on the HW wallet page.

# Changes

- Add `LedgerNeuronHotkeyWarning` component.
- Display `LedgerNeuronHotkeyWarning` .

# Tests

- Added.
- Tested locally that the banner is closable.
<img width="744" alt="image" src="https://github.com/user-attachments/assets/51b6fec2-3c57-4040-88d4-a07e4d190fbf" />

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.