### PR TITLE
Update IC Cargo Dependencies to release-2025-01-03_03-07-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -194,18 +194,18 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -545,7 +545,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "shlex",
 ]
@@ -681,7 +681,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -886,13 +886,13 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1021,13 +1021,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1073,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "on_wire",
  "prost",
@@ -1126,7 +1126,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1257,7 +1257,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1394,7 +1394,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "serde",
 ]
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1758,7 +1758,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.2",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1772,7 +1772,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.2",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "getrandom",
 ]
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hex",
  "ic-types",
@@ -1871,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "sha2",
 ]
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-canister-threshold-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hmac",
  "k256",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "serde",
  "zeroize",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2097,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2119,8 +2119,8 @@ dependencies = [
 
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2130,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ciborium",
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ciborium",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -2223,8 +2223,8 @@ dependencies = [
 
 [[package]]
 name = "ic-icrc1-tokens-u64"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "hex",
@@ -2278,12 +2278,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2309,7 +2309,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -2349,12 +2349,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2389,12 +2389,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2407,12 +2407,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-initial-supply"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -2438,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-linear-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "rust_decimal",
 ]
@@ -2446,12 +2446,23 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
+
+[[package]]
+name = "ic-nervous-system-long-message"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
+dependencies = [
+ "candid",
+ "ic-cdk 0.16.0",
+ "ic-nervous-system-temporary",
+ "serde",
+]
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "comparable",
@@ -2464,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
 ]
@@ -2472,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2488,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -2501,17 +2512,25 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
+
+[[package]]
+name = "ic-nervous-system-timestamp"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2524,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "comparable",
@@ -2550,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2559,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2589,6 +2608,7 @@ dependencies = [
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-governance",
  "ic-nervous-system-linear-map",
+ "ic-nervous-system-long-message",
  "ic-nervous-system-proto",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
@@ -2633,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "bytes",
  "candid",
@@ -2662,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2679,18 +2699,19 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
+ "ic-cdk 0.16.0",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -2699,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "bincode",
  "candid",
@@ -2713,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2724,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2736,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2745,7 +2766,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2756,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2767,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2779,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2791,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2826,6 +2847,7 @@ dependencies = [
  "ic-nervous-system-proto",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nervous-system-timestamp",
  "ic-nns-constants",
  "ic-protobuf",
  "ic-sns-governance-api",
@@ -2849,13 +2871,12 @@ dependencies = [
  "serde_bytes",
  "strum",
  "strum_macros",
- "time",
 ]
 
 [[package]]
 name = "ic-sns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "bytes",
  "candid",
@@ -2879,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2887,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2898,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -2920,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -2948,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2979,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3019,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "comparable",
@@ -3034,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -3080,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3117,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3127,16 +3148,16 @@ dependencies = [
 
 [[package]]
 name = "ic-validate-eq"
-version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "ic-validate-eq-derive",
 ]
 
 [[package]]
 name = "ic-validate-eq-derive"
-version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3220,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "comparable",
@@ -3235,6 +3256,7 @@ dependencies = [
  "ic-ledger-canister-core",
  "ic-ledger-core",
  "ic-ledger-hash-of",
+ "ic-stable-structures",
  "icrc-ledger-types",
  "lazy_static",
  "on_wire",
@@ -3249,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "icrc-cbor"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "minicbor",
@@ -3260,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "async-trait",
  "candid",
@@ -3271,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "base32",
  "candid",
@@ -3406,7 +3428,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3724,7 +3746,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3850,7 +3872,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4009,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 
 [[package]]
 name = "once_cell"
@@ -4122,7 +4144,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4149,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "candid",
  "num-traits",
@@ -4275,7 +4297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4432,7 +4454,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.93",
+ "syn 2.0.95",
  "tempfile",
 ]
 
@@ -4446,7 +4468,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4605,7 +4627,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-12-06_03-16-base#d9fe2076f677a08734bed90c67b1c3f4056ed621"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-01-03_03-07-base#76a634c31dfb840da25fbe286855eb0be1818ca8"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4875,7 +4897,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4910,7 +4932,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5156,7 +5178,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5178,9 +5200,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5195,7 +5217,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5217,12 +5239,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -5280,7 +5303,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5291,7 +5314,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5391,7 +5414,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5587,7 +5610,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -5609,7 +5632,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5767,9 +5790,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -5864,7 +5887,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -5886,7 +5909,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5906,7 +5929,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -5927,7 +5950,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5949,5 +5972,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ ic-cdk = "0.17.1"
 ic-cdk-macros = "0.17.0"
 ic-cdk-timers = "0.11.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-12-06_03-16-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2025-01-03_03-07-base" }
 
 [profile.release]
 lto = false

--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -3,6 +3,7 @@ canister_heartbeat
 canister_init
 canister_post_upgrade
 canister_pre_upgrade
+canister_query __long_message_noop
 canister_query get_account
 canister_query get_canisters
 canister_query get_exceptional_transactions

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -3,6 +3,7 @@ canister_heartbeat
 canister_init
 canister_post_upgrade
 canister_pre_upgrade
+canister_query __long_message_noop
 canister_query get_account
 canister_query get_canisters
 canister_query get_exceptional_transactions

--- a/rs/backend/src/canisters/ledger.rs
+++ b/rs/backend/src/canisters/ledger.rs
@@ -31,7 +31,7 @@ pub async fn get_blocks(canister_id: CanisterId, from: BlockIndex, length: u32) 
         protobuf,
         GetBlocksArgs {
             start: from,
-            length: length as u64,
+            length: u64::from(length),
         },
     )
     .await

--- a/rs/backend/src/canisters/ledger.rs
+++ b/rs/backend/src/canisters/ledger.rs
@@ -31,7 +31,7 @@ pub async fn get_blocks(canister_id: CanisterId, from: BlockIndex, length: u32) 
         protobuf,
         GetBlocksArgs {
             start: from,
-            length: length as usize,
+            length: length as u64,
         },
     )
     .await


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

Handles #6099

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.
* Fixes the casting issue required since https://github.com/dfinity/ic/commit/b1f4339d483be025eb7a52c6ee997d22a8d1b382
* Run script `scripts/nns-dapp/test-exports --wasm nns-dapp_test.wasm.gz --update-golden --flavour test`

# Tests
* See CI