### PR TITLE
Recover from interrupted canister creation in frontend

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 - Allow `dfinity:` token prefix in QR code for ICP payment.
+- Recover from interrupted canister creation in the frontend.
 
 #### Deprecated
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import IC_LOGO from "$lib/assets/icp.svg";
+  import type { CanisterDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import HardwareWalletListNeuronsButton from "$lib/components/accounts/HardwareWalletListNeuronsButton.svelte";
   import HardwareWalletShowActionButton from "$lib/components/accounts/HardwareWalletShowActionButton.svelte";
   import LedgerNeuronHotkeyWarning from "$lib/components/accounts/LedgerNeuronHotkeyWarning.svelte";
@@ -28,6 +29,7 @@
   import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
   import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
   import WalletModals from "$lib/modals/accounts/WalletModals.svelte";
+  import { notifyAndAttachCanisterIfNeeded } from "$lib/services/canisters.services";
   import {
     cancelPollAccounts,
     loadBalance,
@@ -42,6 +44,7 @@
     listNeurons,
   } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
+  import { canistersStore } from "$lib/stores/canisters.store";
   import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
@@ -156,6 +159,35 @@
     account: $selectedAccountStore.account,
     transactionsStore: $icpTransactionsStore,
     neuronAccounts: $neuronAccountsStore,
+  });
+
+  const tryNotifyAndAttachCanister = ({
+    account,
+    transactionsStore,
+    canisters,
+  }: {
+    account: Account | undefined;
+    transactionsStore: IcpTransactionsStoreData;
+    canisters: CanisterDetails[] | undefined;
+  }) => {
+    if (
+      isNullish(canisters) ||
+      isNullish(account) ||
+      isNullish(transactionsStore[account.identifier])
+    ) {
+      return;
+    }
+    const transactions = transactionsStore[account.identifier].transactions;
+    notifyAndAttachCanisterIfNeeded({
+      transactions,
+      canisters,
+    });
+  };
+
+  $: tryNotifyAndAttachCanister({
+    account: $selectedAccountStore.account,
+    transactionsStore: $icpTransactionsStore,
+    canisters: $canistersStore?.canisters,
   });
 
   let uiTransactions: UiTransaction[] | undefined;


### PR DESCRIPTION
# Motivation

Currently, the NNS dapp backend canister monitors every transaction on the ICP ledger in order to catch canister creation funding transactions for which the notify+attach process might have been interrupted.
We want to remove this logic from the backend and perform it in the frontend in order to simplify the responsibilities of the backend canister.

In this PR we check if loaded transactions contain any canister creation funding transactions for which there is no corresponding canister.
This is done if the user visits the wallet page after visiting the canisters page.
Since it should be rare for canister creation to be interrupted, we assume that when it happens, a user will look around for their canister and eventually trigger the recovery process.

# Changes

1. In `NnsWallet`, if the canisters are loaded, check if we need to notify for interrupted canister creation.

# Tests

1. Unit tests added.
2. Tested manually with a backend canister where the fallback process is disabled.
3. Tested manually with a backend canister that still has the fallback process as well to make sure this doesn't break anything until it's remove from the backend.

# Todos

- [x] Add entry to changelog (if necessary).
