### PR TITLE
Neuron confirm following confirmation

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -16,9 +16,9 @@
   import { secondsToDuration } from "@dfinity/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import FollowNeuronsButton from "./actions/FollowNeuronsButton.svelte";
-  import ConfirmFollowingButton from "./actions/ConfirmFollowingButton.svelte";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
+  import ConfirmFollowingActionButton from "$lib/components/neuron-detail/actions/ConfirmFollowingActionButton.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -103,7 +103,7 @@
   {#if isFollowingReset}
     <FollowNeuronsButton variant="secondary" />
   {:else}
-    <ConfirmFollowingButton neuronIds={[neuron.neuronId]} />
+    <ConfirmFollowingActionButton {neuron} />
   {/if}
 </CommonItemAction>
 

--- a/frontend/src/lib/components/neuron-detail/actions/ConfirmFollowingActionButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/ConfirmFollowingActionButton.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { openNnsNeuronModal } from "$lib/utils/modals.utils";
+  import type { NeuronInfo } from "@dfinity/nns";
+
+  export let neuron: NeuronInfo;
+</script>
+
+<button
+  data-tid="confirm-following-action-button-component"
+  class="secondary"
+  on:click={() =>
+    openNnsNeuronModal({
+      type: "confirm-following",
+      data: { neuron },
+    })}>{$i18n.losing_rewards.confirm}</button
+>

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -57,6 +57,9 @@
   {/if}
 
   {#if isModalVisible}
-    <LosingRewardNeuronsModal on:nnsClose={() => (isModalVisible = false)} />
+    <LosingRewardNeuronsModal
+      neurons={$soonLosingRewardNeuronsStore}
+      on:nnsClose={() => (isModalVisible = false)}
+    />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -12,12 +12,13 @@
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { i18n } from "$lib/stores/i18n";
   import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
-  import { createEventDispatcher } from "svelte";
-
-  const dispatch = createEventDispatcher<{ nnsClick: void }>();
+  import { nonNullish } from "@dfinity/utils";
 
   export let neuron: NeuronInfo;
-  export let clickable = true;
+  export let onClick: (() => void) | undefined;
+
+  let isClickable: boolean;
+  $: isClickable = nonNullish(onClick);
 
   let neuronTags: NeuronTagData[];
   $: neuronTags = getNeuronTags({
@@ -33,10 +34,10 @@
 
 <Card
   testId="nns-loosing-rewards-neuron-card-component"
-  role={clickable ? "button" : undefined}
+  role={isClickable ? "button" : undefined}
   noMargin
   ariaLabel={$i18n.losing_rewards_modal.goto_neuron}
-  on:click={() => clickable && dispatch("nnsClick")}
+  on:click={() => isClickable && onClick()}
 >
   <div class="wrapper">
     <div class="header">
@@ -48,7 +49,7 @@
           <NeuronTag {tag} />
         {/each}
       </div>
-      {#if clickable}
+      {#if isClickable}
         <div class="icon-right">
           <IconRight />
         </div>

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -37,7 +37,7 @@
   role={isClickable ? "button" : undefined}
   noMargin
   ariaLabel={$i18n.losing_rewards_modal.goto_neuron}
-  on:click={() => isClickable && onClick()}
+  on:click={onClick}
 >
   <div class="wrapper">
     <div class="header">

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -17,6 +17,7 @@
   const dispatch = createEventDispatcher<{ nnsClick: void }>();
 
   export let neuron: NeuronInfo;
+  export let clickable = true;
 
   let neuronTags: NeuronTagData[];
   $: neuronTags = getNeuronTags({
@@ -32,10 +33,10 @@
 
 <Card
   testId="nns-loosing-rewards-neuron-card-component"
-  role="button"
+  role={clickable ? "button" : undefined}
   noMargin
   ariaLabel={$i18n.losing_rewards_modal.goto_neuron}
-  on:click={() => dispatch("nnsClick")}
+  on:click={() => clickable && dispatch("nnsClick")}
 >
   <div class="wrapper">
     <div class="header">
@@ -47,9 +48,11 @@
           <NeuronTag {tag} />
         {/each}
       </div>
-      <div class="icon-right">
-        <IconRight />
-      </div>
+      {#if clickable}
+        <div class="icon-right">
+          <IconRight />
+        </div>
+      {/if}
     </div>
 
     {#if followees.length > 0}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -405,8 +405,8 @@
   },
   "losing_rewards_modal": {
     "goto_neuron": "Go to neuron details",
-    "title": "Review your following for neurons",
-    "label": "Neurons",
+    "title": "Review following",
+    "label": "Neuron(s)",
     "no_following": "This neuron has no following configured. You need to vote manually to earn voting rewards."
   },
   "new_followee": {

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -5,7 +5,6 @@
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { soonLosingRewardNeuronsStore } from "$lib/derived/neurons.derived";
   import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
   import { goto } from "$app/navigation";
@@ -13,6 +12,9 @@
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import type { NeuronInfo } from "@dfinity/nns";
   import ConfirmFollowingButton from "$lib/components/neuron-detail/actions/ConfirmFollowingButton.svelte";
+
+  export let neurons: NeuronInfo[];
+  export let withNeuronNavigation = true;
 
   const dispatcher = createEventDispatcher<{ nnsClose: void }>();
 
@@ -41,7 +43,7 @@
   };
 
   let neuronIds: bigint[];
-  $: neuronIds = $soonLosingRewardNeuronsStore.map((neuron) => neuron.neuronId);
+  $: neuronIds = neurons.map(({ neuronId }) => neuronId);
 </script>
 
 <Modal on:nnsClose testId="losing-reward-neurons-modal-component">
@@ -60,10 +62,11 @@
 
     <h3 class="label">{$i18n.losing_rewards_modal.label}</h3>
     <ul class="cards">
-      {#each $soonLosingRewardNeuronsStore as neuron (neuron.neuronId)}
+      {#each neurons as neuron (neuron.neuronId)}
         <li>
           <NnsLosingRewardsNeuronCard
             {neuron}
+            clickable={withNeuronNavigation}
             on:nnsClick={() => navigateToNeuronDetail(neuron)}
           />
         </li>

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -66,8 +66,9 @@
         <li>
           <NnsLosingRewardsNeuronCard
             {neuron}
-            clickable={withNeuronNavigation}
-            on:nnsClick={() => navigateToNeuronDetail(neuron)}
+            onClick={withNeuronNavigation
+              ? () => navigateToNeuronDetail(neuron)
+              : undefined}
           />
         </li>
       {/each}

--- a/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
@@ -28,6 +28,7 @@
   import ChangeNeuronVisibilityModal from "./ChangeNeuronVisibilityModal.svelte";
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
+  import LosingRewardNeuronsModal from "./LosingRewardNeuronsModal.svelte";
 
   let modal: NnsNeuronModal<NnsNeuronModalData> | undefined;
   const close = () => (modal = undefined);
@@ -107,6 +108,14 @@
       <ChangeNeuronVisibilityModal
         defaultSelectedNeuron={neuron}
         makePublic={!isPublicNeuron(neuron)}
+        on:nnsClose={close}
+      />
+    {/if}
+
+    {#if type === "confirm-following"}
+      <LosingRewardNeuronsModal
+        withNeuronNavigation={false}
+        neurons={[neuron]}
         on:nnsClose={close}
       />
     {/if}

--- a/frontend/src/lib/types/nns-neuron-detail.modal.ts
+++ b/frontend/src/lib/types/nns-neuron-detail.modal.ts
@@ -17,7 +17,8 @@ export type NnsNeuronModalType =
   | "dev-add-maturity"
   | "voting-history"
   | "change-neuron-visibility"
-  | "dev-update-voting-power-refreshed";
+  | "dev-update-voting-power-refreshed"
+  | "confirm-following";
 export interface NnsNeuronModalData {
   neuron: NeuronInfo | undefined | null;
 }

--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -205,7 +205,7 @@ export const addNeuronWith = ({
 }: {
   identity?: Identity;
   votingPowerRefreshedTimestampSeconds?: bigint | number;
-} & Partial<FakeNeuronParams>) => {
+} & Partial<FakeNeuronParams>): NeuronInfo => {
   const neuron = { ...mockNeuron, fullNeuron: { ...mockNeuron.fullNeuron } };
   if (neuronId) {
     neuron.neuronId = neuronId;
@@ -230,6 +230,8 @@ export const addNeuronWith = ({
     throw new Error(`A neuron with id ${neuron.neuronId} already exists`);
   }
   getNeurons(identity).push(neuron);
+
+  return { ...neuron };
 };
 
 export const addNeurons = ({

--- a/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
@@ -66,11 +66,19 @@ describe("LosingRewardNeuronsModal", () => {
   let spyRefreshVotingPower;
 
   const renderComponent = ({
-    onClose,
     neurons,
-  }: { onClose?: () => void; neurons?: NeuronInfo[] } = {}) => {
+    withNeuronNavigation,
+    onClose,
+  }: {
+    neurons?: NeuronInfo[];
+    withNeuronNavigation?: boolean;
+    onClose?: () => void;
+  } = {}) => {
     const { container, component } = render(LosingRewardNeuronsModal, {
-      props: { neurons },
+      props: {
+        neurons,
+        withNeuronNavigation,
+      },
     });
 
     if (nonNullish(onClose)) {
@@ -165,6 +173,24 @@ describe("LosingRewardNeuronsModal", () => {
       universe: OWN_CANISTER_ID_TEXT,
       neuron: losingRewardsNeuron.neuronId.toString(),
     });
+  });
+
+  it("should not navigate to the neuron details when withNeuronNavigation=false", async () => {
+    const onClose = vi.fn();
+    const po = await renderComponent({
+      onClose,
+      neurons: [losingRewardsNeuron],
+      withNeuronNavigation: false,
+    });
+    const firstCards = (await po.getNnsLosingRewardsNeuronCardPos())[0];
+    expect(get(pageStore).path).toEqual("/staking");
+    expect(firstCards).not.toEqual(undefined);
+
+    await firstCards.click();
+    await runResolvedPromises();
+
+    expect(onClose).toHaveBeenCalledTimes(0);
+    expect(get(pageStore).path).toEqual("/staking");
   });
 
   it("should fetch known neurons", async () => {

--- a/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
@@ -4,7 +4,6 @@ import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsLosingRewardsNeuronCardPo } from "$tests/page-objects/NnsLosingRewardsNeuronCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Topic, type NeuronInfo } from "@dfinity/nns";
-import { nonNullish } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("NnsLosingRewardsNeuronCard", () => {
@@ -37,15 +36,12 @@ describe("NnsLosingRewardsNeuronCard", () => {
     neuron: NeuronInfo;
     onClick?: () => void;
   }) => {
-    const { container, component } = render(NnsLosingRewardsNeuronCard, {
+    const { container } = render(NnsLosingRewardsNeuronCard, {
       props: {
         neuron,
+        onClick,
       },
     });
-
-    if (nonNullish(onClick)) {
-      component.$on("nnsClick", onClick);
-    }
 
     return NnsLosingRewardsNeuronCardPo.under(
       new JestPageObjectElement(container)

--- a/frontend/src/tests/page-objects/ConfirmFollowingActionButton.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmFollowingActionButton.page-object.ts
@@ -1,0 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ConfirmFollowingActionButtonPo extends BasePageObject {
+  private static readonly TID = "confirm-following-action-button-component";
+
+  static under(element: PageObjectElement): ConfirmFollowingActionButtonPo {
+    return new ConfirmFollowingActionButtonPo(
+      element.byTestId(ConfirmFollowingActionButtonPo.TID)
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -9,6 +9,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ConfirmFollowingBannerPo } from "./ConfirmFollowingBanner.page-object";
 import { NnsNeuronPageHeaderPo } from "./NnsNeuronPageHeader.page-object";
+import { NnsNeuronRewardStatusActionPo } from "./NnsNeuronRewardStatusAction.page-object";
 
 export class NnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "nns-neuron-detail-component";
@@ -72,6 +73,10 @@ export class NnsNeuronDetailPo extends BasePageObject {
 
   getConfirmFollowingBannerPo(): ConfirmFollowingBannerPo {
     return ConfirmFollowingBannerPo.under(this.root);
+  }
+
+  getNnsNeuronRewardStatusActionPo(): NnsNeuronRewardStatusActionPo {
+    return NnsNeuronRewardStatusActionPo.under(this.root);
   }
 
   getVotingPowerSectionPo(): NnsNeuronVotingPowerSectionPo {

--- a/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
@@ -7,6 +7,7 @@ import { NnsAddMaturityModalPo } from "$tests/page-objects/NnsAddMaturityModal.p
 import { SpawnNeuronModalPo } from "$tests/page-objects/SpawnNeuronModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { LosingRewardNeuronsModalPo } from "./LosingRewardNeuronsModal.page-object";
 
 export class NnsNeuronModalsPo extends BasePageObject {
   private static readonly TID = "nns-neuron-modals-component";
@@ -41,5 +42,9 @@ export class NnsNeuronModalsPo extends BasePageObject {
 
   getSpawnNeuronModalPo(): SpawnNeuronModalPo {
     return SpawnNeuronModalPo.under(this.root);
+  }
+
+  getLosingRewardNeuronsModalPo(): LosingRewardNeuronsModalPo {
+    return LosingRewardNeuronsModalPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ConfirmFollowingButtonPo } from "./ConfirmFollowingButton.page-object";
+import { ConfirmFollowingActionButtonPo } from "./ConfirmFollowingActionButton.page-object";
 import { FollowNeuronsButtonPo } from "./FollowNeuronsButton.page-object";
 
 export class NnsNeuronRewardStatusActionPo extends BasePageObject {
@@ -20,8 +20,8 @@ export class NnsNeuronRewardStatusActionPo extends BasePageObject {
     return this.getText("state-description");
   }
 
-  getConfirmFollowingButtonPo(): ConfirmFollowingButtonPo {
-    return ConfirmFollowingButtonPo.under(this.root);
+  getConfirmFollowingButtonPo(): ConfirmFollowingActionButtonPo {
+    return ConfirmFollowingActionButtonPo.under(this.root);
   }
 
   getFollowNeuronsButtonPo(): FollowNeuronsButtonPo {


### PR DESCRIPTION
# Motivation

To provide users with a clearer understanding of what they are confirming, we need to display the confirmation dialog, including the current following state, on the neuron detail page when they click ‘Confirm Following’ (using the same dialog as in the LosingRewardsBanner).

# Changes

- Add `clickable` prop to NnsLosingRewardsNeuronCard to support not clickable neuron cards.
- Add `LosingRewardNeuronsModal` to available NNS neuron modals.
- Display `LosingRewardNeuronsModal` instead of calling `refreshVotingPower`.
- Minor text changes.

# Tests

- Move "call refreshVotingPower" test from `NnsNeuronRewardStatusAction.spec` to `NnsNeuronDetail.spec`.
- Tested locally that it works.

https://github.com/user-attachments/assets/0a4b778f-5a98-4e5a-a58d-68ebeadc348f

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.