### PR TITLE
feat(portfolio): implement projects data loading in route

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -11,7 +11,7 @@
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
 
   export let userTokensData: UserToken[];
-  export let tableProjects: TableProject[] = [];
+  export let tableProjects: TableProject[];
 
   let totalTokensBalanceInUsd: number;
   $: totalTokensBalanceInUsd = getTotalBalanceInUsd(userTokensData);

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -2,7 +2,9 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
+  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
   import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
   import Portfolio from "$lib/pages/Portfolio.svelte";
@@ -12,6 +14,9 @@
     resetBalanceLoading,
   } from "$lib/services/accounts-balances.services";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { neuronsStore } from "$lib/stores/neurons.store";
+  import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+  import { getTableProjects } from "$lib/utils/staking.utils";
 
   resetBalanceLoading();
   loadIcpSwapTickers();
@@ -37,5 +42,14 @@
 </script>
 
 <TestIdWrapper testId="portfolio-route-component"
-  ><Portfolio userTokensData={$tokensListUserStore} /></TestIdWrapper
+  ><Portfolio
+    userTokensData={$tokensListUserStore}
+    tableProjects={getTableProjects({
+      universes: $selectableUniversesStore,
+      isSignedIn: $authSignedInStore,
+      nnsNeurons: $neuronsStore?.neurons,
+      snsNeurons: $snsNeuronsStore,
+      icpSwapUsdPrices: $icpSwapUsdPricesStore,
+    })}
+  /></TestIdWrapper
 >

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -15,7 +15,7 @@ import { render } from "@testing-library/svelte";
 describe("Portfolio page", () => {
   const renderPage = ({
     userTokensData = [],
-    tableProjects,
+    tableProjects = [],
   }: { userTokensData?: UserToken[]; tableProjects?: TableProject[] } = {}) => {
     const { container } = render(Portfolio, {
       props: {

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -83,8 +83,8 @@ describe("Portfolio route", () => {
     const importedToken1BalanceE6s = 100n * 1_000_000n; // 100ZTOKEN1(1ZTOKEN1==1ICP) -> $1000
     const ckUSDCBalanceE6s = 1n * 1_000_000n; // 1USDC -> $1
 
-    const nnsNeuronStake = 1n * 100_000_000n; // 1ICP -> 10USD
-    const tetrisSnsNeuronStake = 20n * 100_000_000n; // 20Tetris -> 20USD
+    const nnsNeuronStake = 1n * 100_000_000n; // 1ICP -> $10
+    const tetrisSnsNeuronStake = 20n * 100_000_000n; // 20Tetris -> $200
 
     const importedToken1Id = Principal.fromText(
       "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -15,6 +15,8 @@ import {
 import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+import { neuronsStore } from "$lib/stores/neurons.store";
+import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
@@ -27,6 +29,8 @@ import {
 import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
@@ -78,6 +82,9 @@ describe("Portfolio route", () => {
     const tetrisBalanceE8s = 2n * 100_000_000n; // 2Tetris(1Tetris==1ICP) -> $20
     const importedToken1BalanceE6s = 100n * 1_000_000n; // 100ZTOKEN1(1ZTOKEN1==1ICP) -> $1000
     const ckUSDCBalanceE6s = 1n * 1_000_000n; // 1USDC -> $1
+
+    const nnsNeuronStake = 1n * 100_000_000n; // 1ICP -> 10USD
+    const tetrisSnsNeuronStake = 20n * 100_000_000n; // 20Tetris -> 20USD
 
     const importedToken1Id = Principal.fromText(
       "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
@@ -278,6 +285,27 @@ describe("Portfolio route", () => {
         },
       ]);
 
+      const nnsNeuronWithStake = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: nnsNeuronStake,
+        },
+      };
+      neuronsStore.setNeurons({
+        neurons: [nnsNeuronWithStake],
+        certified: true,
+      });
+
+      const snsNeuronWithStake = createMockSnsNeuron({
+        stake: tetrisSnsNeuronStake,
+      });
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: tetrisSNS.rootCanisterId,
+        neurons: [snsNeuronWithStake],
+        certified: true,
+      });
+
       const po = await renderPage();
       const portfolioPagePo = po.getPortfolioPagePo();
 
@@ -288,15 +316,17 @@ describe("Portfolio route", () => {
       // 1USDC -> $1
       // 100ZTOKEN1 -> $1000
       // 2Tetris -> $20
+      // 1ICP Neuron -> 10$
+      // 20Tetris Neuron -> 200$
       // --------------------
-      // Total: $203’021.00
+      // Total: $203’231.00
       expect(
         await portfolioPagePo.getUsdValueBannerPo().getPrimaryAmount()
-      ).toBe("$203’021.00");
+      ).toBe("$203’231.00");
       // $1 -> 0.1ICP
       expect(
         await portfolioPagePo.getUsdValueBannerPo().getSecondaryAmount()
-      ).toBe("20’302.10 ICP");
+      ).toBe("20’323.10 ICP");
     });
   });
 });


### PR DESCRIPTION
# Motivation

Follows up on #6139 by loading the project information and passing it to the portfolio page.

[NNS1-3520](https://dfinity.atlassian.net/browse/NNS1-3520)

# Changes

- Loads `tableProjects` and passes it down to the Portfolio page

# Tests

- Extends Portfolio route unit test with Projects stake. 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3520]: https://dfinity.atlassian.net/browse/NNS1-3520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ