### PR TITLE
Fix errors logged in SnsProposalDetail.spec.ts

### DIFF
--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -322,7 +322,7 @@ async function queryProposal({
 }): Promise<SnsProposalData> {
   const proposal = proposals
     .get(mapKey({ identity, rootCanisterId }))
-    .proposals.find(({ id }) => fromNullable(id).id === proposalId.id);
+    ?.proposals.find(({ id }) => fromNullable(id).id === proposalId.id);
   if (isNullish(proposal)) {
     throw new SnsGovernanceError(
       `No proposal for given proposalId ${proposalId.id}`

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -79,7 +79,6 @@ describe("SnsProposalDetail", () => {
 
   describe("not logged in", () => {
     beforeEach(() => {
-      vi.spyOn(console, "error").mockImplementation(() => undefined);
       setNoIdentity();
       page.mock({ data: { universe: rootCanisterId.toText() } });
       setSnsProjects([
@@ -210,6 +209,7 @@ describe("SnsProposalDetail", () => {
     });
 
     it("should redirect to the list of sns proposals if proposal is not found", async () => {
+      vi.spyOn(console, "error").mockReturnValue();
       // There is no proposal with id 2 in the fake implementation.
       // Therefore, the page should redirect to the list of proposals.
       render(SnsProposalDetail, {
@@ -221,6 +221,12 @@ describe("SnsProposalDetail", () => {
         const { path } = get(pageStore);
         return expect(path).toEqual(AppPath.Proposals);
       });
+      expect(console.error).toBeCalledWith(
+        expect.objectContaining({
+          error: new Error("No proposal for given proposalId 2"),
+        })
+      );
+      expect(console.error).toBeCalledTimes(1);
     });
 
     it("should not render content if universe changes to Nns", async () => {
@@ -401,6 +407,7 @@ describe("SnsProposalDetail", () => {
     });
 
     it("should navigate to the proposal from the next Sns", async () => {
+      vi.spyOn(console, "error").mockReturnValue();
       mockCommittedSnsProjectsWithVotableProposals([
         { rootCanisterId: principal1, proposalIds: [20n, 19n] },
         { rootCanisterId: principal2, proposalIds: [30n, 29n] },
@@ -433,9 +440,32 @@ describe("SnsProposalDetail", () => {
           id: "/(app)/proposal/",
         },
       });
+
+      await runResolvedPromises();
+      // The navigation changes both the proposal ID and the universe.
+      // In reality this will cause a navigation and a new component will be
+      // rendered with the new proposal ID and universe.
+      // But in the test, the component notices the change in universe (because
+      // it comes from the store) but not the change in proposal ID (because
+      // it's passed in as a prop). So it tries to load proposal 19 from the
+      // wrong universe, which causes these errors.
+      expect(console.error).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          error: new Error("No proposal for given proposalId 19"),
+        })
+      );
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          error: new Error("No proposal for given proposalId 19"),
+        })
+      );
+      expect(console.error).toBeCalledTimes(2);
     });
 
     it("should navigate to the proposal from the previous Sns", async () => {
+      vi.spyOn(console, "error").mockReturnValue();
       mockCommittedSnsProjectsWithVotableProposals([
         { rootCanisterId: principal1, proposalIds: [20n, 19n] },
         { rootCanisterId: principal2, proposalIds: [30n, 29n] },
@@ -468,12 +498,33 @@ describe("SnsProposalDetail", () => {
           id: "/(app)/proposal/",
         },
       });
+
+      await runResolvedPromises();
+      // The navigation changes both the proposal ID and the universe.
+      // In reality this will cause a navigation and a new component will be
+      // rendered with the new proposal ID and universe.
+      // But in the test, the component notices the change in universe (because
+      // it comes from the store) but not the change in proposal ID (because
+      // it's passed in as a prop). So it tries to load proposal 30 from the
+      // wrong universe, which causes these errors.
+      expect(console.error).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          error: new Error("No proposal for given proposalId 30"),
+        })
+      );
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          error: new Error("No proposal for given proposalId 30"),
+        })
+      );
+      expect(console.error).toBeCalledTimes(2);
     });
   });
 
   describe("not logged in that logs in afterwards", () => {
     beforeEach(() => {
-      vi.spyOn(console, "error").mockImplementation(() => undefined);
       page.mock({ data: { universe: rootCanisterId.toText() } });
     });
 
@@ -512,6 +563,23 @@ describe("SnsProposalDetail", () => {
 
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
+        rootCanisterId,
+        ...proposal,
+        proposal_creation_timestamp_seconds: proposalCreatedTimestamp,
+        ballots: [
+          [
+            getSnsNeuronIdAsHexString(mockSnsNeuron),
+            {
+              vote: SnsVote.Unspecified,
+              voting_power: 100_000_000n,
+              cast_timestamp_seconds: 0n,
+            },
+          ],
+        ],
+      });
+
+      fakeSnsGovernanceApi.addProposalWith({
+        identity: mockIdentity,
         rootCanisterId,
         ...proposal,
         proposal_creation_timestamp_seconds: proposalCreatedTimestamp,

--- a/frontend/src/tests/utils/console.test-utils.ts
+++ b/frontend/src/tests/utils/console.test-utils.ts
@@ -1,3 +1,5 @@
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+
 type LogType = "log" | "debug" | "warn" | "error";
 
 const logTypes: LogType[] = ["log", "debug", "warn", "error"];
@@ -22,7 +24,8 @@ export const failTestsThatLogToConsole = () => {
     gotLogs = false;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await runResolvedPromises();
     if (!isLoggingAllowed && gotLogs) {
       throw new Error(
         "Your test produced console logs, which is not allowed.\n" +


### PR DESCRIPTION
# Motivation

These 2 tests in `SnsProposalDetail.spec.ts`:
```
"should navigate to the proposal from the previous Sns"
"should navigate to the proposal from the next Sns"
```
are currently logging errors like this:
```
{
  certified: false,
  strategy: 'query_and_update',
  error: t [Error]: No proposal for given proposalId 19
      at Object.queryProposal (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/tests/fakes/sns-governance-api.fake.ts:327:11)
      at fn (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/tests/utils/module.test-utils.ts:158:33)
      at wrapMaybePaused (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/tests/utils/module.test-utils.ts:140:20)
      at Module.pausableFunctions.<computed> (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/tests/utils/module.test-utils.ts:157:14)
      at Module.mockCall (file:///Users/dskloet/dev/nns-dapp/tree4/frontend/node_modules/@vitest/spy/dist/index.js:61:17)
      at Module.queryProposal (file:///Users/dskloet/dev/nns-dapp/tree4/frontend/node_modules/tinyspy/dist/index.js:45:80)
      at request (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/lib/services/public/sns-proposals.services.ts:209:7)
      at queryOrUpdate (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/lib/services/utils.services.ts:85:5)
      at Module.queryAndUpdate (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/lib/services/utils.services.ts:105:17)
      at Module.getSnsProposalById (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/lib/services/public/sns-proposals.services.ts:206:10),
  identity: {
    getPrincipal: [Function: getPrincipal],
    transformRequest: [Function: transformRequest]
  }
}
```

This started happening after https://github.com/dfinity/nns-dapp/pull/5788
Before that PR, the tests were relying on `console.error` being mocked in the `beforeEach` of a different `describe` block but after that PR all mocks are always restored before each test so the mocking of `console.error` was being reverted.

However logging during tests is not allowed and normally results in test failure. However these test passed before the logging happened so the logging could happen without the tests failing.

And in general mocking `console.error` in `beforeEach` is dangerous because it can hide problems in other tests.
It's best to only mock `console.error` in tests that expect logging and always expect the specific messages being logged so no other errors are hidden.

# Changes

1. Stop mocking `console.error` in `beforeEach` in `SnsProposalDetail.spec.ts`.
2. Mock `console.error` in specific tests where errors are logged and expect what is being logged.
3. In `"show neurons that can vote"`, add a missing proposal that the test expects. It was logging errors for this that were ignored. The test does not seem to intend the proposal to be missing.
4. Add `await runResolvedPromises();` in `afterEach` in `failTestsThatLogToConsole` in order to prevent tests from passing before they log some errors.
5. In `queryProposal` in the fake SNS API, take into account that there may not be any proposals for an identity+SNS combination and allow to throw the intended error instead of `undefined.proposals` not existing. This happened in one of the tests making the logged error message even more confusing.

# Tests

Tests only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary