### PR TITLE
NNS1-3527: Allow dfinity: prefix for ICP payments

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,6 +19,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+- Allow `dfinity:` token prefix in QR code for ICP payment.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -70,9 +70,20 @@
 
     const { token, identifier, amount } = payment;
 
+    // NOTE: Coinbase incorrectly uses "dfinity" instead of "icp" as the token
+    // symbol in the QR payment URI. We've asked them to fix this but so far
+    // they haven't. So we work around this by allowing "dfinity" in place of
+    // "icp".
+    const coinbaseIcpTokenSymbol = "dfinity";
+    const correctIcpTokenSymbol = "icp";
+
     if (
       nonNullish(requiredToken) &&
-      token.toLowerCase() !== requiredToken.symbol.toLowerCase()
+      !(
+        token.toLowerCase() === requiredToken.symbol.toLowerCase() ||
+        (token.toLowerCase() === coinbaseIcpTokenSymbol &&
+          requiredToken.symbol.toLowerCase() === correctIcpTokenSymbol)
+      )
     ) {
       toastsError({
         labelKey: "error.qrcode_token_incompatible",

--- a/frontend/src/tests/lib/modals/transaction/MockQRCodeReaderModal.svelte
+++ b/frontend/src/tests/lib/modals/transaction/MockQRCodeReaderModal.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  let value = "";
+
+  const dispatch = createEventDispatcher();
+
+  const handleInput = (event: Event) => {
+    value = (event.target as HTMLInputElement).value;
+  };
+
+  const handleClick = () => {
+    dispatch("nnsQRCode", value);
+  };
+</script>
+
+<input type="text" data-tid="mock-qr-input" on:input={handleInput} />
+<button data-tid="mock-qr-dispatch" on:click={handleClick}>Send dskloet</button>

--- a/frontend/src/tests/lib/modals/transaction/MockQRCodeReaderModal.svelte
+++ b/frontend/src/tests/lib/modals/transaction/MockQRCodeReaderModal.svelte
@@ -15,4 +15,4 @@
 </script>
 
 <input type="text" data-tid="mock-qr-input" on:input={handleInput} />
-<button data-tid="mock-qr-dispatch" on:click={handleClick}>Send dskloet</button>
+<button data-tid="mock-qr-dispatch" on:click={handleClick}>Send</button>

--- a/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
@@ -1,16 +1,30 @@
+// This import needs to be at the top for the mock to work:
+import MockQRCodeReaderModal from "./MockQRCodeReaderModal.svelte";
+
 import QrWizardModal from "$lib/modals/transaction/QrWizardModal.svelte";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { ICPToken } from "@dfinity/utils";
 import { fireEvent, render } from "@testing-library/svelte";
 
+vi.mock("@dfinity/gix-components", async () => ({
+  ...(await vi.importActual("@dfinity/gix-components")),
+  QRCodeReaderModal: MockQRCodeReaderModal,
+}));
+
 describe("QrWizardModal", () => {
+  beforeEach(() => {
+    mockedConstants.ENABLE_QR_CODE_READER = true;
+  });
+
   const getCurrentStep = (component) => {
     return component.$$.ctx[component.$$.props["currentStep"]];
   };
 
-  const scanQrCode = (component) => {
+  const scanQrCode = ({ component, requiredToken }) => {
     return component.$$.ctx[component.$$.props["scanQrCode"]]({
-      requiredToken: ICPToken,
+      requiredToken,
     });
   };
 
@@ -34,10 +48,276 @@ describe("QrWizardModal", () => {
 
     expect(getCurrentStep(component).name).toEqual("step1");
 
-    scanQrCode(component);
+    scanQrCode({
+      component,
+      requiredToken: ICPToken,
+    });
     await runResolvedPromises();
 
     expect(getCurrentStep(component).name).toEqual("QRCode");
+  });
+
+  it("scanQrCode() returns identifier", async () => {
+    const identifier =
+      "97731a95e48d63106ede6e6a7c4937475f0a2a1ef0f42f46956a3e06f8e32ba7";
+
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    const qrPromise = scanQrCode({
+      component,
+      requiredToken: ICPToken,
+    });
+    const qrPromiseResolved = vi.fn();
+    qrPromise.then(qrPromiseResolved);
+
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    expect(qrPromiseResolved).not.toBeCalled();
+
+    fireEvent.input(getByTestId("mock-qr-input"), {
+      target: { value: identifier },
+    });
+    fireEvent.click(getByTestId("mock-qr-dispatch"));
+
+    await runResolvedPromises();
+
+    expect(qrPromiseResolved).toBeCalled();
+    expect(await qrPromise).toEqual({ result: "success", identifier });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+  });
+
+  it("scanQrCode() accepts token prefix for ICP", async () => {
+    const identifier =
+      "97731a95e48d63106ede6e6a7c4937475f0a2a1ef0f42f46956a3e06f8e32ba7";
+    const paymentUri = `icp:${identifier}`;
+
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    const qrPromise = scanQrCode({
+      component,
+      requiredToken: ICPToken,
+    });
+    const qrPromiseResolved = vi.fn();
+    qrPromise.then(qrPromiseResolved);
+
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    expect(qrPromiseResolved).not.toBeCalled();
+
+    fireEvent.input(getByTestId("mock-qr-input"), {
+      target: { value: paymentUri },
+    });
+    fireEvent.click(getByTestId("mock-qr-dispatch"));
+
+    await runResolvedPromises();
+
+    expect(qrPromiseResolved).toBeCalled();
+    expect(await qrPromise).toEqual({
+      result: "success",
+      identifier,
+      token: "icp",
+    });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+  });
+
+  it("scanQrCode() accepts token prefix for non-ICP token", async () => {
+    const identifier =
+      "97731a95e48d63106ede6e6a7c4937475f0a2a1ef0f42f46956a3e06f8e32ba7";
+    const tokenSymbol = "abc";
+    const paymentUri = `${tokenSymbol}:${identifier}`;
+
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    const qrPromise = scanQrCode({
+      component,
+      requiredToken: {
+        ...mockSnsToken,
+        symbol: tokenSymbol,
+      },
+    });
+    const qrPromiseResolved = vi.fn();
+    qrPromise.then(qrPromiseResolved);
+
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    expect(qrPromiseResolved).not.toBeCalled();
+
+    fireEvent.input(getByTestId("mock-qr-input"), {
+      target: { value: paymentUri },
+    });
+    fireEvent.click(getByTestId("mock-qr-dispatch"));
+
+    await runResolvedPromises();
+
+    expect(qrPromiseResolved).toBeCalled();
+    expect(await qrPromise).toEqual({
+      result: "success",
+      identifier,
+      token: tokenSymbol,
+    });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+  });
+
+  it("scanQrCode() rejects different token prefix", async () => {
+    const identifier =
+      "97731a95e48d63106ede6e6a7c4937475f0a2a1ef0f42f46956a3e06f8e32ba7";
+    const paymentUri = `abc:${identifier}`;
+
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    const qrPromise = scanQrCode({
+      component,
+      requiredToken: ICPToken,
+    });
+    const qrPromiseResolved = vi.fn();
+    qrPromise.then(qrPromiseResolved);
+
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    expect(qrPromiseResolved).not.toBeCalled();
+
+    fireEvent.input(getByTestId("mock-qr-input"), {
+      target: { value: paymentUri },
+    });
+    fireEvent.click(getByTestId("mock-qr-dispatch"));
+
+    await runResolvedPromises();
+
+    expect(qrPromiseResolved).toBeCalled();
+    expect(await qrPromise).toEqual({ result: "token_incompatible" });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+  });
+
+  it("scanQrCode() accepts 'dfinity' token prefix for ICP", async () => {
+    const identifier =
+      "97731a95e48d63106ede6e6a7c4937475f0a2a1ef0f42f46956a3e06f8e32ba7";
+    const paymentUri = `dfinity:${identifier}`;
+
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    const qrPromise = scanQrCode({
+      component,
+      requiredToken: ICPToken,
+    });
+    const qrPromiseResolved = vi.fn();
+    qrPromise.then(qrPromiseResolved);
+
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    expect(qrPromiseResolved).not.toBeCalled();
+
+    fireEvent.input(getByTestId("mock-qr-input"), {
+      target: { value: paymentUri },
+    });
+    fireEvent.click(getByTestId("mock-qr-dispatch"));
+
+    await runResolvedPromises();
+
+    expect(qrPromiseResolved).toBeCalled();
+    expect(await qrPromise).toEqual({
+      result: "success",
+      identifier,
+      token: "dfinity",
+    });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+  });
+
+  it("scanQrCode() accepts 'dfinity' prefix for DFINITY token", async () => {
+    const identifier =
+      "97731a95e48d63106ede6e6a7c4937475f0a2a1ef0f42f46956a3e06f8e32ba7";
+    const tokenSymbol = "dfinity";
+    const paymentUri = `${tokenSymbol}:${identifier}`;
+
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    const qrPromise = scanQrCode({
+      component,
+      requiredToken: {
+        ...mockSnsToken,
+        symbol: tokenSymbol,
+      },
+    });
+    const qrPromiseResolved = vi.fn();
+    qrPromise.then(qrPromiseResolved);
+
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    expect(qrPromiseResolved).not.toBeCalled();
+
+    fireEvent.input(getByTestId("mock-qr-input"), {
+      target: { value: paymentUri },
+    });
+    fireEvent.click(getByTestId("mock-qr-dispatch"));
+
+    await runResolvedPromises();
+
+    expect(qrPromiseResolved).toBeCalled();
+    expect(await qrPromise).toEqual({
+      result: "success",
+      identifier,
+      token: tokenSymbol,
+    });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
   });
 
   it("resolves scanQrCode() to 'canceled' when canceled", async () => {
@@ -50,7 +330,10 @@ describe("QrWizardModal", () => {
 
     const { getByTestId, component } = render(QrWizardModal, { steps });
 
-    const qrPromise = scanQrCode(component);
+    const qrPromise = scanQrCode({
+      component,
+      requiredToken: ICPToken,
+    });
     const qrPromiseResolved = vi.fn();
     qrPromise.then(qrPromiseResolved);
 
@@ -118,7 +401,10 @@ describe("QrWizardModal", () => {
     await runResolvedPromises();
     expect(getCurrentStep(component).name).toEqual("step2");
 
-    scanQrCode(component);
+    scanQrCode({
+      component,
+      requiredToken: ICPToken,
+    });
     await runResolvedPromises();
 
     expect(getCurrentStep(component).name).toEqual("QRCode");


### PR DESCRIPTION
# Motivation

Coinbase incorrectly uses `dfinity:` instead of `icp:` as the token symbol in the QR payment URI. We've asked them to fix this but so far they haven't. So we work around this by allowing `dfinity:` in place of `icp:`.

# Changes

1. Don't reject the payment URL from the QR code if the prefix is `dfinity:` but the required token is ICP.

# Tests

1. Added a `MockQRCodeReaderModal` component which has just a text input to fake what was scanned by the QR code reader.
2. Added missing unit tests using the `MockQRCodeReaderModal`.
3. Add unit tests for `dfinity:` prefix.

# Todos

- [x] Add entry to changelog (if necessary).
