### PR TITLE
Update update-sns-aggregator-response.yml

### DIFF
--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -24,7 +24,7 @@ jobs:
         run: scripts/nns-dapp/replace-sns-aggregator-response.sh
       - name: Read Node.js version from .nvmrc
         id: node-version
-        run: echo "NODE_VERSION=$(cat frontend/.nvmrc)" >> $GITHUB_ENV      
+        run: echo "NODE_VERSION=$(cat frontend/.nvmrc)" >> $GITHUB_ENV
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -60,9 +60,8 @@ jobs:
       - name: Notify Slack on failure
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.
-        # uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
+        uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
         if: ${{ failure() }}
-        run: echo "🤦‍♂️ SNS aggregator response update failed"
-        #with:
-          #WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          #MESSAGE: "SNS aggregator response update failed"
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "SNS aggregator response update failed"

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Notify Slack on failure
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.
-        uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
+        # uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
         if: ${{ failure() }}
         run: echo "🤦‍♂️ SNS aggregator response update failed"
         #with:

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -22,6 +22,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update the SNS aggregator response files
         run: scripts/nns-dapp/replace-sns-aggregator-response.sh
+      - name: Read Node.js version from .nvmrc
+        id: node-version
+        run: echo "NODE_VERSION=$(cat frontend/.nvmrc)" >> $GITHUB_ENV      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Format the updated files
         run: scripts/fmt-frontend
       - name: Create Pull Request

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -62,6 +62,7 @@ jobs:
         # PR status. To notify the team, we send a message to our Slack channel on failure.
         uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
         if: ${{ failure() }}
-        with:
-          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "SNS aggregator response update failed"
+        run: echo "🤦‍♂️ SNS aggregator response update failed"
+        #with:
+          #WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          #MESSAGE: "SNS aggregator response update failed"


### PR DESCRIPTION
# Motivation

The action “Update the SNS aggregator response for ProdLaunchpad.spec” fails (https://github.com/dfinity/nns-dapp/actions/runs/12687417665) due to an incompatible Node.js version, presumably provided by `ubuntu-latest` (v20.18.1). To resolve the issue, we set up Node.js with the version specified in the `.nvmrc` file.

# Changes

- Setup node with the `.nvmrc` file version.

# Tests

- Ran the action using the branch version: https://github.com/dfinity/nns-dapp/actions/runs/12687681982.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.