### PR TITLE
Display missing rewards indicator in navigation

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -7,7 +7,10 @@
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { pageStore } from "$lib/derived/page.derived";
   import { proposalsPathStore } from "$lib/derived/paths.derived";
-  import { ENABLE_PORTFOLIO_PAGE } from "$lib/stores/feature-flags.store";
+  import {
+    ENABLE_PERIODIC_FOLLOWING_CONFIRMATION,
+    ENABLE_PORTFOLIO_PAGE,
+  } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import {
     ACTIONABLE_PROPOSALS_URL,
@@ -27,6 +30,7 @@
   import type { ComponentType } from "svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { scale } from "svelte/transition";
+  import NnsNeuronsMissingRewardsBadge from "$lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte";
 
   let routes: {
     context: string;
@@ -74,6 +78,9 @@
       }),
       title: $i18n.navigation.neurons,
       icon: IconNeurons,
+      statusIcon: $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION
+        ? NnsNeuronsMissingRewardsBadge
+        : undefined,
     },
     {
       context: "proposals",

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -283,4 +283,28 @@ describe("MenuItems", () => {
       expect(await po.getPortfolioLinkPo().isPresent()).toBe(true);
     });
   });
+
+  describe("Nns neurons missing rewards badge", () => {
+    it("should not render the badge when feature flag disabled", async () => {
+      overrideFeatureFlagsStore.setFlag(
+        "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+        false
+      );
+      const po = renderComponent();
+      expect(await po.getNnsNeuronsMissingRewardsBadgePo().isPresent()).toEqual(
+        false
+      );
+    });
+
+    it("should render the badge when feature flag enabled", async () => {
+      overrideFeatureFlagsStore.setFlag(
+        "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+        true
+      );
+      const po = renderComponent();
+      expect(await po.getNnsNeuronsMissingRewardsBadgePo().isPresent()).toEqual(
+        true
+      );
+    });
+  });
 });

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -1,6 +1,7 @@
 import { ActionableProposalCountBadgePo } from "$tests/page-objects/ActionableProposalCountBadge.page-object";
 import { GetTokensPo } from "$tests/page-objects/GetTokens.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
+import { NnsNeuronsMissingRewardsBadgePo } from "$tests/page-objects/NnsNeuronsMissingRewardsBadge.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -13,6 +14,10 @@ export class MenuItemsPo extends BasePageObject {
 
   getProposalsActionableCountBadgePo(): ActionableProposalCountBadgePo {
     return ActionableProposalCountBadgePo.under(this.root);
+  }
+
+  getNnsNeuronsMissingRewardsBadgePo(): NnsNeuronsMissingRewardsBadgePo {
+    return NnsNeuronsMissingRewardsBadgePo.under(this.root);
   }
 
   clickAccounts(): Promise<void> {


### PR DESCRIPTION
# Motivation

When the user has Nns neurons that haven’t been active and are set to start losing rewards in 30 days or less, a red circle needs to be displayed next to the “Neuron Staking” sidebar item and on in the Neuron Staking page table to indicate that action is required.
In this PR, we add the indicator component next to the “Neuron Staking” navigation entry.

# Changes

- Display the indicator in the menu.

# Tests

- Test the presence of the indicator component. The logic is tested in the `NnsNeuronsMissingRewardsBadge.specs` file.

## Screenshot

<img width="350" alt="image" src="https://github.com/user-attachments/assets/42445884-4852-44d4-9d0c-0b51f6b82fce" />



# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.