### PR TITLE
Clean up SelectUniverseList.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -11,11 +11,19 @@ import {
 } from "$tests/mocks/sns-projects.mock";
 import { SelectUniverseListPo } from "$tests/page-objects/SelectUniverseList.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { fireEvent, render } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseList", () => {
   const projects = [
-    mockSnsFullProject,
+    {
+      ...mockSnsFullProject,
+      summary: mockSnsFullProject.summary.override({
+        metadata: {
+          ...mockSnsFullProject.summary.metadata,
+          name: "project name",
+        },
+      }),
+    },
     {
       ...mockSnsFullProject,
       rootCanisterId: principal(1),
@@ -29,8 +37,11 @@ describe("SelectUniverseList", () => {
     },
   ];
 
-  const renderComponent = () => {
-    const { container } = render(SelectUniverseList);
+  const renderComponent = ({ onSelect }: { onSelect?: () => void } = {}) => {
+    const { container, component } = render(SelectUniverseList);
+    if (onSelect) {
+      component.$on("nnsSelectUniverse", onSelect);
+    }
     return SelectUniverseListPo.under(new JestPageObjectElement(container));
   };
 
@@ -45,48 +56,82 @@ describe("SelectUniverseList", () => {
     );
   });
 
-  it("should render universe cards", () => {
-    const { getAllByTestId } = render(SelectUniverseList);
-    // +1 for Internet Computer / NNS and +1 for ckBTC +1 for ckTESTBTC
-    expect(getAllByTestId("select-universe-card").length).toEqual(
-      projects.length + 3
-    );
+  it("should render universe cards", async () => {
+    const po = renderComponent();
+
+    const cards = await po.getSelectUniverseCardPos();
+    const names = await Promise.all(cards.map((card) => card.getName()));
+
+    expect(names).toEqual([
+      "Internet Computer",
+      "another name",
+      "ckBTC",
+      "ckTESTBTC",
+      "project name",
+    ]);
   });
 
-  it("should render project selected", () => {
-    const { container } = render(SelectUniverseList);
-    const card = container.querySelector(".selected");
-    expect(card?.textContent.trim() ?? "").toEqual(
-      projects[0].summary.metadata.name
-    );
-    expect(card?.textContent.trim() ?? "").not.toEqual(
-      projects[1].summary.metadata.name
-    );
+  it("should render project selected", async () => {
+    const po = renderComponent();
+
+    const cards = await po.getSelectUniverseCardPos();
+
+    // The last card ("project name") is selected based on the current page set
+    // in beforeEach.
+    expect(await Promise.all(cards.map((card) => card.isSelected()))).toEqual([
+      false,
+      false,
+      false,
+      false,
+      true,
+    ]);
   });
 
   it("should trigger select project", async () => {
-    const { component, getAllByTestId } = render(SelectUniverseList);
-
     const onSelect = vi.fn();
-    component.$on("nnsSelectUniverse", onSelect);
+    const po = renderComponent({ onSelect });
 
-    const cards = getAllByTestId("select-universe-card");
-    cards && (await fireEvent.click(cards[0]));
+    const cards = await po.getSelectUniverseCardPos();
 
-    expect(onSelect).toHaveBeenCalled();
+    expect(onSelect).toBeCalledTimes(0);
+
+    await cards[0].click();
+
+    expect(onSelect).toBeCalledWith(
+      new CustomEvent("nnsSelectUniverse", {
+        detail: OWN_CANISTER_ID_TEXT,
+        bubbles: false,
+      })
+    );
+    expect(onSelect).toBeCalledTimes(1);
+
+    await cards[1].click();
+
+    expect(onSelect).toBeCalledWith(
+      new CustomEvent("nnsSelectUniverse", {
+        detail: principal(1).toText(),
+        bubbles: false,
+      })
+    );
+    expect(onSelect).toBeCalledTimes(2);
   });
 
-  it("should not render ckBTC universe cards if route not accounts", () => {
+  it("should not render ckBTC universe cards if route not accounts", async () => {
     page.mock({
       routeId: AppPath.Neurons,
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
 
-    const { getAllByTestId } = render(SelectUniverseList);
-    // +1 for Internet Computer / NNS
-    expect(getAllByTestId("select-universe-card").length).toEqual(
-      projects.length + 1
-    );
+    const po = renderComponent();
+
+    const cards = await po.getSelectUniverseCardPos();
+    const names = await Promise.all(cards.map((card) => card.getName()));
+
+    expect(names).toEqual([
+      "Internet Computer",
+      "another name",
+      "project name",
+    ]);
   });
 
   describe('"all actionable" card', () => {


### PR DESCRIPTION
# Motivation

Make the test easier to read and maintain.

Note: In practice we no longer use `SelectUniverseList` on pages other than Proposals but I don't intend to address that at the moment.

# Changes

1. Use page objects in all the tests.
2. Explicitly set the name of both projects instead of relying on `mockSnsFullProject` implicitly.
3. Expect specific card names instead of just expecting a certain number of cards.
4. Expect event content instead of just an event occurring when selecting a card.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary