### PR TITLE
chore(ci): add rust-toolchain configuration to BOT_APPROVED_FILES

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -8,3 +8,4 @@ frontend/package-lock.json
 frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json
 rs/proposals/src/canisters/*/api.rs
 rs/sns_aggregator/src/types/*.rs
+rust-toolchain.toml


### PR DESCRIPTION
# Motivation

#6041 defined a list of approved bot files. #6134 is failing because `root-toolchain.toml` is not allowed.

Handles: #6134

# Changes

Adds `rust-toolchain.toml` to `.github/repo_policies/BOT_APPROVED_FILES`.

# Tests

- Once merged, it should be possible to rebase #6134 and merge

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary