### PR TITLE
Remove hardcoded known neurons

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -58,3 +58,4 @@ protobuf
 se
 TVL
 backend
+DFINITY

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+- Remove hardcoding of "DFINITY Foundation" and "Internet Computer Association" in the displayed list of known neurons.
+
 #### Fixed
 
 #### Security

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -1,6 +1,5 @@
 import { createAgent } from "$lib/api/agent.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { DFINITY_NEURON, IC_NEURON } from "$lib/constants/api.constants";
 import { GOVERNANCE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST } from "$lib/constants/environment.constants";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
@@ -450,14 +449,6 @@ export const queryKnownNeurons = async ({
   const { canister } = await governanceCanister({ identity });
 
   const knownNeurons = await canister.listKnownNeurons(certified);
-
-  if (knownNeurons.find(({ id }) => id === DFINITY_NEURON.id) === undefined) {
-    knownNeurons.push(DFINITY_NEURON);
-  }
-
-  if (knownNeurons.find(({ id }) => id === IC_NEURON.id) === undefined) {
-    knownNeurons.push(IC_NEURON);
-  }
 
   logWithTimestamp(`Querying Known Neurons certified:${certified} complete.`);
   return knownNeurons;

--- a/frontend/src/lib/constants/api.constants.ts
+++ b/frontend/src/lib/constants/api.constants.ts
@@ -1,14 +1,2 @@
-export const DFINITY_NEURON = {
-  id: 27n,
-  name: "DFINITY Foundation",
-  description: undefined,
-};
-
-export const IC_NEURON = {
-  id: 28n,
-  name: "Internet Computer Association (winding down)",
-  description: undefined,
-};
-
 export const CREATE_CANISTER_MEMO = BigInt(0x41455243); // CREA,
 export const TOP_UP_CANISTER_MEMO = BigInt(0x50555054); // TPUP


### PR DESCRIPTION
# Motivation

Neither neurons 27 and 28 used to known neurons but we present them in the UI as if they are known neurons.
Now 27 is an actual known neuron and 28 should no longer be a known neuron.
So neither needs special treatment anymore.

# Changes

Stop injecting these 2 neurons into the known neurons results.

# Tests

1. Tested manually.
2. Surprisingly no unit tests failed so apparently this was not tested.

# Todos

- [x] Add entry to changelog (if necessary).
