### PR TITLE
refactor: consolidate imports when duplicates are present

### DIFF
--- a/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -3,8 +3,10 @@
   import { authStore } from "$lib/stores/auth.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import type { WalletContext } from "$lib/types/wallet.context";
-  import { WALLET_CONTEXT_KEY } from "$lib/types/wallet.context";
+  import {
+    WALLET_CONTEXT_KEY,
+    type WalletContext,
+  } from "$lib/types/wallet.context";
   import { mapHardwareWalletNeuronInfo } from "$lib/utils/hardware-wallet-neurons.utils";
   import { openWalletModal } from "$lib/utils/modals.utils";
   import { busy } from "@dfinity/gix-components";

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-  import { formatTokenV2 } from "$lib/utils/token.utils";
+  import {
+    formatTokenV2,
+    UnavailableTokenAmount,
+  } from "$lib/utils/token.utils";
   import { Copy } from "@dfinity/gix-components";
   import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 

--- a/frontend/src/lib/components/ic/AmountWithUsd.svelte
+++ b/frontend/src/lib/components/ic/AmountWithUsd.svelte
@@ -2,8 +2,7 @@
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { formatNumber } from "$lib/utils/format.utils";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-  import { TokenAmountV2 } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { nonNullish, TokenAmountV2 } from "@dfinity/utils";
 
   export let amount: TokenAmountV2 | UnavailableTokenAmount;
   export let amountInUsd: number | undefined;

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -10,11 +10,14 @@
     durationTillSwapStart,
   } from "$lib/utils/projects.utils";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
-  import TestIdWrapper from "../common/TestIdWrapper.svelte";
   import { SnsSwapLifecycle } from "@dfinity/sns";
-  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
-  import { secondsToDuration } from "@dfinity/utils";
+  import {
+    ICPToken,
+    nonNullish,
+    secondsToDuration,
+    TokenAmountV2,
+  } from "@dfinity/utils";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let project: SnsFullProject;
   // The data to know whether it's finalizing or not is not in the SnsFullProject.

--- a/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
+++ b/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import Separator from "$lib/components/ui/Separator.svelte";
+  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
   import { i18n } from "$lib/stores/i18n";
-  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { topicsToFollow } from "$lib/utils/neuron.utils";
-  import FollowNnsTopicSection from "./FollowNnsTopicSection.svelte";
-  import type { NeuronId, NeuronInfo } from "@dfinity/nns";
-  import type { Topic } from "@dfinity/nns";
+  import type { NeuronId, NeuronInfo, Topic } from "@dfinity/nns";
   import { onMount } from "svelte";
+  import FollowNnsTopicSection from "./FollowNnsTopicSection.svelte";
 
   export let neuronId: NeuronId;
 

--- a/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
+++ b/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { ICON_SIZE_SMALL_PIXELS } from "$lib/constants/layout.constants";
   import { i18n } from "$lib/stores/i18n";
-  import type { StateInfo } from "$lib/utils/neuron.utils";
-  import { getStateInfo } from "$lib/utils/neuron.utils";
+  import { getStateInfo, type StateInfo } from "$lib/utils/neuron.utils";
   import { keyOf } from "$lib/utils/utils";
   import type { NeuronState } from "@dfinity/nns";
 

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
@@ -2,8 +2,7 @@
   import { ICON_SIZE_SMALL_PIXELS } from "$lib/constants/layout.constants";
   import { i18n } from "$lib/stores/i18n";
   import type { TableNeuron } from "$lib/types/neurons-table";
-  import type { StateInfo } from "$lib/utils/neuron.utils";
-  import { getStateInfo } from "$lib/utils/neuron.utils";
+  import { getStateInfo, type StateInfo } from "$lib/utils/neuron.utils";
   import { Tooltip } from "@dfinity/gix-components";
   import { NeuronState } from "@dfinity/nns";
 

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -18,8 +18,7 @@
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import { getMaxTransactionAmount } from "$lib/utils/token.utils";
   import { Checkbox, busy } from "@dfinity/gix-components";
-  import { ICPToken } from "@dfinity/utils";
-  import { isNullish } from "@dfinity/utils";
+  import { ICPToken, isNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let account: Account | undefined;

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -14,17 +14,16 @@
     type ProjectCommitmentSplit,
   } from "$lib/utils/projects.utils";
   import { swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
-  import TestIdWrapper from "../common/TestIdWrapper.svelte";
-  import AmountDisplay from "../ic/AmountDisplay.svelte";
-  import CommitmentProgressBar from "./CommitmentProgressBar.svelte";
   import {
     Html,
     KeyValuePair,
     KeyValuePairInfo,
   } from "@dfinity/gix-components";
-  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { ICPToken, nonNullish, TokenAmountV2 } from "@dfinity/utils";
   import { getContext } from "svelte";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import AmountDisplay from "../ic/AmountDisplay.svelte";
+  import CommitmentProgressBar from "./CommitmentProgressBar.svelte";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -3,10 +3,9 @@
   import { loadProposal } from "$lib/services/public/proposals.services";
   import { i18n } from "$lib/stores/i18n";
   import type { SnsSummary } from "$lib/types/sns";
-  import NnsProposalCard from "../proposals/NnsProposalCard.svelte";
-  import type { ProposalId } from "@dfinity/nns";
-  import type { ProposalInfo } from "@dfinity/nns";
+  import type { ProposalId, ProposalInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
+  import NnsProposalCard from "../proposals/NnsProposalCard.svelte";
 
   export let summary: SnsSummary;
 

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -5,14 +5,13 @@
   } from "$lib/types/project-detail.context";
   import type { SnsSwapCommitment } from "$lib/types/sns";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
+  import { SnsSwapLifecycle } from "@dfinity/sns";
+  import { ICPToken, TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
+  import { getContext } from "svelte";
   import ParticipateButton from "./ParticipateButton.svelte";
   import ProjectCommitment from "./ProjectCommitment.svelte";
   import ProjectStatus from "./ProjectStatus.svelte";
   import ProjectTimelineUserCommitment from "./ProjectTimelineUserCommitment.svelte";
-  import { SnsSwapLifecycle } from "@dfinity/sns";
-  import { ICPToken, TokenAmount, nonNullish } from "@dfinity/utils";
-  import { isNullish } from "@dfinity/utils";
-  import { getContext } from "svelte";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -1,24 +1,23 @@
 <script lang="ts">
   import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
   import {
-    getDeniedCountries,
-    getMaxNeuronsFundParticipation,
+      getDeniedCountries,
+      getMaxNeuronsFundParticipation,
   } from "$lib/getters/sns-summary";
   import { i18n } from "$lib/stores/i18n";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import type { CountryCode } from "$lib/types/location";
   import {
-    PROJECT_DETAIL_CONTEXT_KEY,
-    type ProjectDetailContext,
+      PROJECT_DETAIL_CONTEXT_KEY,
+      type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
   import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import { formatNumber } from "$lib/utils/format.utils";
+  import { KeyValuePair } from "@dfinity/gix-components";
+  import { ICPToken, nonNullish, TokenAmountV2 } from "@dfinity/utils";
+  import { getContext } from "svelte";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
-  import { KeyValuePair } from "@dfinity/gix-components";
-  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
-  import { getContext } from "svelte";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
   import {
-      getDeniedCountries,
-      getMaxNeuronsFundParticipation,
+    getDeniedCountries,
+    getMaxNeuronsFundParticipation,
   } from "$lib/getters/sns-summary";
   import { i18n } from "$lib/stores/i18n";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import type { CountryCode } from "$lib/types/location";
   import {
-      PROJECT_DETAIL_CONTEXT_KEY,
-      type ProjectDetailContext,
+    PROJECT_DETAIL_CONTEXT_KEY,
+    type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
   import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import { formatNumber } from "$lib/utils/format.utils";

--- a/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
@@ -6,13 +6,12 @@
     durationTillSwapDeadline,
     durationTillSwapStart,
   } from "$lib/utils/projects.utils";
+  import { KeyValuePair, Value } from "@dfinity/gix-components";
+  import { SnsSwapLifecycle } from "@dfinity/sns";
+  import { nonNullish, secondsToDuration, TokenAmount } from "@dfinity/utils";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import Separator from "../ui/Separator.svelte";
   import ProjectUserCommitmentLabel from "./ProjectUserCommitmentLabel.svelte";
-  import { KeyValuePair, Value } from "@dfinity/gix-components";
-  import { SnsSwapLifecycle } from "@dfinity/sns";
-  import { TokenAmount, nonNullish } from "@dfinity/utils";
-  import { secondsToDuration } from "@dfinity/utils";
 
   export let myCommitment: TokenAmount | undefined;
   export let summary: SnsSummaryWrapper;

--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -5,8 +5,10 @@
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import type { IneligibleNeuronData } from "$lib/utils/neuron.utils";
-  import type { NeuronIneligibilityReason } from "$lib/utils/neuron.utils";
+  import type {
+    IneligibleNeuronData,
+    NeuronIneligibilityReason,
+  } from "$lib/utils/neuron.utils";
   import { nonNullish } from "@dfinity/utils";
 
   export let ineligibleNeurons: IneligibleNeuronData[] = [];

--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
@@ -2,9 +2,8 @@
   import { loadProposalPayload } from "$lib/services/public/proposals.services";
   import { proposalPayloadsStore } from "$lib/stores/proposals.store";
   import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
+  import type { Proposal, ProposalId } from "@dfinity/nns";
   import ProposalProposerPayloadEntry from "./ProposalProposerPayloadEntry.svelte";
-  import type { Proposal } from "@dfinity/nns";
-  import type { ProposalId } from "@dfinity/nns";
 
   export let proposalId: ProposalId | undefined;
   export let proposal: Proposal | undefined;

--- a/frontend/src/lib/components/proposal-detail/NnsProposalSummarySection.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalSummarySection.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { mapProposalInfo } from "$lib/utils/proposals.utils";
+  import type { Proposal, ProposalInfo } from "@dfinity/nns";
   import ProposalSummarySection from "./ProposalSummarySection.svelte";
-  import type { Proposal } from "@dfinity/nns";
-  import type { ProposalInfo } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
 

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -2,11 +2,9 @@
   import { i18n } from "$lib/stores/i18n";
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import { mapProposalInfo } from "$lib/utils/proposals.utils";
+  import type { NeuronId, ProposalId, ProposalInfo } from "@dfinity/nns";
   import ProposalSystemInfoEntry from "./ProposalSystemInfoEntry.svelte";
   import ProposalSystemInfoProposerEntry from "./ProposalSystemInfoProposerEntry.svelte";
-  import type { NeuronId } from "@dfinity/nns";
-  import type { ProposalId } from "@dfinity/nns";
-  import type { ProposalInfo } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
 

--- a/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
@@ -6,9 +6,8 @@
     MINIMUM_YES_PROPORTION_OF_TOTAL_VOTING_POWER,
   } from "$lib/constants/proposals.constants";
   import { basisPointsToPercent } from "$lib/utils/utils";
+  import { ProposalRewardStatus, type ProposalInfo } from "@dfinity/nns";
   import VotesResults from "./VotesResults.svelte";
-  import type { ProposalInfo } from "@dfinity/nns";
-  import { ProposalRewardStatus } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
 

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import VoteConfirmationModal from "$lib/modals/proposals/VoteConfirmationModal.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { VoteRegistrationStoreEntry } from "$lib/stores/vote-registration.store";
-  import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
+  import {
+    votingNeuronSelectStore,
+    type VoteRegistrationStoreEntry,
+  } from "$lib/stores/vote-registration.store";
   import { selectedNeuronsVotingPower } from "$lib/utils/proposals.utils";
   import { Spinner, busy } from "@dfinity/gix-components";
   import { Vote } from "@dfinity/nns";

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -8,9 +8,10 @@
     SELECTED_SNS_NEURON_CONTEXT_KEY,
     type SelectedSnsNeuronContext,
   } from "$lib/types/sns-neuron-detail.context";
-  import { followeesByFunction } from "$lib/utils/sns-neuron.utils";
-  import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
-  import Hash from "../ui/Hash.svelte";
+  import {
+    followeesByFunction,
+    subaccountToHexString,
+  } from "$lib/utils/sns-neuron.utils";
   import { IconClose, Value } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type {
@@ -20,6 +21,7 @@
   } from "@dfinity/sns";
   import { fromNullable } from "@dfinity/utils";
   import { getContext } from "svelte";
+  import Hash from "../ui/Hash.svelte";
 
   export let neuron: SnsNeuron;
   export let rootCanisterId: Principal;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
@@ -8,14 +8,13 @@
     getSnsNeuronState,
     hasPermissionToDissolve,
   } from "$lib/utils/sns-neuron.utils";
-  import DissolveDelayBonusText from "../neuron-detail/DissolveDelayBonusText.svelte";
-  import CommonItemAction from "../ui/CommonItemAction.svelte";
-  import IncreaseSnsDissolveDelayButton from "./actions/IncreaseSnsDissolveDelayButton.svelte";
   import { IconClockNoFill } from "@dfinity/gix-components";
   import { NeuronState } from "@dfinity/nns";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
-  import { fromNullable } from "@dfinity/utils";
-  import { secondsToDuration, type Token } from "@dfinity/utils";
+  import { fromNullable, secondsToDuration, type Token } from "@dfinity/utils";
+  import DissolveDelayBonusText from "../neuron-detail/DissolveDelayBonusText.svelte";
+  import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import IncreaseSnsDissolveDelayButton from "./actions/IncreaseSnsDissolveDelayButton.svelte";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -19,13 +19,16 @@
     canIdentityManageHotkeys,
     getSnsNeuronHotkeys,
   } from "$lib/utils/sns-neuron.utils";
-  import TestIdWrapper from "../common/TestIdWrapper.svelte";
-  import AddSnsHotkeyButton from "./actions/AddSnsHotkeyButton.svelte";
   import { IconClose, IconWarning, Value } from "@dfinity/gix-components";
-  import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
+  import type {
+    SnsNervousSystemParameters,
+    SnsNeuron,
+    SnsNeuronId,
+  } from "@dfinity/sns";
   import { fromDefinedNullable } from "@dfinity/utils";
   import { getContext } from "svelte";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import AddSnsHotkeyButton from "./actions/AddSnsHotkeyButton.svelte";
 
   export let parameters: SnsNervousSystemParameters;
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -13,14 +13,17 @@
     snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
   import { formatTokenE8s } from "$lib/utils/token.utils";
-  import SnsNeuronDissolveDelayItemAction from "./SnsNeuronDissolveDelayItemAction.svelte";
-  import SnsNeuronStateItemAction from "./SnsNeuronStateItemAction.svelte";
-  import SnsStakeItemAction from "./SnsStakeItemAction.svelte";
   import { Html, Section } from "@dfinity/gix-components";
   import { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
-  import { secondsToDuration } from "@dfinity/utils";
-  import { fromDefinedNullable, type Token } from "@dfinity/utils";
+  import {
+    fromDefinedNullable,
+    secondsToDuration,
+    type Token,
+  } from "@dfinity/utils";
+  import SnsNeuronDissolveDelayItemAction from "./SnsNeuronDissolveDelayItemAction.svelte";
+  import SnsNeuronStateItemAction from "./SnsNeuronStateItemAction.svelte";
+  import SnsStakeItemAction from "./SnsStakeItemAction.svelte";
 
   export let parameters: SnsNervousSystemParameters;
   export let neuron: SnsNeuron;

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
@@ -5,15 +5,17 @@
   import {
     hasEnoughStakeToSplit,
     isVesting,
+    minNeuronSplittable,
   } from "$lib/utils/sns-neuron.utils";
-  import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
   import { formatTokenE8s } from "$lib/utils/token.utils";
-  import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
   import { Tooltip } from "@dfinity/gix-components";
-  import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { SnsNeuron } from "@dfinity/sns";
-  import type { Token, TokenAmountV2 } from "@dfinity/utils";
-  import { fromDefinedNullable } from "@dfinity/utils";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import {
+    fromDefinedNullable,
+    type Token,
+    type TokenAmountV2,
+  } from "@dfinity/utils";
+  import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;

--- a/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
@@ -13,10 +13,8 @@
   import { valueSpan } from "$lib/utils/utils";
   import { Html, busy } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { SnsNeuron } from "@dfinity/sns";
-  import type { Token } from "@dfinity/utils";
-  import { secondsToDuration } from "@dfinity/utils";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import { secondsToDuration, type Token } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let rootCanisterId: Principal;

--- a/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
@@ -7,18 +7,20 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
     getSnsLockedTimeInSeconds,
+    getSnsNeuronIdAsHexString,
     getSnsNeuronStake,
     getSnsNeuronState,
     snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
-  import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
   import type { NeuronState } from "@dfinity/nns";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { SnsNeuron } from "@dfinity/sns";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import type { Token } from "@dfinity/utils";
-  import { TokenAmountV2, isNullish } from "@dfinity/utils";
-  import { fromDefinedNullable } from "@dfinity/utils";
+  import {
+    TokenAmountV2,
+    fromDefinedNullable,
+    isNullish,
+  } from "@dfinity/utils";
 
   export let rootCanisterId: Principal;
   export let neuron: SnsNeuron;

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -10,9 +10,9 @@
   import { InvalidAmountError } from "$lib/types/neurons.errors";
   import type {
     TransactionNetwork,
+    TransactionSelectDestinationMethods,
     ValidateAmountFn,
   } from "$lib/types/transaction";
-  import type { TransactionSelectDestinationMethods } from "$lib/types/transaction";
   import {
     assertEnoughAccountFunds,
     invalidAddress,
@@ -24,8 +24,12 @@
     toTokenAmountV2,
   } from "$lib/utils/token.utils";
   import type { Principal } from "@dfinity/principal";
-  import { TokenAmount, TokenAmountV2, type Token } from "@dfinity/utils";
-  import { isNullish } from "@dfinity/utils";
+  import {
+    isNullish,
+    TokenAmount,
+    TokenAmountV2,
+    type Token,
+  } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   // Tested in the TransactionModal

--- a/frontend/src/lib/components/transaction/TransactionFromAccount.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFromAccount.svelte
@@ -5,8 +5,7 @@
   import type { Account } from "$lib/types/account";
   import { KeyValuePair } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
-  import { TokenAmountV2, type Token } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { nonNullish, TokenAmountV2, type Token } from "@dfinity/utils";
 
   export let rootCanisterId: Principal;
   export let canSelectSource: boolean;

--- a/frontend/src/lib/components/transaction/TransactionReview.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReview.svelte
@@ -5,8 +5,10 @@
   import TransactionSummary from "$lib/components/transaction/TransactionSummary.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
-  import type { NewTransaction } from "$lib/types/transaction";
-  import type { TransactionNetwork } from "$lib/types/transaction";
+  import type {
+    NewTransaction,
+    TransactionNetwork,
+  } from "$lib/types/transaction";
   import { busy } from "@dfinity/gix-components";
   import type { Token, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -18,8 +18,7 @@
   } from "$lib/utils/responsive-table.utils";
   import { heightTransition } from "$lib/utils/transition.utils";
   import { IconSort, IconSouth } from "@dfinity/gix-components";
-  import { assertNonNullish, isNullish } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
 
   export let testId = "responsive-table-component";
   export let tableData: Array<RowDataType>;

--- a/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
+++ b/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
@@ -4,8 +4,7 @@
   import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
   import type { Universe } from "$lib/types/universe";
   import { SkeletonText } from "@dfinity/gix-components";
-  import { TokenAmountV2, type Token } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { nonNullish, TokenAmountV2, type Token } from "@dfinity/utils";
 
   export let universe: Universe;
 

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -21,17 +21,19 @@
   import type { Account } from "$lib/types/account";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
   import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
-  import type { NewTransaction, TransactionInit } from "$lib/types/transaction";
-  import type { TransactionNetwork } from "$lib/types/transaction";
-  import type { ValidateAmountFn } from "$lib/types/transaction";
+  import type {
+    NewTransaction,
+    TransactionInit,
+    TransactionNetwork,
+    ValidateAmountFn,
+  } from "$lib/types/transaction";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import { assertCkBTCUserInputAmount } from "$lib/utils/ckbtc.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { numberToE8s } from "$lib/utils/token.utils";
   import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
   import type { WizardStep } from "@dfinity/gix-components";
-  import type { Token, TokenAmountV2 } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { nonNullish, type Token, type TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let selectedAccount: Account | undefined = undefined;

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
@@ -9,8 +9,7 @@
   import type { CkBTCTransactionModalData } from "$lib/types/ckbtc-accounts.modal";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
   import type { UniverseCanisterId } from "$lib/types/universe";
-  import type { TokenAmountV2 } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { nonNullish, type TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let data: CkBTCTransactionModalData;

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -7,8 +7,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import type { Account } from "$lib/types/account";
-  import type { NewTransaction } from "$lib/types/transaction";
-  import type { TransactionInit } from "$lib/types/transaction";
+  import type { NewTransaction, TransactionInit } from "$lib/types/transaction";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type { WizardStep } from "@dfinity/gix-components";

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -5,8 +5,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import type { Account } from "$lib/types/account";
-  import type { NewTransaction } from "$lib/types/transaction";
-  import type { TransactionInit } from "$lib/types/transaction";
+  import type { NewTransaction, TransactionInit } from "$lib/types/transaction";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { numberToUlps } from "$lib/utils/token.utils";
   import type { WizardStep } from "@dfinity/gix-components";

--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -27,8 +27,7 @@
     assertNonNullish,
     type Token,
   } from "@dfinity/utils";
-  import { createEventDispatcher, onDestroy } from "svelte";
-  import { onMount } from "svelte";
+  import { createEventDispatcher, onDestroy, onMount } from "svelte";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -7,8 +7,7 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsSuccess } from "$lib/stores/toasts.store";
-  import type { NewTransaction } from "$lib/types/transaction";
-  import type { TransactionInit } from "$lib/types/transaction";
+  import type { NewTransaction, TransactionInit } from "$lib/types/transaction";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type { WizardStep } from "@dfinity/gix-components";

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
@@ -5,8 +5,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { Modal, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemFunction } from "@dfinity/sns";
-  import type { SnsNeuron } from "@dfinity/sns";
+  import type { SnsNervousSystemFunction, SnsNeuron } from "@dfinity/sns";
   import { createEventDispatcher } from "svelte";
   import type { Readable } from "svelte/store";
 

--- a/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementEntry.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementEntry.svelte
@@ -3,8 +3,10 @@
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import { formatMaturity } from "$lib/utils/neuron.utils";
   import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger-icrc";
-  import type { Account } from "@dfinity/sns/dist/candid/sns_governance";
-  import type { DisburseMaturityInProgress } from "@dfinity/sns/dist/candid/sns_governance";
+  import type {
+    Account,
+    DisburseMaturityInProgress,
+  } from "@dfinity/sns/dist/candid/sns_governance";
   import { fromDefinedNullable, fromNullable } from "@dfinity/utils";
 
   export let disbursement: DisburseMaturityInProgress;

--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -14,8 +14,7 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuronId } from "@dfinity/sns";
-  import type { Token, TokenAmountV2 } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { type Token, TokenAmountV2, nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let neuronId: SnsNeuronId;

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -24,16 +24,21 @@
     SnsNeuronModalType,
   } from "$lib/types/sns-neuron-detail.modal";
   import { getSnsNeuronState } from "$lib/utils/sns-neuron.utils";
-  import AddPermissionsModal from "./AddPermissionsModal.svelte";
-  import type { E8s } from "@dfinity/nns";
-  import type { NeuronState } from "@dfinity/nns";
+  import type { E8s, NeuronState } from "@dfinity/nns";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
-  import type { Token } from "@dfinity/utils";
-  import { fromDefinedNullable } from "@dfinity/utils";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import type {
+    SnsNervousSystemParameters,
+    SnsNeuron,
+    SnsNeuronId,
+  } from "@dfinity/sns";
+  import {
+    fromDefinedNullable,
+    isNullish,
+    nonNullish,
+    type Token,
+  } from "@dfinity/utils";
   import { getContext } from "svelte";
+  import AddPermissionsModal from "./AddPermissionsModal.svelte";
 
   // Modal events
 

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronTransactionModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronTransactionModal.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { TransactionInit } from "$lib/types/transaction";
-  import type { ValidateAmountFn } from "$lib/types/transaction";
+  import type {
+    TransactionInit,
+    ValidateAmountFn,
+  } from "$lib/types/transaction";
   import type { WizardStep } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { Token, TokenAmountV2 } from "@dfinity/utils";

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeMaturityModal.svelte
@@ -4,8 +4,7 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNeuron } from "@dfinity/sns";
-  import type { SnsNeuronId } from "@dfinity/sns";
+  import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
   import { createEventDispatcher } from "svelte";
 
   export let neuron: SnsNeuron;

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -14,9 +14,12 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { Token, TokenAmountV2 } from "@dfinity/utils";
-  import { fromNullable } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import {
+    fromNullable,
+    nonNullish,
+    type Token,
+    type TokenAmountV2,
+  } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let token: Token;

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -9,14 +9,15 @@
   import { isValidInputAmount } from "$lib/utils/neuron.utils";
   import { getSnsNeuronStake } from "$lib/utils/sns-neuron.utils";
   import { formatTokenE8s } from "$lib/utils/token.utils";
-  import { Modal, Value, busy } from "@dfinity/gix-components";
+  import { busy, Modal, Value } from "@dfinity/gix-components";
   import type { E8s } from "@dfinity/nns";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { SnsNeuron } from "@dfinity/sns";
-  import type { Token } from "@dfinity/utils";
-  import { TokenAmountV2 } from "@dfinity/utils";
-  import { fromDefinedNullable } from "@dfinity/utils";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import {
+    fromDefinedNullable,
+    TokenAmountV2,
+    type Token,
+  } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let rootCanisterId: Principal;

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -23,9 +23,9 @@
   import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import type {
     NewTransaction,
+    TransactionInit,
     ValidateAmountFn,
   } from "$lib/types/transaction";
-  import type { TransactionInit } from "$lib/types/transaction";
   import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
   import {
     currentUserMaxCommitment,
@@ -37,8 +37,7 @@
     hasOpenTicketInProcess,
   } from "$lib/utils/sns.utils";
   import type { WizardStep } from "@dfinity/gix-components";
-  import { ICPToken, TokenAmount } from "@dfinity/utils";
-  import { nonNullish } from "@dfinity/utils";
+  import { ICPToken, nonNullish, TokenAmount } from "@dfinity/utils";
   import {
     createEventDispatcher,
     getContext,

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -8,8 +8,12 @@
     type WizardSteps,
   } from "@dfinity/gix-components";
   import { decodePayment } from "@dfinity/ledger-icrc";
-  import type { Token } from "@dfinity/utils";
-  import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
+  import {
+    assertNonNullish,
+    isNullish,
+    nonNullish,
+    type Token,
+  } from "@dfinity/utils";
 
   export let testId: string | undefined = undefined;
   export let steps: WizardSteps;

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -3,6 +3,7 @@
   import IC_LOGO from "$lib/assets/icp.svg";
   import HardwareWalletListNeuronsButton from "$lib/components/accounts/HardwareWalletListNeuronsButton.svelte";
   import HardwareWalletShowActionButton from "$lib/components/accounts/HardwareWalletShowActionButton.svelte";
+  import LedgerNeuronHotkeyWarning from "$lib/components/accounts/LedgerNeuronHotkeyWarning.svelte";
   import NoTransactions from "$lib/components/accounts/NoTransactions.svelte";
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
   import RenameSubAccountButton from "$lib/components/accounts/RenameSubAccountButton.svelte";
@@ -41,6 +42,7 @@
     listNeurons,
   } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
   import {
@@ -48,8 +50,7 @@
     type IcpTransactionsStoreData,
   } from "$lib/stores/icp-transactions.store";
   import { toastsError } from "$lib/stores/toasts.store";
-  import type { Account } from "$lib/types/account";
-  import type { AccountIdentifierText } from "$lib/types/account";
+  import type { Account, AccountIdentifierText } from "$lib/types/account";
   import type { UiTransaction } from "$lib/types/transaction";
   import {
     WALLET_CONTEXT_KEY,
@@ -76,8 +77,6 @@
   } from "@dfinity/utils";
   import { onDestroy, onMount, setContext } from "svelte";
   import { writable, type Readable } from "svelte/store";
-  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
-  import LedgerNeuronHotkeyWarning from "$lib/components/accounts/LedgerNeuronHotkeyWarning.svelte";
 
   $: if ($authSignedInStore) {
     pollAccounts();

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -27,8 +27,10 @@
   import { loadUserCountry } from "$lib/services/user-country.services";
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-  import { snsSummariesStore } from "$lib/stores/sns.store";
-  import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+  import {
+    snsSummariesStore,
+    snsSwapCommitmentsStore,
+  } from "$lib/stores/sns.store";
   import { toastsError } from "$lib/stores/toasts.store";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -38,10 +38,13 @@
   import { toTokenAmountV2 } from "$lib/utils/token.utils";
   import { Island } from "@dfinity/gix-components";
   import { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import type { SnsNeuron } from "@dfinity/sns";
-  import type { Token, TokenAmountV2 } from "@dfinity/utils";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import {
+    isNullish,
+    nonNullish,
+    type Token,
+    type TokenAmountV2,
+  } from "@dfinity/utils";
   import { onMount, setContext } from "svelte";
 
   export let neuronId: string | null | undefined;

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -27,7 +27,6 @@
   import type { ProposalsNavigationId } from "$lib/types/proposals";
   import type { UniverseCanisterIdText } from "$lib/types/universe";
   import { buildProposalsUrl } from "$lib/utils/navigation.utils";
-  import { navigateToProposal } from "$lib/utils/proposals.utils";
   import {
     getUniversalProposalStatus,
     mapProposalInfo,
@@ -37,14 +36,17 @@
     type SnsProposalDataMap,
   } from "$lib/utils/sns-proposals.utils";
   import { isUniverseNns } from "$lib/utils/universe.utils";
-  import { debugSnsProposalStore } from "../derived/debug.derived";
   import { SplitBlock } from "@dfinity/gix-components";
   import { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemFunction } from "@dfinity/sns";
-  import type { SnsProposalData, SnsProposalId } from "@dfinity/sns";
+  import type {
+    SnsNervousSystemFunction,
+    SnsProposalData,
+    SnsProposalId,
+  } from "@dfinity/sns";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { tick } from "svelte";
   import type { Readable } from "svelte/store";
+  import { debugSnsProposalStore } from "../derived/debug.derived";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -217,6 +219,14 @@
   const selectProposal = (id: ProposalsNavigationId) => {
     navigateToProposal({ ...id, actionable: $pageStore.actionable });
   };
+
+  function navigateToProposal(arg0: {
+    actionable: boolean;
+    proposalId: bigint;
+    universe: string;
+  }) {
+    throw new Error("Function not implemented.");
+  }
 </script>
 
 <TestIdWrapper testId="sns-proposal-details-grid">

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -27,6 +27,7 @@
   import type { ProposalsNavigationId } from "$lib/types/proposals";
   import type { UniverseCanisterIdText } from "$lib/types/universe";
   import { buildProposalsUrl } from "$lib/utils/navigation.utils";
+  import { navigateToProposal } from "$lib/utils/proposals.utils";
   import {
     getUniversalProposalStatus,
     mapProposalInfo,
@@ -219,14 +220,6 @@
   const selectProposal = (id: ProposalsNavigationId) => {
     navigateToProposal({ ...id, actionable: $pageStore.actionable });
   };
-
-  function navigateToProposal(arg0: {
-    actionable: boolean;
-    proposalId: bigint;
-    universe: string;
-  }) {
-    throw new Error("Function not implemented.");
-  }
 </script>
 
 <TestIdWrapper testId="sns-proposal-details-grid">

--- a/frontend/src/lib/routes/Settings.svelte
+++ b/frontend/src/lib/routes/Settings.svelte
@@ -8,8 +8,7 @@
     KeyValuePairInfo,
     SkeletonText,
   } from "@dfinity/gix-components";
-  import { debounce, nonNullish } from "@dfinity/utils";
-  import { secondsToDuration } from "@dfinity/utils";
+  import { debounce, nonNullish, secondsToDuration } from "@dfinity/utils";
   import { onMount } from "svelte";
 
   let principalText = "";

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,8 +4,7 @@
     initAuthWorker,
     type AuthWorker,
   } from "$lib/services/worker-auth.services";
-  import type { AuthStoreData } from "$lib/stores/auth.store";
-  import { authStore } from "$lib/stores/auth.store";
+  import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
   import { toastsClean } from "$lib/stores/toasts.store";
   import { onMount } from "svelte";
 


### PR DESCRIPTION
# Motivation

Follow up of #6085

It seems that `prettier-plugin-organize-imports` still doesn't support Svelte files (#404). Therefore, I've updated the original script to search for and fix any duplicated imports within the project for `.svelte` files.

```
#!/bin/bash

# Get src directory path
SRC_DIR="$(dirname "$(dirname "$0")")/src"

find "$SRC_DIR" -name "*.svelte" -type f | while read -r file; do
    # Extract imports between <script> tags and find duplicates
    imports=$(sed -n '/<script/,/<\/script>/p' "$file" | grep '^[[:space:]]*import')

    # Extract and count import sources
    sources=$(echo "$imports" | sed -n "s/.*from ['\"]\\([^'\"]*\\)['\"].*/\\1/p")
    duplicates=$(echo "$sources" | sort | uniq -d)

    # Print results if duplicates found
    if [ ! -z "$duplicates" ]; then
        echo "File with duplicate imports: $file"
        echo "Duplicate sources:"
        echo "$duplicates"
        echo "---"
    fi
done
```

# Changes

- Consolidate imports when duplicates are present.

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary