### PR TITLE
Display missing rewards indicator in projects table

### DIFF
--- a/frontend/src/lib/components/staking/ProjectTitleCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectTitleCell.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import Logo from "$lib/components/ui/Logo.svelte";
   import type { TableProject } from "$lib/types/staking";
+  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+  import NnsNeuronsMissingRewardsBadge from "$lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
 
   export let rowData: TableProject;
 </script>
@@ -10,6 +13,9 @@
   <div class="title-wrapper">
     <h5 data-tid="project-title">{rowData.title}</h5>
   </div>
+  {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION && rowData.universeId === OWN_CANISTER_ID_TEXT}
+    <NnsNeuronsMissingRewardsBadge />
+  {/if}
 </div>
 
 <style lang="scss">

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -693,6 +693,66 @@ describe("ProjectsTable", () => {
       expect(console.error).toBeCalledWith(error);
       expect(console.error).toBeCalledTimes(1);
     });
+
+    describe("Nns neurons missing rewards badge", () => {
+      it("should render the badge in Nns row", async () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+        neuronsStore.setNeurons({
+          neurons: [nnsNeuronWithStake],
+          certified: true,
+        });
+        snsNeuronsStore.setNeurons({
+          rootCanisterId: snsCanisterId,
+          neurons: [snsNeuronWithStake],
+          certified: true,
+        });
+        const po = renderComponent();
+        const [firstRow, secondRow] = await po.getProjectsTableRowPos();
+
+        expect(await firstRow.getHref()).toBe(
+          `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
+        );
+        expect(
+          await firstRow
+            .getProjectTitleCellPo()
+            .getNnsNeuronsMissingRewardsBadgePo()
+            .isPresent()
+        ).toBe(true);
+        expect(await secondRow.getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
+        expect(
+          await secondRow
+            .getProjectTitleCellPo()
+            .getNnsNeuronsMissingRewardsBadgePo()
+            .isPresent()
+        ).toBe(false);
+      });
+
+      it("should not render the badge when feature flag off", async () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          false
+        );
+        neuronsStore.setNeurons({
+          neurons: [nnsNeuronWithStake],
+          certified: true,
+        });
+        const po = renderComponent();
+        const [firstRow] = await po.getProjectsTableRowPos();
+
+        expect(await firstRow.getHref()).toBe(
+          `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
+        );
+        expect(
+          await firstRow
+            .getProjectTitleCellPo()
+            .getNnsNeuronsMissingRewardsBadgePo()
+            .isPresent()
+        ).toBe(false);
+      });
+    });
   });
 
   it("should update table when universes store changes", async () => {

--- a/frontend/src/tests/page-objects/ProjectTitleCell.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectTitleCell.page-object.ts
@@ -1,3 +1,4 @@
+import { NnsNeuronsMissingRewardsBadgePo } from "$tests/page-objects/NnsNeuronsMissingRewardsBadge.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -10,5 +11,9 @@ export class ProjectTitleCellPo extends BasePageObject {
 
   getProjectTitle(): Promise<string> {
     return this.getText("project-title");
+  }
+
+  getNnsNeuronsMissingRewardsBadgePo(): NnsNeuronsMissingRewardsBadgePo {
+    return NnsNeuronsMissingRewardsBadgePo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

When the user has Nns neurons that haven’t been active and are set to start losing rewards in 30 days or less, a red circle needs to be displayed next to the “Neuron Staking” sidebar item and on in the Neuron Staking page table to indicate that action is required.
In this PR, we add the indicator component in the projects table.

# Changes

- Display the indicator in the table.

# Tests

- Test the presence of the indicator component. The logic is tested in the NnsNeuronsMissingRewardsBadge.specs file.

## Screenshot
<img width="925" alt="image" src="https://github.com/user-attachments/assets/d70b3e60-a08b-4427-aed2-4a1b5447dd32" />

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary