### PR TITLE
Add missing $ in TVL replacement

### DIFF
--- a/frontend/src/tests/e2e/design.spec.ts
+++ b/frontend/src/tests/e2e/design.spec.ts
@@ -81,7 +81,7 @@ test.describe("Design", () => {
           page,
           selectors: ['[data-tid="tvl-metric"]'],
           pattern: /\$[0-9’]+/,
-          replacements: ["4’500’001’000"],
+          replacements: ["$4’500’001’000"],
         });
       }
 


### PR DESCRIPTION
# Motivation

A "$" was missing in the TVL replacement in https://github.com/dfinity/nns-dapp/pull/6093
I didn't catch this before because I had seen the test pass.
But the screenshots are only checked after all the tests finish by checking if any of the screenshot files were updated and I had forgotten about this.


# Changes

Add the missing "$".

# Tests

[This run](https://github.com/dfinity/nns-dapp/actions/runs/12600053915/job/35118450954?pr=6092) on [this PR](https://github.com/dfinity/nns-dapp/pull/6092) passes, including the screenshot check.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary