### PR TITLE
refactor: consolidate Gix imports when duplicates are present

### DIFF
--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -4,8 +4,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import PrincipalInput from "$lib/components/ui/PrincipalInput.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { Html } from "@dfinity/gix-components";
-  import { IconOpenInNew } from "@dfinity/gix-components";
+  import { Html, IconOpenInNew } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { isNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";

--- a/frontend/src/lib/components/common/InProgress.svelte
+++ b/frontend/src/lib/components/common/InProgress.svelte
@@ -2,8 +2,11 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { ICON_SIZE_LARGE } from "$lib/constants/layout.constants";
   import { i18n } from "$lib/stores/i18n";
-  import { IconWarning } from "@dfinity/gix-components";
-  import { ProgressSteps, type ProgressStep } from "@dfinity/gix-components";
+  import {
+    IconWarning,
+    ProgressSteps,
+    type ProgressStep,
+  } from "@dfinity/gix-components";
 
   // The current step of the process that is in progress
   export let progressStep: string;

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import GetTokens from "$lib/components/ic/GetTokens.svelte";
   import TotalValueLocked from "$lib/components/metrics/TotalValueLocked.svelte";
+  import NnsNeuronsMissingRewardsBadge from "$lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte";
   import ActionableProposalTotalCountBadge from "$lib/components/proposals/ActionableProposalTotalCountBadge.svelte";
   import { IS_TESTNET } from "$lib/constants/environment.constants";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -16,7 +17,6 @@
     ACTIONABLE_PROPOSALS_URL,
     isSelectedPath,
   } from "$lib/utils/navigation.utils";
-  import SourceCodeButton from "./SourceCodeButton.svelte";
   import {
     IconHome,
     IconNeurons,
@@ -25,12 +25,13 @@
     IconWallet,
     MenuItem,
     ThemeToggleButton,
+    layoutMenuOpen,
+    menuCollapsed,
   } from "@dfinity/gix-components";
-  import { layoutMenuOpen, menuCollapsed } from "@dfinity/gix-components";
   import type { ComponentType } from "svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { scale } from "svelte/transition";
-  import NnsNeuronsMissingRewardsBadge from "$lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte";
+  import SourceCodeButton from "./SourceCodeButton.svelte";
 
   let routes: {
     context: string;

--- a/frontend/src/lib/components/header/AccountSyncIndicator.svelte
+++ b/frontend/src/lib/components/header/AccountSyncIndicator.svelte
@@ -3,8 +3,7 @@
   import { syncOverallStatusStore } from "$lib/derived/sync.derived";
   import { i18n } from "$lib/stores/i18n";
   import type { SyncState } from "$lib/types/sync";
-  import { IconError, Popover } from "@dfinity/gix-components";
-  import { IconSync } from "@dfinity/gix-components";
+  import { IconError, IconSync, Popover } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
   import type { ComponentType } from "svelte";
 

--- a/frontend/src/lib/components/ic/GetTokensModal.svelte
+++ b/frontend/src/lib/components/ic/GetTokensModal.svelte
@@ -17,8 +17,12 @@
   import { toastsError } from "$lib/stores/toasts.store";
   import type { Universe } from "$lib/types/universe";
   import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
-  import { Dropdown, DropdownItem, Modal } from "@dfinity/gix-components";
-  import { Spinner } from "@dfinity/gix-components";
+  import {
+    Dropdown,
+    DropdownItem,
+    Modal,
+    Spinner,
+  } from "@dfinity/gix-components";
   import { Principal } from "@dfinity/principal";
   import { isNullish, nonNullish, type Token } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -8,13 +8,12 @@
   import { createIsSnsFinalizingStore } from "$lib/stores/sns-finalization-status.store";
   import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
-  import ProjectCardSwapInfo from "./ProjectCardSwapInfo.svelte";
-  import { Card } from "@dfinity/gix-components";
-  import { Spinner } from "@dfinity/gix-components";
+  import { Card, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
   import type { Readable } from "svelte/store";
+  import ProjectCardSwapInfo from "./ProjectCardSwapInfo.svelte";
 
   export let project: SnsFullProject;
 

--- a/frontend/src/lib/components/neuron-detail/NeuronSelectPercentage.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronSelectPercentage.svelte
@@ -4,8 +4,7 @@
   import { formatPercentage } from "$lib/utils/format.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { formatMaturity } from "$lib/utils/neuron.utils";
-  import { InputRange, KeyValuePair } from "@dfinity/gix-components";
-  import { Tooltip } from "@dfinity/gix-components";
+  import { InputRange, KeyValuePair, Tooltip } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -16,8 +16,7 @@
     participateButtonStatus,
     type ParticipationButtonStatus,
   } from "$lib/utils/projects.utils";
-  import { BottomSheet } from "@dfinity/gix-components";
-  import { Tooltip } from "@dfinity/gix-components";
+  import { BottomSheet, Tooltip } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
   import { nonNullish } from "@dfinity/utils";

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
-  import { Copy } from "@dfinity/gix-components";
-  import { Tooltip } from "@dfinity/gix-components";
+  import { Copy, Tooltip } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
 
   export let tagName: "h3" | "p" | "span" | "h5" = "h3";

--- a/frontend/src/lib/components/ui/SkeletonCard.svelte
+++ b/frontend/src/lib/components/ui/SkeletonCard.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import Separator from "$lib/components/ui/Separator.svelte";
   import type { CardType } from "$lib/types/card";
+  import { Card, SkeletonText } from "@dfinity/gix-components";
   import CardInfo from "./CardInfo.svelte";
   import SkeletonCardContent from "./SkeletonCardContent.svelte";
-  import { Card } from "@dfinity/gix-components";
-  import { SkeletonText } from "@dfinity/gix-components";
 
   export let size: "small" | "medium" | "large" = "small";
   export let cardType: CardType = "card";

--- a/frontend/src/lib/components/ui/SkeletonProjectCard.svelte
+++ b/frontend/src/lib/components/ui/SkeletonProjectCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+  import { Card, SkeletonText } from "@dfinity/gix-components";
   import SkeletonLogo from "./SkeletonLogo.svelte";
-  import { Card } from "@dfinity/gix-components";
-  import { SkeletonText } from "@dfinity/gix-components";
 </script>
 
 <Card testId="skeleton-card">

--- a/frontend/src/lib/components/ui/SkeletonProposalCard.svelte
+++ b/frontend/src/lib/components/ui/SkeletonProposalCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { Card } from "@dfinity/gix-components";
-  import { SkeletonText } from "@dfinity/gix-components";
+  import { Card, SkeletonText } from "@dfinity/gix-components";
 </script>
 
 <Card testId="skeleton-card">

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
-  import { Checkbox } from "@dfinity/gix-components";
-  import { Modal, Spinner } from "@dfinity/gix-components";
+  import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import type { ProposalStatus, Topic } from "@dfinity/nns";
   import type { SnsProposalDecisionStatus } from "@dfinity/sns";
   import { isNullish } from "@dfinity/utils";

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -4,25 +4,24 @@
   import EditFollowNeurons from "$lib/components/neurons/EditFollowNeurons.svelte";
   import NnsStakeNeuron from "$lib/components/neurons/NnsStakeNeuron.svelte";
   import SetNnsDissolveDelay from "$lib/components/neurons/SetNnsDissolveDelay.svelte";
+  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import {
     cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
   import { i18n } from "$lib/stores/i18n";
-  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { toastsError, toastsShow } from "$lib/stores/toasts.store";
   import type { Account } from "$lib/types/account";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import {
     WizardModal,
+    wizardStepIndex,
     type WizardStep,
     type WizardSteps,
   } from "@dfinity/gix-components";
-  import { wizardStepIndex } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
-  import { createEventDispatcher, onDestroy, tick } from "svelte";
-  import { onMount } from "svelte";
+  import { createEventDispatcher, onDestroy, onMount, tick } from "svelte";
 
   onMount(() => {
     pollAccounts();

--- a/frontend/src/lib/modals/neurons/VotingHistoryModal.svelte
+++ b/frontend/src/lib/modals/neurons/VotingHistoryModal.svelte
@@ -5,10 +5,8 @@
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
-  import { Modal } from "@dfinity/gix-components";
-  import { Spinner } from "@dfinity/gix-components";
-  import type { NeuronId } from "@dfinity/nns";
-  import type { NeuronInfo } from "@dfinity/nns";
+  import { Modal, Spinner } from "@dfinity/gix-components";
+  import type { NeuronId, NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher, onMount } from "svelte";
 
   export let neuronId: NeuronId;

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -15,8 +15,7 @@
   import { findAccount } from "$lib/utils/accounts.utils";
   import { openAccountsModal } from "$lib/utils/modals.utils";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
-  import { IconAccountsPage } from "@dfinity/gix-components";
-  import { IconAdd } from "@dfinity/gix-components";
+  import { IconAccountsPage, IconAdd } from "@dfinity/gix-components";
   import { isNullish } from "@dfinity/utils";
   import { onDestroy, onMount } from "svelte";
 

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -10,15 +10,16 @@
   import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
-  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
-  import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
+  import {
+    ENABLE_PERIODIC_FOLLOWING_CONFIRMATION,
+    ENABLE_USD_VALUES_FOR_NEURONS,
+  } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import { tableNeuronsFromNeuronInfos } from "$lib/utils/neurons-table.utils";
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
-  import { IconNeuronsPage } from "@dfinity/gix-components";
-  import { Spinner } from "@dfinity/gix-components";
+  import { IconNeuronsPage, Spinner } from "@dfinity/gix-components";
   import { onMount } from "svelte";
 
   let isLoading = false;

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -21,8 +21,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { tableNeuronsFromSnsNeurons } from "$lib/utils/neurons-table.utils";
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
-  import { IconNeuronsPage } from "@dfinity/gix-components";
-  import { Spinner } from "@dfinity/gix-components";
+  import { IconNeuronsPage, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { nonNullish } from "@dfinity/utils";
 

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -14,9 +14,13 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { isImportedToken } from "$lib/utils/imported-tokens.utils";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
-  import { IconAccountsPage } from "@dfinity/gix-components";
-  import { IconPlus, IconSettings, Tooltip } from "@dfinity/gix-components";
-  import { Popover } from "@dfinity/gix-components";
+  import {
+    IconAccountsPage,
+    IconPlus,
+    IconSettings,
+    Popover,
+    Tooltip,
+  } from "@dfinity/gix-components";
   import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
 
   export let userTokensData: UserToken[];


### PR DESCRIPTION
# Motivation

Through our codebase, we have multiple files where we import Gix dependencies on different lines. Since we don't use modules and always import everything from the root, I don't see any benefit in this duplication.

I used this script to find the files:
```
find ./src -type f -name "*.svelte" | while read -r file; do
    count=$(grep -c 'from "@dfinity/gix-components"' "$file")
    
    if [ "$count" -gt 1 ]; then
        echo -e "Found ${count} gix-components imports in:${NC} $file"
    fi
done
```

In the future, we can rely on ESLint or Prettier to prevent this issue:
```
"rules": {
    "import/no-duplicates": "error"
  }
```
```
{
  "plugins": ["prettier-plugin-organize-imports"],
  "organizeImportsSkipDestructiveCodeActions": true
}
```

# Changes

-  Consolidates duplicate Gix imports into a single entry when duplicates are present.
- As a side effect of consolidating files with Gix duplicates, some imports are now properly sorted, and other dependencies with duplicates have been consolidated.

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary