### PR TITLE
Refactor attach_canister to prepare for block_index

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -635,20 +635,39 @@ impl AccountsStore {
             return AttachCanisterResponse::AccountNotFound;
         };
 
+        let mut new_canister = NamedCanister {
+            name: request.name,
+            canister_id: request.canister_id,
+        };
+
         let mut index_to_remove: Option<usize> = None;
-        for (index, c) in account.canisters.iter().enumerate() {
-            if !request.name.is_empty() && c.name == request.name {
+        for (index, existing_canister) in account.canisters.iter().enumerate() {
+            if !new_canister.name.is_empty() && existing_canister.name == new_canister.name {
                 return AttachCanisterResponse::NameAlreadyTaken;
             }
-            // The periodic_task_runner might attach the canister before this call.
-            // The canister attached by the periodic_task_runner has name `""`
-            if c.canister_id == request.canister_id {
-                if c.name.is_empty() && !request.name.is_empty() {
-                    index_to_remove = Some(index);
-                } else {
-                    return AttachCanisterResponse::CanisterAlreadyAttached;
-                    // Note: It might be nice to tell the user the name of the existing canister.
+            // The canister might already be attached.
+            // If the request is compatible with the existing canister, merge
+            // any existing information into the new canister.
+            if existing_canister.canister_id == new_canister.canister_id {
+                // We return CanisterAlreadyAttached if either the request is
+                // incompatible with the existing canister or this request
+                // doesn't add anything new.
+
+                if !existing_canister.name.is_empty() {
+                    if new_canister.name.is_empty() {
+                        new_canister.name.clone_from(&existing_canister.name);
+                    } else if existing_canister.name != new_canister.name {
+                        // Incompatible names.
+                        return AttachCanisterResponse::CanisterAlreadyAttached;
+                    }
                 }
+
+                if new_canister == *existing_canister {
+                    // Nothing new to add.
+                    return AttachCanisterResponse::CanisterAlreadyAttached;
+                }
+
+                index_to_remove = Some(index);
             }
         }
 
@@ -660,10 +679,7 @@ impl AccountsStore {
         if account.canisters.len() >= u8::MAX as usize {
             return AttachCanisterResponse::CanisterLimitExceeded;
         }
-        account.canisters.push(NamedCanister {
-            name: request.name,
-            canister_id: request.canister_id,
-        });
+        account.canisters.push(new_canister);
         account.canisters.sort();
 
         self.accounts_db.db_insert_account(&account_identifier, account);
@@ -681,10 +697,10 @@ impl AccountsStore {
                 }
 
                 if let Some(index) = Self::find_canister_index(&account, request.canister_id) {
-                    account.canisters.remove(index);
+                    let existing_canister = account.canisters.remove(index);
                     account.canisters.push(NamedCanister {
                         name: request.name,
-                        canister_id: request.canister_id,
+                        ..existing_canister
                     });
                     account.canisters.sort();
                     self.accounts_db.db_insert_account(&account_identifier, account);

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -251,7 +251,61 @@ fn attach_canister_account_not_found() {
 }
 
 #[test]
-fn attach_canister_canister_already_attached() {
+fn attach_canister_canister_already_attached_with_name() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    let result1 = store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "ABC".to_string(),
+            canister_id,
+        },
+    );
+    let result2 = store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "".to_string(),
+            canister_id,
+        },
+    );
+
+    assert!(matches!(result1, AttachCanisterResponse::Ok));
+    assert!(matches!(result2, AttachCanisterResponse::CanisterAlreadyAttached));
+}
+
+#[test]
+fn attach_canister_canister_already_attached_with_same_name() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    let result1 = store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "ABC".to_string(),
+            canister_id,
+        },
+    );
+    let result2 = store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "ABC".to_string(),
+            canister_id,
+        },
+    );
+
+    assert!(matches!(result1, AttachCanisterResponse::Ok));
+    // It could have returned CanisterAlreadyAttached instead of actually
+    // returns NameAlreadyTaken, which is also true.
+    assert!(matches!(result2, AttachCanisterResponse::NameAlreadyTaken));
+}
+
+#[test]
+fn attach_canister_canister_already_attached_with_different_name() {
     let mut store = setup_test_store();
     let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
 
@@ -268,6 +322,32 @@ fn attach_canister_canister_already_attached() {
         principal,
         AttachCanisterRequest {
             name: "XYZ".to_string(),
+            canister_id,
+        },
+    );
+
+    assert!(matches!(result1, AttachCanisterResponse::Ok));
+    assert!(matches!(result2, AttachCanisterResponse::CanisterAlreadyAttached));
+}
+
+#[test]
+fn attach_canister_canister_already_attached_both_without_name() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    let result1 = store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "".to_string(),
+            canister_id,
+        },
+    );
+    let result2 = store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "".to_string(),
             canister_id,
         },
     );

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -463,6 +463,38 @@ fn attach_canister_and_rename() {
 }
 
 #[test]
+fn rename_to_empty_name_succeeds() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    let initial_name = "ABC".to_string();
+    store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: initial_name.clone(),
+            canister_id,
+        },
+    );
+
+    let canisters = store.get_canisters(principal);
+    assert_eq!(initial_name, canisters[0].name);
+
+    let final_name = "".to_string();
+    store.rename_canister(
+        principal,
+        RenameCanisterRequest {
+            name: final_name.clone(),
+            canister_id,
+        },
+    );
+
+    let canisters = store.get_canisters(principal);
+    assert_eq!(final_name, canisters[0].name);
+}
+
+#[test]
 fn rename_to_taken_name_fails() {
     let mut store = setup_test_store();
     let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();


### PR DESCRIPTION
# Motivation

To support moving the fallback logic for canister creation to the frontend, we want to add a `block_index` field to the `NamedCanister` type stored in the canister.
See [this doc](https://docs.google.com/document/d/1hjMSTzjnVbU9Q4rJk233M3uNcKC-RLhme25nahHpTZg/edit?tab=t.0#heading=h.qtiuv2x3gsjy) for details.

In this PR we don't yet add the new field but change the logic to make it easier to add a new field.

# Changes

1. Change the code in `attach_canister` to be more generic so it requires fewer changes when we add the `block_index` field to `NamedCanister`.
2. Change `rename_canister` so it changes only the name and keeps everything else from the canister. Currently "everything else" is just the canister ID but this is more resilient when we add more fields.

# Tests

1. New unit tests were added to expand test coverage. Tests were added before the code was changed to make sure the behavior was not changed in the refactoring.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary