### PR TITLE
feat: add NoTokensCard component for empty tokens portfolio state

### DIFF
--- a/frontend/src/lib/components/portfolio/NoTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/NoTokensCard.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import Card from "$lib/components/portfolio/Card.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { IconAccountsPage } from "@dfinity/gix-components";
+
+  const href = "/tokens";
+</script>
+
+<Card testId="no-tokens-card">
+  <div class="wrapper">
+    <div class="icon">
+      <IconAccountsPage />
+    </div>
+    <div class="text">
+      <h5>{$i18n.portfolio.no_tokens_card_title}</h5>
+      <p>{$i18n.portfolio.no_tokens_card_description}</p>
+    </div>
+    <a {href} data-sveltekit-preload-data="hover" class="button primary"
+      >{$i18n.portfolio.no_tokens_card_button}</a
+    >
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  .wrapper {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    gap: var(--padding-2x);
+    padding: var(--padding-3x) var(--padding-2x);
+    margin: 0 auto;
+    height: 100%;
+    @include media.min-width(medium) {
+      gap: var(--padding-4x);
+      padding: var(--padding-6x) var(--padding-4x);
+      max-width: 450px;
+    }
+
+    .icon {
+      width: 80px;
+      height: 80px;
+      @include media.min-width(medium) {
+        width: 144px;
+        height: 144px;
+      }
+    }
+
+    .text {
+      text-align: center;
+      color: var(--text-description);
+
+      h5,
+      p {
+        margin: 0;
+        padding: 0;
+        color: inherit;
+      }
+
+      h5 {
+        font-weight: bold;
+        text-wrap: pretty;
+      }
+
+      p {
+        margin-top: var(--padding);
+        text-wrap: balance;
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/NoTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/NoTokensCard.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
+  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import { i18n } from "$lib/stores/i18n";
+  import { buildAccountsUrl } from "$lib/utils/navigation.utils";
   import { IconAccountsPage } from "@dfinity/gix-components";
 
-  const href = "/tokens";
+  const href = buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT });
 </script>
 
 <Card testId="no-tokens-card">
@@ -15,9 +17,7 @@
       <h5>{$i18n.portfolio.no_tokens_card_title}</h5>
       <p>{$i18n.portfolio.no_tokens_card_description}</p>
     </div>
-    <a {href} data-sveltekit-preload-data="hover" class="button primary"
-      >{$i18n.portfolio.no_tokens_card_button}</a
-    >
+    <a {href} class="button primary">{$i18n.portfolio.no_tokens_card_button}</a>
   </div>
 </Card>
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1192,6 +1192,9 @@
   },
   "portfolio": {
     "login_title": "Session expired",
-    "login_description": "Earn rewards, participate in governance and join the communities. Login to gain optimal access of the platform."
+    "login_description": "Earn rewards, participate in governance and join the communities. Login to gain optimal access of the platform.",
+    "no_tokens_card_title": "Store tokens safely, invest and become part of shaping the Internet Computer",
+    "no_tokens_card_description": "Vote on project and protocol developments and earn rewards - Ready to get started?",
+    "no_tokens_card_button": "Buy ICP"
   }
 }

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
   import LoginCard from "$lib/components/portfolio/LoginCard.svelte";
+  import NoTokensCard from "$lib/components/portfolio/NoTokensCard.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
 </script>
 
@@ -12,7 +13,7 @@
     <Card>Card1</Card>
   </div>
   <div class="content">
-    <Card>Card3</Card>
+    <NoTokensCard />
     <Card>Card4</Card>
   </div>
 </main>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1258,6 +1258,9 @@ interface I18nImport_token {
 interface I18nPortfolio {
   login_title: string;
   login_description: string;
+  no_tokens_card_title: string;
+  no_tokens_card_description: string;
+  no_tokens_card_button: string;
 }
 
 interface I18nNeuron_state {


### PR DESCRIPTION
# Motivation

We want to display a `Card` to users without tokens, directing them to the Tokens page.

Design comments:
- There are no mobile or tablet designs yet, so we will keep it simple for now.  
- The icon is slightly different from the design, with the colors being a darker. We need to check with the design team to see if this additional icon is necessary.  
- The button padding is also slightly different from the design, as we are using Gix styles.

Design reference:
<img width="561" alt="Screenshot 2024-12-31 at 11 36 10" src="https://github.com/user-attachments/assets/35aff8c6-47ad-434f-8a47-9d97957c53c1" />

Implementation:
<img width="498" alt="Screenshot 2024-12-31 at 11 35 31" src="https://github.com/user-attachments/assets/85f75d06-ec38-44bc-a1ad-ace2fb259c1c" />

Ticket [NNS1-3519](https://dfinity.atlassian.net/browse/NNS1-3519)

# Changes

- New component `NoTokensCard` with a link to the `/tokens/` page.

# Tests

- It will be added together with the logic for checking if the correct `Card` is displayed on the `Portfolio` page.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

Prev. PR: #6086 

[NNS1-3519]: https://dfinity.atlassian.net/browse/NNS1-3519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ