### PR TITLE
feat(portfolio): integrate Tokens card into Portfolio page

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -2,10 +2,12 @@
   import LoginCard from "$lib/components/portfolio/LoginCard.svelte";
   import NoProjectsCard from "$lib/components/portfolio/NoProjectsCard.svelte";
   import NoTokensCard from "$lib/components/portfolio/NoTokensCard.svelte";
+  import TokensCard from "$lib/components/portfolio/TokensCard.svelte";
   import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import type { TableProject } from "$lib/types/staking";
-  import type { UserToken } from "$lib/types/tokens-page";
+  import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+  import { getTopTokens } from "$lib/utils/portfolio.utils";
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
@@ -52,6 +54,12 @@
   // This occurs when there are tokens but no stake.
   let hasNoProjectsCardAPrimaryAction: boolean;
   $: hasNoProjectsCardAPrimaryAction = !showNoTokensCard;
+
+  let topTokens: UserTokenData[];
+  $: topTokens = getTopTokens({
+    userTokens: userTokensData,
+    isSignedIn: $authSignedInStore,
+  });
 </script>
 
 <main data-tid="portfolio-page-component">
@@ -67,6 +75,8 @@
   <div class="content">
     {#if showNoTokensCard}
       <NoTokensCard />
+    {:else}
+      <TokensCard {topTokens} usdAmount={totalTokensBalanceInUsd} />
     {/if}
     {#if showNoProjectsCard}
       <NoProjectsCard primaryCard={hasNoProjectsCardAPrimaryAction} />

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -241,24 +241,36 @@ describe("Portfolio page", () => {
     });
 
     describe("UsdValueBanner", () => {
-      it("should display total assets", async () => {
-        const token1 = createUserToken({
-          universeId: principal(1),
-          balanceInUsd: 5,
-        });
-        const token2 = createUserToken({
-          universeId: principal(1),
-          balanceInUsd: 7,
-        });
+      const token1 = createUserToken({
+        universeId: principal(1),
+        balanceInUsd: 5,
+        rowHref: "/token/1",
+      });
+      const token2 = createUserToken({
+        universeId: principal(1),
+        balanceInUsd: 7,
+        rowHref: "/token/2",
+      });
+      const token3 = createUserToken({
+        universeId: principal(1),
+        balanceInUsd: undefined,
+        rowHref: "/token/3",
+      });
 
-        const tableProject1: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 2,
-        };
-        const tableProject2: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 10.5,
-        };
+      const tableProject1: TableProject = {
+        ...mockTableProject,
+        stakeInUsd: 2,
+      };
+      const tableProject2: TableProject = {
+        ...mockTableProject,
+        stakeInUsd: 10.5,
+      };
+      const tableProject3: TableProject = {
+        ...mockTableProject,
+        stakeInUsd: undefined,
+      };
+
+      it("should display total assets", async () => {
         const po = renderPage({
           userTokensData: [token1, token2],
           tableProjects: [tableProject1, tableProject2],
@@ -278,18 +290,6 @@ describe("Portfolio page", () => {
       });
 
       it("should ignore tokens with unknown balance in USD and display tooltip", async () => {
-        const token1 = createUserToken({
-          universeId: principal(1),
-          balanceInUsd: 5,
-        });
-        const token2 = createUserToken({
-          universeId: principal(1),
-          balanceInUsd: 7,
-        });
-        const token3 = createUserToken({
-          universeId: principal(1),
-          balanceInUsd: undefined,
-        });
         const po = renderPage({ userTokensData: [token1, token2, token3] });
 
         expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe(
@@ -304,18 +304,6 @@ describe("Portfolio page", () => {
       });
 
       it("should ignore neurons with unknown balance in USD and display tooltip", async () => {
-        const tableProject1: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 2,
-        };
-        const tableProject2: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 10.5,
-        };
-        const tableProject3: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: undefined,
-        };
         const po = renderPage({
           tableProjects: [tableProject1, tableProject2, tableProject3],
         });

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -5,11 +5,12 @@ import type { TableProject } from "$lib/types/staking";
 import type { UserToken } from "$lib/types/tokens-page";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
-import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import { mockTableProject } from "$tests/mocks/staking.mock";
 import { createUserToken } from "$tests/mocks/tokens-page.mock";
 import { PortfolioPagePo } from "$tests/page-objects/PortfolioPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("Portfolio page", () => {
@@ -88,6 +89,108 @@ describe("Portfolio page", () => {
 
         expect(await po.getNoTokensCard().isPresent()).toBe(false);
         expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$2.00");
+      });
+    });
+
+    describe("TokensCard", () => {
+      const token1 = createUserToken({
+        balanceInUsd: 100,
+        rowHref: "/tokens/1",
+        title: "Token1",
+        balance: TokenAmountV2.fromUlps({
+          amount: 2160000000n,
+          token: mockToken,
+        }),
+      });
+      const token2 = createUserToken({
+        balanceInUsd: 200,
+        rowHref: "/tokens/2",
+        title: "Token2",
+        balance: TokenAmountV2.fromUlps({
+          amount: 2160000000n,
+          token: mockToken,
+        }),
+      });
+      const token3 = createUserToken({
+        balanceInUsd: 300,
+        rowHref: "/tokens/3",
+        title: "Token3",
+        balance: TokenAmountV2.fromUlps({
+          amount: 2160000000n,
+          token: mockToken,
+        }),
+      });
+      const token4 = createUserToken({
+        balanceInUsd: 400,
+        rowHref: "/tokens/4",
+        title: "Token4",
+        balance: TokenAmountV2.fromUlps({
+          amount: 2160000000n,
+          token: mockToken,
+        }),
+      });
+      const token5 = createUserToken({
+        balanceInUsd: 500,
+        rowHref: "/tokens/5",
+        title: "Token5",
+        balance: TokenAmountV2.fromUlps({
+          amount: 2160000000n,
+          token: mockToken,
+        }),
+      });
+
+      it("should display the top four tokens by balanceInUsd", async () => {
+        const po = renderPage({
+          userTokensData: [token1, token2, token3, token4, token5],
+        });
+        const tokensCardPo = po.getTokensCardPo();
+
+        const titles = await tokensCardPo.getTokensTitles();
+        const usdBalances = await tokensCardPo.getTokensUsdBalances();
+        const nativeBalances = await tokensCardPo.getTokensNativeBalances();
+
+        expect(titles.length).toBe(4);
+        expect(titles).toEqual(["Token5", "Token4", "Token3", "Token2"]);
+
+        expect(usdBalances.length).toBe(4);
+        expect(usdBalances).toEqual([
+          "$500.00",
+          "$400.00",
+          "$300.00",
+          "$200.00",
+        ]);
+
+        expect(nativeBalances.length).toBe(4);
+        expect(nativeBalances).toEqual([
+          "21.60 TET",
+          "21.60 TET",
+          "21.60 TET",
+          "21.60 TET",
+        ]);
+
+        expect(await tokensCardPo.getInfoRow().isPresent()).toBe(false);
+      });
+
+      it("should display the the information row when less then three tokens", async () => {
+        const po = renderPage({
+          userTokensData: [token1, token2],
+        });
+        const tokensCardPo = po.getTokensCardPo();
+
+        const titles = await tokensCardPo.getTokensTitles();
+        const usdBalances = await tokensCardPo.getTokensUsdBalances();
+        const nativeBalances = await tokensCardPo.getTokensNativeBalances();
+
+        expect(titles.length).toBe(2);
+        expect(titles).toEqual(["Token2", "Token1"]);
+
+        expect(usdBalances.length).toBe(2);
+        expect(usdBalances).toEqual(["$200.00", "$100.00"]);
+
+        expect(nativeBalances.length).toBe(2);
+        expect(nativeBalances).toEqual(["21.60 TET", "21.60 TET"]);
+
+        expect(await tokensCardPo.getInfoRow().isPresent()).toBe(true);
       });
     });
 

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -175,7 +175,7 @@ describe("Portfolio page", () => {
         expect(await tokensCardPo.getInfoRow().isPresent()).toBe(false);
       });
 
-      it("should display the the information row when less then three tokens", async () => {
+      it("should display the information row when less then three tokens", async () => {
         const po = renderPage({
           userTokensData: [token1, token2],
         });

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -77,6 +77,7 @@ describe("Portfolio page", () => {
         const po = renderPage();
 
         expect(await po.getNoTokensCard().isPresent()).toBe(true);
+        expect(await po.getTokensCardPo().isPresent()).toBe(false);
         expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$0.00");
       });
 
@@ -88,6 +89,7 @@ describe("Portfolio page", () => {
         const po = renderPage({ userTokensData: [token] });
 
         expect(await po.getNoTokensCard().isPresent()).toBe(false);
+        expect(await po.getTokensCardPo().isPresent()).toBe(true);
         expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$2.00");
       });
     });
@@ -149,6 +151,8 @@ describe("Portfolio page", () => {
         const usdBalances = await tokensCardPo.getTokensUsdBalances();
         const nativeBalances = await tokensCardPo.getTokensNativeBalances();
 
+        expect(await po.getNoTokensCard().isPresent()).toBe(false);
+
         expect(titles.length).toBe(4);
         expect(titles).toEqual(["Token5", "Token4", "Token3", "Token2"]);
 
@@ -180,6 +184,8 @@ describe("Portfolio page", () => {
         const titles = await tokensCardPo.getTokensTitles();
         const usdBalances = await tokensCardPo.getTokensUsdBalances();
         const nativeBalances = await tokensCardPo.getTokensNativeBalances();
+
+        expect(await po.getNoTokensCard().isPresent()).toBe(false);
 
         expect(titles.length).toBe(2);
         expect(titles).toEqual(["Token2", "Token1"]);

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -2,6 +2,7 @@ import { NoProjectsCardPo } from "$tests/page-objects/NoProjectsCard.page-object
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TokensCardPo } from "./TokensCard.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
   private static readonly TID = "portfolio-page-component";
@@ -24,5 +25,9 @@ export class PortfolioPagePo extends BasePageObject {
 
   getUsdValueBannerPo(): UsdValueBannerPo {
     return UsdValueBannerPo.under(this.root);
+  }
+
+  getTokensCardPo(): TokensCardPo {
+    return TokensCardPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation



# Changes

- Calls `getTopTokens` on the Portfolio page to retrieve the list of top tokens based on rules #6153.  
-  Renders the `TokensCard` on the Portfolio page with the top tokens.

# Tests

- Unit test to verify the presence of the component when the user has tokens.  
-  Unit test to check the contents of the TokensCards when the user has tokens.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary