### PR TITLE
Add CustomEventForTesting for proper event comparison

### DIFF
--- a/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
@@ -74,7 +74,7 @@ describe("CanisterHeadingTitle", () => {
     await po.clickUnlink();
     expect(eventListener).toHaveBeenCalledTimes(1);
     const $event = new CustomEvent("nnsCanisterDetailModal", {
-      detail: { type: "unlink", canisterId },
+      detail: { type: "unlink", data: { canisterId } },
       bubbles: true,
     });
     expect(eventListener).toHaveBeenCalledWith($event);

--- a/frontend/src/tests/utils/actions.test-utils.ts
+++ b/frontend/src/tests/utils/actions.test-utils.ts
@@ -6,5 +6,5 @@ export const createActionEvent = ({ type, data }: Action) =>
       type,
       data,
     },
-    bubbles: true,
+    bubbles: false,
   });

--- a/frontend/src/tests/utils/custom-event.test-utils.spec.ts
+++ b/frontend/src/tests/utils/custom-event.test-utils.spec.ts
@@ -9,12 +9,21 @@ describe("custom-event", () => {
       expect(event1).not.toEqual(event2);
     });
 
+    it("should consider events with different bubbles to be different", () => {
+      // This test relies on CustomEvent being overridden with
+      // CustomEventForTesting in vitest.setup.ts.
+      const event1 = new CustomEvent("test", { detail: "1", bubbles: true });
+      const event2 = new CustomEvent("test", { detail: "1", bubbles: false });
+
+      expect(event1).not.toEqual(event2);
+    });
+
     it("demonstrates the issue with standard CustomEvent", () => {
       // Restores the original CustomEvent type.
       vi.unstubAllGlobals();
 
-      const event1 = new CustomEvent("test", { detail: "1" });
-      const event2 = new CustomEvent("test", { detail: "2" });
+      const event1 = new CustomEvent("test", { detail: "1", bubbles: true });
+      const event2 = new CustomEvent("test", { detail: "2", bubbles: false });
 
       // The events are different but appear to be the same.
       expect(event1).toEqual(event2);

--- a/frontend/src/tests/utils/custom-event.test-utils.spec.ts
+++ b/frontend/src/tests/utils/custom-event.test-utils.spec.ts
@@ -1,0 +1,23 @@
+describe("custom-event", () => {
+  describe("CustomEventForTesting", () => {
+    it("should consider events with different detail to be different", () => {
+      // This test relies on CustomEvent being overridden with
+      // CustomEventForTesting in vitest.setup.ts.
+      const event1 = new CustomEvent("test", { detail: "1" });
+      const event2 = new CustomEvent("test", { detail: "2" });
+
+      expect(event1).not.toEqual(event2);
+    });
+
+    it("demonstrates the issue with standard CustomEvent", () => {
+      // Restores the original CustomEvent type.
+      vi.unstubAllGlobals();
+
+      const event1 = new CustomEvent("test", { detail: "1" });
+      const event2 = new CustomEvent("test", { detail: "2" });
+
+      // The events are different but appear to be the same.
+      expect(event1).toEqual(event2);
+    });
+  });
+});

--- a/frontend/src/tests/utils/custom-event.test-utils.ts
+++ b/frontend/src/tests/utils/custom-event.test-utils.ts
@@ -5,10 +5,12 @@
 export class CustomEventForTesting<T> extends CustomEvent<T> {
   public readonly type: string;
   public readonly detail: T;
+  public readonly bubbles: boolean | undefined;
 
   constructor(type: string, options?: CustomEventInit<T>) {
     super(type, options);
     this.type = type;
     this.detail = options?.detail;
+    this.bubbles = options?.bubbles;
   }
 }

--- a/frontend/src/tests/utils/custom-event.test-utils.ts
+++ b/frontend/src/tests/utils/custom-event.test-utils.ts
@@ -1,0 +1,14 @@
+// CustomEvent.detail is a getter rather than a property.
+// Because of this, it's not taken into account when vi.expect() checks if two
+// events are equal. By overriding CustomEvent with this class, we make sure
+// that events are properly compared.
+export class CustomEventForTesting<T> extends CustomEvent<T> {
+  public readonly type: string;
+  public readonly detail: T;
+
+  constructor(type: string, options?: CustomEventInit<T>) {
+    super(type, options);
+    this.type = type;
+    this.detail = options?.detail;
+  }
+}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -15,6 +15,7 @@ import {
 import { navigating, page } from "./__mocks__/$app/stores";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
 import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
+import { CustomEventForTesting } from "./src/tests/utils/custom-event.test-utils";
 import {
   mockedConstants,
   setDefaultTestConstants,
@@ -31,6 +32,8 @@ beforeEach(() => {
 
   // Resets/restores any global objects(eg. window, document, Date, ) that were stubbed/mocked during testing
   vi.unstubAllGlobals();
+
+  vi.stubGlobal("CustomEvent", CustomEventForTesting);
 });
 
 const cleanupFunctions = vi.hoisted(() => {


### PR DESCRIPTION
# Motivation

`CustomEvent.detail` and `CustomEvent.bubbles` are getters rather than properties.
Because of this, they are not taken into account when comparing events in unit tests.
Concretely, this means that, for example, if we change `Send` to `Receive` in [this test](https://github.com/dfinity/nns-dapp/blob/2898582db3a21587755960ee7da580a74a163587/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts#L334), the test doesn't fail.

# Changes

1. Create `CustomEventForTesting` which exposes `.detail` and `.bubbles` as props.
2. Stub `CustomEvent` with `CustomEventForTesting` in `vitest.setup.ts`.

# Tests

1. Added a unit test that demonstrates the bad behavior of `CustomEvent`.
2. Added a unit test that shows that the problem no longer appears unless we `vi.unstubAllGlobals();`
3. Verified that without my change `TokensTable.spec.ts` does not fail if `ActionType.Send` is replaced with `ActionType.Receive` and with my change it does.
4. Fixed `CanisterPageHeading.spec.ts` which as a result was discovered to be broken all along.
5. Make the test event created in `frontend/src/tests/utils/actions.test-utils.ts` match what we actually see in the test.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary