### PR TITLE
chore(ci): add Cargo.toml configuration to BOT_APPROVED_FILES

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -2,6 +2,7 @@
 # This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
 
 Cargo.lock
+Cargo.toml
 declarations/*/*/*.did
 dfx.json
 frontend/package-lock.json


### PR DESCRIPTION
# Motivation

#6041 defined a list of approved bot files. #6134 is failing because `Cargo.toml` is not allowed.

Handles: #6134

# Changes

Adds `Cargo.toml` to `.github/repo_policies/BOT_APPROVED_FILES`.

# Tests

- Once merged, it should be possible to rebase #6148 and merge

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary