### PR TITLE
fix(build): Bad HTML filtering regexp

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -110,7 +110,7 @@ const injectLinkPreloader = (indexHtml) => {
 const extractStartScript = (htmlFile) => {
   const indexHtml = readFileSync(htmlFile, "utf-8");
 
-  const svelteKitStartScript = /(<script>)([\s\S]*?)(<\/script>)/gm;
+  const svelteKitStartScript = /(<script>)([\s\S]*?)(<\/script>)/gim;
 
   // 1. extract SvelteKit start script to a separate main.js file
   const [_script, _scriptStartTag, content, _scriptEndTag] =


### PR DESCRIPTION
# Motivation

Based on suggestion https://github.com/dfinity/oisy-wallet/pull/4165#pullrequestreview-2541785546 :

`const svelteKitStartScript = /(<script>)([\s\S]*?)(<\/script>)/gm;`

This regular expression does not match upper case <SCRIPT> tags.

# Description

It is possible to match some single HTML tags using regular expressions (parsing general HTML using regular expressions is impossible). However, if the regular expression is not written well it might be possible to circumvent it, which can lead to cross-site scripting or other security issues.

Some of these mistakes are caused by browsers having very forgiving HTML parsers, and will often render invalid HTML containing syntax errors. Regular expressions that attempt to match HTML should also recognize tags containing such syntax errors.

# Fix

To fix the problem, we need to modify the regular expression to be case-insensitive. This can be achieved by adding the `i` flag to the regular expression. This change ensures that the regular expression will match `<script>`, `<SCRIPT>`, `<Script>`, and other case variations.

The best way to fix the problem without changing existing functionality is to update the regular expression on line 97 to include the `i` flag. This change will ensure that the regular expression matches script tags regardless of their case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
