### PR TITLE
refactor: simplifies logic for uncertifiedLoadSnsesAccountsBalances and uncertifiedLoadAccountsBalance

### DIFF
--- a/frontend/src/lib/services/sns-accounts-balance.services.ts
+++ b/frontend/src/lib/services/sns-accounts-balance.services.ts
@@ -1,5 +1,5 @@
 import { toastsError } from "$lib/stores/toasts.store";
-import type { RootCanisterId, RootCanisterIdText } from "$lib/types/sns";
+import type { RootCanisterId } from "$lib/types/sns";
 import { loadSnsAccounts } from "./sns-accounts.services";
 
 /**
@@ -9,28 +9,18 @@ import { loadSnsAccounts } from "./sns-accounts.services";
  *
  * @param {rootCanisterIds: RootCanisterId[], excludeRootCanisterIds?: RootCanisterIdText[]} params
  * @param {RootCanisterId[]} params.rootCanisterIds The list of root canister ids - Sns projects - for which the balance of the accounts should be fetched.
- * @param {RootCanisterIdText[] | undefined} params.excludeRootCanisterIds As the balance is also loaded by loadSnsAccounts() - to perform query and UPDATE call - this variable can be used to avoid to perform unnecessary query and per extension to override data in the balance store.
  */
 export const uncertifiedLoadSnsesAccountsBalances = async ({
   rootCanisterIds,
-  excludeRootCanisterIds = [],
 }: {
   rootCanisterIds: RootCanisterId[];
-  excludeRootCanisterIds?: RootCanisterIdText[];
 }): Promise<void> => {
-  const results: PromiseSettledResult<[void]>[] = await Promise.allSettled(
-    (
-      rootCanisterIds.filter(
-        (rootCanisterId) =>
-          !excludeRootCanisterIds.includes(rootCanisterId.toText())
-      ) ?? []
-    ).map((rootCanisterId) =>
-      Promise.all([
-        loadSnsAccounts({
-          rootCanisterId,
-          strategy: "query",
-        }),
-      ])
+  const results: PromiseSettledResult<void>[] = await Promise.allSettled(
+    rootCanisterIds.map((rootCanisterId) =>
+      loadSnsAccounts({
+        rootCanisterId,
+        strategy: "query",
+      })
     )
   );
 

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -10,22 +10,15 @@ import { loadAccounts, loadIcrcToken } from "./icrc-accounts.services";
  *
  * @param {universeIds: UniverseCanisterId[]; excludeUniverseIds: RootCanisterIdText[] | undefined} params
  * @param {UniverseCanisterId[]} params.universeIds The Icrc environment for which the balances should be loaded.
- * @param {RootCanisterIdText[] | undefined} params.excludeUniverseIds As the balance is also loaded by loadSnsAccounts() - to perform query and UPDATE call - this variable can be used to avoid to perform unnecessary query and per extension to override data in the balance store.
  */
 export const uncertifiedLoadAccountsBalance = async ({
   universeIds,
-  excludeUniverseIds = [],
 }: {
   universeIds: UniverseCanisterIdText[];
-  excludeUniverseIds?: UniverseCanisterIdText[] | undefined;
 }): Promise<void> => {
   const results: PromiseSettledResult<[void, void]>[] =
     await Promise.allSettled(
-      (
-        universeIds.filter(
-          (universeId) => !excludeUniverseIds.includes(universeId)
-        ) ?? []
-      ).map((universeId) =>
+      universeIds.map((universeId) =>
         Promise.all([
           loadAccounts({
             strategy: "query",

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -83,7 +83,6 @@
 
     await uncertifiedLoadSnsesAccountsBalances({
       rootCanisterIds: notLoadedCanisterIds.map((id) => Principal.fromText(id)),
-      excludeRootCanisterIds: [],
     });
   };
 
@@ -146,7 +145,6 @@
 
     await uncertifiedLoadAccountsBalance({
       universeIds,
-      excludeUniverseIds: [],
     });
   };
 
@@ -157,7 +155,6 @@
     if (isSnsProject) {
       return uncertifiedLoadSnsesAccountsBalances({
         rootCanisterIds: [universeId],
-        excludeRootCanisterIds: [],
       });
     }
     return loadAccountsBalances([universeId.toText()]);


### PR DESCRIPTION
# Motivation

The `excludeRootCanisterIds` parameter has not been used for a long time because we filter the canisters before passing them to the function.

Additionally, there is a leftover from [this change](https://github.com/dfinity/nns-dapp/pull/4444/files#diff-987b8deb5a94449419857056024e572fc65d6a43a9156cee3517fd3b723b2b3cR28), and `Promise.all` is no longer necessary since we only have one promise.

# Changes

- Removes the `excludeRootCanisterIds` parameter and the filtering logic from both `uncertifiedLoadSnsesAccountsBalances` and `uncertifiedLoadAccountsBalance`
-  Removes `Promise.all` from `uncertifiedLoadSnsesAccountsBalances` as we only fetch SnsAccounts.

# Tests

- The `excludeRootCanisterIds` feature was not tested so nothing to change.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary