### PR TITLE
feat(portfolio): new utility to get top projects for the ProjectsCard

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -80,7 +80,7 @@ export const getTopProjects = ({
   maxResults?: number;
   isSignedIn?: boolean;
 }): TableProject[] => {
-  const topProjects = projects.sort(compareProjects).slice(0, maxResults);
+  const topProjects = [...projects].sort(compareProjects).slice(0, maxResults);
 
   if (!isSignedIn) return topProjects;
 

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -68,19 +68,19 @@ const compareProjects = mergeComparators([
  * - Always prioritizes ICP project first
  * - Sorts remaining projects by USD stake value
  * - Sorts remaining projects by title alphabetically
- * - Limits the number of returned projects to maxResults
+ * - Limits the number of returned projects to MAX_NUMBER_OF_ITEMS
  * - When isSignedIn true, filters out projects with zero stake as we show only projects with guaranteed stake
  */
 export const getTopProjects = ({
   projects,
-  maxResults = MAX_NUMBER_OF_ITEMS,
   isSignedIn = false,
 }: {
   projects: TableProject[];
-  maxResults?: number;
   isSignedIn?: boolean;
 }): TableProject[] => {
-  const topProjects = [...projects].sort(compareProjects).slice(0, maxResults);
+  const topProjects = [...projects]
+    .sort(compareProjects)
+    .slice(0, MAX_NUMBER_OF_ITEMS);
 
   if (!isSignedIn) return topProjects;
 

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,13 +1,20 @@
+import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
 import {
   createDescendingComparator,
   mergeComparators,
 } from "$lib/utils/sort.utils";
 import {
+  compareByProjectTitle,
+  compareIcpFirst,
+} from "$lib/utils/staking.utils";
+import {
   compareTokensByImportance,
   compareTokensIcpFirst,
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
+
+const MAX_NUMBER_OF_ITEMS = 4;
 
 const compareTokensByUsdBalance = createDescendingComparator(
   (token: UserTokenData) => token?.balanceInUsd ?? 0 > 0
@@ -29,7 +36,7 @@ const compareTokens = mergeComparators([
  */
 export const getTopTokens = ({
   userTokens,
-  maxResults = 4,
+  maxResults = MAX_NUMBER_OF_ITEMS,
   isSignedIn = false,
 }: {
   userTokens: UserToken[];
@@ -44,4 +51,38 @@ export const getTopTokens = ({
   if (!isSignedIn) return topTokens;
 
   return topTokens.filter((token) => token?.balanceInUsd ?? 0 > 0);
+};
+
+const compareProjectsByUsdBalance = createDescendingComparator(
+  (project: TableProject) => project?.stakeInUsd ?? 0 > 0
+);
+
+const compareProjects = mergeComparators([
+  compareIcpFirst,
+  compareProjectsByUsdBalance,
+  compareByProjectTitle,
+]);
+
+/**
+ * Filters and sorts projects based on specific criteria:
+ * - Always prioritizes ICP project first
+ * - Sorts remaining projects by USD stake value
+ * - Sorts remaining projects by title alphabetically
+ * - Limits the number of returned projects to maxResults
+ * - When isSignedIn true, filters out projects with zero stake as we show only projects with guaranteed stake
+ */
+export const getTopProjects = ({
+  projects,
+  maxResults = MAX_NUMBER_OF_ITEMS,
+  isSignedIn = false,
+}: {
+  projects: TableProject[];
+  maxResults?: number;
+  isSignedIn?: boolean;
+}): TableProject[] => {
+  const topProjects = projects.sort(compareProjects).slice(0, maxResults);
+
+  if (!isSignedIn) return topProjects;
+
+  return topProjects.filter((project) => project?.stakeInUsd ?? 0 > 0);
 };

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -198,7 +198,7 @@ export const getTableProjects = ({
   });
 };
 
-const compareIcpFirst = createDescendingComparator(
+export const compareIcpFirst = createDescendingComparator(
   (project: TableProject) => project.universeId === OWN_CANISTER_ID_TEXT
 );
 
@@ -206,7 +206,7 @@ const comparePositiveNeuronsFirst = createDescendingComparator(
   (project: TableProject) => (project.neuronCount ?? 0) > 0
 );
 
-const compareByProjectTitle = createAscendingComparator(
+export const compareByProjectTitle = createAscendingComparator(
   (project: TableProject) => project.title.toLowerCase()
 );
 

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -6,9 +6,9 @@ import { getTopProjects, getTopTokens } from "$lib/utils/portfolio.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockTableProject } from "$tests/mocks/staking.mock";
 import {
-    createIcpUserToken,
-    createUserToken,
-    createUserTokenLoading,
+  createIcpUserToken,
+  createUserToken,
+  createUserTokenLoading,
 } from "$tests/mocks/tokens-page.mock";
 
 describe("Portfolio utils", () => {

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -159,25 +159,28 @@ describe("Portfolio utils", () => {
     const mockIcpProject: TableProject = {
       ...mockTableProject,
       title: "Internet Computer",
-      stakeInUsd: 100,
+      stakeInUsd: 0,
     };
 
     const mockProject1: TableProject = {
       ...mockTableProject,
       title: "Alpha Project",
-      stakeInUsd: 50,
+      stakeInUsd: 0,
+      universeId: "1",
     };
 
     const mockProject2: TableProject = {
       ...mockTableProject,
       title: "Beta Project",
-      stakeInUsd: 25,
+      stakeInUsd: 0,
+      universeId: "2",
     };
 
     const mockProject3: TableProject = {
       ...mockTableProject,
       title: "Gamma Project",
-      stakeInUsd: 10,
+      stakeInUsd: 0,
+      universeId: "3",
     };
 
     it("should respect the result limit", () => {
@@ -226,24 +229,28 @@ describe("Portfolio utils", () => {
         ...mockTableProject,
         title: "Alpha Project",
         stakeInUsd: 2000,
+        universeId: "1",
       };
 
       const mockProject2: TableProject = {
         ...mockTableProject,
         title: "Beta Project",
         stakeInUsd: 1000,
+        universeId: "2",
       };
 
       const mockProject3: TableProject = {
         ...mockTableProject,
         title: "Gamma Project",
         stakeInUsd: 10,
+        universeId: "3",
       };
 
       const mockZeroStakeProject: TableProject = {
         ...mockTableProject,
         title: "Zero Stake Project",
         stakeInUsd: 0,
+        universeId: "4",
       };
 
       it("should exclude projects with zero stake", () => {

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -1,28 +1,26 @@
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import type { TableProject } from "$lib/types/staking";
 import type { UserToken } from "$lib/types/tokens-page";
-import { getTopTokens } from "$lib/utils/portfolio.utils";
+import { getTopProjects, getTopTokens } from "$lib/utils/portfolio.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockTableProject } from "$tests/mocks/staking.mock";
 import {
-  createIcpUserToken,
-  createUserToken,
-  createUserTokenLoading,
+    createIcpUserToken,
+    createUserToken,
+    createUserTokenLoading,
 } from "$tests/mocks/tokens-page.mock";
 
 describe("Portfolio utils", () => {
   describe("getTopTokens", () => {
     const mockNonUserToken = createUserTokenLoading();
-
-    const mockIcpToken = createIcpUserToken({});
-
+    const mockIcpToken = createIcpUserToken();
     const mockCkBTCToken = createUserToken({
       universeId: CKBTC_UNIVERSE_CANISTER_ID,
     });
-
     const mockCkUSDCToken = createUserToken({
       universeId: CKUSDC_UNIVERSE_CANISTER_ID,
     });
-
     const mockOtherToken = createUserToken({
       universeId: principal(1),
     });
@@ -149,6 +147,155 @@ describe("Portfolio utils", () => {
         ];
         const result = getTopTokens({
           userTokens: tokens,
+          isSignedIn: true,
+        });
+
+        expect(result).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("getTopProjects", () => {
+    const mockIcpProject: TableProject = {
+      ...mockTableProject,
+      title: "Internet Computer",
+      stakeInUsd: 100,
+    };
+
+    const mockProject1: TableProject = {
+      ...mockTableProject,
+      title: "Alpha Project",
+      stakeInUsd: 50,
+    };
+
+    const mockProject2: TableProject = {
+      ...mockTableProject,
+      title: "Beta Project",
+      stakeInUsd: 25,
+    };
+
+    const mockProject3: TableProject = {
+      ...mockTableProject,
+      title: "Gamma Project",
+      stakeInUsd: 10,
+    };
+
+    it("should respect the result limit", () => {
+      const projects = [
+        mockIcpProject,
+        mockProject1,
+        mockProject2,
+        mockProject3,
+      ];
+
+      const result = getTopProjects({
+        projects,
+        maxResults: 2,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual([mockIcpProject, mockProject1]);
+    });
+
+    it("should order projects: ICP first, then by project title value", () => {
+      const projects = [
+        mockProject2,
+        mockProject3,
+        mockProject1,
+        mockIcpProject,
+      ];
+
+      const result = getTopProjects({ projects });
+
+      expect(result).toEqual([
+        mockIcpProject,
+        mockProject1,
+        mockProject2,
+        mockProject3,
+      ]);
+    });
+
+    describe("when signed in", () => {
+      const mockIcpProject: TableProject = {
+        ...mockTableProject,
+        title: "Internet Computer",
+        stakeInUsd: 100,
+      };
+
+      const mockProject1: TableProject = {
+        ...mockTableProject,
+        title: "Alpha Project",
+        stakeInUsd: 2000,
+      };
+
+      const mockProject2: TableProject = {
+        ...mockTableProject,
+        title: "Beta Project",
+        stakeInUsd: 1000,
+      };
+
+      const mockProject3: TableProject = {
+        ...mockTableProject,
+        title: "Gamma Project",
+        stakeInUsd: 10,
+      };
+
+      const mockZeroStakeProject: TableProject = {
+        ...mockTableProject,
+        title: "Zero Stake Project",
+        stakeInUsd: 0,
+      };
+
+      it("should exclude projects with zero stake", () => {
+        const projects = [
+          mockZeroStakeProject,
+          mockProject1,
+          mockProject2,
+          mockProject3,
+          mockIcpProject,
+        ];
+
+        const result = getTopProjects({
+          projects,
+          isSignedIn: true,
+        });
+
+        expect(result).toHaveLength(4);
+        expect(result).not.toContainEqual(mockZeroStakeProject);
+      });
+
+      it("should order projects: ICP first, then by descending USD stake", () => {
+        const projects = [
+          mockProject3,
+          mockProject2,
+          mockProject1,
+          mockZeroStakeProject,
+          mockIcpProject,
+        ];
+
+        const result = getTopProjects({
+          projects,
+          isSignedIn: true,
+        });
+
+        expect(result).toEqual([
+          mockIcpProject, // ICP first, 100$
+          mockProject1, // 2000$
+          mockProject2, // 1000$
+          mockProject3, // 10$
+        ]);
+      });
+
+      it("should return empty array when all projects have zero stake", () => {
+        const zeroIcpProject: TableProject = {
+          ...mockTableProject,
+          stakeInUsd: 0,
+        };
+
+        const projects = [mockZeroStakeProject, zeroIcpProject];
+
+        const result = getTopProjects({
+          projects,
           isSignedIn: true,
         });
 

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -164,40 +164,52 @@ describe("Portfolio utils", () => {
 
     const mockProject1: TableProject = {
       ...mockTableProject,
-      title: "Alpha Project",
+      title: "A Project",
       stakeInUsd: 0,
       universeId: "1",
     };
 
     const mockProject2: TableProject = {
       ...mockTableProject,
-      title: "Beta Project",
+      title: "B Project",
       stakeInUsd: 0,
       universeId: "2",
     };
 
     const mockProject3: TableProject = {
       ...mockTableProject,
-      title: "Gamma Project",
+      title: "C Project",
       stakeInUsd: 0,
       universeId: "3",
     };
 
-    it("should respect the result limit", () => {
+    const mockProject4: TableProject = {
+      ...mockTableProject,
+      title: "D Project",
+      stakeInUsd: 0,
+      universeId: "4",
+    };
+
+    it("should respect the result limit of MAX_NUMBER_OF_ITEMS(4)", () => {
       const projects = [
         mockIcpProject,
         mockProject1,
         mockProject2,
         mockProject3,
+        mockProject4,
       ];
 
       const result = getTopProjects({
         projects,
-        maxResults: 2,
       });
 
-      expect(result).toHaveLength(2);
-      expect(result).toEqual([mockIcpProject, mockProject1]);
+      expect(result).toHaveLength(4);
+      expect(result).toEqual([
+        mockIcpProject,
+        mockProject1,
+        mockProject2,
+        mockProject3,
+      ]);
     });
 
     it("should order projects: ICP first, then by project title value", () => {


### PR DESCRIPTION
# Motivation

The Portfolio page displays a list of projects that behaves differently based on specific rules.

The `getTopProjects` function encapsulates the following logic:  

- It should return up to four projects.  
- When the user is logged out, the function returns the top four projects, listing ICP first, followed by three sorted by name. This is similar to how we do it in the Staking page when the user is logged out.
- When the user is logged in, it returns the projects with the highest `stakeInUsd`. If ICP is present, it should be the first item in the list.

# Changes

-  Added a new descending comparator, `compareProjectsByUsdBalance`
- Exported `compareIcpFirst` and `compareByProjectTitle` from _staking.utils_ to build the sorting comparator.
-  Introduced a new utility, `getTopProjects`

# Tests

-  Created unit tests for `getTopProjects`

# Todos

-  [ ] Add an entry to the changelog (if necessary). Not necessary.
Not necessary.