### PR TITLE
test: clean up the tests for the Reporting route

### DIFF
--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -20,7 +20,7 @@
   );
 </script>
 
-<Island testId="reporting-page">
+<Island testId="reporting-page-component">
   <main>
     <ReportingNeurons />
     <Separator spacing="medium" />

--- a/frontend/src/lib/routes/Reporting.svelte
+++ b/frontend/src/lib/routes/Reporting.svelte
@@ -20,7 +20,7 @@
   );
 </script>
 
-<Island>
+<Island testId="reporting-page">
   <main>
     <ReportingNeurons />
     <Separator spacing="medium" />

--- a/frontend/src/routes/(app)/(nns)/reporting/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/reporting/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import SignInReporting from "$lib/pages/SignInReporting.svelte";
   import Reporting from "$lib/routes/Reporting.svelte";
 </script>
 
-{#if $authSignedInStore}
-  <Reporting />
-{:else}
-  <SignInReporting />
-{/if}
+<TestIdWrapper testId="reporting-route-component">
+  {#if $authSignedInStore}
+    <Reporting />
+  {:else}
+    <SignInReporting />
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
@@ -11,7 +11,7 @@ export class ReportingRoutePo extends BasePageObject {
   }
 
   getLoginButtonPo(): ButtonPo {
-    return ButtonPo.under({ element: this.root, testId: "login-button" });
+    return this.getButton("login-button");
   }
 
   getReportingPagePo(): ReportingPagePo {

--- a/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ButtonPo } from "./Button.page-object";
 import { ReportingPagePo } from "./ReportingPage.page-object";
 
 export class ReportingRoutePo extends BasePageObject {
@@ -9,8 +10,8 @@ export class ReportingRoutePo extends BasePageObject {
     return new ReportingRoutePo(element.byTestId(ReportingRoutePo.TID));
   }
 
-  getLoginButtonPo(): PageObjectElement {
-    return this.getElement("login-button");
+  getLoginButtonPo(): ButtonPo {
+    return ButtonPo.under({ element: this.root, testId: "login-button" });
   }
 
   getReportingPagePo(): ReportingPagePo {

--- a/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
@@ -1,0 +1,19 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ReportingPagePo } from "./ReportingPage.page-object";
+
+export class ReportingRoutePo extends BasePageObject {
+  private static readonly TID = "reporting-route-component";
+
+  static under(element: PageObjectElement): ReportingRoutePo {
+    return new ReportingRoutePo(element.byTestId(ReportingRoutePo.TID));
+  }
+
+  getLoginButtonPo(): PageObjectElement {
+    return this.getElement("login-button");
+  }
+
+  getReportingPagePo(): ReportingPagePo {
+    return ReportingPagePo.under(this.root);
+  }
+}

--- a/frontend/src/tests/routes/app/reporting/page.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/page.spec.ts
@@ -11,7 +11,7 @@ describe("Reporting page", () => {
     expect(queryByTestId("reporting-page")).toBeNull();
   });
 
-  it("should render transactions page if logged in", () => {
+  it("should render reporting page if logged in", () => {
     resetIdentity();
 
     const { queryByTestId } = render(ReportingPage);

--- a/frontend/src/tests/routes/app/reporting/page.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/page.spec.ts
@@ -3,25 +3,19 @@ import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
 
 describe("Reporting page", () => {
-  describe("not signed in", () => {
-    beforeEach(() => {
-      setNoIdentity();
-    });
+  it("should render sign-in if not logged in", () => {
+    setNoIdentity();
 
-    it("should render sign-in if not logged in", () => {
-      const { getByTestId } = render(ReportingPage);
-
-      expect(getByTestId("login-button")).not.toBeNull();
-    });
+    const { queryByTestId } = render(ReportingPage);
+    expect(queryByTestId("login-button")).not.toBeNull();
+    expect(queryByTestId("reporting-page")).toBeNull();
   });
 
-  describe("signed in", () => {
-    beforeEach(() => {
-      resetIdentity();
-    });
+  it("should render transactions page if logged in", () => {
+    resetIdentity();
 
-    // TODO: Once the ExportNeurons and ExportTransactions components are migrated to this new page
-    it.skip("should render generate neurons report section", () => {});
-    it.skip("should render generate transactions report section", () => {});
+    const { queryByTestId } = render(ReportingPage);
+    expect(queryByTestId("login-button")).toBeNull();
+    expect(queryByTestId("reporting-page")).not.toBeNull();
   });
 });

--- a/frontend/src/tests/routes/app/reporting/page.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/page.spec.ts
@@ -1,21 +1,31 @@
 import ReportingPage from "$routes/(app)/(nns)/reporting/+page.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { ReportingRoutePo } from "$tests/page-objects/ReportingRoute.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("Reporting page", () => {
-  it("should render sign-in if not logged in", () => {
+  const renderComponent = () => {
+    const { container } = render(ReportingPage);
+    const po = ReportingRoutePo.under(new JestPageObjectElement(container));
+    return po;
+  };
+
+  it("should render sign-in if not logged in", async () => {
     setNoIdentity();
 
-    const { queryByTestId } = render(ReportingPage);
-    expect(queryByTestId("login-button")).not.toBeNull();
-    expect(queryByTestId("reporting-page")).toBeNull();
+    const po = renderComponent();
+
+    expect(await po.getLoginButtonPo().isPresent()).toBe(true);
+    expect(await po.getReportingPagePo().isPresent()).toBe(false);
   });
 
-  it("should render reporting page if logged in", () => {
+  it("should render reporting page if logged in", async () => {
     resetIdentity();
 
-    const { queryByTestId } = render(ReportingPage);
-    expect(queryByTestId("login-button")).toBeNull();
-    expect(queryByTestId("reporting-page")).not.toBeNull();
+    const po = renderComponent();
+
+    expect(await po.getLoginButtonPo().isPresent()).toBe(false);
+    expect(await po.getReportingPagePo().isPresent()).toBe(true);
   });
 });


### PR DESCRIPTION
# Motivation

We want to ensure that the correct page is displayed when the user is logged in, rather than the sign-in page.

# Changes

- Added a `testId` to the Reporting page

# Tests

- Unit test to verify that the `Reporting` page is displayed when signed in.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary