### PR TITLE
Add a warning HW neurons staking step 2

### DIFF
--- a/frontend/src/lib/components/common/CalloutWarning.svelte
+++ b/frontend/src/lib/components/common/CalloutWarning.svelte
@@ -2,6 +2,7 @@
   import { Html, IconError } from "@dfinity/gix-components";
 
   export let htmlText: string;
+  // TODO(mstr): Use Banner component here instead of custom styling.
 </script>
 
 <article data-tid="callout-warning-component">

--- a/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -6,6 +6,7 @@
   import { busy } from "@dfinity/gix-components";
   import type { NeuronId } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
+  import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
 
   export let account: Account;
   export let neuronId: NeuronId;
@@ -30,6 +31,8 @@
 </script>
 
 <div class="wrapper" data-tid="add-principal-to-hotkeys-modal">
+  <CalloutWarning htmlText={$i18n.losing_rewards.hw_create_neuron_warning} />
+
   <p class="description">{$i18n.neurons.add_user_as_hotkey_message}</p>
 
   <div>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -395,6 +395,7 @@
     "confirming": "Confirming following. This may take a moment.",
     "confirm": "Confirm Following",
     "badge_label": "Confirm following to avoid missing rewards",
+    "hw_create_neuron_warning": "It is recommended to <strong>Add Hotkey</strong> now, otherwise the NNS dapp will not be able to warn you if this neuron starts missing voting rewards due to inactivity.",
     "hw_hotkey_warning": "You may have neurons that are not added to the NNS dapp. If you want to view your neurons and get alerts in case they start missing voting rewards, you can add them by clicking <strong>Show Neurons > Add to NNS Dapp</strong>."
   },
   "losing_rewards_banner": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -409,6 +409,7 @@ interface I18nLosing_rewards {
   confirming: string;
   confirm: string;
   badge_label: string;
+  hw_create_neuron_warning: string;
   hw_hotkey_warning: string;
 }
 


### PR DESCRIPTION
# Motivation

Add a warning to the HW neuron creation form to inform the user about the consequences of not creating a hotkey for the new neuron.

# Changes

- Add a static warning.

# Tests

- Tested locally to confirm that the warning is displayed.

| 🌚 | 🌝 |
|--------|--------|
| <img width="622" alt="image" src="https://github.com/user-attachments/assets/1e83f3a9-7cf0-48d5-a4c3-df829847bc24" /> | <img width="615" alt="image" src="https://github.com/user-attachments/assets/368da8e6-2e94-4e34-a6b1-6dc235d65be4" /> | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.