### PR TITLE
Skip download test if last commit is too old

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -272,9 +272,6 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
-        #with:
-          # Needed to get the timestamp of the latest commit on main for "Download NNS-dapp CI wasm "
-          # fetch-depth: 0
       - name: Install tools on Linux
         run: |
           if command -v apt-get; then
@@ -309,8 +306,7 @@ jobs:
           LAST_COMMIT_TIMESTAMP="$(git log -1 --format=%ct "$MAIN_COMMIT")"
           AGE_OF_LAST_COMMIT="$(( $(date +%s) - LAST_COMMIT_TIMESTAMP ))"
           if [[ "$AGE_OF_LAST_COMMIT" -gt "$((3 * 24 * 60 * 60))" ]]; then
-            echo "The last commit to the main branch is over 3 days old so the
-            build artifact may have expired, which means we can't download it."
+            echo "The last commit to the main branch is over 3 days old so the build artifact may have expired, which means we can't download it."
             echo "We'll test again after the next commit."
           else
             scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -308,7 +308,7 @@ jobs:
           MAIN_COMMIT="$(git rev-parse origin/main)"
           LAST_COMMIT_TIMESTAMP="$(git log -1 --format=%ct "$MAIN_COMMIT")"
           AGE_OF_LAST_COMMIT="$(( $(date +%s) - LAST_COMMIT_TIMESTAMP ))"
-          if [[ $AGE_OF_LAST_COMMIT -gt $((3 * 24 * 60 * 60 ]]; then
+          if [[ "$AGE_OF_LAST_COMMIT" -gt "$((3 * 24 * 60 * 60))" ]]; then
             echo "The last commit to the main branch is over 3 days old so the
             build artifact may have expired, which means we can't download it."
             echo "We'll test again after the next commit."

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -302,7 +302,15 @@ jobs:
       - name: Download NNS-dapp CI wasm
         run: |
           MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
-          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
+          LAST_COMMIT_TIMESTAMP="$(git log -1 --format=%ct "$MAIN_COMMIT")"
+          AGE_OF_LAST_COMMIT="$(( $(date +%s) - LAST_COMMIT_TIMESTAMP ))"
+          if [[ $AGE_OF_LAST_COMMIT -gt $((3 * 24 * 60 * 60 ]]; then
+            echo "The last commit to the main branch is over 3 days old so the
+            build artifact may have expired, which means we can't download it."
+            echo "We'll test again after the next commit."
+          else
+            scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
+          fi
       - name: Test canister_ids tool
         run: scripts/canister_ids.test
       - name: Test release-sop script

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -272,6 +272,9 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
+        #with:
+          # Needed to get the timestamp of the latest commit on main for "Download NNS-dapp CI wasm "
+          # fetch-depth: 0
       - name: Install tools on Linux
         run: |
           if command -v apt-get; then
@@ -301,7 +304,8 @@ jobs:
         run: ./scripts/docker-build --help | grep -i usage
       - name: Download NNS-dapp CI wasm
         run: |
-          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
+          git fetch --depth=1 origin main
+          MAIN_COMMIT="$(git rev-parse origin/main)"
           LAST_COMMIT_TIMESTAMP="$(git log -1 --format=%ct "$MAIN_COMMIT")"
           AGE_OF_LAST_COMMIT="$(( $(date +%s) - LAST_COMMIT_TIMESTAMP ))"
           if [[ $AGE_OF_LAST_COMMIT -gt $((3 * 24 * 60 * 60 ]]; then


### PR DESCRIPTION
# Motivation

We keep build artifacts for 3 days as specified [here](https://github.com/dfinity/nns-dapp/blob/b8e278aa4361df2abe0cd9cc7dda69b591cb73e5/.github/workflows/build.yml#L52).
We have a script for downloading build artifacts, which we test for the main branch.
This test fails if artifacts for the latest commit to the main branch have already expired, as can be seen [here](https://github.com/dfinity/nns-dapp/actions/runs/12592378031/job/35096899373?pr=6089).

# Changes

Skip the test if the latest commit is too old.
This should be rare so hopefully on the next commit the test will run again.

# Tests

The test passes with
```
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary