### PR TITLE
registerCleanupForTesting

### DIFF
--- a/frontend/src/lib/utils/test-support.utils.ts
+++ b/frontend/src/lib/utils/test-support.utils.ts
@@ -1,0 +1,6 @@
+// The purpose of this function is to be mocked by tests.
+//
+// Production code should use this function to register cleanup functions that
+// should be run before each test.
+export const registerCleanupForTesting = (cleanup: () => void) => {
+};

--- a/frontend/src/lib/utils/test-support.utils.ts
+++ b/frontend/src/lib/utils/test-support.utils.ts
@@ -2,4 +2,4 @@
 //
 // Production code should use this function to register cleanup functions that
 // should be run before each test.
-export const registerCleanupForTesting = (cleanup: () => void) => {};
+export const registerCleanupForTesting = (_cleanup: () => void) => {};

--- a/frontend/src/lib/utils/test-support.utils.ts
+++ b/frontend/src/lib/utils/test-support.utils.ts
@@ -2,5 +2,4 @@
 //
 // Production code should use this function to register cleanup functions that
 // should be run before each test.
-export const registerCleanupForTesting = (cleanup: () => void) => {
-};
+export const registerCleanupForTesting = (cleanup: () => void) => {};

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -12,7 +12,6 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetMockedConstants } from "$tests/utils/mockable-constants.test-utils";
 import {
   advanceTime,
   runResolvedPromises,

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -64,7 +64,6 @@ describe("MenuItems", () => {
   };
 
   beforeEach(() => {
-    resetMockedConstants();
     menuStore.resetForTesting();
     layoutMenuOpen.set(false);
     vi.useFakeTimers();

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -35,7 +35,6 @@ import {
   mockSnsNeuron,
 } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsToken, mockTokenStore } from "$tests/mocks/sns-projects.mock";
-import { resetMockedConstants } from "$tests/utils/mockable-constants.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -93,7 +93,6 @@ describe("sns-neurons-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetMockedConstants();
     resetSnsProjects();
     vi.spyOn(console, "error").mockReturnValue(undefined);
   });

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -29,10 +29,6 @@ describe("ckbtc.utils", () => {
     },
   };
 
-  beforeEach(() => {
-    resetMockedConstants();
-  });
-
   it("should not throw error", () => {
     expect(() =>
       assertCkBTCUserInputAmount({

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -7,10 +7,7 @@ import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
-import {
-  mockedConstants,
-  resetMockedConstants,
-} from "$tests/utils/mockable-constants.test-utils";
+import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
 
 describe("ckbtc.utils", () => {
   const RETRIEVE_BTC_MIN_AMOUNT = 100_000n;

--- a/frontend/src/tests/utils/mockable-constants.test-utils.ts
+++ b/frontend/src/tests/utils/mockable-constants.test-utils.ts
@@ -1,6 +1,7 @@
 // Values used during unit testing for the constants in
 // frontend/src/lib/constants/mockable.constants.ts
 
+import { registerCleanupForTesting } from "$lib/utils/test-support.utils";
 import type * as mockableConstants from "$lib/constants/mockable.constants";
 
 type MockableConstantsKey = keyof typeof mockableConstants;
@@ -29,3 +30,5 @@ export const setDefaultTestConstants = (constants: MockableConstants) => {
   defaultTestConstants = constants;
   resetMockedConstants();
 };
+
+registerCleanupForTesting(resetMockedConstants);

--- a/frontend/src/tests/utils/mockable-constants.test-utils.ts
+++ b/frontend/src/tests/utils/mockable-constants.test-utils.ts
@@ -1,8 +1,8 @@
 // Values used during unit testing for the constants in
 // frontend/src/lib/constants/mockable.constants.ts
 
-import { registerCleanupForTesting } from "$lib/utils/test-support.utils";
 import type * as mockableConstants from "$lib/constants/mockable.constants";
+import { registerCleanupForTesting } from "$lib/utils/test-support.utils";
 
 type MockableConstantsKey = keyof typeof mockableConstants;
 type MockableConstants = { [K in MockableConstantsKey]: unknown };

--- a/frontend/src/tests/utils/mockable-constants.test-utils.ts
+++ b/frontend/src/tests/utils/mockable-constants.test-utils.ts
@@ -20,7 +20,7 @@ export const mockedConstants: MockableConstants = {
   notForceCallStrategy: undefined,
 };
 
-export const resetMockedConstants = () => {
+const resetMockedConstants = () => {
   Object.keys(mockedConstants).forEach((key) => {
     mockedConstants[key] = defaultTestConstants[key];
   });


### PR DESCRIPTION
# Motivation

Our unit tests have always been quite brittle because we need to remember to clean up all global state between each test.
Often tests fail when run in a different order because one test accidentally depends on state left behind by other tests.

This has improved a lot now that we always [reset all stores](https://github.com/dfinity/nns-dapp/pull/5724) and [restore all mocks](https://github.com/dfinity/nns-dapp/pull/5788), but there are still other cleanups that need to be performed in tests.

This PR proposes a generic way of registering a cleanup in the file that defines the thing that needs to be cleaned up, instead of in every test. As a proof of concept, it is then used to automatically call `resetMockedConstants();` in every test that (transitively) imports `$tests/utils/mockable-constants.test-utils.ts`.

# Changes

1. Create an empty `registerCleanupForTesting` function which should be used to register cleanup functions.
2. In `frontend/vitest.setup.ts` mock `frontend/src/lib/utils/test-support.utils.ts` such that the registered cleanup functions are called before every test.

# Tests

Tests only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary