### PR TITLE
feat(ui): add login card component for portfolio page

### DIFF
--- a/frontend/src/lib/components/portfolio/LoginCard.svelte
+++ b/frontend/src/lib/components/portfolio/LoginCard.svelte
@@ -5,7 +5,7 @@
   import { IconAccountsPage } from "@dfinity/gix-components";
 </script>
 
-<Card>
+<Card testId="portfolio-login-card">
   <div class="wrapper">
     <div class="icon">
       <IconAccountsPage />

--- a/frontend/src/lib/components/portfolio/LoginCard.svelte
+++ b/frontend/src/lib/components/portfolio/LoginCard.svelte
@@ -1,0 +1,84 @@
+<script>
+  import { i18n } from "$lib/stores/i18n";
+  import { IconAccountsPage } from "@dfinity/gix-components";
+  import SignIn from "../common/SignIn.svelte";
+  import Card from "./Card.svelte";
+</script>
+
+<Card>
+  <div class="wrapper">
+    <div class="icon">
+      <IconAccountsPage />
+    </div>
+    <h2>{$i18n.portfolio.login_title}</h2>
+    <p>{$i18n.portfolio.login_description}</p>
+    <div class="action">
+      <SignIn />
+    </div>
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  .wrapper {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "icon title"
+      "icon description"
+      "action action";
+    gap: var(--padding-2x);
+    padding: var(--padding-2x);
+    @include media.min-width(medium) {
+      grid-template-columns: auto 1fr;
+      grid-template-areas:
+        "icon title"
+        "icon description"
+        "icon action";
+      gap: var(--padding-3x);
+      padding: var(--padding-3x) var(--padding-4x);
+    }
+    h2 {
+      grid-area: title;
+      margin: 0;
+      padding: 0;
+      margin-bottom: calc(var(--padding) * -1);
+      @include media.min-width(medium) {
+        margin-bottom: calc(var(--padding-2x) * -1);
+      }
+    }
+    p {
+      grid-area: description;
+      margin: 0;
+      padding: 0;
+      @include media.min-width(medium) {
+        grid-area: description;
+        display: block;
+      }
+    }
+    .icon {
+      grid-area: icon;
+      width: 80px;
+      height: 80px;
+      @include media.min-width(medium) {
+        grid-area: icon;
+        width: 144px;
+        height: 144px;
+      }
+    }
+    .action {
+      grid-area: action;
+      width: 100%;
+      :global(button) {
+        width: 100%;
+      }
+      @include media.min-width(medium) {
+        grid-area: action;
+        width: auto;
+        :global(button) {
+          width: auto;
+        }
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/LoginCard.svelte
+++ b/frontend/src/lib/components/portfolio/LoginCard.svelte
@@ -1,8 +1,8 @@
 <script>
+  import SignIn from "$lib/components/common/SignIn.svelte";
+  import Card from "$lib/components/portfolio/Card.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { IconAccountsPage } from "@dfinity/gix-components";
-  import SignIn from "../common/SignIn.svelte";
-  import Card from "./Card.svelte";
 </script>
 
 <Card>
@@ -10,8 +10,10 @@
     <div class="icon">
       <IconAccountsPage />
     </div>
-    <h2>{$i18n.portfolio.login_title}</h2>
-    <p>{$i18n.portfolio.login_description}</p>
+    <div class="content">
+      <h2>{$i18n.portfolio.login_title}</h2>
+      <p>{$i18n.portfolio.login_description}</p>
+    </div>
     <div class="action">
       <SignIn />
     </div>
@@ -24,57 +26,47 @@
     display: grid;
     grid-template-columns: auto 1fr;
     grid-template-areas:
-      "icon title"
-      "icon description"
+      "icon content"
       "action action";
     gap: var(--padding-2x);
     padding: var(--padding-2x);
+
     @include media.min-width(medium) {
       grid-template-columns: auto 1fr;
       grid-template-areas:
-        "icon title"
-        "icon description"
+        "icon content"
         "icon action";
       gap: var(--padding-3x);
       padding: var(--padding-3x) var(--padding-4x);
     }
-    h2 {
-      grid-area: title;
-      margin: 0;
-      padding: 0;
-      margin-bottom: calc(var(--padding) * -1);
-      @include media.min-width(medium) {
-        margin-bottom: calc(var(--padding-2x) * -1);
+    .content {
+      h2,
+      p {
+        margin: 0;
+        padding: 0;
       }
-    }
-    p {
-      grid-area: description;
-      margin: 0;
-      padding: 0;
-      @include media.min-width(medium) {
-        grid-area: description;
-        display: block;
-      }
+      grid-area: content;
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding);
     }
     .icon {
       grid-area: icon;
       width: 80px;
       height: 80px;
+
       @include media.min-width(medium) {
-        grid-area: icon;
         width: 144px;
         height: 144px;
       }
     }
     .action {
       grid-area: action;
-      width: 100%;
       :global(button) {
         width: 100%;
       }
+
       @include media.min-width(medium) {
-        grid-area: action;
-        width: auto;
         :global(button) {
           width: auto;
         }

--- a/frontend/src/lib/components/portfolio/LoginCard.svelte
+++ b/frontend/src/lib/components/portfolio/LoginCard.svelte
@@ -32,7 +32,6 @@
     padding: var(--padding-2x);
 
     @include media.min-width(medium) {
-      grid-template-columns: auto 1fr;
       grid-template-areas:
         "icon content"
         "icon action";

--- a/frontend/src/lib/components/portfolio/LoginCard.svelte
+++ b/frontend/src/lib/components/portfolio/LoginCard.svelte
@@ -39,6 +39,7 @@
       gap: var(--padding-3x);
       padding: var(--padding-3x) var(--padding-4x);
     }
+
     .content {
       h2,
       p {
@@ -50,6 +51,7 @@
       flex-direction: column;
       gap: var(--padding);
     }
+
     .icon {
       grid-area: icon;
       width: 80px;
@@ -60,6 +62,7 @@
         height: 144px;
       }
     }
+
     .action {
       grid-area: action;
       :global(button) {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1188,5 +1188,9 @@
     "failed_tooltip": "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers.",
     "maximum_reached_tooltip": "You've already imported the maximum number of $max tokens. You need to remove another token before you can import more.",
     "doc_link_label": "How to find ICRC token ledger"
+  },
+  "portfolio": {
+    "login_title": "Session expired",
+    "login_description": "Earn rewards, participate in governance and join the communities. Login to gain optimal access of the platform."
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1254,6 +1254,11 @@ interface I18nImport_token {
   doc_link_label: string;
 }
 
+interface I18nPortfolio {
+  login_title: string;
+  login_description: string;
+}
+
 interface I18nNeuron_state {
   Unspecified: string;
   Locked: string;
@@ -1544,6 +1549,7 @@ interface I18n {
   sync: I18nSync;
   tokens: I18nTokens;
   import_token: I18nImport_token;
+  portfolio: I18nPortfolio;
   neuron_state: I18nNeuron_state;
   topics: I18nTopics;
   topics_description: I18nTopics_description;


### PR DESCRIPTION
# Motivation

The portfolio page needs a dedicated login card to allow the user to login from this page.

Ticket [NNS1-3510](https://dfinity.atlassian.net/browse/NNS1-3510)

https://github.com/user-attachments/assets/1c551e5e-45f1-44e6-ac44-a9076a1adf24

# Changes

- Creates new LoginCard component with authentication form

# Tests

- Not necessary as there is no logic

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev. PR: #6069

[NNS1-3510]: https://dfinity.atlassian.net/browse/NNS1-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ