### PR TITLE
Missing rewards tag hours

### DIFF
--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -503,6 +503,11 @@ export const getNeuronTags = ({
 /**
  * Converts seconds to a human-readable duration for missing rewards tag.
  * Uses more detailed format when the duration is < 7 days.
+ * Examples:
+ * - 7d 23h — `7 days to confirm`
+ * - 7d 11h — `7 days to confirm`
+ * - 7d 1h — `7 days to confirm`
+ * - 6d 2h — `6 days, 2 hours to confirm`
  */
 const secondsToMissingRewardsDuration = ({
   seconds,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -500,6 +500,24 @@ export const getNeuronTags = ({
   return tags;
 };
 
+/**
+ * Converts seconds to a human-readable duration for missing rewards tag.
+ * Uses more detailed format when the duration is < 7 days.
+ */
+const secondsToMissingRewardsDuration = ({
+  seconds,
+  i18n,
+}: {
+  seconds: bigint;
+  i18n: I18n;
+}): string => {
+  const days = Math.floor(Number(seconds) / SECONDS_IN_DAY);
+  return secondsToDuration({
+    seconds: days < 7 ? seconds : BigInt(days * SECONDS_IN_DAY),
+    i18n: i18n.time,
+  });
+};
+
 const getNeuronTagsUnrelatedToController = ({
   neuron,
   i18n,
@@ -528,9 +546,9 @@ const getNeuronTagsUnrelatedToController = ({
     } else if (shouldDisplayRewardLossNotification(neuron)) {
       tags.push({
         text: replacePlaceholders(i18n.neurons.missing_rewards_soon, {
-          $timeLeft: secondsToDuration({
+          $timeLeft: secondsToMissingRewardsDuration({
             seconds: BigInt(secondsUntilLosingRewards(neuron)),
-            i18n: i18n.time,
+            i18n,
           }),
         }),
         status: "warning",

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1749,6 +1749,75 @@ describe("neuron-utils", () => {
         },
       };
 
+      it.only("returns 'XX days to confirm' tag", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+        const testTag = ({
+          secondsToConfirm,
+          expectedText,
+        }: {
+          secondsToConfirm: number;
+          expectedText: string;
+        }) =>
+          expect(
+            getNeuronTags({
+              neuron: {
+                ...mockNeuron,
+                votingPowerRefreshedTimestampSeconds: BigInt(
+                  nowSeconds - SECONDS_IN_HALF_YEAR + secondsToConfirm
+                ),
+                fullNeuron: {
+                  ...mockNeuron.fullNeuron,
+                  votingPowerRefreshedTimestampSeconds: BigInt(
+                    nowSeconds - SECONDS_IN_HALF_YEAR + secondsToConfirm
+                  ),
+                },
+              } as NeuronInfo,
+              identity: mockIdentity,
+              accounts: accountsWithHW,
+              i18n: en,
+            })
+          ).toEqual([
+            {
+              text: expectedText,
+              status: "warning",
+            },
+          ]);
+
+        expect(
+          testTag({
+            secondsToConfirm: SECONDS_IN_DAY * 10,
+            expectedText: "10 days to confirm",
+          })
+        );
+        expect(
+          testTag({
+            secondsToConfirm: SECONDS_IN_DAY * 7,
+            expectedText: "7 days to confirm",
+          })
+        );
+        expect(
+          testTag({
+            secondsToConfirm: SECONDS_IN_DAY * 6 + 23 * 60 * 60,
+            expectedText: "6 days, 23 hours to confirm",
+          })
+        );
+        expect(
+          testTag({
+            secondsToConfirm: SECONDS_IN_DAY * 1,
+            expectedText: "1 day to confirm",
+          })
+        );
+        expect(
+          testTag({
+            secondsToConfirm: 3 * 60 * 60 + 60,
+            expectedText: "3 hours, 1 minute to confirm",
+          })
+        );
+      });
+
       it("returns 'Missing rewards' tag", () => {
         overrideFeatureFlagsStore.setFlag(
           "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1749,7 +1749,7 @@ describe("neuron-utils", () => {
         },
       };
 
-      it.only("returns 'XX days to confirm' tag", () => {
+      it("returns 'XX days to confirm' tag", () => {
         overrideFeatureFlagsStore.setFlag(
           "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
           true

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1788,13 +1788,13 @@ describe("neuron-utils", () => {
 
         expect(
           testTag({
-            secondsToConfirm: SECONDS_IN_DAY * 10,
+            secondsToConfirm: SECONDS_IN_DAY * 10 + 10 * 60 * 60,
             expectedText: "10 days to confirm",
           })
         );
         expect(
           testTag({
-            secondsToConfirm: SECONDS_IN_DAY * 7,
+            secondsToConfirm: SECONDS_IN_DAY * 7 + 23 * 60 * 60,
             expectedText: "7 days to confirm",
           })
         );


### PR DESCRIPTION
# Motivation

Use a shorter duration format for the ‘missing rewards’ tag to improve the UI.

Samples:
- 7d 23h — 7 days to confirm
- 7d 11h — 7 days to confirm
- 7d 1h — 7 days to confirm
- 6d 2h — 6 days, 2 hours to confirm

# Changes

- Update tag text logic.

# Tests

- Added.
- Tested locally.

<img width="334" alt="image" src="https://github.com/user-attachments/assets/01d48341-9fce-488e-8b49-3704fc4f3115" />
<img width="318" alt="image" src="https://github.com/user-attachments/assets/33295034-66b2-44b4-83ca-d28276b0882a" />


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.