### PR TITLE
feat: add NoNeuronsCard component for empty Neurons portfolio state

### DIFF
--- a/frontend/src/lib/components/portfolio/NoNeuronsCard.svelte
+++ b/frontend/src/lib/components/portfolio/NoNeuronsCard.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import Card from "$lib/components/portfolio/Card.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { IconNeuronsPage } from "@dfinity/gix-components";
+
+  export let primaryCard = false;
+  const href = "/staking";
+</script>
+
+<Card testId="no-neurons-card">
+  <div class="wrapper">
+    <div class="icon">
+      <IconNeuronsPage />
+    </div>
+    <div class="text">
+      <p>{$i18n.portfolio.no_neurons_card_description}</p>
+    </div>
+    <a {href} class={`button ${primaryCard ? "primary" : "secondary"}`}
+      >{$i18n.portfolio.no_neurons_card_button}</a
+    >
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  .wrapper {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--padding-2x);
+    padding: var(--padding-2x);
+    margin: 0 auto;
+    height: 100%;
+    text-align: center;
+    @include media.min-width(medium) {
+      gap: var(--padding-4x);
+      padding: var(--padding-6x) var(--padding-4x);
+      max-width: 400px;
+    }
+    .icon {
+      width: 80px;
+      height: 80px;
+      @include media.min-width(medium) {
+        width: 144px;
+        height: 144px;
+      }
+    }
+    .text {
+      color: var(--text-description);
+      p {
+        margin: 0;
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/NoNeuronsCard.svelte
+++ b/frontend/src/lib/components/portfolio/NoNeuronsCard.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
+  import { AppPath } from "$lib/constants/routes.constants";
   import { i18n } from "$lib/stores/i18n";
   import { IconNeuronsPage } from "@dfinity/gix-components";
 
   export let primaryCard = false;
-  const href = "/staking";
+  const href = AppPath.Staking;
 </script>
 
 <Card testId="no-neurons-card">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1196,7 +1196,7 @@
     "no_tokens_card_title": "Store tokens safely, invest and become part of shaping the Internet Computer",
     "no_tokens_card_description": "Vote on project and protocol developments and earn rewards - Ready to get started?",
     "no_tokens_card_button": "Buy ICP",
-    "no_neurons_card_description": "Take part of voting for development decisions on SNS projects and earn rewards - start staking your neurons",
+    "no_neurons_card_description": "Take part in voting for development decisions on SNS projects and earn rewards - start staking your neurons",
     "no_neurons_card_button": "Start Staking"
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1195,6 +1195,8 @@
     "login_description": "Earn rewards, participate in governance and join the communities. Login to gain optimal access of the platform.",
     "no_tokens_card_title": "Store tokens safely, invest and become part of shaping the Internet Computer",
     "no_tokens_card_description": "Vote on project and protocol developments and earn rewards - Ready to get started?",
-    "no_tokens_card_button": "Buy ICP"
+    "no_tokens_card_button": "Buy ICP",
+    "no_neurons_card_description": "Take part of voting for development decisions on SNS projects and earn rewards - start staking your neurons",
+    "no_neurons_card_button": "Start Staking"
   }
 }

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
   import LoginCard from "$lib/components/portfolio/LoginCard.svelte";
+  import NoNeuronsCard from "$lib/components/portfolio/NoNeuronsCard.svelte";
   import NoTokensCard from "$lib/components/portfolio/NoTokensCard.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
 </script>
@@ -14,7 +15,7 @@
   </div>
   <div class="content">
     <NoTokensCard />
-    <Card>Card4</Card>
+    <NoNeuronsCard />
   </div>
 </main>
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1261,6 +1261,8 @@ interface I18nPortfolio {
   no_tokens_card_title: string;
   no_tokens_card_description: string;
   no_tokens_card_button: string;
+  no_neurons_card_description: string;
+  no_neurons_card_button: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/components/portfolio/NoNeuronsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/NoNeuronsCard.spec.ts
@@ -1,0 +1,29 @@
+import NoNeuronsCard from "$lib/components/portfolio/NoNeuronsCard.svelte";
+import { NoNeuronsCardPo } from "$tests/page-objects/NoNeuronsCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("NoNeuronsCard", () => {
+  const renderComponent = (props = {}) => {
+    const { container } = render(NoNeuronsCard, props);
+    return NoNeuronsCardPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render secondary button styling by default", async () => {
+    const po = renderComponent();
+    expect(await po.hasPrimaryAction()).toBe(false);
+    expect(await po.hasSecondaryAction()).toBe(true);
+  });
+
+  it("should render primary button styling when primaryCard is true", async () => {
+    const po = renderComponent({ primaryCard: true });
+    expect(await po.hasPrimaryAction()).toBe(true);
+    expect(await po.hasSecondaryAction()).toBe(false);
+  });
+
+  it("should render secondary button styling when primaryCard is false", async () => {
+    const po = renderComponent({ primaryCard: false });
+    expect(await po.hasPrimaryAction()).toBe(false);
+    expect(await po.hasSecondaryAction()).toBe(true);
+  });
+});

--- a/frontend/src/tests/page-objects/NoNeuronsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NoNeuronsCard.page-object.ts
@@ -1,0 +1,20 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BasePageObject } from "./base.page-object";
+
+export class NoNeuronsCardPo extends BasePageObject {
+  private static readonly TID = "no-neurons-card";
+
+  static under(element: PageObjectElement): NoNeuronsCardPo {
+    return new NoNeuronsCardPo(element.byTestId(NoNeuronsCardPo.TID));
+  }
+
+  async hasPrimaryAction(): Promise<boolean> {
+    const classes = await this.root.querySelector("a").getClasses();
+    return classes.includes("primary");
+  }
+
+  async hasSecondaryAction(): Promise<boolean> {
+    const classes = await this.root.querySelector("a").getClasses();
+    return classes.includes("secondary");
+  }
+}


### PR DESCRIPTION
# Motivation

We want to display a Card to users without neurons, directing them to the Neurons page.

Design comments:

- There are no mobile or tablet designs yet, so we will keep it simple for now.
- The icon is different from the design. We need to check with the design team to see if this additional icon is necessary.
- The button padding is also slightly different from the design, as we are using Gix styles.

Design reference:
<img width="543" alt="Screenshot 2025-01-04 at 16 55 07" src="https://github.com/user-attachments/assets/d3479e56-cc9e-4755-a09f-3df095e162d8" />

Implementation:
<img width="615" alt="Screenshot 2025-01-04 at 16 59 31" src="https://github.com/user-attachments/assets/2b25e117-e77e-4d6c-b50b-29da98dd1d96" />

# Changes

- New component `NoNeuronsCard` with a link to the /staking page.

# Tests

- Unit test 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

Prev. PR: #6087