### PR TITLE
test(portfolio): adds tests for unauthenticated state

### DIFF
--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -11,18 +11,36 @@ describe("Portfolio page", () => {
     return PortfolioPagePo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    resetIdentity();
+  describe("when not logged in", () => {
+    beforeEach(() => {
+      setNoIdentity();
+    });
+
+    it("should display the login card when the user is not logged in", async () => {
+      const po = renderPage();
+      expect(await po.getLoginCard().isPresent()).toBe(true);
+    });
+
+    it("should show the NoTokensCard", async () => {
+      const po = renderPage();
+      expect(await po.getNoTokensCard().isPresent()).toBe(true);
+    });
+
+    it("should show the NoNeuronsCard with secondary action", async () => {
+      const po = renderPage();
+      expect(await po.getNoNeuronsCarPo().isPresent()).toBe(true);
+      expect(await po.getNoNeuronsCarPo().hasSecondaryAction()).toBe(true);
+    });
   });
 
-  it("should display the login card when the user is not logged in", async () => {
-    setNoIdentity();
-    const po = renderPage();
-    expect(await po.getLoginCard().isPresent()).toBe(true);
-  });
+  describe("when logged in", () => {
+    beforeEach(() => {
+      resetIdentity();
+    });
 
-  it("should not display the login card when the user is logged in", async () => {
-    const page = renderPage();
-    expect(await page.getLoginCard().isPresent()).toBe(false);
+    it("should not display the login card when the user is logged in", async () => {
+      const page = renderPage();
+      expect(await page.getLoginCard().isPresent()).toBe(false);
+    });
   });
 });

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -1,4 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NoNeuronsCardPo } from "./NoNeuronsCard.page-object";
 import { BasePageObject } from "./base.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
@@ -8,7 +9,15 @@ export class PortfolioPagePo extends BasePageObject {
     return new PortfolioPagePo(element.byTestId(PortfolioPagePo.TID));
   }
 
-  getLoginCard() {
+  getLoginCard(): PageObjectElement {
     return this.getElement("portfolio-login-card");
+  }
+
+  getNoTokensCard(): PageObjectElement {
+    return this.getElement("no-tokens-card");
+  }
+
+  getNoNeuronsCarPo(): NoNeuronsCardPo {
+    return NoNeuronsCardPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

When the user is not authenticated, we display the `NoTokensCards` and the `NoNeuronsCard`.

Design discrepancies:
* The design shows these cards with disabled links. Since there is no semantic meaning for a disabled link, I will leave it as is until we determine whether to replace the link with a disabled button.

# Changes

* Adds new methods to the Portfolio page object

# Tests

* Added unit test

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.