### PR TITLE
Update banners background

### DIFF
--- a/frontend/src/lib/components/neurons/MakeNeuronsPublicBanner.svelte
+++ b/frontend/src/lib/components/neurons/MakeNeuronsPublicBanner.svelte
@@ -97,7 +97,7 @@
   .banner {
     display: flex;
     align-items: center;
-    background: var(--input-background);
+    background-color: var(--banner-background);
     border-radius: var(--border-radius);
     padding: var(--padding) var(--padding-1_5x);
     gap: var(--padding-1_5x);

--- a/frontend/src/lib/components/ui/Banner.svelte
+++ b/frontend/src/lib/components/ui/Banner.svelte
@@ -75,11 +75,11 @@
 
     padding: var(--padding-2x);
     border-radius: var(--border-radius);
-    background: var(--input-background);
+    background-color: var(--banner-background);
   }
 
   .banner.isCritical {
-    background: var(--tooltip-background);
+    background-color: var(--tooltip-background);
 
     .title {
       color: var(--tooltip-text-color);

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -102,7 +102,7 @@
     align-items: center;
     gap: var(--padding-2x);
 
-    background-color: var(--card-background-tint);
+    background-color: var(--banner-background);
     padding: var(--padding-2x);
     border-radius: var(--padding);
     border: 1.5px solid var(--card-border);


### PR DESCRIPTION
# Motivation

Update the banner backgrounds to align with the design.

# Changes

- Replace the background variable for the identified banners, using background-color instead of background for improved clarity.

# Tests

- Tested locally:

| 🌝 | 🌚 |
|--------|--------|
| <img width="1235" alt="image" src="https://github.com/user-attachments/assets/33bb3c0e-f058-4325-89c7-6277cfefcf4e" /> | <img width="1231" alt="image" src="https://github.com/user-attachments/assets/877ff493-e037-4b7f-9a30-a33614879f80" /> |
| <img width="789" alt="image" src="https://github.com/user-attachments/assets/fd2ba1a3-8898-4d45-bc73-f88492bdb641" /> | <img width="803" alt="image" src="https://github.com/user-attachments/assets/cdd7a5d2-1696-4c8e-ba08-acdc1caa6ca4" /> |
| <img width="793" alt="image" src="https://github.com/user-attachments/assets/cf007cf3-2a1a-44f5-a492-bdc6becb08d7" /> | <img width="801" alt="image" src="https://github.com/user-attachments/assets/1a786e5c-cb93-4ce8-9dbf-0899e8a2050a" /> | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.