### PR TITLE
chore(ci): fixes relative imports for src/tests files

### DIFF
--- a/frontend/src/tests/lib/components/accounts/AddAccountType.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddAccountType.spec.ts
@@ -1,11 +1,11 @@
 import AddAccountType from "$lib/components/accounts/AddAccountType.svelte";
 import type { AccountType } from "$lib/types/add-account.context";
+import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 import { addAccountStoreMock } from "$tests/mocks/add-account.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 
 describe("AddAccountType", () => {
   const props = { testComponent: AddAccountType };

--- a/frontend/src/tests/lib/components/accounts/AddAccountType.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddAccountType.spec.ts
@@ -5,7 +5,7 @@ import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import AddAccountTest from "./AddAccountTest.svelte";
+import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 
 describe("AddAccountType", () => {
   const props = { testComponent: AddAccountType };

--- a/frontend/src/tests/lib/components/accounts/BitcoinFeeDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinFeeDisplay.spec.ts
@@ -2,7 +2,7 @@ import BitcoinFeeDisplay from "$lib/components/accounts/BitcoinFeeDisplay.svelte
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
-import BitcoinFeeDisplayTest from "./BitcoinFeeDisplayTest.svelte";
+import BitcoinFeeDisplayTest from "$tests/lib/components/accounts/BitcoinFeeDisplayTest.svelte";
 
 describe("BitcoinFeeDisplay", () => {
   const testId = "bitcoin-estimated-fee-display";

--- a/frontend/src/tests/lib/components/accounts/BitcoinFeeDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinFeeDisplay.spec.ts
@@ -1,8 +1,8 @@
 import BitcoinFeeDisplay from "$lib/components/accounts/BitcoinFeeDisplay.svelte";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
+import BitcoinFeeDisplayTest from "$tests/lib/components/accounts/BitcoinFeeDisplayTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
-import BitcoinFeeDisplayTest from "$tests/lib/components/accounts/BitcoinFeeDisplayTest.svelte";
 
 describe("BitcoinFeeDisplay", () => {
   const testId = "bitcoin-estimated-fee-display";

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
@@ -5,6 +5,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { page } from "$mocks/$app/stores";
+import CkBTCWalletContextTest from "$tests/lib/components/accounts/CkBTCWalletContextTest.svelte";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockBTCAddressTestnet,
@@ -17,7 +18,6 @@ import {
 } from "$tests/mocks/tokens.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import CkBTCWalletContextTest from "$tests/lib/components/accounts/CkBTCWalletContextTest.svelte";
 
 vi.mock("$lib/api/ckbtc-minter.api");
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "$tests/mocks/tokens.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import CkBTCWalletContextTest from "./CkBTCWalletContextTest.svelte";
+import CkBTCWalletContextTest from "$tests/lib/components/accounts/CkBTCWalletContextTest.svelte";
 
 vi.mock("$lib/api/ckbtc-minter.api");
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletConnect.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletConnect.spec.ts
@@ -9,7 +9,7 @@ import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
-import AddAccountTest from "./AddAccountTest.svelte";
+import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletConnect.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletConnect.spec.ts
@@ -4,12 +4,12 @@ import {
   connectToHardwareWalletProxy,
   registerHardwareWalletProxy,
 } from "$lib/proxy/icp-ledger.services.proxy";
+import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 import { addAccountStoreMock } from "$tests/mocks/add-account.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
-import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
@@ -1,12 +1,12 @@
 import HardwareWalletListNeurons from "$lib/components/accounts/HardwareWalletListNeuronsButton.svelte";
 import { listNeuronsHardwareWalletProxy } from "$lib/proxy/icp-ledger.services.proxy";
+import WalletContextTest from "$tests/lib/components/accounts/WalletContextTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
-import WalletContextTest from "$tests/lib/components/accounts/WalletContextTest.svelte";
 
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
@@ -6,7 +6,7 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
-import WalletContextTest from "./WalletContextTest.svelte";
+import WalletContextTest from "$tests/lib/components/accounts/WalletContextTest.svelte";
 
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletName.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletName.spec.ts
@@ -1,10 +1,10 @@
 import HardwareWalletName from "$lib/components/accounts/HardwareWalletName.svelte";
+import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 import { addAccountStoreMock } from "$tests/mocks/add-account.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
-import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 
 describe("HardwareWalletName", () => {
   const props = { testComponent: HardwareWalletName };

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletName.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletName.spec.ts
@@ -4,7 +4,7 @@ import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
-import AddAccountTest from "./AddAccountTest.svelte";
+import AddAccountTest from "$tests/lib/components/accounts/AddAccountTest.svelte";
 
 describe("HardwareWalletName", () => {
   const props = { testComponent: HardwareWalletName };

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletNeuronAddHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletNeuronAddHotkeyButton.spec.ts
@@ -1,8 +1,8 @@
 import HardwareWalletNeuronAddHotkeyButton from "$lib/components/accounts/HardwareWalletNeuronAddHotkeyButton.svelte";
+import HardwareWalletAddNeuronHotkeyTest from "$tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
-import HardwareWalletAddNeuronHotkeyTest from "$tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte";
 
 describe("HardwareWalletNeuronAddHotkeyButton", () => {
   const props = { testComponent: HardwareWalletNeuronAddHotkeyButton };

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletNeuronAddHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletNeuronAddHotkeyButton.spec.ts
@@ -2,7 +2,7 @@ import HardwareWalletNeuronAddHotkeyButton from "$lib/components/accounts/Hardwa
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
-import HardwareWalletAddNeuronHotkeyTest from "./HardwareWalletAddNeuronHotkeyTest.svelte";
+import HardwareWalletAddNeuronHotkeyTest from "$tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte";
 
 describe("HardwareWalletNeuronAddHotkeyButton", () => {
   const props = { testComponent: HardwareWalletNeuronAddHotkeyButton };

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
@@ -1,11 +1,11 @@
 import HardwareWalletNeurons from "$lib/components/accounts/HardwareWalletNeurons.svelte";
 import { formatTokenE8s } from "$lib/utils/token.utils";
+import HardwareWalletNeuronsTest from "$tests/lib/components/accounts/HardwareWalletNeuronsTest.svelte";
 import { mockNeuronStake } from "$tests/mocks/hardware-wallet-neurons.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { Neuron } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import HardwareWalletNeuronsTest from "$tests/lib/components/accounts/HardwareWalletNeuronsTest.svelte";
 
 describe("HardwareWalletNeurons", () => {
   const props = { testComponent: HardwareWalletNeurons };

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
@@ -5,7 +5,7 @@ import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { Neuron } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import HardwareWalletNeuronsTest from "./HardwareWalletNeuronsTest.svelte";
+import HardwareWalletNeuronsTest from "$tests/lib/components/accounts/HardwareWalletNeuronsTest.svelte";
 
 describe("HardwareWalletNeurons", () => {
   const props = { testComponent: HardwareWalletNeurons };

--- a/frontend/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
@@ -1,9 +1,9 @@
 import RenameSubAccount from "$lib/components/accounts/RenameSubAccountButton.svelte";
+import WalletContextTest from "$tests/lib/components/accounts/WalletContextTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import WalletContextTest from "$tests/lib/components/accounts/WalletContextTest.svelte";
 
 describe("RenameSubAccountButton", () => {
   const renderTestCmp = () =>

--- a/frontend/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
@@ -3,7 +3,7 @@ import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import WalletContextTest from "./WalletContextTest.svelte";
+import WalletContextTest from "$tests/lib/components/accounts/WalletContextTest.svelte";
 
 describe("RenameSubAccountButton", () => {
   const renderTestCmp = () =>

--- a/frontend/src/tests/lib/components/canister-detail/ControllersCard.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/ControllersCard.spec.ts
@@ -1,6 +1,6 @@
+import ControllersCard from "$tests/lib/components/canister-detail/ControllersCardTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
-import ControllersCard from "$tests/lib/components/canister-detail/ControllersCardTest.svelte";
 
 describe("ControllersCard", () => {
   it("renders title", () => {

--- a/frontend/src/tests/lib/components/canister-detail/ControllersCard.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/ControllersCard.spec.ts
@@ -1,6 +1,6 @@
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
-import ControllersCard from "./ControllersCardTest.svelte";
+import ControllersCard from "$tests/lib/components/canister-detail/ControllersCardTest.svelte";
 
 describe("ControllersCard", () => {
   it("renders title", () => {

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
@@ -1,9 +1,9 @@
 import * as canisterServices from "$lib/services/canisters.services";
 import { removeController } from "$lib/services/canisters.services";
+import RemoveCanisterControllerButton from "$tests/lib/components/canister-detail/RemoveCanisterControllerButtonTest.svelte";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import RemoveCanisterControllerButton from "$tests/lib/components/canister-detail/RemoveCanisterControllerButtonTest.svelte";
 
 describe("RemoveCanisterControllerButton", () => {
   const controller = "ryjl3-tyaaa-aaaaa-aaaba-cai";

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
@@ -3,7 +3,7 @@ import { removeController } from "$lib/services/canisters.services";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import RemoveCanisterControllerButton from "./RemoveCanisterControllerButtonTest.svelte";
+import RemoveCanisterControllerButton from "$tests/lib/components/canister-detail/RemoveCanisterControllerButtonTest.svelte";
 
 describe("RemoveCanisterControllerButton", () => {
   const controller = "ryjl3-tyaaa-aaaaa-aaaba-cai";

--- a/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
@@ -1,7 +1,7 @@
 import * as canistersServices from "$lib/services/canisters.services";
 import { detachCanister } from "$lib/services/canisters.services";
 import { fireEvent, render } from "@testing-library/svelte";
-import UnlinkActionButtonTest from "./UnlinkActionButtonTest.svelte";
+import UnlinkActionButtonTest from "$tests/lib/components/canister-detail/UnlinkActionButtonTest.svelte";
 
 describe("DissolveActionButton", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
@@ -1,7 +1,7 @@
 import * as canistersServices from "$lib/services/canisters.services";
 import { detachCanister } from "$lib/services/canisters.services";
-import { fireEvent, render } from "@testing-library/svelte";
 import UnlinkActionButtonTest from "$tests/lib/components/canister-detail/UnlinkActionButtonTest.svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 
 describe("DissolveActionButton", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -1,9 +1,9 @@
 import SelectCyclesCanister from "$lib/components/canisters/SelectCyclesCanister.svelte";
+import SelectCyclesCanisterTest from "$tests/lib/components/canisters/SelectCyclesCanisterTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import SelectCyclesCanisterTest from "$tests/lib/components/canisters/SelectCyclesCanisterTest.svelte";
 
 vitest.mock("$lib/services/canisters.services", () => {
   return {

--- a/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -3,7 +3,7 @@ import en from "$tests/mocks/i18n.mock";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import SelectCyclesCanisterTest from "./SelectCyclesCanisterTest.svelte";
+import SelectCyclesCanisterTest from "$tests/lib/components/canisters/SelectCyclesCanisterTest.svelte";
 
 vitest.mock("$lib/services/canisters.services", () => {
   return {

--- a/frontend/src/tests/lib/components/common/SignInGuard.spec.ts
+++ b/frontend/src/tests/lib/components/common/SignInGuard.spec.ts
@@ -1,6 +1,6 @@
+import SignInGuardTest from "$tests/lib/components/common/SignInGuardTest.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
-import SignInGuardTest from "$tests/lib/components/common/SignInGuardTest.svelte";
 
 describe("SignInGuard", () => {
   describe("not signed in", () => {

--- a/frontend/src/tests/lib/components/common/SignInGuard.spec.ts
+++ b/frontend/src/tests/lib/components/common/SignInGuard.spec.ts
@@ -1,6 +1,6 @@
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
-import SignInGuardTest from "./SignInGuardTest.svelte";
+import SignInGuardTest from "$tests/lib/components/common/SignInGuardTest.svelte";
 
 describe("SignInGuard", () => {
   describe("not signed in", () => {

--- a/frontend/src/tests/lib/components/common/SignedInOnly.spec.ts
+++ b/frontend/src/tests/lib/components/common/SignedInOnly.spec.ts
@@ -1,6 +1,6 @@
+import SignedInOnlyTest from "$tests/lib/components/common/SignedInOnlyTest.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
-import SignedInOnlyTest from "$tests/lib/components/common/SignedInOnlyTest.svelte";
 
 describe("SignedInOnly", () => {
   describe("not signed in", () => {

--- a/frontend/src/tests/lib/components/common/SignedInOnly.spec.ts
+++ b/frontend/src/tests/lib/components/common/SignedInOnly.spec.ts
@@ -1,6 +1,6 @@
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
-import SignedInOnlyTest from "./SignedInOnlyTest.svelte";
+import SignedInOnlyTest from "$tests/lib/components/common/SignedInOnlyTest.svelte";
 
 describe("SignedInOnly", () => {
   describe("not signed in", () => {

--- a/frontend/src/tests/lib/components/layout/Layout.spec.ts
+++ b/frontend/src/tests/lib/components/layout/Layout.spec.ts
@@ -1,7 +1,7 @@
 import { layoutTitleStore } from "$lib/stores/layout.store";
+import LayoutTest from "$tests/lib/components/layout/LayoutTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import LayoutTest from "$tests/lib/components/layout/LayoutTest.svelte";
 
 vi.mock("$lib/services/public/worker-metrics.services", () => ({
   initMetricsWorker: vi.fn(() =>

--- a/frontend/src/tests/lib/components/layout/Layout.spec.ts
+++ b/frontend/src/tests/lib/components/layout/Layout.spec.ts
@@ -1,7 +1,7 @@
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import LayoutTest from "./LayoutTest.svelte";
+import LayoutTest from "$tests/lib/components/layout/LayoutTest.svelte";
 
 vi.mock("$lib/services/public/worker-metrics.services", () => ({
   initMetricsWorker: vi.fn(() =>

--- a/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
+++ b/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
@@ -4,7 +4,7 @@ import * as workerMetricsServices from "$lib/services/public/worker-metrics.serv
 import { metricsStore } from "$lib/stores/metrics.store";
 import { nonNullish } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
-import TotalValueLockedTest from "./TotalValueLockedTest.svelte";
+import TotalValueLockedTest from "$tests/lib/components/metrics/TotalValueLockedTest.svelte";
 
 let metricsCallback: MetricsCallback | undefined;
 

--- a/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
+++ b/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
@@ -2,9 +2,9 @@ import type { FiatCurrency } from "$lib/canisters/tvl/tvl.types";
 import type { MetricsCallback } from "$lib/services/public/worker-metrics.services";
 import * as workerMetricsServices from "$lib/services/public/worker-metrics.services";
 import { metricsStore } from "$lib/stores/metrics.store";
+import TotalValueLockedTest from "$tests/lib/components/metrics/TotalValueLockedTest.svelte";
 import { nonNullish } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
-import TotalValueLockedTest from "$tests/lib/components/metrics/TotalValueLockedTest.svelte";
 
 let metricsCallback: MetricsCallback | undefined;
 

--- a/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
@@ -2,7 +2,7 @@ import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
-import ConfirmDisburseNeuronTest from "./ConfirmDisburseNeuronTest.svelte";
+import ConfirmDisburseNeuronTest from "$tests/lib/components/neuron-detail/ConfirmDisburseNeuronTest.svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
@@ -1,8 +1,8 @@
 import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
+import ConfirmDisburseNeuronTest from "$tests/lib/components/neuron-detail/ConfirmDisburseNeuronTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
-import ConfirmDisburseNeuronTest from "$tests/lib/components/neuron-detail/ConfirmDisburseNeuronTest.svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreen.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreen.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronConfirmActionScreenTest from "./NeuronConfirmActionScreenTest.svelte";
+import NeuronConfirmActionScreenTest from "$tests/lib/components/neuron-detail/NeuronConfirmActionScreenTest.svelte";
 
 describe("NeuronConfirmActionScreen", () => {
   it("should render main information", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreen.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreen.spec.ts
@@ -1,5 +1,5 @@
-import { fireEvent, render } from "@testing-library/svelte";
 import NeuronConfirmActionScreenTest from "$tests/lib/components/neuron-detail/NeuronConfirmActionScreenTest.svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 
 describe("NeuronConfirmActionScreen", () => {
   it("should render main information", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -5,7 +5,7 @@ import { VotingHistoryModalPo } from "$tests/page-objects/VotingHistoryModal.pag
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import FolloweeTest from "./FolloweeTest.svelte";
+import FolloweeTest from "$tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte";
 
 describe("Followee", () => {
   let copySpy;

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -1,11 +1,11 @@
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
+import FolloweeTest from "$tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { FolloweePo } from "$tests/page-objects/Followee.page-object";
 import { VotingHistoryModalPo } from "$tests/page-objects/VotingHistoryModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import FolloweeTest from "$tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte";
 
 describe("Followee", () => {
   let copySpy;

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
@@ -1,12 +1,12 @@
 import NeuronFollowingCard from "$lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte";
 import { listKnownNeurons } from "$lib/services/known-neurons.services";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronFollowingCardPo } from "$tests/page-objects/NeuronFollowingCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
 import { Topic, type NeuronInfo } from "@dfinity/nns";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 vi.mock("$lib/services/known-neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
@@ -6,7 +6,7 @@ import { NeuronFollowingCardPo } from "$tests/page-objects/NeuronFollowingCard.p
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
 import { Topic, type NeuronInfo } from "@dfinity/nns";
-import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 vi.mock("$lib/services/known-neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "$tests/utils/accounts.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsAvailableMaturityItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -1,4 +1,5 @@
 import NnsAvailableMaturityItemAction from "$lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
@@ -14,7 +15,6 @@ import {
 } from "$tests/utils/accounts.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsAvailableMaturityItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -22,7 +22,7 @@ import {
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronAdvancedSection", () => {
   const nowInSeconds = new Date("Jul 20, 2023 8:53 AM").getTime() / 1000;

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -4,6 +4,7 @@ import {
   SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
@@ -22,7 +23,6 @@ import {
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronAdvancedSection", () => {
   const nowInSeconds = new Date("Jul 20, 2023 8:53 AM").getTime() / 1000;

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -1,5 +1,6 @@
 import NnsNeuronDissolveDelayItemAction from "$lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte";
 import { SECONDS_IN_MONTH, SECONDS_IN_YEAR } from "$lib/constants/constants";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
@@ -14,7 +15,6 @@ import {
 } from "$tests/utils/accounts.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronDissolveDelayItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "$tests/utils/accounts.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronDissolveDelayItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
@@ -8,7 +8,7 @@ import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronHotkeysCard", () => {
   const hotKeys = [

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
@@ -3,12 +3,12 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import * as neuronsServices from "$lib/services/neurons.services";
 import { removeHotkey } from "$lib/services/neurons.services";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronHotkeysCard", () => {
   const hotKeys = [

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
@@ -1,10 +1,10 @@
 import NnsNeuronMaturitySection from "$lib/components/neuron-detail/NnsNeuronMaturitySection.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronMaturitySectionPo } from "$tests/page-objects/NnsNeuronMaturitySection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronMaturitySection", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
@@ -4,7 +4,7 @@ import { NnsNeuronMaturitySectionPo } from "$tests/page-objects/NnsNeuronMaturit
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronMaturitySection", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
@@ -4,13 +4,13 @@ import {
   SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
 import { nowInSeconds } from "$lib/utils/date.utils";
+import NnsNeuronRewardStatusActionTest from "$tests/lib/components/neuron-detail/NnsNeuronRewardStatusActionTest.svelte";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NnsNeuronRewardStatusActionTest from "$tests/lib/components/neuron-detail/NnsNeuronRewardStatusActionTest.svelte";
 
 describe("NnsNeuronRewardStatusAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronRewardStatusAction.spec.ts
@@ -10,7 +10,7 @@ import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewa
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NnsNeuronRewardStatusActionTest from "./NnsNeuronRewardStatusActionTest.svelte";
+import NnsNeuronRewardStatusActionTest from "$tests/lib/components/neuron-detail/NnsNeuronRewardStatusActionTest.svelte";
 
 describe("NnsNeuronRewardStatusAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -11,7 +11,7 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronStateItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -1,5 +1,6 @@
 import NnsNeuronStateItemAction from "$lib/components/neuron-detail/NnsNeuronStateItemAction.svelte";
 import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
@@ -11,7 +12,6 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronStateItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -6,7 +6,7 @@ import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVoti
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakeItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -1,12 +1,12 @@
 import NnsNeuronVotingPowerSection from "$lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte";
 import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVotingPowerSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakeItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
@@ -4,7 +4,7 @@ import { StakeItemActionPo } from "$tests/page-objects/StakeItemAction.page-obje
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakeItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
@@ -1,10 +1,10 @@
 import NnsStakeItemAction from "$lib/components/neuron-detail/NnsStakeItemAction.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { StakeItemActionPo } from "$tests/page-objects/StakeItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakeItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityItemAction.spec.ts
@@ -1,10 +1,10 @@
 import NnsStakedMaturityItemAction from "$lib/components/neuron-detail/NnsStakedMaturityItemAction.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsStakedMaturityItemActionPo } from "$tests/page-objects/NnsStakedMaturityItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakedMaturityItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityItemAction.spec.ts
@@ -4,7 +4,7 @@ import { NnsStakedMaturityItemActionPo } from "$tests/page-objects/NnsStakedMatu
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakedMaturityItemAction", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
@@ -2,7 +2,7 @@ import AddHotkeyButton from "$lib/components/neuron-detail/actions/AddHotkeyButt
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextTest from "../NeuronContextTest.svelte";
+import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 
 describe("AddHotkeyButton", () => {
   it("renders add hotkey message", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
@@ -1,8 +1,8 @@
 import AddHotkeyButton from "$lib/components/neuron-detail/actions/AddHotkeyButton.svelte";
+import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 
 describe("AddHotkeyButton", () => {
   it("renders add hotkey message", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -4,7 +4,7 @@ import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextTest from "../NeuronContextTest.svelte";
+import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 
 describe("DisburseButton", () => {
   it("renders title", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -1,10 +1,10 @@
 import DisburseButton from "$lib/components/neuron-detail/actions/DisburseButton.svelte";
+import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 
 describe("DisburseButton", () => {
   it("renders title", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
@@ -6,7 +6,7 @@ import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronState } from "@dfinity/nns";
 import { fireEvent, render } from "@testing-library/svelte";
-import DissolveActionButtonTest from "./DissolveActionButtonTest.svelte";
+import DissolveActionButtonTest from "$tests/lib/components/neuron-detail/actions/DissolveActionButtonTest.svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
@@ -2,11 +2,11 @@ import {
   startDissolving,
   stopDissolving,
 } from "$lib/services/neurons.services";
+import DissolveActionButtonTest from "$tests/lib/components/neuron-detail/actions/DissolveActionButtonTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronState } from "@dfinity/nns";
 import { fireEvent, render } from "@testing-library/svelte";
-import DissolveActionButtonTest from "$tests/lib/components/neuron-detail/actions/DissolveActionButtonTest.svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
@@ -1,10 +1,10 @@
 import IncreaseDissolveDelayButton from "$lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte";
+import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 
 describe("IncreaseDissolveDelayButton", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
@@ -4,7 +4,7 @@ import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextTest from "../NeuronContextTest.svelte";
+import NeuronContextTest from "$tests/lib/components/neuron-detail/NeuronContextTest.svelte";
 
 describe("IncreaseDissolveDelayButton", () => {
   const renderComponent = (neuron: NeuronInfo) => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
@@ -1,8 +1,8 @@
 import JoinCommunityFundCheckbox from "$lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.svelte";
 import { toggleCommunityFund } from "$lib/services/neurons.services";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
@@ -2,7 +2,7 @@ import JoinCommunityFundCheckbox from "$lib/components/neuron-detail/actions/Joi
 import { toggleCommunityFund } from "$lib/services/neurons.services";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -1,13 +1,13 @@
 import NnsAutoStakeMaturity from "$lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte";
 import * as neuronsServices from "$lib/services/neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockPrincipalText, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsAutoStakeMaturity", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -7,7 +7,7 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsAutoStakeMaturity", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsChangeNeuronVisibilityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsChangeNeuronVisibilityButton.spec.ts
@@ -5,7 +5,7 @@ import { ChangeNeuronVisibilityModalPo } from "$tests/page-objects/ChangeNeuronV
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronVisibility } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsChangeNeuronVisibilityButton", () => {
   const renderComponentAndModal = ({

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsChangeNeuronVisibilityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsChangeNeuronVisibilityButton.spec.ts
@@ -1,11 +1,11 @@
 import NnsChangeNeuronVisibilityButton from "$lib/components/neuron-detail/actions/NnsChangeNeuronVisibilityButton.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ChangeNeuronVisibilityModalPo } from "$tests/page-objects/ChangeNeuronVisibilityModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronVisibility } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsChangeNeuronVisibilityButton", () => {
   const renderComponentAndModal = ({

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
@@ -1,8 +1,8 @@
 import NnsStakeMaturityButton from "$lib/components/neuron-detail/actions/NnsStakeMaturityButton.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakeMaturityButton", () => {
   it("should open stake maturity modal", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
@@ -2,7 +2,7 @@ import NnsStakeMaturityButton from "$lib/components/neuron-detail/actions/NnsSta
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("NnsStakeMaturityButton", () => {
   it("should open stake maturity modal", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
@@ -2,7 +2,7 @@ import SplitNeuronButton from "$lib/components/neuron-detail/actions/SplitNnsNeu
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("SplitNeuronButton", () => {
   it("renders split neuron message", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
@@ -1,8 +1,8 @@
 import SplitNeuronButton from "$lib/components/neuron-detail/actions/SplitNnsNeuronButton.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 
 describe("SplitNeuronButton", () => {
   it("renders split neuron message", () => {

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
@@ -1,6 +1,6 @@
 import FollowTopicsSection from "$lib/components/neurons/FollowTopicSection.svelte";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import FollowTopicsSectionTest from "$tests/lib/components/neurons/FollowTopicSectionTest.svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("FollowTopicsSection", () => {
   const title = "title";

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
@@ -1,6 +1,6 @@
 import FollowTopicsSection from "$lib/components/neurons/FollowTopicSection.svelte";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import FollowTopicsSectionTest from "./FollowTopicSectionTest.svelte";
+import FollowTopicsSectionTest from "$tests/lib/components/neurons/FollowTopicSectionTest.svelte";
 
 describe("FollowTopicsSection", () => {
   const title = "title";

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -27,7 +27,7 @@ import {
 } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import NnsProposalTest from "./NnsProposalTest.svelte";
+import NnsProposalTest from "$tests/lib/components/proposal-detail/NnsProposalTest.svelte";
 
 vi.mock("$lib/api/nns-dapp.api");
 

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -7,6 +7,7 @@ import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposal
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
+import NnsProposalTest from "$tests/lib/components/proposal-detail/NnsProposalTest.svelte";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   generateMockProposals,
@@ -27,7 +28,6 @@ import {
 } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import NnsProposalTest from "$tests/lib/components/proposal-detail/NnsProposalTest.svelte";
 
 vi.mock("$lib/api/nns-dapp.api");
 

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
@@ -11,7 +11,7 @@ import {
   type NeuronInfo,
 } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import ProposalVotingSectionTest from "./ProposalVotingSectionTest.svelte";
+import ProposalVotingSectionTest from "$tests/lib/components/proposal-detail/ProposalVotingSectionTest.svelte";
 
 describe("ProposalVotingSection", () => {
   const neuronIds = [111, 222].map(BigInt);

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
@@ -1,5 +1,6 @@
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { neuronsStore } from "$lib/stores/neurons.store";
+import ProposalVotingSectionTest from "$tests/lib/components/proposal-detail/ProposalVotingSectionTest.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
@@ -11,7 +12,6 @@ import {
   type NeuronInfo,
 } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import ProposalVotingSectionTest from "$tests/lib/components/proposal-detail/ProposalVotingSectionTest.svelte";
 
 describe("ProposalVotingSection", () => {
   const neuronIds = [111, 222].map(BigInt);

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -26,7 +26,7 @@ import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { writable } from "svelte/store";
 import { mock } from "vitest-mock-extended";
-import ContextWrapperTest from "../../ContextWrapperTest.svelte";
+import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 
 describe("VotingCard", () => {
   const neuronIds = [111, 222].map(BigInt);

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -13,6 +13,7 @@ import {
   type SelectedProposalContext,
   type SelectedProposalStore,
 } from "$lib/types/selected-proposal.context";
+import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
@@ -26,7 +27,6 @@ import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { writable } from "svelte/store";
 import { mock } from "vitest-mock-extended";
-import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 
 describe("VotingCard", () => {
   const neuronIds = [111, 222].map(BigInt);

--- a/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposals.spec.ts
@@ -1,8 +1,8 @@
+import UniverseWithActionableProposalsTest from "$tests/lib/components/proposals/UniverseWithActionableProposalsTest.svelte";
 import { mockUniverse } from "$tests/mocks/sns-projects.mock";
 import { UniverseWithActionableProposalsPo } from "$tests/page-objects/UniverseWithActionableProposals.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import UniverseWithActionableProposalsTest from "$tests/lib/components/proposals/UniverseWithActionableProposalsTest.svelte";
 
 describe("UniverseWithActionableProposals", () => {
   const renderComponent = (props) => {

--- a/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposals.spec.ts
@@ -2,7 +2,7 @@ import { mockUniverse } from "$tests/mocks/sns-projects.mock";
 import { UniverseWithActionableProposalsPo } from "$tests/page-objects/UniverseWithActionableProposals.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import UniverseWithActionableProposalsTest from "./UniverseWithActionableProposalsTest.svelte";
+import UniverseWithActionableProposalsTest from "$tests/lib/components/proposals/UniverseWithActionableProposalsTest.svelte";
 
 describe("UniverseWithActionableProposals", () => {
   const renderComponent = (props) => {

--- a/frontend/src/tests/lib/components/sale/AdditionalInfoForm.spec.ts
+++ b/frontend/src/tests/lib/components/sale/AdditionalInfoForm.spec.ts
@@ -2,7 +2,7 @@ import { AdditionalInfoFormPo } from "$tests/page-objects/AdditionalInfoForm.pag
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 import { get, writable, type Writable } from "svelte/store";
-import AdditionalInfoFormTest from "./AdditionalInfoFormTest.svelte";
+import AdditionalInfoFormTest from "$tests/lib/components/sale/AdditionalInfoFormTest.svelte";
 
 const renderComponent = ({
   conditionsToAccept,

--- a/frontend/src/tests/lib/components/sale/AdditionalInfoForm.spec.ts
+++ b/frontend/src/tests/lib/components/sale/AdditionalInfoForm.spec.ts
@@ -1,8 +1,8 @@
+import AdditionalInfoFormTest from "$tests/lib/components/sale/AdditionalInfoFormTest.svelte";
 import { AdditionalInfoFormPo } from "$tests/page-objects/AdditionalInfoForm.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 import { get, writable, type Writable } from "svelte/store";
-import AdditionalInfoFormTest from "$tests/lib/components/sale/AdditionalInfoFormTest.svelte";
 
 const renderComponent = ({
   conditionsToAccept,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
@@ -5,7 +5,7 @@ import { SnsStakedMaturityItemActionPo } from "$tests/page-objects/SnsStakedMatu
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { SnsNeuron } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./SnsNeuronContextTest.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("SnsStakedMaturityItemAction", () => {
   const renderComponent = (neuron: SnsNeuron) => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
@@ -1,11 +1,11 @@
 import SnsStakedMaturityItemAction from "$lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.svelte";
+import NeuronContextActionsTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { SnsStakedMaturityItemActionPo } from "$tests/page-objects/SnsStakedMaturityItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { SnsNeuron } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("SnsStakedMaturityItemAction", () => {
   const renderComponent = (neuron: SnsNeuron) => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
@@ -1,9 +1,9 @@
 import AddSnsHotkeyButton from "$lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("AddSnsHotkeyButton", () => {
   const renderCard = () =>

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
@@ -3,7 +3,7 @@ import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("AddSnsHotkeyButton", () => {
   const renderCard = () =>

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("DisburseSnsButton", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
@@ -1,5 +1,6 @@
 import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
@@ -8,7 +9,6 @@ import {
 } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("DisburseSnsButton", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
@@ -2,6 +2,7 @@ import {
   startDissolving,
   stopDissolving,
 } from "$lib/services/sns-neurons.services";
+import DissolveSnsNeuronButtonTest from "$tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButtonTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import {
   createMockSnsNeuron,
@@ -9,7 +10,6 @@ import {
 } from "$tests/mocks/sns-neurons.mock";
 import { NeuronState } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import DissolveSnsNeuronButtonTest from "$tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButtonTest.svelte";
 
 vi.mock("$lib/services/sns-neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "$tests/mocks/sns-neurons.mock";
 import { NeuronState } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import DissolveSnsNeuronButtonTest from "./DissolveSnsNeuronButtonTest.svelte";
+import DissolveSnsNeuronButtonTest from "$tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButtonTest.svelte";
 
 vi.mock("$lib/services/sns-neurons.services", () => {
   return {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
@@ -5,7 +5,7 @@ import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("FollowSnsNeuronsButton", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
@@ -1,11 +1,11 @@
 import FollowSnsNeuronsButton from "$lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.svelte";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("FollowSnsNeuronsButton", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -1,6 +1,7 @@
 import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   createMockSnsNeuron,
@@ -13,7 +14,6 @@ import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
-import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 // Avoid triggering the api call to not have to mock the api layer. Not needed for this test.
 vi.mock("$lib/services/sns-parameters.services");

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -13,7 +13,7 @@ import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 // Avoid triggering the api call to not have to mock the api layer. Not needed for this test.
 vi.mock("$lib/services/sns-parameters.services");

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -2,6 +2,7 @@ import SnsAutoStakeMaturity from "$lib/components/sns-neuron-detail/actions/SnsA
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/sns-neurons.services";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
@@ -10,7 +11,6 @@ import { toastsStore } from "@dfinity/gix-components";
 import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("SnsAutoStakeMaturity", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -10,7 +10,7 @@ import { toastsStore } from "@dfinity/gix-components";
 import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("SnsAutoStakeMaturity", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -2,7 +2,7 @@ import SnsStakeMaturityButton from "$lib/components/sns-neuron-detail/actions/Sn
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("SnsStakeMaturityButton", () => {
   it("should open stake maturity modal", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -1,8 +1,8 @@
 import SnsStakeMaturityButton from "$lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte";
+import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "$tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte";
 
 describe("SnsStakeMaturityButton", () => {
   it("should open stake maturity modal", async () => {

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -10,6 +10,7 @@ import {
   type UserTokenLoading,
 } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import TokensTableTest from "$tests/lib/components/tokens/TokensTableTest.svelte";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import {
   createUserToken,
@@ -21,7 +22,6 @@ import { createActionEvent } from "$tests/utils/actions.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
-import TokensTableTest from "$tests/lib/components/tokens/TokensTableTest.svelte";
 
 describe("TokensTable", () => {
   const renderTable = ({

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -21,7 +21,7 @@ import { createActionEvent } from "$tests/utils/actions.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
-import TokensTableTest from "./TokensTableTest.svelte";
+import TokensTableTest from "$tests/lib/components/tokens/TokensTableTest.svelte";
 
 describe("TokensTable", () => {
   const renderTable = ({

--- a/frontend/src/tests/lib/components/ui/Banner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Banner.spec.ts
@@ -1,7 +1,7 @@
+import BannerTest from "$tests/lib/components/ui/BannerTest.svelte";
 import { BannerPo } from "$tests/page-objects/Banner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import BannerTest from "$tests/lib/components/ui/BannerTest.svelte";
 
 describe("Banner", () => {
   const renderComponent = ({

--- a/frontend/src/tests/lib/components/ui/Banner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Banner.spec.ts
@@ -1,7 +1,7 @@
 import { BannerPo } from "$tests/page-objects/Banner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import BannerTest from "./BannerTest.svelte";
+import BannerTest from "$tests/lib/components/ui/BannerTest.svelte";
 
 describe("Banner", () => {
   const renderComponent = ({

--- a/frontend/src/tests/lib/components/ui/BannerIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/BannerIcon.spec.ts
@@ -1,7 +1,7 @@
+import BannerIconTest from "$tests/lib/components/ui/BannerIconTest.svelte";
 import { BannerIconPo } from "$tests/page-objects/BannerIcon.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import BannerIconTest from "$tests/lib/components/ui/BannerIconTest.svelte";
 
 describe("BannerIcon", () => {
   const renderComponent = (props?: unknown) => {

--- a/frontend/src/tests/lib/components/ui/BannerIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/BannerIcon.spec.ts
@@ -1,7 +1,7 @@
 import { BannerIconPo } from "$tests/page-objects/BannerIcon.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import BannerIconTest from "./BannerIconTest.svelte";
+import BannerIconTest from "$tests/lib/components/ui/BannerIconTest.svelte";
 
 describe("BannerIcon", () => {
   const renderComponent = (props?: unknown) => {

--- a/frontend/src/tests/lib/components/ui/CardInfo.spec.ts
+++ b/frontend/src/tests/lib/components/ui/CardInfo.spec.ts
@@ -1,6 +1,6 @@
 import CardInfo from "$lib/components/ui/CardInfo.svelte";
-import { render } from "@testing-library/svelte";
 import CardInfoTest from "$tests/lib/components/ui/CardInfoTest.svelte";
+import { render } from "@testing-library/svelte";
 
 describe("CardInfo", () => {
   it("should render an article", () => {

--- a/frontend/src/tests/lib/components/ui/CardInfo.spec.ts
+++ b/frontend/src/tests/lib/components/ui/CardInfo.spec.ts
@@ -1,6 +1,6 @@
 import CardInfo from "$lib/components/ui/CardInfo.svelte";
 import { render } from "@testing-library/svelte";
-import CardInfoTest from "./CardInfoTest.svelte";
+import CardInfoTest from "$tests/lib/components/ui/CardInfoTest.svelte";
 
 describe("CardInfo", () => {
   it("should render an article", () => {

--- a/frontend/src/tests/lib/components/ui/DayInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DayInput.spec.ts
@@ -1,9 +1,9 @@
 import DayInput from "$lib/components/ui/DayInput.svelte";
 import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
+import DayInputTest from "$tests/lib/components/ui/DayInputTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import { tick } from "svelte";
-import DayInputTest from "$tests/lib/components/ui/DayInputTest.svelte";
 
 describe("DayInput", () => {
   const defaultProps = {

--- a/frontend/src/tests/lib/components/ui/DayInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DayInput.spec.ts
@@ -3,7 +3,7 @@ import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import { tick } from "svelte";
-import DayInputTest from "./DayInputTest.svelte";
+import DayInputTest from "$tests/lib/components/ui/DayInputTest.svelte";
 
 describe("DayInput", () => {
   const defaultProps = {

--- a/frontend/src/tests/lib/components/ui/PrincipalInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/PrincipalInput.spec.ts
@@ -1,7 +1,7 @@
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import PrincipalInputTest from "./PrincipalInputTest.svelte";
+import PrincipalInputTest from "$tests/lib/components/ui/PrincipalInputTest.svelte";
 
 describe("PrincipalInput", () => {
   const props = {

--- a/frontend/src/tests/lib/components/ui/PrincipalInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/PrincipalInput.spec.ts
@@ -1,7 +1,7 @@
+import PrincipalInputTest from "$tests/lib/components/ui/PrincipalInputTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import PrincipalInputTest from "$tests/lib/components/ui/PrincipalInputTest.svelte";
 
 describe("PrincipalInput", () => {
   const props = {

--- a/frontend/src/tests/lib/components/ui/TagsList.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TagsList.spec.ts
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/svelte";
-import TagsListTest from "./TagsListTest.svelte";
+import TagsListTest from "$tests/lib/components/ui/TagsListTest.svelte";
 
 describe("TagsList", () => {
   it("should render a ul", () => {

--- a/frontend/src/tests/lib/components/ui/TagsList.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TagsList.spec.ts
@@ -1,5 +1,5 @@
-import { render } from "@testing-library/svelte";
 import TagsListTest from "$tests/lib/components/ui/TagsListTest.svelte";
+import { render } from "@testing-library/svelte";
 
 describe("TagsList", () => {
   it("should render a ul", () => {

--- a/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
@@ -1,8 +1,8 @@
 import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+import TooltipIconTest from "$tests/lib/components/ui/TooltipIconTest.svelte";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
-import TooltipIconTest from "$tests/lib/components/ui/TooltipIconTest.svelte";
 
 describe("TooltipIcon", () => {
   const text = "This is the text displayed in the tooltip";

--- a/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
@@ -2,7 +2,7 @@ import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
-import TooltipIconTest from "./TooltipIconTest.svelte";
+import TooltipIconTest from "$tests/lib/components/ui/TooltipIconTest.svelte";
 
 describe("TooltipIcon", () => {
   const text = "This is the text displayed in the tooltip";

--- a/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
+++ b/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
@@ -2,12 +2,12 @@ import Warnings from "$lib/components/warnings/Warnings.svelte";
 import type { MetricsCallback } from "$lib/services/public/worker-metrics.services";
 import { metricsStore } from "$lib/stores/metrics.store";
 import type { DashboardMessageExecutionRateResponse } from "$lib/types/dashboard";
+import WarningsTest from "$tests/lib/components/warnings/WarningsTest.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
-import WarningsTest from "$tests/lib/components/warnings/WarningsTest.svelte";
 
 let metricsCallback: MetricsCallback | undefined;
 

--- a/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
+++ b/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
@@ -7,7 +7,7 @@ import en from "$tests/mocks/i18n.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
-import WarningsTest from "./WarningsTest.svelte";
+import WarningsTest from "$tests/lib/components/warnings/WarningsTest.svelte";
 
 let metricsCallback: MetricsCallback | undefined;
 

--- a/frontend/src/tests/lib/directives/intersection.directives.spec.ts
+++ b/frontend/src/tests/lib/directives/intersection.directives.spec.ts
@@ -4,7 +4,7 @@ import {
   mockIntersectionObserverIsIntersecting,
 } from "$tests/mocks/infinitescroll.mock";
 import { render } from "@testing-library/svelte";
-import IntersectionTest from "./IntersectionTest.svelte";
+import IntersectionTest from "$tests/lib/directives/IntersectionTest.svelte";
 
 describe("IntersectionDirectives", () => {
   let spy;

--- a/frontend/src/tests/lib/directives/intersection.directives.spec.ts
+++ b/frontend/src/tests/lib/directives/intersection.directives.spec.ts
@@ -1,10 +1,10 @@
 import * as dispatchEvents from "$lib/utils/events.utils";
+import IntersectionTest from "$tests/lib/directives/IntersectionTest.svelte";
 import {
   IntersectionObserverActive,
   mockIntersectionObserverIsIntersecting,
 } from "$tests/mocks/infinitescroll.mock";
 import { render } from "@testing-library/svelte";
-import IntersectionTest from "$tests/lib/directives/IntersectionTest.svelte";
 
 describe("IntersectionDirectives", () => {
   let spy;

--- a/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -3,7 +3,7 @@ import { addController } from "$lib/services/canisters.services";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
-import AddControllerModal from "./AddControllerModalTest.svelte";
+import AddControllerModal from "$tests/lib/modals/canisters/AddControllerModalTest.svelte";
 
 describe("AddControllerModal", () => {
   const reloadMock = vi.fn();

--- a/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -1,9 +1,9 @@
 import * as canistersServices from "$lib/services/canisters.services";
 import { addController } from "$lib/services/canisters.services";
+import AddControllerModal from "$tests/lib/modals/canisters/AddControllerModalTest.svelte";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
-import AddControllerModal from "$tests/lib/modals/canisters/AddControllerModalTest.svelte";
 
 describe("AddControllerModal", () => {
   const reloadMock = vi.fn();

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -4,6 +4,7 @@ import {
   getIcpToCyclesExchangeRate,
   topUpCanister,
 } from "$lib/services/canisters.services";
+import AddCyclesModalTest from "$tests/lib/modals/canisters/AddCyclesModalTest.svelte";
 import { mockCanister } from "$tests/mocks/canisters.mock";
 import {
   mockAccountsStoreSubscribe,
@@ -18,7 +19,6 @@ import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
-import AddCyclesModalTest from "$tests/lib/modals/canisters/AddCyclesModalTest.svelte";
 
 describe("AddCyclesModal", () => {
   const reloadDetails = vi.fn();

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -18,7 +18,7 @@ import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
-import AddCyclesModalTest from "./AddCyclesModalTest.svelte";
+import AddCyclesModalTest from "$tests/lib/modals/canisters/AddCyclesModalTest.svelte";
 
 describe("AddCyclesModal", () => {
   const reloadDetails = vi.fn();

--- a/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
@@ -7,7 +7,7 @@ import { RenameCanisterModalPo } from "$tests/page-objects/RenameCanisterModal.p
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
-import RenameCanisterModalTest from "./RenameCanisterModalTest.svelte";
+import RenameCanisterModalTest from "$tests/lib/modals/canisters/RenameCanisterModalTest.svelte";
 
 vi.mock("$lib/api/canisters.api");
 

--- a/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
@@ -1,13 +1,13 @@
 import * as canisterApi from "$lib/api/canisters.api";
 import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import { authStore } from "$lib/stores/auth.store";
+import RenameCanisterModalTest from "$tests/lib/modals/canisters/RenameCanisterModalTest.svelte";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId, mockCanisters } from "$tests/mocks/canisters.mock";
 import { RenameCanisterModalPo } from "$tests/page-objects/RenameCanisterModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
-import RenameCanisterModalTest from "$tests/lib/modals/canisters/RenameCanisterModalTest.svelte";
 
 vi.mock("$lib/api/canisters.api");
 

--- a/frontend/src/tests/lib/modals/common/ConfirmationModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ConfirmationModal.spec.ts
@@ -1,7 +1,7 @@
 import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
+import ConfirmationModalTest from "$tests/lib/modals/common/ConfirmationModalTest.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import ConfirmationModalTest from "$tests/lib/modals/common/ConfirmationModalTest.svelte";
 
 const yesButtonText = en.core.confirm_yes;
 const noButtonText = en.core.confirm_no;

--- a/frontend/src/tests/lib/modals/common/ConfirmationModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ConfirmationModal.spec.ts
@@ -1,7 +1,7 @@
 import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
 import en from "$tests/mocks/i18n.mock";
 import { fireEvent, render } from "@testing-library/svelte";
-import ConfirmationModalTest from "./ConfirmationModalTest.svelte";
+import ConfirmationModalTest from "$tests/lib/modals/common/ConfirmationModalTest.svelte";
 
 const yesButtonText = en.core.confirm_yes;
 const noButtonText = en.core.confirm_no;

--- a/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
@@ -1,6 +1,6 @@
 import FilterModal from "$lib/modals/common/FilterModal.svelte";
 import { fireEvent, render } from "@testing-library/svelte";
-import FilterModalTest from "./FilterModalTest.svelte";
+import FilterModalTest from "$tests/lib/modals/common/FilterModalTest.svelte";
 
 describe("FilterModal", () => {
   const filters = [

--- a/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
@@ -1,6 +1,6 @@
 import FilterModal from "$lib/modals/common/FilterModal.svelte";
-import { fireEvent, render } from "@testing-library/svelte";
 import FilterModalTest from "$tests/lib/modals/common/FilterModalTest.svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 
 describe("FilterModal", () => {
   const filters = [

--- a/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
@@ -1,5 +1,5 @@
 // This import needs to be at the top for the mock to work:
-import MockQRCodeReaderModal from "./MockQRCodeReaderModal.svelte";
+import MockQRCodeReaderModal from "$tests/lib/modals/transaction/MockQRCodeReaderModal.svelte";
 
 import QrWizardModal from "$lib/modals/transaction/QrWizardModal.svelte";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -5,6 +5,7 @@ import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { ValidateAmountFn } from "$lib/types/transaction";
 import { formatTokenE8s } from "$lib/utils/token.utils";
+import TransactionModalTest from "$tests/lib/modals/transaction/TransactionModalTest.svelte";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
@@ -29,7 +30,6 @@ import {
   type RenderResult,
 } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
-import TransactionModalTest from "$tests/lib/modals/transaction/TransactionModalTest.svelte";
 
 describe("TransactionModal", () => {
   const renderTransactionModal = ({

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -29,7 +29,7 @@ import {
   type RenderResult,
 } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
-import TransactionModalTest from "./TransactionModalTest.svelte";
+import TransactionModalTest from "$tests/lib/modals/transaction/TransactionModalTest.svelte";
 
 describe("TransactionModal", () => {
   const renderTransactionModal = ({

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -22,6 +22,7 @@ import { neuronsStore } from "$lib/stores/neurons.store";
 import { getCanisterCreationCmcAccountIdentifierHex } from "$lib/utils/canisters.utils";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
 import { page } from "$mocks/$app/stores";
+import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
 import {
   mockIdentity,
   resetIdentity,
@@ -63,7 +64,6 @@ import { memoToNeuronAccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
-import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
 
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/accounts.api");

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -63,7 +63,7 @@ import { memoToNeuronAccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
-import AccountsTest from "./AccountsTest.svelte";
+import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
 
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/accounts.api");

--- a/frontend/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/src/tests/mocks/auth.store.mock.ts
@@ -2,7 +2,7 @@ import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
 import type { Identity, SignIdentity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
-import en from "./i18n.mock";
+import en from "$tests/mocks/i18n.mock";
 
 export const mockPrincipalText =
   "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";

--- a/frontend/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/src/tests/mocks/auth.store.mock.ts
@@ -1,8 +1,8 @@
 import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
+import en from "$tests/mocks/i18n.mock";
 import type { Identity, SignIdentity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
-import en from "$tests/mocks/i18n.mock";
 
 export const mockPrincipalText =
   "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";

--- a/frontend/src/tests/mocks/canisters.mock.ts
+++ b/frontend/src/tests/mocks/canisters.mock.ts
@@ -11,7 +11,7 @@ import type { CanistersStore } from "$lib/stores/canisters.store";
 import type { SelectCanisterDetailsStore } from "$lib/types/canister-detail.context";
 import { Principal } from "@dfinity/principal";
 import { writable, type Subscriber } from "svelte/store";
-import { mockIdentity } from "./auth.store.mock";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 
 export const mockCanisterId = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
 export const mockCanister: CanisterInfo = {

--- a/frontend/src/tests/mocks/canisters.mock.ts
+++ b/frontend/src/tests/mocks/canisters.mock.ts
@@ -9,9 +9,9 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import type { CanistersStore } from "$lib/stores/canisters.store";
 import type { SelectCanisterDetailsStore } from "$lib/types/canister-detail.context";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { Principal } from "@dfinity/principal";
 import { writable, type Subscriber } from "svelte/store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
 
 export const mockCanisterId = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
 export const mockCanister: CanisterInfo = {

--- a/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
@@ -1,7 +1,7 @@
 import type { Account } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import { decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger-icrc";
 
 export const mockCkBTCToken: IcrcTokenMetadata = {
   name: "Test account",

--- a/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
@@ -1,7 +1,7 @@
 import type { Account } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger-icrc";
-import { mockPrincipal } from "./auth.store.mock";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 
 export const mockCkBTCToken: IcrcTokenMetadata = {
   name: "Test account",

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -10,12 +10,12 @@ import {
 } from "$lib/types/wallet.context";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import type { SnsNeuron } from "@dfinity/sns";
 import type { RenderResult } from "@testing-library/svelte";
 import { render } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { writable } from "svelte/store";
-import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 
 export const renderContextWrapper = <T>({
   Component,

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -15,7 +15,7 @@ import type { RenderResult } from "@testing-library/svelte";
 import { render } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { writable } from "svelte/store";
-import { rootCanisterIdMock } from "./sns.api.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 
 export const renderContextWrapper = <T>({
   Component,

--- a/frontend/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/src/tests/mocks/governance.canister.mock.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { LedgerCanister } from "@dfinity/ledger-icp";
 import type {
   ListProposalsRequest,
@@ -9,7 +10,6 @@ import type {
 } from "@dfinity/nns";
 import { GovernanceCanister, Vote } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
 
 // eslint-disable-next-line
 // @ts-ignore: test file

--- a/frontend/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/src/tests/mocks/governance.canister.mock.ts
@@ -9,7 +9,7 @@ import type {
 } from "@dfinity/nns";
 import { GovernanceCanister, Vote } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
-import { mockNeuron } from "./neurons.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
 
 // eslint-disable-next-line
 // @ts-ignore: test file

--- a/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
+++ b/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
@@ -1,7 +1,7 @@
 import type { WalletStore } from "$lib/types/wallet.context";
-import { writable } from "svelte/store";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { writable } from "svelte/store";
 
 export const mockNeuronStake = {
   ...mockNeuron,

--- a/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
+++ b/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
@@ -1,7 +1,7 @@
 import type { WalletStore } from "$lib/types/wallet.context";
 import { writable } from "svelte/store";
-import { mockMainAccount } from "./icp-accounts.store.mock";
-import { mockFullNeuron, mockNeuron } from "./neurons.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 
 export const mockNeuronStake = {
   ...mockNeuron,

--- a/frontend/src/tests/mocks/icp-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icp-transactions.mock.ts
@@ -1,10 +1,13 @@
 import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
+import {
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import type {
   Operation,
   Transaction,
   TransactionWithId,
 } from "@dfinity/ledger-icp";
-import { mockMainAccount, mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 
 export const mockTransactionTransfer: Transaction = {
   memo: 0n,

--- a/frontend/src/tests/mocks/icp-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icp-transactions.mock.ts
@@ -4,7 +4,7 @@ import type {
   Transaction,
   TransactionWithId,
 } from "@dfinity/ledger-icp";
-import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
+import { mockMainAccount, mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 
 export const mockTransactionTransfer: Transaction = {
   memo: 0n,

--- a/frontend/src/tests/mocks/icrc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/icrc-accounts.mock.ts
@@ -5,7 +5,7 @@ import {
   ledgerCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
-import { mockPrincipal } from "./auth.store.mock";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 
 export const mockIcrcMainAccount: Account = {
   identifier: encodeIcrcAccount({

--- a/frontend/src/tests/mocks/icrc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/icrc-accounts.mock.ts
@@ -1,11 +1,11 @@
 import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { Account } from "$lib/types/account";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   indexCanisterIdMock,
   ledgerCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 
 export const mockIcrcMainAccount: Account = {
   identifier: encodeIcrcAccount({

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -4,7 +4,7 @@ import type { KnownNeuron, Neuron, NeuronInfo } from "@dfinity/nns";
 import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
-import { mockIdentity } from "./auth.store.mock";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 
 export const mockFullNeuron: Neuron = {
   id: 1n,

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -1,10 +1,10 @@
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { TableNeuron } from "$lib/types/neurons-table";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import type { KnownNeuron, Neuron, NeuronInfo } from "@dfinity/nns";
 import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
 
 export const mockFullNeuron: Neuron = {
   id: 1n,

--- a/frontend/src/tests/mocks/proposal.mock.ts
+++ b/frontend/src/tests/mocks/proposal.mock.ts
@@ -1,6 +1,6 @@
 import type { VoteRegistrationStoreEntry } from "$lib/stores/vote-registration.store";
 import { Vote, type Action, type ProposalInfo } from "@dfinity/nns";
-import { deadlineTimestampSeconds } from "./proposals.store.mock";
+import { deadlineTimestampSeconds } from "$tests/mocks/proposals.store.mock";
 
 /**
  * Generate mock proposals with autoincremented "id".

--- a/frontend/src/tests/mocks/proposal.mock.ts
+++ b/frontend/src/tests/mocks/proposal.mock.ts
@@ -1,6 +1,6 @@
 import type { VoteRegistrationStoreEntry } from "$lib/stores/vote-registration.store";
-import { Vote, type Action, type ProposalInfo } from "@dfinity/nns";
 import { deadlineTimestampSeconds } from "$tests/mocks/proposals.store.mock";
+import { Vote, type Action, type ProposalInfo } from "@dfinity/nns";
 
 /**
  * Generate mock proposals with autoincremented "id".

--- a/frontend/src/tests/mocks/proposals.store.mock.ts
+++ b/frontend/src/tests/mocks/proposals.store.mock.ts
@@ -1,4 +1,5 @@
 import type { ProposalsStore } from "$lib/stores/proposals.store";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { ProposalInfo } from "@dfinity/nns";
 import {
   ProposalRewardStatus,
@@ -8,7 +9,6 @@ import {
   type Ballot,
 } from "@dfinity/nns";
 import type { Subscriber } from "svelte/store";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
 
 export const deadlineTimestampSeconds = BigInt(
   Math.round(new Date().getTime() / 1000 + 10000)

--- a/frontend/src/tests/mocks/proposals.store.mock.ts
+++ b/frontend/src/tests/mocks/proposals.store.mock.ts
@@ -8,7 +8,7 @@ import {
   type Ballot,
 } from "@dfinity/nns";
 import type { Subscriber } from "svelte/store";
-import { mockNeuron } from "./neurons.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
 
 export const deadlineTimestampSeconds = BigInt(
   Math.round(new Date().getTime() / 1000 + 10000)

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -2,7 +2,7 @@ import type { Account } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
-import { mockPrincipal } from "./auth.store.mock";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 
 export const token: IcrcTokenMetadata = {
   name: "Test",

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -1,8 +1,8 @@
 import type { Account } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 
 export const token: IcrcTokenMetadata = {
   name: "Test",

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -7,10 +7,10 @@ import type {
 } from "$lib/types/sns-aggregator";
 import { convertDtoToTokenMetadata } from "$lib/utils/sns-aggregator-converters.utils";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
+import { mockQueryTokenResponse } from "$tests/mocks/sns-projects.mock";
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle, type SnsNervousSystemFunction } from "@dfinity/sns";
 import { fromNullable, nonNullish } from "@dfinity/utils";
-import { mockQueryTokenResponse } from "$tests/mocks/sns-projects.mock";
 
 export const aggregatorMockSnsesDataDto: CachedSnsDto[] = tenAggregatedSnses;
 

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -10,7 +10,7 @@ import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle, type SnsNervousSystemFunction } from "@dfinity/sns";
 import { fromNullable, nonNullish } from "@dfinity/utils";
-import { mockQueryTokenResponse } from "./sns-projects.mock";
+import { mockQueryTokenResponse } from "$tests/mocks/sns-projects.mock";
 
 export const aggregatorMockSnsesDataDto: CachedSnsDto[] = tenAggregatedSnses;
 

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -25,7 +25,7 @@ import {
   nonNullish,
 } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
-import { mockIdentity, mockPrincipal } from "./auth.store.mock";
+import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 
 export const mockSnsNeuronTimestampSeconds = 3600 * 24 * 6;
 

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -7,6 +7,7 @@ import type { ProjectNeuronStore } from "$lib/stores/sns-neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { enumValues } from "$lib/utils/enum.utils";
 import { convertNervousSystemParameters } from "$lib/utils/sns-aggregator-converters.utils";
+import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { NeuronState, type NeuronId } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
@@ -25,7 +26,6 @@ import {
   nonNullish,
 } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
-import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 
 export const mockSnsNeuronTimestampSeconds = 3600 * 24 * 6;
 

--- a/frontend/src/tests/mocks/sns.api.mock.ts
+++ b/frontend/src/tests/mocks/sns.api.mock.ts
@@ -1,7 +1,7 @@
 import type { DeployedSns } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { SnsCanisterStatus } from "@dfinity/sns";
-import { principal } from "./sns-projects.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
 
 export const mockSnsCanisterIdText = "pin7y-wyaaa-aaaaa-aacpa-cai";
 export const mockSnsCanisterId = Principal.fromText(mockSnsCanisterIdText);

--- a/frontend/src/tests/mocks/sns.api.mock.ts
+++ b/frontend/src/tests/mocks/sns.api.mock.ts
@@ -1,7 +1,7 @@
+import { principal } from "$tests/mocks/sns-projects.mock";
 import type { DeployedSns } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { SnsCanisterStatus } from "@dfinity/sns";
-import { principal } from "$tests/mocks/sns-projects.mock";
 
 export const mockSnsCanisterIdText = "pin7y-wyaaa-aaaaa-aacpa-cai";
 export const mockSnsCanisterId = Principal.fromText(mockSnsCanisterIdText);

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -21,8 +21,8 @@ import {
 } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { TokenAmountV2, nonNullish } from "@dfinity/utils";
-import { mockCkBTCToken } from "./ckbtc-accounts.mock";
-import { mockSnsToken, principal } from "./sns-projects.mock";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 
 export const icpTokenBase: UserTokenBase = {
   universeId: OWN_CANISTER_ID,

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -20,9 +20,9 @@ import {
   type UserTokenLoading,
 } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-import { TokenAmountV2, nonNullish } from "@dfinity/utils";
 import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
+import { TokenAmountV2, nonNullish } from "@dfinity/utils";
 
 export const icpTokenBase: UserTokenBase = {
   universeId: OWN_CANISTER_ID,

--- a/frontend/src/tests/mocks/tokens.mock.ts
+++ b/frontend/src/tests/mocks/tokens.mock.ts
@@ -15,8 +15,8 @@ import {
   mockCkETHToken,
 } from "$tests/mocks/cketh-accounts.mock";
 import type { Subscriber } from "svelte/store";
-import { mockCkBTCToken } from "./ckbtc-accounts.mock";
-import { mockSnsFullProject, mockSnsToken } from "./sns-projects.mock";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockSnsFullProject, mockSnsToken } from "$tests/mocks/sns-projects.mock";
 
 export const mockCkUSDCToken: IcrcTokenMetadata = {
   name: "ckUSDC",

--- a/frontend/src/tests/mocks/tokens.mock.ts
+++ b/frontend/src/tests/mocks/tokens.mock.ts
@@ -10,13 +10,16 @@ import {
 import { NNS_TOKEN } from "$lib/constants/tokens.constants";
 import type { TokensStoreData } from "$lib/stores/tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import {
   mockCkETHTESTToken,
   mockCkETHToken,
 } from "$tests/mocks/cketh-accounts.mock";
+import {
+  mockSnsFullProject,
+  mockSnsToken,
+} from "$tests/mocks/sns-projects.mock";
 import type { Subscriber } from "svelte/store";
-import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
-import { mockSnsFullProject, mockSnsToken } from "$tests/mocks/sns-projects.mock";
 
 export const mockCkUSDCToken: IcrcTokenMetadata = {
   name: "ckUSDC",

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,9 +1,9 @@
 import type { GetTransactionsResponse } from "$lib/api/icp-index.api";
 import type { UiTransaction } from "$lib/types/transaction";
-import type { TransactionWithId } from "@dfinity/ledger-icp";
-import { TokenAmount } from "@dfinity/utils";
 import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import type { TransactionWithId } from "@dfinity/ledger-icp";
+import { TokenAmount } from "@dfinity/utils";
 
 export const createMockUiTransaction = ({
   domKey = "123-1",

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -2,8 +2,8 @@ import type { GetTransactionsResponse } from "$lib/api/icp-index.api";
 import type { UiTransaction } from "$lib/types/transaction";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { TokenAmount } from "@dfinity/utils";
-import { mockSubAccount } from "./icp-accounts.store.mock";
-import { mockSnsToken } from "./sns-projects.mock";
+import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 
 export const createMockUiTransaction = ({
   domKey = "123-1",

--- a/frontend/src/tests/mocks/wallet.store.mock.ts
+++ b/frontend/src/tests/mocks/wallet.store.mock.ts
@@ -1,6 +1,6 @@
 import type { WalletStore } from "$lib/types/wallet.context";
 import { writable } from "svelte/store";
-import { mockMainAccount } from "./icp-accounts.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 
 export const mockWalletStore = writable<WalletStore>({
   account: mockMainAccount,

--- a/frontend/src/tests/mocks/wallet.store.mock.ts
+++ b/frontend/src/tests/mocks/wallet.store.mock.ts
@@ -1,6 +1,6 @@
 import type { WalletStore } from "$lib/types/wallet.context";
-import { writable } from "svelte/store";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { writable } from "svelte/store";
 
 export const mockWalletStore = writable<WalletStore>({
   account: mockMainAccount,

--- a/frontend/src/tests/page-objects/AccountDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountDetails.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { IdentifierHashPo } from "./IdentifierHash.page-object";
-import { TooltipIconPo } from "./TooltipIcon.page-object";
+import { IdentifierHashPo } from "$tests/page-objects/IdentifierHash.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 
 export class AccountDetailsPo extends BasePageObject {
   private static readonly TID = "account-details-component";

--- a/frontend/src/tests/page-objects/AccountDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountDetails.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { IdentifierHashPo } from "$tests/page-objects/IdentifierHash.page-object";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountDetailsPo extends BasePageObject {
   private static readonly TID = "account-details-component";

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -1,8 +1,8 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AccountDetailsPo } from "./AccountDetails.page-object";
-import { LinkPo } from "./Link.page-object";
+import { AccountDetailsPo } from "$tests/page-objects/AccountDetails.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
 
 export class AccountMenuPo extends BasePageObject {
   private static readonly TID = "account-menu-component";

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -1,8 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AccountDetailsPo } from "$tests/page-objects/AccountDetails.page-object";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountMenuPo extends BasePageObject {
   private static readonly TID = "account-menu-component";

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -2,10 +2,10 @@ import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
 import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AddAccountModalPo } from "./AddAccountModal.page-object";
-import { BuyICPModalPo } from "./BuyICPModal.page-object";
-import { IcpTransactionModalPo } from "./IcpTransactionModal.page-object";
-import { ReceiveModalPo } from "./ReceiveModal.page-object";
+import { AddAccountModalPo } from "$tests/page-objects/AddAccountModal.page-object";
+import { BuyICPModalPo } from "$tests/page-objects/BuyICPModal.page-object";
+import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 
 export class AccountsPo extends BasePageObject {
   private static readonly TID = "accounts-component";

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -1,11 +1,11 @@
-import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
-import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AddAccountModalPo } from "$tests/page-objects/AddAccountModal.page-object";
 import { BuyICPModalPo } from "$tests/page-objects/BuyICPModal.page-object";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
+import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountsPo extends BasePageObject {
   private static readonly TID = "accounts-component";

--- a/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { SignInAccountsPo } from "$tests/page-objects/SignInAccounts.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountsPlusPagePo extends BasePageObject {
   private static readonly TID = "accounts-plus-page-component";

--- a/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AccountsPo } from "./Accounts.page-object";
-import { SignInAccountsPo } from "./SignInAccounts.page-object";
+import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
+import { SignInAccountsPo } from "$tests/page-objects/SignInAccounts.page-object";
 
 export class AccountsPlusPagePo extends BasePageObject {
   private static readonly TID = "accounts-plus-page-component";

--- a/frontend/src/tests/page-objects/AddUserToHotkeys.page-object.ts
+++ b/frontend/src/tests/page-objects/AddUserToHotkeys.page-object.ts
@@ -1,6 +1,6 @@
+import { BannerPo } from "$tests/page-objects/Banner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BannerPo } from "$tests/page-objects/Banner.page-object";
 
 export class AddUserToHotkeysPo extends BasePageObject {
   private static readonly TID = "add-principal-to-hotkeys-modal";

--- a/frontend/src/tests/page-objects/AddUserToHotkeys.page-object.ts
+++ b/frontend/src/tests/page-objects/AddUserToHotkeys.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BannerPo } from "./Banner.page-object";
+import { BannerPo } from "$tests/page-objects/Banner.page-object";
 
 export class AddUserToHotkeysPo extends BasePageObject {
   private static readonly TID = "add-principal-to-hotkeys-modal";

--- a/frontend/src/tests/page-objects/AmountWithUsd.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountWithUsd.page-object.ts
@@ -1,6 +1,6 @@
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 
 export class AmountWithUsdPo extends BasePageObject {
   private static readonly TID = "amount-with-usd-component";

--- a/frontend/src/tests/page-objects/AmountWithUsd.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountWithUsd.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AmountDisplayPo } from "./AmountDisplay.page-object";
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 
 export class AmountWithUsdPo extends BasePageObject {
   private static readonly TID = "amount-with-usd-component";

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -20,8 +20,8 @@ import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { isNullish } from "@dfinity/utils";
 import { expect } from "@playwright/test";
-import { SignInAccountsPo } from "./SignInAccounts.page-object";
-import { TokensRoutePo } from "./TokensRoute.page-object";
+import { SignInAccountsPo } from "$tests/page-objects/SignInAccounts.page-object";
+import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
 
 export class AppPo extends BasePageObject {
   getSignInPo(): SignInPo {

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -14,14 +14,14 @@ import { ProposalDetailPo } from "$tests/page-objects/ProposalDetail.page-object
 import { ProposalsPo } from "$tests/page-objects/Proposals.page-object";
 import { SelectUniverseListPo } from "$tests/page-objects/SelectUniverseList.page-object";
 import { SignInPo } from "$tests/page-objects/SignIn.page-object";
+import { SignInAccountsPo } from "$tests/page-objects/SignInAccounts.page-object";
 import { StakingPo } from "$tests/page-objects/Staking.page-object";
 import { ToastsPo } from "$tests/page-objects/Toasts.page-object";
+import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
 import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { isNullish } from "@dfinity/utils";
 import { expect } from "@playwright/test";
-import { SignInAccountsPo } from "$tests/page-objects/SignInAccounts.page-object";
-import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
 
 export class AppPo extends BasePageObject {
   getSignInPo(): SignInPo {

--- a/frontend/src/tests/page-objects/Banner.page-object.ts
+++ b/frontend/src/tests/page-objects/Banner.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BannerIconPo } from "./BannerIcon.page-object";
-import type { ButtonPo } from "./Button.page-object";
+import { BannerIconPo } from "$tests/page-objects/BannerIcon.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class BannerPo extends BasePageObject {
   private static readonly TID = "banner-component";

--- a/frontend/src/tests/page-objects/Banner.page-object.ts
+++ b/frontend/src/tests/page-objects/Banner.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BannerIconPo } from "$tests/page-objects/BannerIcon.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class BannerPo extends BasePageObject {
   private static readonly TID = "banner-component";

--- a/frontend/src/tests/page-objects/BuyICPModal.page-object.ts
+++ b/frontend/src/tests/page-objects/BuyICPModal.page-object.ts
@@ -1,6 +1,6 @@
+import { HashPo } from "$tests/page-objects/Hash.page-object";
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { HashPo } from "$tests/page-objects/Hash.page-object";
 
 export class BuyICPModalPo extends ModalPo {
   private static readonly TID = "buy-icp-modal-component";

--- a/frontend/src/tests/page-objects/BuyICPModal.page-object.ts
+++ b/frontend/src/tests/page-objects/BuyICPModal.page-object.ts
@@ -1,6 +1,6 @@
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { HashPo } from "./Hash.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
 
 export class BuyICPModalPo extends ModalPo {
   private static readonly TID = "buy-icp-modal-component";

--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -1,9 +1,9 @@
 import { AddCyclesModalPo } from "$tests/page-objects/AddCyclesModal.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { CanisterPageHeadingPo } from "$tests/page-objects/CanisterPageHeading.page-object";
 import { RenameCanisterModalPo } from "$tests/page-objects/RenameCanisterModal.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class CanisterDetailPo extends BasePageObject {
   private static readonly TID = "canister-detail-component";

--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -1,9 +1,9 @@
 import { AddCyclesModalPo } from "$tests/page-objects/AddCyclesModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "./Button.page-object";
-import { CanisterPageHeadingPo } from "./CanisterPageHeading.page-object";
-import { RenameCanisterModalPo } from "./RenameCanisterModal.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { CanisterPageHeadingPo } from "$tests/page-objects/CanisterPageHeading.page-object";
+import { RenameCanisterModalPo } from "$tests/page-objects/RenameCanisterModal.page-object";
 
 export class CanisterDetailPo extends BasePageObject {
   private static readonly TID = "canister-detail-component";

--- a/frontend/src/tests/page-objects/CanisterHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterHeader.page-object.ts
@@ -1,6 +1,6 @@
+import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 
 export class CanisterHeaderPo extends BasePageObject {
   private static readonly TID = "canister-page-header-component";

--- a/frontend/src/tests/page-objects/CanisterHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterHeader.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { UniverseSummaryPo } from "./UniverseSummary.page-object";
+import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 
 export class CanisterHeaderPo extends BasePageObject {
   private static readonly TID = "canister-page-header-component";

--- a/frontend/src/tests/page-objects/CanisterPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterPageHeading.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { CanisterHeadingTitlePo } from "./CanisterHeadingTitle.page-object";
+import { CanisterHeadingTitlePo } from "$tests/page-objects/CanisterHeadingTitle.page-object";
 
 export class CanisterPageHeadingPo extends BasePageObject {
   private static readonly TID = "canister-page-heading-component";

--- a/frontend/src/tests/page-objects/CanisterPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterPageHeading.page-object.ts
@@ -1,6 +1,6 @@
+import { CanisterHeadingTitlePo } from "$tests/page-objects/CanisterHeadingTitle.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { CanisterHeadingTitlePo } from "$tests/page-objects/CanisterHeadingTitle.page-object";
 
 export class CanisterPageHeadingPo extends BasePageObject {
   private static readonly TID = "canister-page-heading-component";

--- a/frontend/src/tests/page-objects/ChangeBulkNeuronVisibilityForm.page-object.ts
+++ b/frontend/src/tests/page-objects/ChangeBulkNeuronVisibilityForm.page-object.ts
@@ -1,8 +1,8 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ButtonPo } from "./Button.page-object";
-import { CheckboxPo } from "./Checkbox.page-object";
-import { NeuronVisibilityRowPo } from "./NeuronVisibilityRow.page-object";
-import { BasePageObject } from "./base.page-object";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
+import { NeuronVisibilityRowPo } from "$tests/page-objects/NeuronVisibilityRow.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class ChangeBulkNeuronVisibilityFormPo extends BasePageObject {
   private static readonly TID = "change-bulk-visibility-component";

--- a/frontend/src/tests/page-objects/ChangeBulkNeuronVisibilityForm.page-object.ts
+++ b/frontend/src/tests/page-objects/ChangeBulkNeuronVisibilityForm.page-object.ts
@@ -1,8 +1,8 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
 import { NeuronVisibilityRowPo } from "$tests/page-objects/NeuronVisibilityRow.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ChangeBulkNeuronVisibilityFormPo extends BasePageObject {
   private static readonly TID = "change-bulk-visibility-component";

--- a/frontend/src/tests/page-objects/ChangeNeuronVisibilityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ChangeNeuronVisibilityModal.page-object.ts
@@ -1,7 +1,7 @@
-import { ModalPo } from "$tests/page-objects/Modal.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ChangeBulkNeuronVisibilityFormPo } from "$tests/page-objects/ChangeBulkNeuronVisibilityForm.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ChangeNeuronVisibilityModalPo extends ModalPo {
   private static readonly TID = "change-neuron-visibility-modal";

--- a/frontend/src/tests/page-objects/ChangeNeuronVisibilityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ChangeNeuronVisibilityModal.page-object.ts
@@ -1,7 +1,7 @@
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "./Button.page-object";
-import { ChangeBulkNeuronVisibilityFormPo } from "./ChangeBulkNeuronVisibilityForm.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { ChangeBulkNeuronVisibilityFormPo } from "$tests/page-objects/ChangeBulkNeuronVisibilityForm.page-object";
 
 export class ChangeNeuronVisibilityModalPo extends ModalPo {
   private static readonly TID = "change-neuron-visibility-modal";

--- a/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
@@ -1,7 +1,7 @@
 import { InProgressPo } from "$tests/page-objects/InProgress.page-object";
 import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TransactionFormItemNetworkPo } from "./TransactionFormItemNetwor.page-object";
+import { TransactionFormItemNetworkPo } from "$tests/page-objects/TransactionFormItemNetwor.page-object";
 
 export class CkBTCTransactionModalPo extends TransactionModalBasePo {
   private static readonly TID = "ckbtc-transaction-modal-component";

--- a/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
@@ -1,7 +1,7 @@
 import { InProgressPo } from "$tests/page-objects/InProgress.page-object";
+import { TransactionFormItemNetworkPo } from "$tests/page-objects/TransactionFormItemNetwor.page-object";
 import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TransactionFormItemNetworkPo } from "$tests/page-objects/TransactionFormItemNetwor.page-object";
 
 export class CkBTCTransactionModalPo extends TransactionModalBasePo {
   private static readonly TID = "ckbtc-transaction-modal-component";

--- a/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
+++ b/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
@@ -1,5 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class CommitmentProgressBarPo extends BasePageObject {
   private static TID = "commitment-progress-bar-component";

--- a/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
+++ b/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
@@ -1,5 +1,5 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class CommitmentProgressBarPo extends BasePageObject {
   private static TID = "commitment-progress-bar-component";

--- a/frontend/src/tests/page-objects/ConfirmFollowingBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmFollowingBanner.page-object.ts
@@ -1,5 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class ConfirmFollowingBannerPo extends BasePageObject {
   private static readonly TID = "confirm-following-banner-component";

--- a/frontend/src/tests/page-objects/ConfirmFollowingBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmFollowingBanner.page-object.ts
@@ -1,5 +1,5 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ConfirmFollowingBannerPo extends BasePageObject {
   private static readonly TID = "confirm-following-banner-component";

--- a/frontend/src/tests/page-objects/DisburseMaturityButton.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityButton.page-object.ts
@@ -1,7 +1,7 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipPo } from "./Tooltip.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 
 export class DisburseMaturityButtonPo extends BasePageObject {
   private static readonly TID = "disburse-maturity-button-component";

--- a/frontend/src/tests/page-objects/DisburseMaturityButton.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityButton.page-object.ts
@@ -1,7 +1,7 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 
 export class DisburseMaturityButtonPo extends BasePageObject {
   private static readonly TID = "disburse-maturity-button-component";

--- a/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
@@ -2,7 +2,7 @@ import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { NeuronConfirmActionScreenPo } from "$tests/page-objects/NeuronConfirmActionScreen.page-object";
 import { NeuronSelectPercentagePo } from "$tests/page-objects/NeuronSelectPercentage.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SelectDestinationAddressPo } from "./SelectDestinationAddress.page-object";
+import { SelectDestinationAddressPo } from "$tests/page-objects/SelectDestinationAddress.page-object";
 
 export class DisburseMaturityModalPo extends ModalPo {
   private static readonly TID = "disburse-maturity-modal-component";

--- a/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
@@ -1,8 +1,8 @@
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { NeuronConfirmActionScreenPo } from "$tests/page-objects/NeuronConfirmActionScreen.page-object";
 import { NeuronSelectPercentagePo } from "$tests/page-objects/NeuronSelectPercentage.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SelectDestinationAddressPo } from "$tests/page-objects/SelectDestinationAddress.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class DisburseMaturityModalPo extends ModalPo {
   private static readonly TID = "disburse-maturity-modal-component";

--- a/frontend/src/tests/page-objects/Followee.page-object.ts
+++ b/frontend/src/tests/page-objects/Followee.page-object.ts
@@ -1,7 +1,7 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { TagPo } from "$tests/page-objects/Tag.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class FolloweePo extends BasePageObject {
   private static readonly TID = "followee-component";

--- a/frontend/src/tests/page-objects/Followee.page-object.ts
+++ b/frontend/src/tests/page-objects/Followee.page-object.ts
@@ -1,7 +1,7 @@
 import { TagPo } from "$tests/page-objects/Tag.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "./Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class FolloweePo extends BasePageObject {
   private static readonly TID = "followee-component";

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -1,6 +1,6 @@
+import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 
 export class GetTokensPo extends BasePageObject {
   static readonly TID = "get-tokens-component";

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DropdownPo } from "./Dropdown.page-object";
+import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 
 export class GetTokensPo extends BasePageObject {
   static readonly TID = "get-tokens-component";

--- a/frontend/src/tests/page-objects/HeadingSubtitleWithUsdValue.page-object.ts
+++ b/frontend/src/tests/page-objects/HeadingSubtitleWithUsdValue.page-object.ts
@@ -1,6 +1,6 @@
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 
 export class HeadingSubtitleWithUsdValuePo extends BasePageObject {
   private static readonly TID = "heading-subtitle-with-usd-value-component";

--- a/frontend/src/tests/page-objects/HeadingSubtitleWithUsdValue.page-object.ts
+++ b/frontend/src/tests/page-objects/HeadingSubtitleWithUsdValue.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipIconPo } from "./TooltipIcon.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 
 export class HeadingSubtitleWithUsdValuePo extends BasePageObject {
   private static readonly TID = "heading-subtitle-with-usd-value-component";

--- a/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
@@ -1,3 +1,4 @@
+import { AddIndexCanisterModalPo } from "$tests/page-objects/AddIndexCanisterModal.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcrcWalletFooterPo } from "$tests/page-objects/IcrcWalletFooter.page-object";
 import { ImportTokenRemoveConfirmationPo } from "$tests/page-objects/ImportTokenRemoveConfirmation.page-object";
@@ -7,7 +8,6 @@ import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-ob
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AddIndexCanisterModalPo } from "$tests/page-objects/AddIndexCanisterModal.page-object";
 
 export class IcrcWalletPo extends BasePageObject {
   private static readonly TID = "icrc-wallet-component";

--- a/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
@@ -7,7 +7,7 @@ import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-ob
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AddIndexCanisterModalPo } from "./AddIndexCanisterModal.page-object";
+import { AddIndexCanisterModalPo } from "$tests/page-objects/AddIndexCanisterModal.page-object";
 
 export class IcrcWalletPo extends BasePageObject {
   private static readonly TID = "icrc-wallet-component";

--- a/frontend/src/tests/page-objects/LedgerNeuronHotkeyWarning.page-object.ts
+++ b/frontend/src/tests/page-objects/LedgerNeuronHotkeyWarning.page-object.ts
@@ -1,6 +1,6 @@
+import { BannerPo } from "$tests/page-objects/Banner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BannerPo } from "$tests/page-objects/Banner.page-object";
 
 export class LedgerNeuronHotkeyWarningPo extends BasePageObject {
   private static readonly TID = "ledger-neuron-hotkey-warning-component";

--- a/frontend/src/tests/page-objects/LedgerNeuronHotkeyWarning.page-object.ts
+++ b/frontend/src/tests/page-objects/LedgerNeuronHotkeyWarning.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BannerPo } from "./Banner.page-object";
+import { BannerPo } from "$tests/page-objects/Banner.page-object";
 
 export class LedgerNeuronHotkeyWarningPo extends BasePageObject {
   private static readonly TID = "ledger-neuron-hotkey-warning-component";

--- a/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
@@ -1,7 +1,7 @@
-import { ModalPo } from "$tests/page-objects/Modal.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ConfirmFollowingButtonPo } from "$tests/page-objects/ConfirmFollowingButton.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { NnsLosingRewardsNeuronCardPo } from "$tests/page-objects/NnsLosingRewardsNeuronCard.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class LosingRewardNeuronsModalPo extends ModalPo {
   static readonly TID = "losing-reward-neurons-modal-component";

--- a/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardNeuronsModal.page-object.ts
@@ -1,7 +1,7 @@
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ConfirmFollowingButtonPo } from "./ConfirmFollowingButton.page-object";
-import { NnsLosingRewardsNeuronCardPo } from "./NnsLosingRewardsNeuronCard.page-object";
+import { ConfirmFollowingButtonPo } from "$tests/page-objects/ConfirmFollowingButton.page-object";
+import { NnsLosingRewardsNeuronCardPo } from "$tests/page-objects/NnsLosingRewardsNeuronCard.page-object";
 
 export class LosingRewardNeuronsModalPo extends ModalPo {
   static readonly TID = "losing-reward-neurons-modal-component";

--- a/frontend/src/tests/page-objects/LosingRewardsBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardsBanner.page-object.ts
@@ -1,7 +1,7 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BannerPo } from "$tests/page-objects/Banner.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class LosingRewardsBannerPo extends BasePageObject {
   private static readonly TID = "losing-rewards-banner-component";

--- a/frontend/src/tests/page-objects/LosingRewardsBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/LosingRewardsBanner.page-object.ts
@@ -1,7 +1,7 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BannerPo } from "./Banner.page-object";
-import { BasePageObject } from "./base.page-object";
-import { LosingRewardNeuronsModalPo } from "./LosingRewardNeuronsModal.page-object";
+import { BannerPo } from "$tests/page-objects/Banner.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 
 export class LosingRewardsBannerPo extends BasePageObject {
   private static readonly TID = "losing-rewards-banner-component";

--- a/frontend/src/tests/page-objects/MakeNeuronsPublicBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/MakeNeuronsPublicBanner.page-object.ts
@@ -1,8 +1,8 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "./Button.page-object";
-import { ChangeNeuronVisibilityModalPo } from "./ChangeNeuronVisibilityModal.page-object";
-import { LinkPo } from "./Link.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { ChangeNeuronVisibilityModalPo } from "$tests/page-objects/ChangeNeuronVisibilityModal.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
 
 export class MakeNeuronsPublicBannerPo extends BasePageObject {
   private static readonly TID = "make-neurons-public-banner-component";

--- a/frontend/src/tests/page-objects/MakeNeuronsPublicBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/MakeNeuronsPublicBanner.page-object.ts
@@ -1,8 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ChangeNeuronVisibilityModalPo } from "$tests/page-objects/ChangeNeuronVisibilityModal.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class MakeNeuronsPublicBannerPo extends BasePageObject {
   private static readonly TID = "make-neurons-public-banner-component";

--- a/frontend/src/tests/page-objects/NeuronFollowingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronFollowingCard.page-object.ts
@@ -1,7 +1,7 @@
+import { FollowNeuronsButtonPo } from "$tests/page-objects/FollowNeuronsButton.page-object";
+import { FolloweePo } from "$tests/page-objects/Followee.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { FolloweePo } from "$tests/page-objects/Followee.page-object";
-import { FollowNeuronsButtonPo } from "$tests/page-objects/FollowNeuronsButton.page-object";
 
 export class NeuronFollowingCardPo extends BasePageObject {
   static readonly TID = "neuron-following-card-component";

--- a/frontend/src/tests/page-objects/NeuronFollowingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronFollowingCard.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { FolloweePo } from "./Followee.page-object";
-import { FollowNeuronsButtonPo } from "./FollowNeuronsButton.page-object";
+import { FolloweePo } from "$tests/page-objects/Followee.page-object";
+import { FollowNeuronsButtonPo } from "$tests/page-objects/FollowNeuronsButton.page-object";
 
 export class NeuronFollowingCardPo extends BasePageObject {
   static readonly TID = "neuron-following-card-component";

--- a/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
@@ -1,8 +1,8 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronTagPo } from "./NeuronTag.page-object";
-import { TooltipPo } from "./Tooltip.page-object";
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 
 export class NeuronIdCellPo extends BasePageObject {
   private static readonly TID = "neuron-id-cell-component";

--- a/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
@@ -1,8 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NeuronIdCellPo extends BasePageObject {
   private static readonly TID = "neuron-id-cell-component";

--- a/frontend/src/tests/page-objects/NeuronTag.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronTag.page-object.ts
@@ -1,5 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TagPo } from "./Tag.page-object";
+import { TagPo } from "$tests/page-objects/Tag.page-object";
 
 export class NeuronTagPo extends TagPo {
   private static readonly NeuronTagTID = "neuron-tag-component";

--- a/frontend/src/tests/page-objects/NeuronTag.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronTag.page-object.ts
@@ -1,5 +1,5 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { TagPo } from "$tests/page-objects/Tag.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NeuronTagPo extends TagPo {
   private static readonly NeuronTagTID = "neuron-tag-component";

--- a/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
@@ -1,9 +1,9 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 
 export class NeuronVisibilityRowPo extends BasePageObject {
   private static readonly BASE_TID = "neuron-visibility-row-component";

--- a/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
@@ -3,7 +3,7 @@ import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronTagPo } from "./NeuronTag.page-object";
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 
 export class NeuronVisibilityRowPo extends BasePageObject {
   private static readonly BASE_TID = "neuron-visibility-row-component";

--- a/frontend/src/tests/page-objects/NfCommitmentProgressBarPo.page-object.ts
+++ b/frontend/src/tests/page-objects/NfCommitmentProgressBarPo.page-object.ts
@@ -1,5 +1,5 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NfCommitmentProgressBarPo extends BasePageObject {
   private static TID = "nf-commitment-progress-bar-component";

--- a/frontend/src/tests/page-objects/NfCommitmentProgressBarPo.page-object.ts
+++ b/frontend/src/tests/page-objects/NfCommitmentProgressBarPo.page-object.ts
@@ -1,5 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class NfCommitmentProgressBarPo extends BasePageObject {
   private static TID = "nf-commitment-progress-bar-component";

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -1,8 +1,8 @@
 import { NnsAddAccountPo } from "$tests/page-objects/NnsAddAccount.page-object";
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TokensTablePo } from "./TokensTable.page-object";
-import { BasePageObject } from "./base.page-object";
+import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class NnsAccountsPo extends BasePageObject {
   private static readonly TID = "accounts-body";

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -1,8 +1,8 @@
 import { NnsAddAccountPo } from "$tests/page-objects/NnsAddAccount.page-object";
-import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsAccountsPo extends BasePageObject {
   private static readonly TID = "accounts-body";

--- a/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
@@ -1,6 +1,6 @@
 import { CardPo } from "$tests/page-objects/Card.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { FolloweePo } from "./Followee.page-object";
+import { FolloweePo } from "$tests/page-objects/Followee.page-object";
 
 export class NnsLosingRewardsNeuronCardPo extends CardPo {
   private static readonly TID = "nns-loosing-rewards-neuron-card-component";

--- a/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
@@ -1,6 +1,6 @@
 import { CardPo } from "$tests/page-objects/Card.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { FolloweePo } from "$tests/page-objects/Followee.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsLosingRewardsNeuronCardPo extends CardPo {
   private static readonly TID = "nns-loosing-rewards-neuron-card-component";

--- a/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
@@ -1,9 +1,9 @@
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import { NnsNeuronAgePo } from "$tests/page-objects/NnsNeuronAge.page-object";
 import { NnsNeuronPublicVisibilityActionPo } from "$tests/page-objects/NnsNeuronPublicVisibilityAction.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronAdvancedSectionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-advanced-section-component";

--- a/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
@@ -1,9 +1,9 @@
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { HashPo } from "./Hash.page-object";
-import { NnsNeuronAgePo } from "./NnsNeuronAge.page-object";
-import { NnsNeuronPublicVisibilityActionPo } from "./NnsNeuronPublicVisibilityAction.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { NnsNeuronAgePo } from "$tests/page-objects/NnsNeuronAge.page-object";
+import { NnsNeuronPublicVisibilityActionPo } from "$tests/page-objects/NnsNeuronPublicVisibilityAction.page-object";
 
 export class NnsNeuronAdvancedSectionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-advanced-section-component";

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronTagPo } from "./NeuronTag.page-object";
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 
 export class NnsNeuronCardTitlePo extends BasePageObject {
   private static readonly TID = "neuron-card-title";

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,6 +1,6 @@
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 
 export class NnsNeuronCardTitlePo extends BasePageObject {
   private static readonly TID = "neuron-card-title";

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -1,15 +1,15 @@
+import { ConfirmFollowingBannerPo } from "$tests/page-objects/ConfirmFollowingBanner.page-object";
 import { NnsNeuronAdvancedSectionPo } from "$tests/page-objects/NnsNeuronAdvancedSection.page-object";
 import { NnsNeuronHotkeysCardPo } from "$tests/page-objects/NnsNeuronHotkeysCard.page-object";
 import { NnsNeuronMaturitySectionPo } from "$tests/page-objects/NnsNeuronMaturitySection.page-object";
 import { NnsNeuronModalsPo } from "$tests/page-objects/NnsNeuronModals.page-object";
+import { NnsNeuronPageHeaderPo } from "$tests/page-objects/NnsNeuronPageHeader.page-object";
+import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 import { NnsNeuronTestnetFunctionsCardPo } from "$tests/page-objects/NnsNeuronTestnetFunctionsCard.page-object";
 import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVotingPowerSection.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ConfirmFollowingBannerPo } from "$tests/page-objects/ConfirmFollowingBanner.page-object";
-import { NnsNeuronPageHeaderPo } from "$tests/page-objects/NnsNeuronPageHeader.page-object";
-import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 
 export class NnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "nns-neuron-detail-component";

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -7,9 +7,9 @@ import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVoti
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ConfirmFollowingBannerPo } from "./ConfirmFollowingBanner.page-object";
-import { NnsNeuronPageHeaderPo } from "./NnsNeuronPageHeader.page-object";
-import { NnsNeuronRewardStatusActionPo } from "./NnsNeuronRewardStatusAction.page-object";
+import { ConfirmFollowingBannerPo } from "$tests/page-objects/ConfirmFollowingBanner.page-object";
+import { NnsNeuronPageHeaderPo } from "$tests/page-objects/NnsNeuronPageHeader.page-object";
+import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 
 export class NnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "nns-neuron-detail-component";

--- a/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
@@ -1,7 +1,7 @@
+import { DissolveDelayBonusTextPo } from "$tests/page-objects/DissolveDelayBonusText.page-object";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DissolveDelayBonusTextPo } from "$tests/page-objects/DissolveDelayBonusText.page-object";
 
 export class NnsNeuronDissolveDelayItemActionPo extends BasePageObject {
   private static readonly TID =

--- a/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
@@ -1,7 +1,7 @@
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DissolveDelayBonusTextPo } from "./DissolveDelayBonusText.page-object";
+import { DissolveDelayBonusTextPo } from "$tests/page-objects/DissolveDelayBonusText.page-object";
 
 export class NnsNeuronDissolveDelayItemActionPo extends BasePageObject {
   private static readonly TID =

--- a/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { NnsAvailableMaturityItemActionPo } from "$tests/page-objects/NnsAvailableMaturityItemAction.page-object";
 import { NnsStakedMaturityItemActionPo } from "$tests/page-objects/NnsStakedMaturityItemAction.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronMaturitySectionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-maturity-section-component";

--- a/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NnsAvailableMaturityItemActionPo } from "./NnsAvailableMaturityItemAction.page-object";
-import { NnsStakedMaturityItemActionPo } from "./NnsStakedMaturityItemAction.page-object";
+import { NnsAvailableMaturityItemActionPo } from "$tests/page-objects/NnsAvailableMaturityItemAction.page-object";
+import { NnsStakedMaturityItemActionPo } from "$tests/page-objects/NnsStakedMaturityItemAction.page-object";
 
 export class NnsNeuronMaturitySectionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-maturity-section-component";

--- a/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
@@ -7,7 +7,7 @@ import { NnsAddMaturityModalPo } from "$tests/page-objects/NnsAddMaturityModal.p
 import { SpawnNeuronModalPo } from "$tests/page-objects/SpawnNeuronModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { LosingRewardNeuronsModalPo } from "./LosingRewardNeuronsModal.page-object";
+import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 
 export class NnsNeuronModalsPo extends BasePageObject {
   private static readonly TID = "nns-neuron-modals-component";

--- a/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
@@ -3,11 +3,11 @@ import { DisburseNnsNeuronModalPo } from "$tests/page-objects/DisburseNnsNeuronM
 import { DissolveActionButtonModalPo } from "$tests/page-objects/DissolveActionButtonModal.page-object";
 import { IncreaseNeuronStakeModalPo } from "$tests/page-objects/IncreaseNeuronStakeModal.page-object";
 import { JoinCommunityFundModalPo } from "$tests/page-objects/JoinCommunityFundModal.page-object";
+import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 import { NnsAddMaturityModalPo } from "$tests/page-objects/NnsAddMaturityModal.page-object";
 import { SpawnNeuronModalPo } from "$tests/page-objects/SpawnNeuronModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 
 export class NnsNeuronModalsPo extends BasePageObject {
   private static readonly TID = "nns-neuron-modals-component";

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeader.page-object.ts
@@ -1,7 +1,7 @@
+import { NeuronNavigationPo } from "$tests/page-objects/NeuronNavigation.page-object";
 import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronNavigationPo } from "$tests/page-objects/NeuronNavigation.page-object";
 
 export class NnsNeuronPageHeaderPo extends BasePageObject {
   private static readonly TID = "nns-neuron-page-header-component";

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeader.page-object.ts
@@ -1,7 +1,7 @@
 import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronNavigationPo } from "./NeuronNavigation.page-object";
+import { NeuronNavigationPo } from "$tests/page-objects/NeuronNavigation.page-object";
 
 export class NnsNeuronPageHeaderPo extends BasePageObject {
   private static readonly TID = "nns-neuron-page-header-component";

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
@@ -1,8 +1,8 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { HeadingSubtitleWithUsdValuePo } from "./HeadingSubtitleWithUsdValue.page-object";
-import { NeuronTagPo } from "./NeuronTag.page-object";
+import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 
 export class NnsNeuronPageHeadingPo extends BasePageObject {
   private static readonly TID = "nns-neuron-page-heading-component";

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
@@ -1,8 +1,8 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
 import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronPageHeadingPo extends BasePageObject {
   private static readonly TID = "nns-neuron-page-heading-component";

--- a/frontend/src/tests/page-objects/NnsNeuronPublicVisibilityAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPublicVisibilityAction.page-object.ts
@@ -1,9 +1,9 @@
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ButtonPo } from "./Button.page-object";
-import { LinkPo } from "./Link.page-object";
-import { TooltipPo } from "./Tooltip.page-object";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 
 export class NnsNeuronPublicVisibilityActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-public-visibility-action-component";

--- a/frontend/src/tests/page-objects/NnsNeuronPublicVisibilityAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPublicVisibilityAction.page-object.ts
@@ -1,9 +1,9 @@
-import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronPublicVisibilityActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-public-visibility-action-component";

--- a/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ConfirmFollowingActionButtonPo } from "./ConfirmFollowingActionButton.page-object";
-import { FollowNeuronsButtonPo } from "./FollowNeuronsButton.page-object";
+import { ConfirmFollowingActionButtonPo } from "$tests/page-objects/ConfirmFollowingActionButton.page-object";
+import { FollowNeuronsButtonPo } from "$tests/page-objects/FollowNeuronsButton.page-object";
 
 export class NnsNeuronRewardStatusActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-reward-status-action-component";

--- a/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronRewardStatusAction.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ConfirmFollowingActionButtonPo } from "$tests/page-objects/ConfirmFollowingActionButton.page-object";
 import { FollowNeuronsButtonPo } from "$tests/page-objects/FollowNeuronsButton.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronRewardStatusActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-reward-status-action-component";

--- a/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AgeBonusTextPo } from "$tests/page-objects/AgeBonusText.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronStateItemActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-state-item-action-component";

--- a/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AgeBonusTextPo } from "./AgeBonusText.page-object";
-import type { ButtonPo } from "./Button.page-object";
+import { AgeBonusTextPo } from "$tests/page-objects/AgeBonusText.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class NnsNeuronStateItemActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-state-item-action-component";

--- a/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
@@ -2,8 +2,8 @@ import { NnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/NnsNeuro
 import { NnsNeuronStateItemActionPo } from "$tests/page-objects/NnsNeuronStateItemAction.page-object";
 import { StakeItemActionPo } from "$tests/page-objects/StakeItemAction.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
-import { NnsNeuronRewardStatusActionPo } from "./NnsNeuronRewardStatusAction.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 
 export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-voting-power-section-component";

--- a/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
@@ -1,9 +1,9 @@
 import { NnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object";
+import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
 import { NnsNeuronStateItemActionPo } from "$tests/page-objects/NnsNeuronStateItemAction.page-object";
 import { StakeItemActionPo } from "$tests/page-objects/StakeItemAction.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
-import { NnsNeuronRewardStatusActionPo } from "$tests/page-objects/NnsNeuronRewardStatusAction.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-voting-power-section-component";

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -1,9 +1,9 @@
+import { LosingRewardsBannerPo } from "$tests/page-objects/LosingRewardsBanner.page-object";
+import { MakeNeuronsPublicBannerPo } from "$tests/page-objects/MakeNeuronsPublicBanner.page-object";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { LosingRewardsBannerPo } from "$tests/page-objects/LosingRewardsBanner.page-object";
-import { MakeNeuronsPublicBannerPo } from "$tests/page-objects/MakeNeuronsPublicBanner.page-object";
 
 export class NnsNeuronsPo extends BasePageObject {
   private static readonly TID = "nns-neurons-component";

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -2,8 +2,8 @@ import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { LosingRewardsBannerPo } from "./LosingRewardsBanner.page-object";
-import { MakeNeuronsPublicBannerPo } from "./MakeNeuronsPublicBanner.page-object";
+import { LosingRewardsBannerPo } from "$tests/page-objects/LosingRewardsBanner.page-object";
+import { MakeNeuronsPublicBannerPo } from "$tests/page-objects/MakeNeuronsPublicBanner.page-object";
 
 export class NnsNeuronsPo extends BasePageObject {
   private static readonly TID = "nns-neurons-component";

--- a/frontend/src/tests/page-objects/NnsStakeNeuron.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakeNeuron.page-object.ts
@@ -4,7 +4,7 @@ import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
 import { TransactionFromAccountPo } from "$tests/page-objects/TransactionFromAccount.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipIconPo } from "./TooltipIcon.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 
 export class NnsStakeNeuronPo extends BasePageObject {
   private static readonly TID = "nns-stake-neuron-component";

--- a/frontend/src/tests/page-objects/NnsStakeNeuron.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakeNeuron.page-object.ts
@@ -1,10 +1,10 @@
 import { AmountInputPo } from "$tests/page-objects/AmountInput.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { TransactionFromAccountPo } from "$tests/page-objects/TransactionFromAccount.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 
 export class NnsStakeNeuronPo extends BasePageObject {
   private static readonly TID = "nns-stake-neuron-component";

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -1,13 +1,13 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { LedgerNeuronHotkeyWarningPo } from "$tests/page-objects/LedgerNeuronHotkeyWarning.page-object";
 import { SignInPo } from "$tests/page-objects/SignIn.page-object";
+import { UiTransactionsListPo } from "$tests/page-objects/UiTransactionsList.page-object";
 import { WalletMorePopoverPo } from "$tests/page-objects/WalletMorePopover.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { LedgerNeuronHotkeyWarningPo } from "$tests/page-objects/LedgerNeuronHotkeyWarning.page-object";
-import { UiTransactionsListPo } from "$tests/page-objects/UiTransactionsList.page-object";
 
 export class NnsWalletPo extends BasePageObject {
   private static readonly TID = "nns-wallet-component";

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -6,8 +6,8 @@ import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-ob
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { LedgerNeuronHotkeyWarningPo } from "./LedgerNeuronHotkeyWarning.page-object";
-import { UiTransactionsListPo } from "./UiTransactionsList.page-object";
+import { LedgerNeuronHotkeyWarningPo } from "$tests/page-objects/LedgerNeuronHotkeyWarning.page-object";
+import { UiTransactionsListPo } from "$tests/page-objects/UiTransactionsList.page-object";
 
 export class NnsWalletPo extends BasePageObject {
   private static readonly TID = "nns-wallet-component";

--- a/frontend/src/tests/page-objects/NoNeuronsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NoNeuronsCard.page-object.ts
@@ -1,5 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class NoNeuronsCardPo extends BasePageObject {
   private static readonly TID = "no-neurons-card";

--- a/frontend/src/tests/page-objects/NoNeuronsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NoNeuronsCard.page-object.ts
@@ -1,5 +1,5 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NoNeuronsCardPo extends BasePageObject {
   private static readonly TID = "no-neurons-card";

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -1,7 +1,7 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NoNeuronsCardPo } from "./NoNeuronsCard.page-object";
-import { UsdValueBannerPo } from "./UsdValueBanner.page-object";
-import { BasePageObject } from "./base.page-object";
+import { NoNeuronsCardPo } from "$tests/page-objects/NoNeuronsCard.page-object";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
   private static readonly TID = "portfolio-page-component";

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -1,7 +1,7 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { NoNeuronsCardPo } from "$tests/page-objects/NoNeuronsCard.page-object";
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class PortfolioPagePo extends BasePageObject {
   private static readonly TID = "portfolio-page-component";

--- a/frontend/src/tests/page-objects/ProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCard.page-object.ts
@@ -1,6 +1,6 @@
 import { CardPo } from "$tests/page-objects/Card.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ProjectCardSwapInfoPo } from "./ProjectCardSwapInfo.page-object";
+import { ProjectCardSwapInfoPo } from "$tests/page-objects/ProjectCardSwapInfo.page-object";
 
 export class ProjectCardPo extends CardPo {
   private static readonly TID = "project-card-component";

--- a/frontend/src/tests/page-objects/ProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCard.page-object.ts
@@ -1,6 +1,6 @@
 import { CardPo } from "$tests/page-objects/Card.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ProjectCardSwapInfoPo } from "$tests/page-objects/ProjectCardSwapInfo.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ProjectCardPo extends CardPo {
   private static readonly TID = "project-card-component";

--- a/frontend/src/tests/page-objects/ProjectCommitment.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCommitment.page-object.ts
@@ -1,8 +1,8 @@
+import { CommitmentProgressBarPo } from "$tests/page-objects/CommitmentProgressBarPo.page-object";
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 import { NfCommitmentProgressBarPo } from "$tests/page-objects/NfCommitmentProgressBarPo.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { CommitmentProgressBarPo } from "$tests/page-objects/CommitmentProgressBarPo.page-object";
-import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 
 export class ProjectCommitmentPo extends BasePageObject {
   private static readonly TID = "project-commitment-component";

--- a/frontend/src/tests/page-objects/ProjectCommitment.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCommitment.page-object.ts
@@ -1,8 +1,8 @@
 import { NfCommitmentProgressBarPo } from "$tests/page-objects/NfCommitmentProgressBarPo.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { CommitmentProgressBarPo } from "./CommitmentProgressBarPo.page-object";
-import { KeyValuePairPo } from "./KeyValuePair.page-object";
+import { CommitmentProgressBarPo } from "$tests/page-objects/CommitmentProgressBarPo.page-object";
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 
 export class ProjectCommitmentPo extends BasePageObject {
   private static readonly TID = "project-commitment-component";

--- a/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
@@ -1,10 +1,10 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { ParticipateSwapModalPo } from "$tests/page-objects/ParticipateSwapModal.page-object";
 import { ProjectInfoSectionPo } from "$tests/page-objects/ProjectInfoSection.page-object";
 import { ProjectMetadataSectionPo } from "$tests/page-objects/ProjectMetadataSection.page-object";
 import { ProjectStatusSectionPo } from "$tests/page-objects/ProjectStatusSection.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class ProjectDetailPo extends BasePageObject {
   private static readonly TID = "project-detail-component";

--- a/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
@@ -4,7 +4,7 @@ import { ProjectMetadataSectionPo } from "$tests/page-objects/ProjectMetadataSec
 import { ProjectStatusSectionPo } from "$tests/page-objects/ProjectStatusSection.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "./Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class ProjectDetailPo extends BasePageObject {
   private static readonly TID = "project-detail-component";

--- a/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
@@ -1,7 +1,7 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SelectAccountDropdownPo } from "$tests/page-objects/SelectAccountDropdown.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ReceiveModalPo extends ModalPo {
   private static readonly TID = "receive-modal";

--- a/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
@@ -1,7 +1,7 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SelectAccountDropdownPo } from "./SelectAccountDropdown.page-object";
+import { SelectAccountDropdownPo } from "$tests/page-objects/SelectAccountDropdown.page-object";
 
 export class ReceiveModalPo extends ModalPo {
   private static readonly TID = "receive-modal";

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -1,6 +1,6 @@
 import type { ReportingPeriod } from "$lib/types/reporting";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SimpleBasePageObject } from "$tests/page-objects/simple-base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
   static readonly TID = "reporting-data-range-selector-component";

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -1,6 +1,6 @@
 import type { ReportingPeriod } from "$lib/types/reporting";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SimpleBasePageObject } from "./simple-base.page-object";
+import { SimpleBasePageObject } from "$tests/page-objects/simple-base.page-object";
 
 export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
   static readonly TID = "reporting-data-range-selector-component";

--- a/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ReportingPagePo } from "$tests/page-objects/ReportingPage.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ReportingRoutePo extends BasePageObject {
   private static readonly TID = "reporting-route-component";

--- a/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingRoute.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ButtonPo } from "./Button.page-object";
-import { ReportingPagePo } from "./ReportingPage.page-object";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { ReportingPagePo } from "$tests/page-objects/ReportingPage.page-object";
 
 export class ReportingRoutePo extends BasePageObject {
   private static readonly TID = "reporting-route-component";

--- a/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
@@ -1,7 +1,7 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ReportingDateRangeSelectorPo } from "$tests/page-objects/ReportingDateRangeSelector.page-object";
 import { ReportingTransactionsButtonPo } from "$tests/page-objects/ReportingTransactionsButton.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ReportingTransactionsPo extends BasePageObject {
   static readonly TID = "reporting-transactions-component";

--- a/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactions.page-object.ts
@@ -1,7 +1,7 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ReportingDateRangeSelectorPo } from "./ReportingDateRangeSelector.page-object";
-import { ReportingTransactionsButtonPo } from "./ReportingTransactionsButton.page-object";
-import { BasePageObject } from "./base.page-object";
+import { ReportingDateRangeSelectorPo } from "$tests/page-objects/ReportingDateRangeSelector.page-object";
+import { ReportingTransactionsButtonPo } from "$tests/page-objects/ReportingTransactionsButton.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class ReportingTransactionsPo extends BasePageObject {
   static readonly TID = "reporting-transactions-component";

--- a/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
@@ -1,5 +1,5 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ResponsiveTableRowPo extends BasePageObject {
   static readonly TID = "responsive-table-row-component";

--- a/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
@@ -1,5 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class ResponsiveTableRowPo extends BasePageObject {
   static readonly TID = "responsive-table-row-component";

--- a/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DropdownPo } from "./Dropdown.page-object";
+import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 
 export class SelectAccountDropdownPo extends BasePageObject {
   private static readonly TID = "select-account-dropdown-component";

--- a/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
@@ -1,6 +1,6 @@
+import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 
 export class SelectAccountDropdownPo extends BasePageObject {
   private static readonly TID = "select-account-dropdown-component";

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,8 +1,8 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
+import { RangeDissolveDelayPo } from "$tests/page-objects/RangeDissolveDelay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { RangeDissolveDelayPo } from "$tests/page-objects/RangeDissolveDelay.page-object";
 
 export class SetDissolveDelayPo extends BasePageObject {
   private static readonly TID = "set-dissolve-delay-component";

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -2,7 +2,7 @@ import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { RangeDissolveDelayPo } from "./RangeDissolveDelay.page-object";
+import { RangeDissolveDelayPo } from "$tests/page-objects/RangeDissolveDelay.page-object";
 
 export class SetDissolveDelayPo extends BasePageObject {
   private static readonly TID = "set-dissolve-delay-component";

--- a/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TokensTablePo } from "./TokensTable.page-object";
+import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 
 export class SignInAccountsPo extends BasePageObject {
   static readonly TID = "accounts-landing-page";

--- a/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
@@ -1,6 +1,6 @@
+import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 
 export class SignInAccountsPo extends BasePageObject {
   static readonly TID = "accounts-landing-page";

--- a/frontend/src/tests/page-objects/SignInTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInTokens.page-object.ts
@@ -1,6 +1,6 @@
+import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 
 export class SignInTokensPagePo extends BasePageObject {
   private static readonly TID = "sign-in-tokens-page-component";

--- a/frontend/src/tests/page-objects/SignInTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInTokens.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TokensTablePo } from "./TokensTable.page-object";
+import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 
 export class SignInTokensPagePo extends BasePageObject {
   private static readonly TID = "sign-in-tokens-page-component";

--- a/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
@@ -1,7 +1,7 @@
+import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
 import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
 
 export class SnsNeuronAdvancedSectionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-advanced-section-component";

--- a/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
@@ -1,7 +1,7 @@
 import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SnsNeuronAgePo } from "./SnsNeuronAge.page-object";
+import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
 
 export class SnsNeuronAdvancedSectionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-advanced-section-component";

--- a/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SnsAvailableMaturityItemActionPo } from "$tests/page-objects/SnsAvailableMaturityItemAction.page-object";
 import { SnsStakedMaturityItemActionPo } from "$tests/page-objects/SnsStakedMaturityItemAction.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronMaturitySectionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-maturity-section-component";

--- a/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SnsAvailableMaturityItemActionPo } from "./SnsAvailableMaturityItemAction.page-object";
-import { SnsStakedMaturityItemActionPo } from "./SnsStakedMaturityItemAction.page-object";
+import { SnsAvailableMaturityItemActionPo } from "$tests/page-objects/SnsAvailableMaturityItemAction.page-object";
+import { SnsStakedMaturityItemActionPo } from "$tests/page-objects/SnsStakedMaturityItemAction.page-object";
 
 export class SnsNeuronMaturitySectionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-maturity-section-component";

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeader.page-object.ts
@@ -1,7 +1,7 @@
 import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronNavigationPo } from "./NeuronNavigation.page-object";
+import { NeuronNavigationPo } from "$tests/page-objects/NeuronNavigation.page-object";
 
 export class SnsNeuronPageHeaderPo extends BasePageObject {
   private static readonly TID = "sns-neuron-page-header-component";

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeader.page-object.ts
@@ -1,7 +1,7 @@
+import { NeuronNavigationPo } from "$tests/page-objects/NeuronNavigation.page-object";
 import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NeuronNavigationPo } from "$tests/page-objects/NeuronNavigation.page-object";
 
 export class SnsNeuronPageHeaderPo extends BasePageObject {
   private static readonly TID = "sns-neuron-page-header-component";

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
@@ -1,7 +1,7 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { HeadingSubtitleWithUsdValuePo } from "./HeadingSubtitleWithUsdValue.page-object";
+import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
 
 export class SnsNeuronPageHeadingPo extends BasePageObject {
   private static readonly TID = "sns-neuron-page-heading-component";

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
@@ -1,7 +1,7 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
 
 export class SnsNeuronPageHeadingPo extends BasePageObject {
   private static readonly TID = "sns-neuron-page-heading-component";

--- a/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
@@ -1,8 +1,8 @@
+import { AgeBonusTextPo } from "$tests/page-objects/AgeBonusText.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AgeBonusTextPo } from "$tests/page-objects/AgeBonusText.page-object";
-import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class SnsNeuronStateItemActionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-state-item-action-component";

--- a/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
@@ -1,8 +1,8 @@
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AgeBonusTextPo } from "./AgeBonusText.page-object";
-import type { ButtonPo } from "./Button.page-object";
+import { AgeBonusTextPo } from "$tests/page-objects/AgeBonusText.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class SnsNeuronStateItemActionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-state-item-action-component";

--- a/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
@@ -1,8 +1,8 @@
 import { SnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object";
 import { SnsNeuronStateItemActionPo } from "$tests/page-objects/SnsNeuronStateItemAction.page-object";
 import { StakeItemActionPo } from "$tests/page-objects/StakeItemAction.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-voting-power-section-component";

--- a/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
@@ -2,7 +2,7 @@ import { SnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/SnsNeuro
 import { SnsNeuronStateItemActionPo } from "$tests/page-objects/SnsNeuronStateItemAction.page-object";
 import { StakeItemActionPo } from "$tests/page-objects/StakeItemAction.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-voting-power-section-component";

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -1,11 +1,11 @@
 import { ProposalNavigationPo } from "$tests/page-objects/ProposalNavigation.page-object";
+import { ProposalSummarySectionPo } from "$tests/page-objects/ProposalSummarySection.page-object";
 import { SkeletonDetailsPo } from "$tests/page-objects/SkeletonDetails.page-object";
+import { SnsProposalPayloadSectionPo } from "$tests/page-objects/SnsProposalPayloadSection.page-object";
 import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
+import { SnsProposalVotingSectionPo } from "$tests/page-objects/SnsProposalVotingSection.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ProposalSummarySectionPo } from "$tests/page-objects/ProposalSummarySection.page-object";
-import { SnsProposalPayloadSectionPo } from "$tests/page-objects/SnsProposalPayloadSection.page-object";
-import { SnsProposalVotingSectionPo } from "$tests/page-objects/SnsProposalVotingSection.page-object";
 
 export class SnsProposalDetailPo extends BasePageObject {
   private static readonly TID = "sns-proposal-details-grid";

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -3,9 +3,9 @@ import { SkeletonDetailsPo } from "$tests/page-objects/SkeletonDetails.page-obje
 import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ProposalSummarySectionPo } from "./ProposalSummarySection.page-object";
-import { SnsProposalPayloadSectionPo } from "./SnsProposalPayloadSection.page-object";
-import { SnsProposalVotingSectionPo } from "./SnsProposalVotingSection.page-object";
+import { ProposalSummarySectionPo } from "$tests/page-objects/ProposalSummarySection.page-object";
+import { SnsProposalPayloadSectionPo } from "$tests/page-objects/SnsProposalPayloadSection.page-object";
+import { SnsProposalVotingSectionPo } from "$tests/page-objects/SnsProposalVotingSection.page-object";
 
 export class SnsProposalDetailPo extends BasePageObject {
   private static readonly TID = "sns-proposal-details-grid";

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -2,11 +2,11 @@ import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-ob
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BackdropPo } from "./Backdrop.page-object";
-import type { ButtonPo } from "./Button.page-object";
-import { HideZeroBalancesTogglePo } from "./HideZeroBalancesToggle.page-object";
-import { TokensTablePo } from "./TokensTable.page-object";
-import type { TokensTableRowData } from "./TokensTableRow.page-object";
+import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { HideZeroBalancesTogglePo } from "$tests/page-objects/HideZeroBalancesToggle.page-object";
+import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
+import type { TokensTableRowData } from "$tests/page-objects/TokensTableRow.page-object";
 
 export class TokensPagePo extends BasePageObject {
   private static readonly TID = "tokens-page-component";

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -1,12 +1,12 @@
-import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
-import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { HideZeroBalancesTogglePo } from "$tests/page-objects/HideZeroBalancesToggle.page-object";
+import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
 import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 import type { TokensTableRowData } from "$tests/page-objects/TokensTableRow.page-object";
+import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class TokensPagePo extends BasePageObject {
   private static readonly TID = "tokens-page-component";

--- a/frontend/src/tests/page-objects/TokensRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensRoute.page-object.ts
@@ -1,12 +1,12 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { CkBTCReceiveModalPo } from "./CkBTCReceiveModal.page-object";
-import { CkBTCTransactionModalPo } from "./CkBTCTransactionModal.page-object";
-import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
-import { ImportTokenRemoveConfirmationPo } from "./ImportTokenRemoveConfirmation.page-object";
-import { ReceiveModalPo } from "./ReceiveModal.page-object";
-import { SignInTokensPagePo } from "./SignInTokens.page-object";
-import { TokensPagePo } from "./TokensPage.page-object";
+import { CkBTCReceiveModalPo } from "$tests/page-objects/CkBTCReceiveModal.page-object";
+import { CkBTCTransactionModalPo } from "$tests/page-objects/CkBTCTransactionModal.page-object";
+import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransactionModal.page-object";
+import { ImportTokenRemoveConfirmationPo } from "$tests/page-objects/ImportTokenRemoveConfirmation.page-object";
+import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
+import { SignInTokensPagePo } from "$tests/page-objects/SignInTokens.page-object";
+import { TokensPagePo } from "$tests/page-objects/TokensPage.page-object";
 
 export class TokensRoutePo extends BasePageObject {
   private static readonly TID = "tokens-route-component";

--- a/frontend/src/tests/page-objects/TokensRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensRoute.page-object.ts
@@ -1,5 +1,3 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { CkBTCReceiveModalPo } from "$tests/page-objects/CkBTCReceiveModal.page-object";
 import { CkBTCTransactionModalPo } from "$tests/page-objects/CkBTCTransactionModal.page-object";
 import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransactionModal.page-object";
@@ -7,6 +5,8 @@ import { ImportTokenRemoveConfirmationPo } from "$tests/page-objects/ImportToken
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { SignInTokensPagePo } from "$tests/page-objects/SignInTokens.page-object";
 import { TokensPagePo } from "$tests/page-objects/TokensPage.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class TokensRoutePo extends BasePageObject {
   private static readonly TID = "tokens-route-component";

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -1,11 +1,11 @@
-import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
-import { nonNullish } from "@dfinity/utils";
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
+import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { nonNullish } from "@dfinity/utils";
 
 export type TokensTableRowData = {
   projectName: string;

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -1,11 +1,11 @@
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
-import { AmountDisplayPo } from "./AmountDisplay.page-object";
-import type { ButtonPo } from "./Button.page-object";
-import { HashPo } from "./Hash.page-object";
-import { LinkToDashboardCanisterPo } from "./LinkToDashboardCanister.page-object";
-import { TooltipPo } from "./Tooltip.page-object";
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 
 export type TokensTableRowData = {
   projectName: string;

--- a/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
@@ -1,6 +1,6 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DropdownPo } from "./Dropdown.page-object";
-import { BasePageObject } from "./base.page-object";
+import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class TransactionFormItemNetworkPo extends BasePageObject {
   private static readonly TID = "transaction-form-item-network-component";

--- a/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
@@ -1,6 +1,6 @@
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class TransactionFormItemNetworkPo extends BasePageObject {
   private static readonly TID = "transaction-form-item-network-component";

--- a/frontend/src/tests/page-objects/VestingTooltipWrapper.page-object.ts
+++ b/frontend/src/tests/page-objects/VestingTooltipWrapper.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipPo } from "./Tooltip.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 
 export class VestingTooltipWrapperPo extends BasePageObject {
   private static readonly TID = "sns-neuron-vesting-tooltip-component";

--- a/frontend/src/tests/page-objects/VestingTooltipWrapper.page-object.ts
+++ b/frontend/src/tests/page-objects/VestingTooltipWrapper.page-object.ts
@@ -1,6 +1,6 @@
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 
 export class VestingTooltipWrapperPo extends BasePageObject {
   private static readonly TID = "sns-neuron-vesting-tooltip-component";

--- a/frontend/src/tests/page-objects/VotingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingCard.page-object.ts
@@ -3,7 +3,7 @@ import { StakeNeuronToVotePo } from "$tests/page-objects/StakeNeuronToVote.page-
 import { VotingConfirmationToolbarPo } from "$tests/page-objects/VotingConfirmationToolbar.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { VotingNeuronSelectListPo } from "./VotingNeuronSelectList.page-object";
+import { VotingNeuronSelectListPo } from "$tests/page-objects/VotingNeuronSelectList.page-object";
 
 export class VotingCardPo extends BasePageObject {
   private static readonly TID = "voting-card-component";

--- a/frontend/src/tests/page-objects/VotingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingCard.page-object.ts
@@ -1,9 +1,9 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { StakeNeuronToVotePo } from "$tests/page-objects/StakeNeuronToVote.page-object";
 import { VotingConfirmationToolbarPo } from "$tests/page-objects/VotingConfirmationToolbar.page-object";
+import { VotingNeuronSelectListPo } from "$tests/page-objects/VotingNeuronSelectList.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { VotingNeuronSelectListPo } from "$tests/page-objects/VotingNeuronSelectList.page-object";
 
 export class VotingCardPo extends BasePageObject {
   private static readonly TID = "voting-card-component";

--- a/frontend/src/tests/page-objects/Wallet.page-object.ts
+++ b/frontend/src/tests/page-objects/Wallet.page-object.ts
@@ -1,10 +1,10 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { CkBTCWalletPo } from "$tests/page-objects/CkBTCWallet.page-object";
-import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
-import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransactionModal.page-object";
 import { IcrcWalletPo } from "$tests/page-objects/IcrcWallet.page-object";
+import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
+import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class WalletPo extends BasePageObject {
   private static readonly TID = "wallet-component";

--- a/frontend/src/tests/page-objects/Wallet.page-object.ts
+++ b/frontend/src/tests/page-objects/Wallet.page-object.ts
@@ -3,8 +3,8 @@ import { CkBTCWalletPo } from "$tests/page-objects/CkBTCWallet.page-object";
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
-import { IcrcWalletPo } from "./IcrcWallet.page-object";
+import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransactionModal.page-object";
+import { IcrcWalletPo } from "$tests/page-objects/IcrcWallet.page-object";
 
 export class WalletPo extends BasePageObject {
   private static readonly TID = "wallet-component";

--- a/frontend/src/tests/page-objects/WalletMorePopover.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletMorePopover.page-object.ts
@@ -1,7 +1,7 @@
 import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "./Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class WalletMorePopoverPo extends BasePageObject {
   private static readonly TID = "wallet-more-popover-component";

--- a/frontend/src/tests/page-objects/WalletMorePopover.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletMorePopover.page-object.ts
@@ -1,7 +1,7 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 
 export class WalletMorePopoverPo extends BasePageObject {
   private static readonly TID = "wallet-more-popover-component";

--- a/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { HashPo } from "./Hash.page-object";
-import { UniverseSummaryPo } from "./UniverseSummary.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 
 export class WalletPageHeaderPo extends BasePageObject {
   private static readonly TID = "wallet-page-header-component";

--- a/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class WalletPageHeaderPo extends BasePageObject {
   private static readonly TID = "wallet-page-header-component";

--- a/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
@@ -1,10 +1,10 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class WalletPageHeadingPo extends BasePageObject {
   private static readonly TID = "wallet-page-heading-component";

--- a/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
@@ -1,10 +1,10 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AmountDisplayPo } from "./AmountDisplay.page-object";
-import { HashPo } from "./Hash.page-object";
-import { HeadingSubtitleWithUsdValuePo } from "./HeadingSubtitleWithUsdValue.page-object";
-import { TooltipPo } from "./Tooltip.page-object";
-import { TooltipIconPo } from "./TooltipIcon.page-object";
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 
 export class WalletPageHeadingPo extends BasePageObject {
   private static readonly TID = "wallet-page-heading-component";

--- a/frontend/src/tests/workflows/Launchpad/LaunchpadWithLayout.svelte
+++ b/frontend/src/tests/workflows/Launchpad/LaunchpadWithLayout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import LaunchpadLayout from "../../../routes/(app)/(nns)/launchpad/+layout.svelte";
-  import Launchpad from "../../../routes/(app)/(nns)/launchpad/+page.svelte";
-  import MainLayout from "../../../routes/(app)/+layout.svelte";
+  import LaunchpadLayout from "$routes/(app)/(nns)/launchpad/+layout.svelte";
+  import Launchpad from "$routes/(app)/(nns)/launchpad/+page.svelte";
+  import MainLayout from "$routes/(app)/+layout.svelte";
 </script>
 
 <MainLayout>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,9 @@
     "strict": true,
     "paths": {
       "$lib": ["./src/lib"],
-      "$lib/*": ["./src/lib/*"]
+      "$lib/*": ["./src/lib/*"],
+      "$routes": ["./src/routes"],
+      "$routes/*": ["./src/routes/*"]
     }
   },
   "exclude": [


### PR DESCRIPTION
# Motivation

This is the first of a series of PRs aimed at replacing relative imports in our codebase with absolute imports using aliases. This change will help prevent future issues related to how different tools sort Svelte imports.

The PRs include:
* Fixing `src/test` files #6143
* Fixing `src/routes` files
* Fixing `src/lib` files
* Introducing a new step in our CI to check for relative imports and fail if any are present.

# Changes

- Replaced relative imports with absolute imports and aliases for the `src/test` directory.
- Run `./scripts/fmt-frontend` to sort imports based on rules

# Tests

- Should work as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary