### PR TITLE
Refactor losing rewards modal

### DIFF
--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -57,6 +57,9 @@
   {/if}
 
   {#if isModalVisible}
-    <LosingRewardNeuronsModal on:nnsClose={() => (isModalVisible = false)} />
+    <LosingRewardNeuronsModal
+      neurons={$soonLosingRewardNeuronsStore}
+      on:nnsClose={() => (isModalVisible = false)}
+    />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -5,7 +5,6 @@
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { soonLosingRewardNeuronsStore } from "$lib/derived/neurons.derived";
   import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
   import { goto } from "$app/navigation";
@@ -13,6 +12,9 @@
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import type { NeuronInfo } from "@dfinity/nns";
   import ConfirmFollowingButton from "$lib/components/neuron-detail/actions/ConfirmFollowingButton.svelte";
+
+  export let neurons: NeuronInfo[];
+  export let withNeuronNavigation = true;
 
   const dispatcher = createEventDispatcher<{ nnsClose: void }>();
 
@@ -41,7 +43,7 @@
   };
 
   let neuronIds: bigint[];
-  $: neuronIds = $soonLosingRewardNeuronsStore.map((neuron) => neuron.neuronId);
+  $: neuronIds = neurons.map(({ neuronId }) => neuronId);
 </script>
 
 <Modal on:nnsClose testId="losing-reward-neurons-modal-component">
@@ -60,10 +62,11 @@
 
     <h3 class="label">{$i18n.losing_rewards_modal.label}</h3>
     <ul class="cards">
-      {#each $soonLosingRewardNeuronsStore as neuron (neuron.neuronId)}
+      {#each neurons as neuron (neuron.neuronId)}
         <li>
           <NnsLosingRewardsNeuronCard
             {neuron}
+            clickable={withNeuronNavigation}
             on:nnsClick={() => navigateToNeuronDetail(neuron)}
           />
         </li>

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -14,7 +14,6 @@
   import ConfirmFollowingButton from "$lib/components/neuron-detail/actions/ConfirmFollowingButton.svelte";
 
   export let neurons: NeuronInfo[];
-  export let withNeuronNavigation = true;
 
   const dispatcher = createEventDispatcher<{ nnsClose: void }>();
 

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -66,7 +66,6 @@
         <li>
           <NnsLosingRewardsNeuronCard
             {neuron}
-            clickable={withNeuronNavigation}
             on:nnsClick={() => navigateToNeuronDetail(neuron)}
           />
         </li>

--- a/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
@@ -13,6 +13,7 @@ import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import type { NeuronInfo } from "@dfinity/nns";
 import { nonNullish } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -64,8 +65,13 @@ describe("LosingRewardNeuronsModal", () => {
   }));
   let spyRefreshVotingPower;
 
-  const renderComponent = ({ onClose }: { onClose?: () => void } = {}) => {
-    const { container, component } = render(LosingRewardNeuronsModal);
+  const renderComponent = ({
+    onClose,
+    neurons,
+  }: { onClose?: () => void; neurons?: NeuronInfo[] } = {}) => {
+    const { container, component } = render(LosingRewardNeuronsModal, {
+      props: { neurons },
+    });
 
     if (nonNullish(onClose)) {
       component.$on("nnsClose", onClose);
@@ -97,31 +103,11 @@ describe("LosingRewardNeuronsModal", () => {
       .mockResolvedValue();
   });
 
-  it("should not display active neurons", async () => {
-    neuronsStore.setNeurons({
-      neurons,
-      certified: true,
-    });
-    const po = await renderComponent();
-    const cards = await po.getNnsLosingRewardsNeuronCardPos();
-
-    expect(cards.length).toEqual(2);
-    expect(await cards[0].getNeuronId()).toEqual(
-      `${losingRewardsNeuron.neuronId}`
-    );
-    expect(await cards[1].getNeuronId()).toEqual(
-      `${in10DaysLosingRewardsNeuron.neuronId}`
-    );
-  });
-
   it("should dispatch on close", async () => {
-    neuronsStore.setNeurons({
-      neurons,
-      certified: true,
-    });
     const onClose = vi.fn();
     const po = await renderComponent({
       onClose,
+      neurons,
     });
 
     expect(onClose).toHaveBeenCalledTimes(0);
@@ -130,17 +116,19 @@ describe("LosingRewardNeuronsModal", () => {
   });
 
   it("should confirm following", async () => {
+    const neurons = [in10DaysLosingRewardsNeuron, losingRewardsNeuron];
     neuronsStore.setNeurons({
-      neurons: [in10DaysLosingRewardsNeuron, losingRewardsNeuron],
+      neurons,
       certified: true,
     });
-    const po = await renderComponent({});
+    const po = await renderComponent({
+      neurons,
+    });
 
     expect((await po.getNnsLosingRewardsNeuronCardPos()).length).toEqual(2);
 
     await po.clickConfirmFollowing();
     await runResolvedPromises();
-    expect((await po.getNnsLosingRewardsNeuronCardPos()).length).toEqual(0);
 
     expect(spyRefreshVotingPower).toHaveBeenCalledTimes(2);
     expect(spyRefreshVotingPower).toHaveBeenCalledWith({
@@ -154,13 +142,10 @@ describe("LosingRewardNeuronsModal", () => {
   });
 
   it("should navigate to the neuron details", async () => {
-    neuronsStore.setNeurons({
-      neurons: [losingRewardsNeuron],
-      certified: true,
-    });
     const onClose = vi.fn();
     const po = await renderComponent({
       onClose,
+      neurons: [losingRewardsNeuron],
     });
     const firstCards = (await po.getNnsLosingRewardsNeuronCardPos())[0];
     expect(onClose).toHaveBeenCalledTimes(0);
@@ -186,13 +171,11 @@ describe("LosingRewardNeuronsModal", () => {
     const queryKnownNeuronsSpy = vi
       .spyOn(governanceApi, "queryKnownNeurons")
       .mockResolvedValue([]);
-    neuronsStore.setNeurons({
-      neurons,
-      certified: true,
-    });
 
     expect(queryKnownNeuronsSpy).toHaveBeenCalledTimes(0);
-    await renderComponent();
+    await renderComponent({
+      neurons,
+    });
     await runResolvedPromises();
     expect(queryKnownNeuronsSpy).toHaveBeenCalledTimes(2);
     expect(queryKnownNeuronsSpy).toHaveBeenCalledWith({

--- a/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
@@ -136,6 +136,24 @@ describe("LosingRewardsBanner", () => {
     expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(true);
   });
 
+  it("should not display active neurons in the modal", async () => {
+    neuronsStore.setNeurons({
+      neurons: [activeNeuron, in10DaysLosingRewardsNeuron],
+      certified: true,
+    });
+    const po = await renderComponent();
+
+    await po.clickConfirm();
+    const cards = await po
+      .getLosingRewardNeuronsModalPo()
+      .getNnsLosingRewardsNeuronCardPos();
+
+    expect(cards.length).toEqual(1);
+    expect(await cards[0].getNeuronId()).toEqual(
+      `${in10DaysLosingRewardsNeuron.neuronId}`
+    );
+  });
+
   it("should close modal when all refreshed", async () => {
     const spyRefreshVotingPower = vi
       .spyOn(governanceApi, "refreshVotingPower")
@@ -149,10 +167,20 @@ describe("LosingRewardsBanner", () => {
     expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(false);
     await po.clickConfirm();
     expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(true);
+    expect(
+      await po
+        .getLosingRewardNeuronsModalPo()
+        .getNnsLosingRewardsNeuronCardPos()
+    ).toHaveLength(1);
 
     await po.getLosingRewardNeuronsModalPo().clickConfirmFollowing();
     await runResolvedPromises();
 
+    expect(
+      await po
+        .getLosingRewardNeuronsModalPo()
+        .getNnsLosingRewardsNeuronCardPos()
+    ).toHaveLength(0);
     vi.advanceTimersToNextFrame();
     expect(spyRefreshVotingPower).toBeCalledTimes(1);
     expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(false);


### PR DESCRIPTION
# Motivation

To reuse the “Losing Rewards” modal on the neuron details page, it should be possible to provide a specific neuron, rather than all inactive neurons.

# Changes

- Added a neurons property to the LosingRewardNeuronsModal component.
- Provided and used the new prop instead of relying on the $soonLosingRewardNeuronsStore.

# Tests

- Update LosingRewardNeuronsModal tests.
- Moved tests related to the soonLosingRewardNeuronsStore to LosingRewardsBanner.spec.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.