### PR TITLE
feat(portfolio):  add getTopTokens utility for TokensCard

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -31,17 +31,17 @@ export type TokenWithRequiredBalance = UserTokenData &
  */
 export const getTopTokens = ({
   userTokens,
-  maxTokensToShow,
+  maxResults = 4,
   isSignedIn = false,
 }: {
   userTokens: UserToken[];
-  maxTokensToShow: number;
+  maxResults?: number;
   isSignedIn?: boolean;
 }): TokenWithRequiredBalance[] => {
   const topTokens = userTokens
     .filter(isUserTokenData)
     .sort(compareTokens)
-    .slice(0, maxTokensToShow)
+    .slice(0, maxResults)
     .map((token) => ({
       ...token,
       balanceInUsd: token?.balanceInUsd ?? 0,

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,0 +1,53 @@
+import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+import {
+  createDescendingComparator,
+  mergeComparators,
+} from "$lib/utils/sort.utils";
+import {
+  compareTokensByImportance,
+  compareTokensIcpFirst,
+} from "$lib/utils/tokens-table.utils";
+import { isUserTokenData } from "$lib/utils/user-token.utils";
+
+const compareTokensByUsdBalance = createDescendingComparator(
+  (token: UserTokenData) => token?.balanceInUsd ?? 0 > 0
+);
+
+const compareTokens = mergeComparators([
+  compareTokensIcpFirst,
+  compareTokensByUsdBalance,
+  compareTokensByImportance,
+]);
+
+export type TokenWithRequiredBalance = UserTokenData &
+  Required<Pick<UserTokenData, "balanceInUsd">>;
+/**
+ * Filters and sorts user tokens based on specific criteria:
+ * - Always prioritizes ICP token first
+ * - Sorts remaining tokens by USD balance in descending order
+ * - Sorts remaining tokens by importance
+ * - Limits the number of returned tokens to maxTokensToShow
+ * - When user is signed in, filters out tokens with zero balance as we show only tokens with guaranteed balance
+ */
+export const getTopTokens = ({
+  userTokens,
+  maxTokensToShow,
+  isSignedIn = false,
+}: {
+  userTokens: UserToken[];
+  maxTokensToShow: number;
+  isSignedIn?: boolean;
+}): TokenWithRequiredBalance[] => {
+  const topTokens = userTokens
+    .filter(isUserTokenData)
+    .sort(compareTokens)
+    .slice(0, maxTokensToShow)
+    .map((token) => ({
+      ...token,
+      balanceInUsd: token?.balanceInUsd ?? 0,
+    }));
+
+  if (!isSignedIn) return topTokens;
+
+  return topTokens.filter((token) => token.balanceInUsd > 0);
+};

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -19,8 +19,6 @@ const compareTokens = mergeComparators([
   compareTokensByImportance,
 ]);
 
-export type TokenWithRequiredBalance = UserTokenData &
-  Required<Pick<UserTokenData, "balanceInUsd">>;
 /**
  * Filters and sorts user tokens based on specific criteria:
  * - Always prioritizes ICP token first
@@ -37,17 +35,13 @@ export const getTopTokens = ({
   userTokens: UserToken[];
   maxResults?: number;
   isSignedIn?: boolean;
-}): TokenWithRequiredBalance[] => {
+}): UserTokenData[] => {
   const topTokens = userTokens
     .filter(isUserTokenData)
     .sort(compareTokens)
-    .slice(0, maxResults)
-    .map((token) => ({
-      ...token,
-      balanceInUsd: token?.balanceInUsd ?? 0,
-    }));
+    .slice(0, maxResults);
 
   if (!isSignedIn) return topTokens;
 
-  return topTokens.filter((token) => token.balanceInUsd > 0);
+  return topTokens.filter((token) => token?.balanceInUsd ?? 0 > 0);
 };

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -24,10 +24,10 @@ export type TokenWithRequiredBalance = UserTokenData &
 /**
  * Filters and sorts user tokens based on specific criteria:
  * - Always prioritizes ICP token first
- * - Sorts remaining tokens by USD balance in descending order
+ * - Sorts remaining tokens by USD balance
  * - Sorts remaining tokens by importance
  * - Limits the number of returned tokens to maxTokensToShow
- * - When user is signed in, filters out tokens with zero balance as we show only tokens with guaranteed balance
+ * - When isSigned true, filters out tokens with zero balance as we show only tokens with guaranteed balance
  */
 export const getTopTokens = ({
   userTokens,

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -1,0 +1,160 @@
+import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import type { UserToken } from "$lib/types/tokens-page";
+import { getTopTokens } from "$lib/utils/portfolio.utils";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import {
+  createIcpUserToken,
+  createUserToken,
+  createUserTokenLoading,
+} from "$tests/mocks/tokens-page.mock";
+
+describe("Portfolio utils", () => {
+  describe("getTopTokens", () => {
+    const mockNonUserToken = createUserTokenLoading();
+
+    const mockIcpToken = createIcpUserToken({
+      balanceInUsd: 0,
+    });
+
+    const mockCkBTCToken = createUserToken({
+      universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      balanceInUsd: 0,
+    });
+
+    const mockCkUSDCToken = createUserToken({
+      universeId: CKUSDC_UNIVERSE_CANISTER_ID,
+      balanceInUsd: 0,
+    });
+
+    const mockOtherToken = createUserToken({
+      universeId: principal(1),
+      balanceInUsd: 0,
+    });
+
+    it("should filter out non UserTokenData", () => {
+      const tokens: UserToken[] = [
+        mockIcpToken,
+        mockOtherToken,
+        mockCkUSDCToken,
+        mockCkBTCToken,
+        mockNonUserToken,
+      ];
+
+      const result = getTopTokens({
+        userTokens: tokens,
+        maxTokensToShow: 10,
+      });
+
+      expect(result).toHaveLength(4);
+      expect(result).not.toContainEqual(mockNonUserToken);
+    });
+
+    it("should limit output to maxTokensToShow", () => {
+      const tokens: UserToken[] = [
+        mockIcpToken,
+        mockOtherToken,
+        mockCkUSDCToken,
+        mockCkBTCToken,
+        mockNonUserToken,
+      ];
+      const result = getTopTokens({
+        userTokens: tokens,
+        maxTokensToShow: 3,
+      });
+
+      expect(result).toHaveLength(3);
+    });
+
+    it("should prioritize ICP token, then important tokens, then rest", () => {
+      const tokens: UserToken[] = [
+        mockOtherToken,
+        mockCkUSDCToken,
+        mockCkBTCToken,
+        mockNonUserToken,
+        mockIcpToken,
+      ];
+      const result = getTopTokens({
+        userTokens: tokens,
+        maxTokensToShow: 10,
+      });
+
+      expect(result).toHaveLength(4);
+      expect(result).toEqual([
+        mockIcpToken,
+        mockCkBTCToken,
+        mockCkUSDCToken,
+        mockOtherToken,
+      ]);
+    });
+
+    describe("when sign in", () => {
+      const mockIcpToken = createIcpUserToken({
+        balanceInUsd: 100,
+      });
+
+      const mockCkBTCToken = createUserToken({
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        balanceInUsd: 10,
+      });
+
+      const mockCkUSDCToken = createUserToken({
+        universeId: CKUSDC_UNIVERSE_CANISTER_ID,
+        balanceInUsd: 1000,
+      });
+
+      const mockOtherToken = createUserToken({
+        universeId: principal(1),
+        balanceInUsd: 2000,
+      });
+
+      const mockZeroBalanceUserTokenData = createUserToken({
+        universeId: principal(2),
+        balanceInUsd: 0,
+      });
+
+      it("should filter out zero balance tokens", () => {
+        const tokens: UserToken[] = [
+          mockZeroBalanceUserTokenData,
+          mockOtherToken,
+          mockCkUSDCToken,
+          mockCkBTCToken,
+          mockNonUserToken,
+          mockIcpToken,
+        ];
+        const result = getTopTokens({
+          userTokens: tokens,
+          maxTokensToShow: 6,
+          isSignedIn: true,
+        });
+
+        expect(result).toHaveLength(4);
+        expect(result).not.toContainEqual(mockZeroBalanceUserTokenData);
+      });
+
+      it("should prioritize ICP token, then sort by balance", () => {
+        const tokens: UserToken[] = [
+          mockOtherToken,
+          mockCkUSDCToken,
+          mockCkBTCToken,
+          mockNonUserToken,
+          mockZeroBalanceUserTokenData,
+          mockIcpToken,
+        ];
+        const result = getTopTokens({
+          userTokens: tokens,
+          maxTokensToShow: 10,
+          isSignedIn: true,
+        });
+
+        expect(result).toHaveLength(4);
+        expect(result).toEqual([
+          mockIcpToken,
+          mockOtherToken,
+          mockCkUSDCToken,
+          mockCkBTCToken,
+        ]);
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -13,23 +13,18 @@ describe("Portfolio utils", () => {
   describe("getTopTokens", () => {
     const mockNonUserToken = createUserTokenLoading();
 
-    const mockIcpToken = createIcpUserToken({
-      balanceInUsd: 0,
-    });
+    const mockIcpToken = createIcpUserToken({});
 
     const mockCkBTCToken = createUserToken({
       universeId: CKBTC_UNIVERSE_CANISTER_ID,
-      balanceInUsd: 0,
     });
 
     const mockCkUSDCToken = createUserToken({
       universeId: CKUSDC_UNIVERSE_CANISTER_ID,
-      balanceInUsd: 0,
     });
 
     const mockOtherToken = createUserToken({
       universeId: principal(1),
-      balanceInUsd: 0,
     });
 
     it("should exclude non-UserTokenData tokens", () => {


### PR DESCRIPTION
# Motivation

The Portfolio page displays a list of tokens that behaves differently based on specific rules.

The `getTopTokens` function encapsulates the following logic:  

- It should return up to four tokens.  
- When the user is logged out, the function returns the top four tokens, listing ICP first, followed by the cK tokens.  
- When the user is logged in, it returns the tokens with the highest `balanceInUsd`. If ICP is present, it should be the first item in the list.

# Changes

-  Added a new descending comparator, `compareTokensByUsdBalance`
-  Introduced a new utility, `getTopTokens`

# Tests

-  Created unit tests for `getTopTokens`

# Todos

-  [ ] Add an entry to the changelog (if necessary). Not necessary.