### PR TITLE
NNS1-3504: Hide Cycle Transfer Station from Voting page

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Allow `dfinity:` token prefix in QR code for ICP payment.
 - Recover from interrupted canister creation in the frontend.
 - Sort projects on the Voting page based on actionable proposals and name.
+- Hide former Cycle-Transfer-Station SNS from Voting page.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -2,6 +2,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
+  import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { AppPath } from "$lib/constants/routes.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { pageStore } from "$lib/derived/page.derived";
@@ -30,11 +31,13 @@
   {/if}
 
   {#each $selectableUniversesStore as universe (universe.canisterId)}
-    <SelectUniverseCard
-      {universe}
-      {role}
-      selected={universe.canisterId === selectedUniverse}
-      on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
-    />
+    {#if universe.canisterId !== CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID}
+      <SelectUniverseCard
+        {universe}
+        {role}
+        selected={universe.canisterId === selectedUniverse}
+        on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
+      />
+    {/if}
   {/each}
 </TestIdWrapper>

--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -21,3 +21,7 @@ export const TVL_CANISTER_ID: Principal | undefined = nonNullish(
 )
   ? Principal.fromText(envVars?.tvlCanisterId)
   : undefined;
+
+// This project has been abandoned https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649
+export const CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID =
+  "ibahq-taaaa-aaaaq-aadna-cai";

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -1,3 +1,4 @@
+import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import type {
   CachedSnsDto,
   CachedSnsTokenMetadataDto,
@@ -34,9 +35,6 @@ const initSnsAggreagatorStore =
 
 export const snsAggregatorIncludingAbortedProjectsStore =
   initSnsAggreagatorStore();
-
-// This project has been abandoned https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649
-const CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID = "ibahq-taaaa-aaaaq-aadna-cai";
 
 export const snsAggregatorStore: SnsAggregatorStore = derived(
   snsAggregatorIncludingAbortedProjectsStore,


### PR DESCRIPTION
# Motivation

The Cycles-Transfer-Station SNS was renamed to `----` and made unusable by impossible proposal fees and transaction fees.

To let people see their former balance and neurons we are keeping it on the Tokens and Staking pages for now but we're hiding it from the Voting page.

# Changes

1. Move `CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID` from `frontend/src/lib/stores/sns-aggregator.store.ts` to `frontend/src/lib/constants/canister-ids.constants.ts`.
2. Hide the former "Cycles-Transfer-Station" SNS from the `SelectUniverseList` which (since the tokens/neurons tables UIs) is only used on the Voting page.

# Tests

1. Simplify test setup by using `setSnsProjects` instead of mocking `snsProjectsCommittedStore`.
2. Add a unit test with a project with the same root canister ID as "Cycles-Transfer-Station".
3. Tested manually against mainnet.

# Todos

- [x] Add entry to changelog (if necessary).
