### PR TITLE
feat(portfolio): implement token data loading in route

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -10,7 +10,7 @@
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
 
-  export let userTokensData: UserToken[] = [];
+  export let userTokensData: UserToken[];
   export let tableProjects: TableProject[] = [];
 
   let totalTokensBalanceInUsd: number;

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -12,13 +12,9 @@
     resetBalanceLoading,
   } from "$lib/services/accounts-balances.services";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
-  import type { UserToken } from "$lib/types/tokens-page";
 
   resetBalanceLoading();
   loadIcpSwapTickers();
-
-  let userTokensData: UserToken[] = [];
-  $: userTokensData = $tokensListUserStore;
 
   $: if ($authSignedInStore) {
     const ckBTCUniverseIds = $ckBTCUniversesStore.map(
@@ -41,5 +37,5 @@
 </script>
 
 <TestIdWrapper testId="portfolio-route-component"
-  ><Portfolio {userTokensData} /></TestIdWrapper
+  ><Portfolio userTokensData={$tokensListUserStore} /></TestIdWrapper
 >

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -1,6 +1,42 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
+  import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
+  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
+  import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
   import Portfolio from "$lib/pages/Portfolio.svelte";
+  import {
+    loadAccountsBalances,
+    loadSnsAccountsBalances,
+    resetBalanceLoading,
+  } from "$lib/services/accounts-balances.services";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import type { UserToken } from "$lib/types/tokens-page";
+
+  let userTokensData: UserToken[] = [];
+
+  resetBalanceLoading();
+  loadIcpSwapTickers();
+
+  $: if ($authSignedInStore) {
+    const ckBTCUniverseIds = $ckBTCUniversesStore.map(
+      (universe) => universe.canisterId
+    );
+    loadAccountsBalances(ckBTCUniverseIds);
+
+    const icrcUniverseIds = Object.keys($icrcCanistersStore);
+    loadAccountsBalances(icrcUniverseIds);
+
+    const snsRootCanisterIds = $snsProjectsCommittedStore.map(
+      ({ rootCanisterId }) => rootCanisterId
+    );
+    loadSnsAccountsBalances(snsRootCanisterIds);
+
+    userTokensData = $tokensListUserStore;
+  }
 </script>
 
-<TestIdWrapper testId="portfolio-route-component"><Portfolio /></TestIdWrapper>
+<TestIdWrapper testId="portfolio-route-component"
+  ><Portfolio {userTokensData} /></TestIdWrapper
+>

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -14,26 +14,29 @@
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
   import type { UserToken } from "$lib/types/tokens-page";
 
-  let userTokensData: UserToken[] = [];
-
   resetBalanceLoading();
   loadIcpSwapTickers();
+
+  let userTokensData: UserToken[] = [];
+  $: userTokensData = $tokensListUserStore;
 
   $: if ($authSignedInStore) {
     const ckBTCUniverseIds = $ckBTCUniversesStore.map(
       (universe) => universe.canisterId
     );
     loadAccountsBalances(ckBTCUniverseIds);
+  }
 
+  $: if ($authSignedInStore) {
     const icrcUniverseIds = Object.keys($icrcCanistersStore);
     loadAccountsBalances(icrcUniverseIds);
+  }
 
+  $: if ($authSignedInStore) {
     const snsRootCanisterIds = $snsProjectsCommittedStore.map(
       ({ rootCanisterId }) => rootCanisterId
     );
     loadSnsAccountsBalances(snsRootCanisterIds);
-
-    userTokensData = $tokensListUserStore;
   }
 </script>
 

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -13,12 +13,10 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("Portfolio page", () => {
-  const renderPage = (
-    {
-      userTokensData = [],
-      tableProjects,
-    }: { userTokensData?: UserToken[]; tableProjects?: TableProject[] } = { }
-  ) => {
+  const renderPage = ({
+    userTokensData = [],
+    tableProjects,
+  }: { userTokensData?: UserToken[]; tableProjects?: TableProject[] } = {}) => {
     const { container } = render(Portfolio, {
       props: {
         userTokensData,

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -15,12 +15,9 @@ import { render } from "@testing-library/svelte";
 describe("Portfolio page", () => {
   const renderPage = (
     {
-      userTokensData,
+      userTokensData = [],
       tableProjects,
-    }: { userTokensData?: UserToken[]; tableProjects?: TableProject[] } = {
-      userTokensData: [],
-      tableProjects: [],
-    }
+    }: { userTokensData?: UserToken[]; tableProjects?: TableProject[] } = { }
   ) => {
     const { container } = render(Portfolio, {
       props: {

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -1,7 +1,7 @@
-import { NoNeuronsCardPo } from "$tests/page-objects/NoNeuronsCard.page-object";
-import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NoNeuronsCardPo } from "./NoNeuronsCard.page-object";
+import { UsdValueBannerPo } from "./UsdValueBanner.page-object";
+import { BasePageObject } from "./base.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
   private static readonly TID = "portfolio-page-component";

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -1,7 +1,7 @@
+import { NoNeuronsCardPo } from "$tests/page-objects/NoNeuronsCard.page-object";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NoNeuronsCardPo } from "./NoNeuronsCard.page-object";
-import { UsdValueBannerPo } from "./UsdValueBanner.page-object";
-import { BasePageObject } from "./base.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
   private static readonly TID = "portfolio-page-component";

--- a/frontend/src/tests/page-objects/PortfolioRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioRoute.page-object.ts
@@ -1,0 +1,15 @@
+import { PortfolioPagePo } from "$tests/page-objects/PortfolioPage.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class PortfolioRoutePo extends BasePageObject {
+  private static readonly TID = "portfolio-route-component";
+
+  static under(element: PageObjectElement): PortfolioRoutePo {
+    return new PortfolioRoutePo(element.byTestId(PortfolioRoutePo.TID));
+  }
+
+  getPortfolioPagePo(): PortfolioPagePo {
+    return PortfolioPagePo.under(this.root);
+  }
+}

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -41,10 +41,6 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/api/sns-ledger.api");
-vi.mock("$lib/api/icrc-ledger.api");
-vi.mock("$lib/api/ckbtc-minter.api");
-
 describe("Portfolio route", () => {
   const renderPage = async () => {
     const { container } = render(PortfolioRoute);
@@ -77,8 +73,8 @@ describe("Portfolio route", () => {
 
   describe("when logged in", () => {
     const icpBalanceE8s = 100n * 100_000_000n; // 100ICP -> $1000
-    const ckBTCBalanceE8s = 1n * 100_000_000_000_000_000n; // 1BTC -> $100_000
-    const ckETHBalanceUlps = 1n * 100_000_000_000_000_000_000_000n; // 1ETH -> $1000
+    const ckBTCBalanceE8s = 1n * 100_000_000n; // 1BTC -> $100_000
+    const ckETHBalanceUlps = 1n * 100_000_000_000_000_000n; // 1ETH -> $1000
     const ckUSDCBalanceE8s = 1n * 1_000_000n; // 1USDC -> $1
     const tetrisBalanceE8s = 2n * 10_000_000n; // 2Tetris -> $2
     const importedToken1BalanceE8s = 100n * 100_000n; // 100ZTOKEN1 -> $100
@@ -253,17 +249,17 @@ describe("Portfolio route", () => {
         {
           ...mockIcpSwapTicker,
           base_id: CKBTC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "100000.00",
+          last_price: "0.0001",
         },
         {
           ...mockIcpSwapTicker,
           base_id: CKTESTBTC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "100000.00",
+          last_price: "0.0001",
         },
         {
           ...mockIcpSwapTicker,
           base_id: CKETH_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "1000.00",
+          last_price: "0.001",
         },
         {
           ...mockIcpSwapTicker,

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -72,12 +72,12 @@ describe("Portfolio route", () => {
   });
 
   describe("when logged in", () => {
-    const icpBalanceE8s = 100n * 100_000_000n; // 100ICP -> $1000
-    const ckBTCBalanceE8s = 1n * 100_000_000n; // 1BTC -> $100_000
-    const ckETHBalanceUlps = 1n * 100_000_000_000_000_000n; // 1ETH -> $1000
-    const ckUSDCBalanceE8s = 1n * 1_000_000n; // 1USDC -> $1
-    const tetrisBalanceE8s = 2n * 10_000_000n; // 2Tetris -> $2
-    const importedToken1BalanceE8s = 100n * 100_000n; // 100ZTOKEN1 -> $100
+    const icpBalanceE8s = 100n * 100_000_000n; // 100ICP(1ICP==10$) -> $1000
+    const ckBTCBalanceE8s = 1n * 100_000_000n; // 1BTC(1BTC==10_000ICP) -> $100_000
+    const ckETHBalanceUlps = 1n * 100_000_000_000_000_000n; // 1ETH(1ETH=100ICP) -> $1000
+    const tetrisBalanceE8s = 2n * 100_000_000n; // 2Tetris(1Tetris==1ICP) -> $20
+    const importedToken1BalanceE6s = 100n * 1_000_000n; // 100ZTOKEN1(1ZTOKEN1==1ICP) -> $1000
+    const ckUSDCBalanceE6s = 1n * 1_000_000n; // 1USDC -> $1
 
     const importedToken1Id = Principal.fromText(
       "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
@@ -97,7 +97,7 @@ describe("Portfolio route", () => {
       rootCanisterId: rootCanisterIdMock,
       ledgerCanisterId: principal(2),
       projectName: "Tetris",
-      tokenMetadata: mockSnsToken,
+      tokenMetadata: { ...mockSnsToken, decimals: 8 },
       lifecycle: SnsSwapLifecycle.Committed,
     };
 
@@ -123,9 +123,9 @@ describe("Portfolio route", () => {
             [CKBTC_UNIVERSE_CANISTER_ID.toText()]: ckBTCBalanceE8s,
             [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: ckBTCBalanceE8s,
             [CKETH_UNIVERSE_CANISTER_ID.toText()]: ckETHBalanceUlps,
-            [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: ckUSDCBalanceE8s,
+            [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: ckUSDCBalanceE6s,
             [tetrisSNS.ledgerCanisterId.toText()]: tetrisBalanceE8s,
-            [importedToken1Id.toText()]: importedToken1BalanceE8s,
+            [importedToken1Id.toText()]: importedToken1BalanceE6s,
           };
 
           return balancesMap[canisterId.toText()];
@@ -286,16 +286,17 @@ describe("Portfolio route", () => {
       // 100ICP -> $1000
       // 1ETH -> $1000
       // 1USDC -> $1
-      // 100ZTOKEN1 -> $100
-      // 2Tetris -> $2
-      // Total: $202’103.00
+      // 100ZTOKEN1 -> $1000
+      // 2Tetris -> $20
+      // --------------------
+      // Total: $203’021.00
       expect(
         await portfolioPagePo.getUsdValueBannerPo().getPrimaryAmount()
-      ).toBe("$202’103.00");
+      ).toBe("$203’021.00");
       // $1 -> 0.1ICP
       expect(
         await portfolioPagePo.getUsdValueBannerPo().getSecondaryAmount()
-      ).toBe("20’210.30 ICP");
+      ).toBe("20’302.10 ICP");
     });
   });
 });

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -1,0 +1,305 @@
+import * as icpSwapApi from "$lib/api/icp-swap.api";
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+
+import * as importedTokensApi from "$lib/api/imported-tokens.api";
+import {
+  CKBTC_UNIVERSE_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import {
+  CKUSDC_INDEX_CANISTER_ID,
+  CKUSDC_LEDGER_CANISTER_ID,
+  CKUSDC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckusdc-canister-ids.constants";
+import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import type { ImportedTokenData } from "$lib/types/imported-tokens";
+import PortfolioRoute from "$routes/(app)/(nns)/portfolio/+page.svelte";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import {
+  mockCkBTCToken,
+  mockCkTESTBTCToken,
+} from "$tests/mocks/ckbtc-accounts.mock";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
+import { PortfolioRoutePo } from "$tests/page-objects/PortfolioRoute.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
+import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { Principal } from "@dfinity/principal";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+vi.mock("$lib/api/sns-ledger.api");
+vi.mock("$lib/api/icrc-ledger.api");
+vi.mock("$lib/api/ckbtc-minter.api");
+
+describe("Portfolio route", () => {
+  const renderPage = async () => {
+    const { container } = render(PortfolioRoute);
+    await runResolvedPromises();
+
+    return PortfolioRoutePo.under(new JestPageObjectElement(container));
+  };
+
+  const tickers = [
+    {
+      ...mockIcpSwapTicker,
+      base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+      last_price: "10.00",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue(tickers);
+  });
+
+  it("should load ICP Swap tickers", async () => {
+    expect(get(icpSwapTickersStore)).toBeUndefined();
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(0);
+
+    await renderPage();
+
+    expect(get(icpSwapTickersStore)).toEqual(tickers);
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
+  });
+
+  describe("when logged in", () => {
+    const icpBalanceE8s = 100n * 100_000_000n; // 100ICP -> $1000
+    const ckBTCBalanceE8s = 1n * 100_000_000_000_000_000n; // 1BTC -> $100_000
+    const ckETHBalanceUlps = 1n * 100_000_000_000_000_000_000_000n; // 1ETH -> $1000
+    const ckUSDCBalanceE8s = 1n * 1_000_000n; // 1USDC -> $1
+    const tetrisBalanceE8s = 2n * 10_000_000n; // 2Tetris -> $2
+    const importedToken1BalanceE8s = 100n * 100_000n; // 100ZTOKEN1 -> $100
+
+    const importedToken1Id = Principal.fromText(
+      "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+    );
+    const importedToken1Metadata = {
+      name: "ZTOKEN1",
+      symbol: "ZTOKEN1",
+      fee: 4_000n,
+      decimals: 6,
+    } as IcrcTokenMetadata;
+    const importedToken1Data: ImportedTokenData = {
+      ledgerCanisterId: importedToken1Id,
+      indexCanisterId: principal(111),
+    };
+
+    const tetrisSNS = {
+      rootCanisterId: rootCanisterIdMock,
+      ledgerCanisterId: principal(2),
+      projectName: "Tetris",
+      tokenMetadata: mockSnsToken,
+      lifecycle: SnsSwapLifecycle.Committed,
+    };
+
+    beforeEach(() => {
+      resetIdentity();
+
+      vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockImplementation(
+        async ({ canisterId }) => {
+          const tokenMap = {
+            [CKBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkBTCToken,
+            [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkTESTBTCToken,
+            [CKETH_UNIVERSE_CANISTER_ID.toText()]: mockCkETHToken,
+            [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: mockCkUSDCToken,
+            [importedToken1Id.toText()]: importedToken1Metadata,
+          };
+          return tokenMap[canisterId.toText()];
+        }
+      );
+
+      vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockImplementation(
+        async ({ canisterId }) => {
+          const balancesMap = {
+            [CKBTC_UNIVERSE_CANISTER_ID.toText()]: ckBTCBalanceE8s,
+            [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: ckBTCBalanceE8s,
+            [CKETH_UNIVERSE_CANISTER_ID.toText()]: ckETHBalanceUlps,
+            [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: ckUSDCBalanceE8s,
+            [tetrisSNS.ledgerCanisterId.toText()]: tetrisBalanceE8s,
+            [importedToken1Id.toText()]: importedToken1BalanceE8s,
+          };
+
+          return balancesMap[canisterId.toText()];
+        }
+      );
+
+      setCkETHCanisters();
+      // TODO: Copy setCkETHCanisters aproach to set the canisters for CKUSDC
+      defaultIcrcCanistersStore.setCanisters({
+        ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
+        indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
+      });
+      tokensStore.setToken({
+        canisterId: CKUSDC_UNIVERSE_CANISTER_ID,
+        token: mockCkUSDCToken,
+      });
+
+      setSnsProjects([tetrisSNS]);
+
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [
+          {
+            ledger_canister_id: importedToken1Id,
+            index_canister_id: [],
+          },
+        ],
+      });
+
+      tokensStore.setToken({
+        canisterId: importedToken1Id,
+        token: importedToken1Metadata,
+      });
+      importedTokensStore.set({
+        importedTokens: [importedToken1Data],
+        certified: true,
+      });
+    });
+
+    it("should get ckBtc tokens", async () => {
+      const identity = mockIdentity;
+
+      expect(icrcLedgerApi.queryIcrcToken).toBeCalledTimes(0);
+
+      await renderPage();
+
+      expect(icrcLedgerApi.queryIcrcToken).toBeCalledTimes(2);
+      expect(icrcLedgerApi.queryIcrcToken).toHaveBeenNthCalledWith(1, {
+        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        certified: false,
+        identity,
+      });
+
+      expect(icrcLedgerApi.queryIcrcToken).toHaveBeenNthCalledWith(2, {
+        canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+        certified: false,
+        identity,
+      });
+    });
+
+    it("should load all accounts balances for both ckBTC and icrc(ckETH, ckUSDC, Tetris(SNS token))", async () => {
+      const identity = mockIdentity;
+      const account = {
+        owner: identity.getPrincipal(),
+      };
+
+      expect(icrcLedgerApi.queryIcrcBalance).toBeCalledTimes(0);
+
+      await renderPage();
+
+      // Should be called 5 times total (2 ckBTC + 2 ICRC + 1 ImportedToken + 1 SNS)
+      expect(icrcLedgerApi.queryIcrcBalance).toBeCalledTimes(6);
+
+      expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenNthCalledWith(1, {
+        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        certified: false,
+        identity,
+        account,
+      });
+
+      expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenNthCalledWith(2, {
+        canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+        certified: false,
+        identity,
+        account,
+      });
+
+      expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenNthCalledWith(3, {
+        canisterId: CKETH_UNIVERSE_CANISTER_ID,
+        certified: false,
+        identity,
+        account,
+      });
+
+      expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenNthCalledWith(4, {
+        canisterId: CKUSDC_UNIVERSE_CANISTER_ID,
+        certified: false,
+        identity,
+        account,
+      });
+
+      expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenNthCalledWith(5, {
+        canisterId: importedToken1Id,
+        certified: false,
+        identity,
+        account,
+      });
+
+      expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenNthCalledWith(6, {
+        canisterId: tetrisSNS.ledgerCanisterId,
+        certified: false,
+        identity,
+        account,
+      });
+    });
+
+    it("should render the Portfolio page with the provided data", async () => {
+      setAccountsForTesting({
+        main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
+      });
+      icpSwapTickersStore.set([
+        {
+          ...mockIcpSwapTicker,
+          base_id: CKBTC_UNIVERSE_CANISTER_ID.toText(),
+          last_price: "100000.00",
+        },
+        {
+          ...mockIcpSwapTicker,
+          base_id: CKTESTBTC_UNIVERSE_CANISTER_ID.toText(),
+          last_price: "100000.00",
+        },
+        {
+          ...mockIcpSwapTicker,
+          base_id: CKETH_UNIVERSE_CANISTER_ID.toText(),
+          last_price: "1000.00",
+        },
+        {
+          ...mockIcpSwapTicker,
+          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+          last_price: "10.00",
+        },
+        {
+          ...mockIcpSwapTicker,
+          base_id: importedToken1Id.toText(),
+          last_price: "1.00",
+        },
+        {
+          ...mockIcpSwapTicker,
+          base_id: tetrisSNS.ledgerCanisterId.toText(),
+          last_price: "1.00",
+        },
+      ]);
+
+      const po = await renderPage();
+      const portfolioPagePo = po.getPortfolioPagePo();
+
+      // 1BTC -> $100_000
+      // 1BTCTest -> $100_000
+      // 100ICP -> $1000
+      // 1ETH -> $1000
+      // 1USDC -> $1
+      // 100ZTOKEN1 -> $100
+      // 2Tetris -> $2
+      // Total: $202’103.00
+      expect(
+        await portfolioPagePo.getUsdValueBannerPo().getPrimaryAmount()
+      ).toBe("$202’103.00");
+      // $1 -> 0.1ICP
+      expect(
+        await portfolioPagePo.getUsdValueBannerPo().getSecondaryAmount()
+      ).toBe("20’210.30 ICP");
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

The `Portfolio` route needs to load the balances for NNS, ICRC, ckBTC, and SNS. This information, along with the projects, is passed down to the `Portfolio` page, which displays it in various cards. Since we will show their value in USD, we also need to load information from `IcpSwap`.

This first PR loads all the tokens. A subsequent PR will handle the Projects.

[NNS1-3520](https://dfinity.atlassian.net/browse/NNS1-3520)

Note: UX/UI improvements will be done later. Eg: loading states, padding, typography, ...

# Changes

- Resets the `resetBalanceLoading` set upon navigation to request accounts only once per page.
- Loads  ICRC, ckBTC, and SNS accounts
- Loads IcpSwapTickers

# Tests

- Unit tests to verify that all data is fetched.  
- Unit test to render the Portfolio page with the correct total assets value with the provided tokens.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necesary

[NNS1-3520]: https://dfinity.atlassian.net/browse/NNS1-3520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ