### PR TITLE
feat(portfolio): implement total assets calculation for tokens

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import Card from "$lib/components/portfolio/Card.svelte";
   import LoginCard from "$lib/components/portfolio/LoginCard.svelte";
   import NoNeuronsCard from "$lib/components/portfolio/NoNeuronsCard.svelte";
   import NoTokensCard from "$lib/components/portfolio/NoTokensCard.svelte";
+  import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import type { UserToken } from "$lib/types/tokens-page";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
 
-  export let userTokensData: UserToken[];
+  export let userTokensData: UserToken[] = [];
 
   let totalTokensBalanceInUsd: number;
   $: totalTokensBalanceInUsd = getTotalBalanceInUsd(userTokensData);
@@ -21,15 +21,11 @@
       (!("balanceInUsd" in token) || isNullish(token.balanceInUsd))
   );
 
-  let totalUsdAmount: number;
+  let totalUsdAmount: number | undefined;
   $: totalUsdAmount = $authSignedInStore ? totalTokensBalanceInUsd : undefined;
 
-  let isNotSignedIn: boolean;
-  $: isNotSignedIn = !$authSignedInStore;
   let showNoTokensCard: boolean;
-  $: showNoTokensCard = isNotSignedIn || totalTokenBalanceInUsd === 0;
-  let showNoNeuronsCard: boolean;
-  $: showNoNeuronsCard = isNotSignedIn || totalStakedInUsd === 0;
+  $: showNoTokensCard = !$authSignedInStore || totalTokensBalanceInUsd === 0;
 </script>
 
 <main data-tid="portfolio-page-component">
@@ -37,10 +33,12 @@
     {#if !$authSignedInStore}
       <LoginCard />
     {/if}
-    <Card>Card1</Card>
+    <UsdValueBanner usdAmount={totalUsdAmount} {hasUnpricedTokens} />
   </div>
   <div class="content">
-    <NoTokensCard />
+    {#if showNoTokensCard}
+      <NoTokensCard />
+    {/if}
     <NoNeuronsCard />
   </div>
 </main>

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -4,6 +4,32 @@
   import NoNeuronsCard from "$lib/components/portfolio/NoNeuronsCard.svelte";
   import NoTokensCard from "$lib/components/portfolio/NoTokensCard.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import type { UserToken } from "$lib/types/tokens-page";
+  import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
+  import { TokenAmountV2, isNullish } from "@dfinity/utils";
+
+  export let userTokensData: UserToken[];
+
+  let totalTokensBalanceInUsd: number;
+  $: totalTokensBalanceInUsd = getTotalBalanceInUsd(userTokensData);
+
+  let hasUnpricedTokens: boolean;
+  $: hasUnpricedTokens = userTokensData.some(
+    (token) =>
+      token.balance instanceof TokenAmountV2 &&
+      token.balance.toUlps() > 0n &&
+      (!("balanceInUsd" in token) || isNullish(token.balanceInUsd))
+  );
+
+  let totalUsdAmount: number;
+  $: totalUsdAmount = $authSignedInStore ? totalTokensBalanceInUsd : undefined;
+
+  let isNotSignedIn: boolean;
+  $: isNotSignedIn = !$authSignedInStore;
+  let showNoTokensCard: boolean;
+  $: showNoTokensCard = isNotSignedIn || totalTokenBalanceInUsd === 0;
+  let showNoNeuronsCard: boolean;
+  $: showNoNeuronsCard = isNotSignedIn || totalStakedInUsd === 0;
 </script>
 
 <main data-tid="portfolio-page-component">

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -1,12 +1,24 @@
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import Portfolio from "$lib/pages/Portfolio.svelte";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import type { UserToken } from "$lib/types/tokens-page";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { createUserToken } from "$tests/mocks/tokens-page.mock";
 import { PortfolioPagePo } from "$tests/page-objects/PortfolioPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("Portfolio page", () => {
-  const renderPage = () => {
-    const { container } = render(Portfolio);
+  const renderPage = (
+    { userTokensData }: { userTokensData: UserToken[] } = { userTokensData: [] }
+  ) => {
+    const { container } = render(Portfolio, {
+      props: {
+        userTokensData: userTokensData,
+      },
+    });
 
     return PortfolioPagePo.under(new JestPageObjectElement(container));
   };
@@ -16,18 +28,21 @@ describe("Portfolio page", () => {
       setNoIdentity();
     });
 
-    it("should display the login card when the user is not logged in", async () => {
+    it("should display the LoginCard when the user is not logged in", async () => {
       const po = renderPage();
+
       expect(await po.getLoginCard().isPresent()).toBe(true);
     });
 
     it("should show the NoTokensCard", async () => {
       const po = renderPage();
+
       expect(await po.getNoTokensCard().isPresent()).toBe(true);
     });
 
     it("should show the NoNeuronsCard with secondary action", async () => {
       const po = renderPage();
+
       expect(await po.getNoNeuronsCarPo().isPresent()).toBe(true);
       expect(await po.getNoNeuronsCarPo().hasSecondaryAction()).toBe(true);
     });
@@ -36,11 +51,87 @@ describe("Portfolio page", () => {
   describe("when logged in", () => {
     beforeEach(() => {
       resetIdentity();
+
+      icpSwapTickersStore.set([
+        {
+          ...mockIcpSwapTicker,
+          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+          last_price: "10.00",
+        },
+      ]);
     });
 
-    it("should not display the login card when the user is logged in", async () => {
-      const page = renderPage();
-      expect(await page.getLoginCard().isPresent()).toBe(false);
+    it("should not display the LoginCard when the user is logged in", async () => {
+      const po = renderPage();
+
+      expect(await po.getLoginCard().isPresent()).toBe(false);
+    });
+
+    describe("NoTokensCard", () => {
+      it("should display the card when the tokens accounts balance is zero", async () => {
+        const po = renderPage();
+
+        expect(await po.getNoTokensCard().isPresent()).toBe(true);
+        expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$0.00");
+      });
+
+      it("should not display the card when the tokens accounts balance is not zero", async () => {
+        const token = createUserToken({
+          universeId: principal(1),
+          balanceInUsd: 2,
+        });
+        const po = renderPage({ userTokensData: [token] });
+
+        expect(await po.getNoTokensCard().isPresent()).toBe(false);
+        expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$2.00");
+      });
+    });
+
+    describe("UsdValueBanner", () => {
+      it("should display total assets", async () => {
+        const token1 = createUserToken({
+          universeId: principal(1),
+          balanceInUsd: 5,
+        });
+        const token2 = createUserToken({
+          universeId: principal(1),
+          balanceInUsd: 7,
+        });
+        const po = renderPage({ userTokensData: [token1, token2] });
+
+        expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe(
+          "$12.00"
+        );
+        expect(await po.getUsdValueBannerPo().getSecondaryAmount()).toBe(
+          "1.20 ICP"
+        );
+      });
+
+      it("should ignore tokens with unknown balance in USD and display tooltip", async () => {
+        const token1 = createUserToken({
+          universeId: principal(1),
+          balanceInUsd: 5,
+        });
+        const token2 = createUserToken({
+          universeId: principal(1),
+          balanceInUsd: 7,
+        });
+        const token3 = createUserToken({
+          universeId: principal(1),
+          balanceInUsd: undefined,
+        });
+        const po = renderPage({ userTokensData: [token1, token2, token3] });
+
+        expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe(
+          "$12.00"
+        );
+        expect(await po.getUsdValueBannerPo().getSecondaryAmount()).toBe(
+          "1.20 ICP"
+        );
+        expect(
+          await po.getUsdValueBannerPo().getTotalsTooltipIconPo().isPresent()
+        ).toBe(true);
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -105,6 +105,9 @@ describe("Portfolio page", () => {
         expect(await po.getUsdValueBannerPo().getSecondaryAmount()).toBe(
           "1.20 ICP"
         );
+        expect(
+          await po.getUsdValueBannerPo().getTotalsTooltipIconPo().isPresent()
+        ).toBe(false);
       });
 
       it("should ignore tokens with unknown balance in USD and display tooltip", async () => {

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -1,5 +1,6 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { NoNeuronsCardPo } from "./NoNeuronsCard.page-object";
+import { UsdValueBannerPo } from "./UsdValueBanner.page-object";
 import { BasePageObject } from "./base.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
@@ -19,5 +20,9 @@ export class PortfolioPagePo extends BasePageObject {
 
   getNoNeuronsCarPo(): NoNeuronsCardPo {
     return NoNeuronsCardPo.under(this.root);
+  }
+
+  getUsdValueBannerPo(): UsdValueBannerPo {
+    return UsdValueBannerPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation
The `Portfolio` page features a card displaying the total assets owned by the user. In this initial iteration, we only showcase the Tokens. A follow-up PR will introduce the concept of Neurons. A final PR will provide both Tokens and Neurons from the `Portfolio` route to the page.

Design discrepancies:
- The `UsdValueBanner` is used to display the assets. We will re-evaluate this with the design team in a later iteration.
  - Missing title
  - Icon slot should not be displayed
  - Icp Conversion Rate should not be displayed
  - Spacing, font size and card styles are different

Design reference:
<img width="754" alt="Screenshot 2025-01-09 at 06 33 08" src="https://github.com/user-attachments/assets/6216b316-2263-409c-b857-54169838e99b" />

Implementation:
<img width="1252" alt="Screenshot 2025-01-09 at 06 31 15" src="https://github.com/user-attachments/assets/4c83b50b-747e-4976-a375-e00a716f3b8e" />

<img width="1251" alt="Screenshot 2025-01-09 at 06 31 57" src="https://github.com/user-attachments/assets/c8833425-a797-4497-b9e0-87fbed23bf04" />

# Changes

- Adds `UsdValueBanner` to display total assets.  
- Exposes `totalTokensBalanceInUsd` prop from the `Portfolio` page to manage tokens.  
- Adds logic to display `NoTokensCard` when the token asset balance is 0.  

# Tests

- Unit test to verify the presence of `NoTokensCard` based on the total token balance.  
- Unit test to ensure that `UsdValueBanner` displays the correct value based on the token balance.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary