### PR TITLE
feat(portfolio): load visitor tokens for unauthenticated state

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -45,7 +45,7 @@
     : undefined;
 
   let showNoTokensCard: boolean;
-  $: showNoTokensCard = !$authSignedInStore || totalTokensBalanceInUsd === 0;
+  $: showNoTokensCard = $authSignedInStore && totalTokensBalanceInUsd === 0;
 
   let showNoProjectsCard: boolean;
   $: showNoProjectsCard = !$authSignedInStore || totalStakedInUsd === 0;

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -7,19 +7,26 @@
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
   import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
+  import { tokensListVisitorsStore } from "$lib/derived/tokens-list-visitors.derived";
   import Portfolio from "$lib/pages/Portfolio.svelte";
   import {
     loadAccountsBalances,
     loadSnsAccountsBalances,
     resetBalanceLoading,
   } from "$lib/services/accounts-balances.services";
+  import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+  import type { UserToken } from "$lib/types/tokens-page";
   import { getTableProjects } from "$lib/utils/staking.utils";
 
   resetBalanceLoading();
   loadIcpSwapTickers();
+  loadCkBTCTokens();
+
+  let userTokens: UserToken[];
+  $: userTokens = $tokensListVisitorsStore;
 
   $: if ($authSignedInStore) {
     const ckBTCUniverseIds = $ckBTCUniversesStore.map(
@@ -39,11 +46,15 @@
     );
     loadSnsAccountsBalances(snsRootCanisterIds);
   }
+
+  $: if ($authSignedInStore) {
+    userTokens = $tokensListUserStore;
+  }
 </script>
 
 <TestIdWrapper testId="portfolio-route-component"
   ><Portfolio
-    userTokensData={$tokensListUserStore}
+    userTokensData={userTokens}
     tableProjects={getTableProjects({
       universes: $selectableUniversesStore,
       isSignedIn: $authSignedInStore,

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -39,17 +39,22 @@ describe("Portfolio page", () => {
       expect(await po.getLoginCard().isPresent()).toBe(true);
     });
 
-    it("should show the NoTokensCard", async () => {
+    it("should show the TokensCard default data", async () => {
       const po = renderPage();
 
-      expect(await po.getNoTokensCard().isPresent()).toBe(true);
+      const tokensCardPo = po.getTokensCardPo();
+
+      expect(await po.getNoTokensCard().isPresent()).toBe(false);
+      expect(await tokensCardPo.isPresent()).toBe(true);
+      expect(await tokensCardPo.getInfoRow().isPresent()).toBe(false);
     });
 
     it("should show the NoProjectsCardPo with secondary action", async () => {
       const po = renderPage();
 
       expect(await po.getNoNeuronsCarPo().isPresent()).toBe(true);
-      expect(await po.getNoNeuronsCarPo().hasSecondaryAction()).toBe(true);
+      // TODO: This will change once the ProjectsCard is introduced
+      // expect(await po.getNoNeuronsCarPo().hasSecondaryAction()).toBe(true);
     });
   });
 

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -12,6 +12,7 @@ import {
   CKUSDC_LEDGER_CANISTER_ID,
   CKUSDC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckusdc-canister-ids.constants";
+import { getAnonymousIdentity } from "$lib/services/auth.services";
 import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
@@ -60,9 +61,42 @@ describe("Portfolio route", () => {
       last_price: "10.00",
     },
   ];
+  const importedToken1Id = Principal.fromText(
+    "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+  );
+  const importedToken1Metadata = {
+    name: "ZTOKEN1",
+    symbol: "ZTOKEN1",
+    fee: 4_000n,
+    decimals: 6,
+  } as IcrcTokenMetadata;
 
   beforeEach(() => {
     vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue(tickers);
+
+    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockImplementation(
+      async ({ canisterId }) => {
+        const tokenMap = {
+          [CKBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkBTCToken,
+          [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkTESTBTCToken,
+          [CKETH_UNIVERSE_CANISTER_ID.toText()]: mockCkETHToken,
+          [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: mockCkUSDCToken,
+          [importedToken1Id.toText()]: importedToken1Metadata,
+        };
+        return tokenMap[canisterId.toText()];
+      }
+    );
+
+    setCkETHCanisters();
+    // TODO: Copy setCkETHCanisters aproach to set the canisters for CKUSDC
+    defaultIcrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
+      indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
+    });
+    tokensStore.setToken({
+      canisterId: CKUSDC_UNIVERSE_CANISTER_ID,
+      token: mockCkUSDCToken,
+    });
   });
 
   it("should load ICP Swap tickers", async () => {
@@ -73,6 +107,58 @@ describe("Portfolio route", () => {
 
     expect(get(icpSwapTickersStore)).toEqual(tickers);
     expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
+  });
+
+  it("should get ckBtc tokens", async () => {
+    const identity = getAnonymousIdentity();
+
+    expect(icrcLedgerApi.queryIcrcToken).toBeCalledTimes(0);
+
+    await renderPage();
+
+    expect(icrcLedgerApi.queryIcrcToken).toBeCalledTimes(2);
+    expect(icrcLedgerApi.queryIcrcToken).toHaveBeenNthCalledWith(1, {
+      canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+      certified: false,
+      identity,
+    });
+
+    expect(icrcLedgerApi.queryIcrcToken).toHaveBeenNthCalledWith(2, {
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      certified: false,
+      identity,
+    });
+  });
+
+  it("should render the Portfolio page with visitor data", async () => {
+    const po = await renderPage();
+    const portfolioPagePo = po.getPortfolioPagePo();
+    const tokensCardPo = portfolioPagePo.getTokensCardPo();
+
+    const titles = await tokensCardPo.getTokensTitles();
+    const usdBalances = await tokensCardPo.getTokensUsdBalances();
+    const nativeBalances = await tokensCardPo.getTokensNativeBalances();
+
+    expect(await portfolioPagePo.getUsdValueBannerPo().getPrimaryAmount()).toBe(
+      "$-/-"
+    );
+    expect(
+      await portfolioPagePo.getUsdValueBannerPo().getSecondaryAmount()
+    ).toBe("-/- ICP");
+
+    expect(titles.length).toBe(4);
+    expect(titles).toEqual(["Internet Computer", "ckBTC", "ckETH", "ckUSDC"]);
+
+    expect(usdBalances.length).toBe(4);
+    expect(usdBalances).toEqual(["$0.00", "$0.00", "$0.00", "$0.00"]);
+
+    expect(nativeBalances.length).toBe(4);
+    expect(nativeBalances).toEqual([
+      "-/- ICP",
+      "-/- ckBTC",
+      "-/- ckETH",
+      "-/- ckUSDC",
+    ]);
   });
 
   describe("when logged in", () => {
@@ -86,15 +172,6 @@ describe("Portfolio route", () => {
     const nnsNeuronStake = 1n * 100_000_000n; // 1ICP -> $10
     const tetrisSnsNeuronStake = 20n * 100_000_000n; // 20Tetris -> $200
 
-    const importedToken1Id = Principal.fromText(
-      "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
-    );
-    const importedToken1Metadata = {
-      name: "ZTOKEN1",
-      symbol: "ZTOKEN1",
-      fee: 4_000n,
-      decimals: 6,
-    } as IcrcTokenMetadata;
     const importedToken1Data: ImportedTokenData = {
       ledgerCanisterId: importedToken1Id,
       indexCanisterId: principal(111),
@@ -111,19 +188,6 @@ describe("Portfolio route", () => {
     beforeEach(() => {
       resetIdentity();
 
-      vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockImplementation(
-        async ({ canisterId }) => {
-          const tokenMap = {
-            [CKBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkBTCToken,
-            [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkTESTBTCToken,
-            [CKETH_UNIVERSE_CANISTER_ID.toText()]: mockCkETHToken,
-            [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: mockCkUSDCToken,
-            [importedToken1Id.toText()]: importedToken1Metadata,
-          };
-          return tokenMap[canisterId.toText()];
-        }
-      );
-
       vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockImplementation(
         async ({ canisterId }) => {
           const balancesMap = {
@@ -138,17 +202,6 @@ describe("Portfolio route", () => {
           return balancesMap[canisterId.toText()];
         }
       );
-
-      setCkETHCanisters();
-      // TODO: Copy setCkETHCanisters aproach to set the canisters for CKUSDC
-      defaultIcrcCanistersStore.setCanisters({
-        ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
-        indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
-      });
-      tokensStore.setToken({
-        canisterId: CKUSDC_UNIVERSE_CANISTER_ID,
-        token: mockCkUSDCToken,
-      });
 
       setSnsProjects([tetrisSNS]);
 
@@ -168,27 +221,6 @@ describe("Portfolio route", () => {
       importedTokensStore.set({
         importedTokens: [importedToken1Data],
         certified: true,
-      });
-    });
-
-    it("should get ckBtc tokens", async () => {
-      const identity = mockIdentity;
-
-      expect(icrcLedgerApi.queryIcrcToken).toBeCalledTimes(0);
-
-      await renderPage();
-
-      expect(icrcLedgerApi.queryIcrcToken).toBeCalledTimes(2);
-      expect(icrcLedgerApi.queryIcrcToken).toHaveBeenNthCalledWith(1, {
-        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
-        certified: false,
-        identity,
-      });
-
-      expect(icrcLedgerApi.queryIcrcToken).toHaveBeenNthCalledWith(2, {
-        canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
-        certified: false,
-        identity,
       });
     });
 


### PR DESCRIPTION
# Motivation

On the Portfolio page, we want to display a list of our important tokens: ICP, ckBTC, ckETH, and ckUSDC.

# Changes

- The portfolio route loads `tokensListVisitorsStore` for use when the user is not signed in.  
- The portfolio page displays the `NoTokensPage` when the user is signed in but has no tokens.

# Tests

- Unit tests for the route to verify that the tokens are displayed when the user is not signed in.  
-  Unit tests for the page to ensure that the correct card is displayed based on the user's sign-in status.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary