### PR TITLE
Fix screenshot test with fresh snapshot

### DIFF
--- a/frontend/src/tests/e2e/design.spec.ts
+++ b/frontend/src/tests/e2e/design.spec.ts
@@ -73,6 +73,18 @@ test.describe("Design", () => {
         replacements: ["9.00"],
       });
 
+      // The governance metrics are only updated once a day so for the first 24h
+      // after a snapshot is created, the metrics might be different than what
+      // we expectand we need to replace them with the expected value.
+      if ((await appPo.getMenuItemsPo().getTvlMetric()) === "$99") {
+        await replaceContent({
+          page,
+          selectors: ['[data-tid="tvl-metric"]'],
+          pattern: /\$[0-9’]+/,
+          replacements: ["4’500’001’000"],
+        });
+      }
+
       await expect(page).toHaveScreenshot();
     };
 

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -58,4 +58,8 @@ export class MenuItemsPo extends BasePageObject {
   hasFooter(): Promise<boolean> {
     return this.isPresent("menu-footer");
   }
+
+  getTvlMetric(): Promise<string> {
+    return this.getText("tvl-metric");
+  }
 }


### PR DESCRIPTION
# Motivation

The NNS dapp displays the TVL (total value locked).
This is the total amount of ICP locked times the price of ICP in USD.
The total amount of ICP locked is provided by the governance canister and calculated once every 24 hours.
As a result, when we create an snsdemo snapshot, for the first 24 hours of the snapshot's existence, the governance canister will return that 11 ICP are locked, after which it will return a much larger number (because a very large neuron is created during the snapshot creation).

This is normally not a problem, because snsdemo releases are created on [Wednesdays](https://github.com/dfinity/snsdemo/blob/3245006806301f3a61f832fe4827d1930d11f96e/.github/workflows/snapshot.yml#L11), while the snsdemo release used by nns-dapp is updated on [Fridays](https://github.com/dfinity/nns-dapp/blob/6f5a105379962c4c2bad7f82f7be17619b8f407a/.github/workflows/update-snsdemo.yml#L7).
However, if we want to manually create a new snsdemo release and use it right away, this will result in the screenshot test that shows the TVL failing with $99 TVL instead of $4'500'001'000.

# Changes

In the screenshot test, if the TVL is "$99", replace it in the DOM with "$4'500'001'000".

# Tests

Tested on https://github.com/dfinity/nns-dapp/pull/6092 which was failing for the reason described above and passing with this change.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary