### PR TITLE
feat(portfolio): implement ProjectsCard component 

### DIFF
--- a/frontend/src/lib/components/portfolio/ProjectsCard.svelte
+++ b/frontend/src/lib/components/portfolio/ProjectsCard.svelte
@@ -22,7 +22,9 @@
     ? formatNumber(usdAmount)
     : PRICE_NOT_AVAILABLE_PLACEHOLDER;
 
-  const numberOfTopProjects = topProjects.length;
+  let numberOfTopProjects: number;
+  $: numberOfTopProjects = topProjects.length;
+
   let showInfoRow: boolean;
   $: showInfoRow = numberOfTopTokens - numberOfTopProjects > 0;
 </script>

--- a/frontend/src/lib/components/portfolio/ProjectsCard.svelte
+++ b/frontend/src/lib/components/portfolio/ProjectsCard.svelte
@@ -25,6 +25,9 @@
   let numberOfTopProjects: number;
   $: numberOfTopProjects = topProjects.length;
 
+  // Show an informational row when there are fewer projects than tokens.
+  // This ensures both cards have consistent heights by filling empty space
+  // with a message instead of leaving blank space.
   let showInfoRow: boolean;
   $: showInfoRow = numberOfTopTokens - numberOfTopProjects > 0;
 </script>
@@ -199,7 +202,6 @@
       .header {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        justify-content: space-between;
 
         font-size: 0.875rem;
         color: var(--text-description);

--- a/frontend/src/lib/components/portfolio/ProjectsCard.svelte
+++ b/frontend/src/lib/components/portfolio/ProjectsCard.svelte
@@ -1,0 +1,328 @@
+<script lang="ts">
+  import Card from "$lib/components/portfolio/Card.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import type { TableProject } from "$lib/types/staking";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { formatTokenV2 } from "$lib/utils/token.utils";
+  import { IconNeuronsPage, IconRight } from "@dfinity/gix-components";
+  import { TokenAmountV2 } from "@dfinity/utils";
+  import MaturityWithTooltip from "../neurons/MaturityWithTooltip.svelte";
+
+  export let topProjects: TableProject[];
+  export let usdAmount: number;
+
+  const href = AppPath.Staking;
+  let usdAmountFormatted: string;
+  $: usdAmountFormatted = $authSignedInStore
+    ? formatNumber(usdAmount)
+    : PRICE_NOT_AVAILABLE_PLACEHOLDER;
+
+  // TODO: This will also depend on the number of tokens
+  let showInfoRow: boolean;
+  $: showInfoRow = topProjects.length > 0 && topProjects.length <= 3;
+</script>
+
+<Card testId="projects-card">
+  <div
+    class="wrapper"
+    role="region"
+    aria-label={$i18n.portfolio.projects_card_title}
+  >
+    <div class="header">
+      <div class="header-wrapper">
+        <div class="icon" aria-hidden="true">
+          <IconNeuronsPage />
+        </div>
+        <div class="text-content">
+          <h5 class="title">{$i18n.portfolio.projects_card_title}</h5>
+          <p
+            class="amount"
+            data-tid="amount"
+            aria-label={`${$i18n.portfolio.projects_card_title}: ${usdAmount}`}
+          >
+            ${usdAmountFormatted}
+          </p>
+        </div>
+      </div>
+      <a
+        {href}
+        class="button secondary"
+        aria-label={$i18n.portfolio.projects_card_link}
+      >
+        <span class="mobile-only">
+          <IconRight />
+        </span>
+        <span class="tablet-up">
+          {$i18n.portfolio.projects_card_link}
+        </span>
+      </a>
+    </div>
+    <div class="body" role="table">
+      <div class="header" role="row">
+        <span role="columnheader"
+          >{$i18n.portfolio.projects_card_list_first_column}</span
+        >
+
+        <span class="mobile-only justify-end" role="columnheader"
+          >{$i18n.portfolio.projects_card_list_second_column_mobile}</span
+        >
+        <span class="tablet-up justify-end" role="columnheader"
+          >{$i18n.portfolio.projects_card_list_second_column}</span
+        >
+        <span class="tablet-up justify-end" role="columnheader"
+          >{$i18n.portfolio.projects_card_list_third_column}</span
+        >
+      </div>
+
+      <div class="list" role="rowgroup">
+        {#each topProjects as project (project.domKey)}
+          <div class="row" data-tid="project-card-row" role="row">
+            <div class="info" role="cell">
+              <div>
+                <Logo
+                  src={project.logo}
+                  alt={project.title}
+                  size="medium"
+                  framed
+                />
+              </div>
+              <span data-tid="title">{project.title}</span>
+            </div>
+
+            <div class="maturity" data-tid="project-maturity" role="cell">
+              {#if $authSignedInStore}
+                <MaturityWithTooltip
+                  availableMaturity={project?.availableMaturity ?? 0n}
+                  stakedMaturity={project?.stakedMaturity ?? 0n}
+                />
+              {:else}
+                {PRICE_NOT_AVAILABLE_PLACEHOLDER}
+              {/if}
+            </div>
+            <div
+              class="usd-balance"
+              data-tid="project-usd-balance"
+              role="cell"
+              aria-label={`${project.title} USD: ${project?.stakeInUsd ?? 0}`}
+            >
+              ${formatNumber(project?.stakeInUsd ?? 0)}
+            </div>
+            {#if project.stake instanceof TokenAmountV2}
+              <div
+                class="native-balance"
+                data-tid="project-native-balance"
+                role="cell"
+                aria-label={`${project.title} D: ${project?.stakeInUsd ?? 0}`}
+              >
+                {formatTokenV2({
+                  value: project.stake,
+                  detailed: true,
+                })}
+                {project.stake.token.symbol}
+              </div>
+            {/if}
+          </div>
+        {/each}
+        {#if showInfoRow}
+          <div class="info-row desktop-only" role="note" data-tid="info-row">
+            <div class="content">
+              <div class="icon" aria-hidden="true">
+                <IconNeuronsPage />
+              </div>
+              <div class="message">
+                {$i18n.portfolio.projects_card_info_row}
+              </div>
+            </div>
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background-color: var(--card-background-tint);
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--padding-3x) var(--padding-2x);
+
+      .header-wrapper {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--padding-2x);
+
+        .icon {
+          width: 50px;
+          height: 50px;
+        }
+
+        .text-content {
+          display: flex;
+          flex-direction: column;
+          gap: var(--padding-0_5x);
+
+          .title {
+            font-size: 0.875rem;
+            font-weight: bold;
+            color: var(--text-description);
+            margin: 0;
+            padding: 0;
+          }
+          .amount {
+            font-size: 1.5rem;
+          }
+        }
+      }
+    }
+
+    .body {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding);
+      flex-grow: 1;
+
+      .header {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        justify-content: space-between;
+
+        font-size: 0.875rem;
+        color: var(--text-description);
+        padding: 0 var(--padding-2x);
+
+        @include media.min-width(medium) {
+          grid-template-columns: 1fr 1fr 1fr;
+        }
+      }
+
+      .list {
+        display: flex;
+        flex-direction: column;
+        background-color: var(--card-background);
+        flex-grow: 1;
+
+        .row {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          grid-template-areas:
+            "info usd"
+            "info maturity";
+          @include media.min-width(medium) {
+            grid-template-columns: 1fr 1fr 1fr;
+            grid-template-areas:
+              "info maturity usd"
+              "info maturity native";
+          }
+
+          align-items: center;
+          padding: var(--padding-3x) var(--padding-2x);
+
+          border-top: 1px solid var(--elements-divider);
+
+          .info {
+            grid-area: info;
+            display: flex;
+            align-items: center;
+            gap: var(--padding);
+          }
+
+          .maturity,
+          .native-balance,
+          .usd-balance {
+            justify-self: end;
+            text-align: right;
+          }
+
+          .maturity {
+            grid-area: maturity;
+            font-size: 0.875rem;
+            color: var(--text-description);
+
+            @include media.min-width(medium) {
+              font-size: var(--font-size-standard);
+              color: var(--text-primary);
+            }
+          }
+
+          .native-balance {
+            display: none;
+            grid-area: native;
+            font-size: 0.875rem;
+            color: var(--text-description);
+
+            @include media.min-width(medium) {
+              display: block;
+            }
+          }
+
+          .usd-balance {
+            grid-area: usd;
+          }
+        }
+      }
+
+      .info-row {
+        flex-grow: 1;
+        border-top: 1px solid var(--elements-divider);
+
+        .content {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          gap: var(--padding-2x);
+          padding: var(--padding-1_5x) 0;
+
+          max-width: 90%;
+          margin: 0 auto;
+          .icon {
+            min-width: 50px;
+            height: 50px;
+          }
+
+          .message {
+            font-size: 0.875rem;
+            color: var(--text-description);
+            max-width: 400px;
+          }
+        }
+      }
+    }
+
+    /* Utilities */
+    .tablet-up,
+    .desktop-only {
+      display: none !important;
+    }
+
+    @include media.min-width(medium) {
+      .mobile-only {
+        display: none;
+      }
+      .tablet-up {
+        display: flex !important;
+      }
+    }
+
+    @include media.min-width(large) {
+      .desktop-only {
+        display: flex !important;
+      }
+    }
+
+    .justify-end {
+      justify-self: end;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/ProjectsCard.svelte
+++ b/frontend/src/lib/components/portfolio/ProjectsCard.svelte
@@ -14,6 +14,7 @@
 
   export let topProjects: TableProject[];
   export let usdAmount: number;
+  export let numberOfTopTokens: number;
 
   const href = AppPath.Staking;
   let usdAmountFormatted: string;
@@ -21,9 +22,9 @@
     ? formatNumber(usdAmount)
     : PRICE_NOT_AVAILABLE_PLACEHOLDER;
 
-  // TODO: This will also depend on the number of tokens
+  const numberOfTopProjects = topProjects.length;
   let showInfoRow: boolean;
-  $: showInfoRow = topProjects.length > 0 && topProjects.length <= 3;
+  $: showInfoRow = numberOfTopTokens - numberOfTopProjects > 0;
 </script>
 
 <Card testId="projects-card">
@@ -90,7 +91,7 @@
                   framed
                 />
               </div>
-              <span data-tid="title">{project.title}</span>
+              <span data-tid="project-title">{project.title}</span>
             </div>
 
             <div class="maturity" data-tid="project-maturity" role="cell">
@@ -104,27 +105,27 @@
               {/if}
             </div>
             <div
-              class="usd-balance"
-              data-tid="project-usd-balance"
+              class="staked-usd"
+              data-tid="project-staked-usd"
               role="cell"
               aria-label={`${project.title} USD: ${project?.stakeInUsd ?? 0}`}
             >
               ${formatNumber(project?.stakeInUsd ?? 0)}
             </div>
-            {#if project.stake instanceof TokenAmountV2}
-              <div
-                class="native-balance"
-                data-tid="project-native-balance"
-                role="cell"
-                aria-label={`${project.title} D: ${project?.stakeInUsd ?? 0}`}
-              >
-                {formatTokenV2({
-                  value: project.stake,
-                  detailed: true,
-                })}
-                {project.stake.token.symbol}
-              </div>
-            {/if}
+            <div
+              class="staked-native"
+              data-tid="project-staked-native"
+              role="cell"
+              aria-label={`${project.title} D: ${project?.stakeInUsd ?? 0}`}
+            >
+              {project.stake instanceof TokenAmountV2
+                ? formatTokenV2({
+                    value: project.stake,
+                    detailed: true,
+                  })
+                : PRICE_NOT_AVAILABLE_PLACEHOLDER}
+              {project.stake.token.symbol}
+            </div>
           </div>
         {/each}
         {#if showInfoRow}
@@ -239,8 +240,8 @@
           }
 
           .maturity,
-          .native-balance,
-          .usd-balance {
+          .staked-usd,
+          .staked-native {
             justify-self: end;
             text-align: right;
           }
@@ -256,7 +257,11 @@
             }
           }
 
-          .native-balance {
+          .staked-usd {
+            grid-area: usd;
+          }
+
+          .staked-native {
             display: none;
             grid-area: native;
             font-size: 0.875rem;
@@ -265,10 +270,6 @@
             @include media.min-width(medium) {
               display: block;
             }
-          }
-
-          .usd-balance {
-            grid-area: usd;
           }
         }
       }

--- a/frontend/src/lib/components/portfolio/ProjectsCard.svelte
+++ b/frontend/src/lib/components/portfolio/ProjectsCard.svelte
@@ -12,9 +12,9 @@
   import { IconNeuronsPage, IconRight } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
 
-  export let topProjects: TableProject[];
+  export let topStakedTokens: TableProject[];
   export let usdAmount: number;
-  export let numberOfTopTokens: number;
+  export let numberOfTopHeldTokens: number;
 
   const href = AppPath.Staking;
   let usdAmountFormatted: string;
@@ -22,14 +22,14 @@
     ? formatNumber(usdAmount)
     : PRICE_NOT_AVAILABLE_PLACEHOLDER;
 
-  let numberOfTopProjects: number;
-  $: numberOfTopProjects = topProjects.length;
+  let numberOfTopStakedTokens: number;
+  $: numberOfTopStakedTokens = topStakedTokens.length;
 
   // Show an informational row when there are fewer projects than tokens.
   // This ensures both cards have consistent heights by filling empty space
   // with a message instead of leaving blank space.
   let showInfoRow: boolean;
-  $: showInfoRow = numberOfTopTokens - numberOfTopProjects > 0;
+  $: showInfoRow = numberOfTopHeldTokens - numberOfTopStakedTokens > 0;
 </script>
 
 <Card testId="projects-card">
@@ -85,25 +85,25 @@
       </div>
 
       <div class="list" role="rowgroup">
-        {#each topProjects as project (project.domKey)}
+        {#each topStakedTokens as stakedToken (stakedToken.domKey)}
           <div class="row" data-tid="project-card-row" role="row">
             <div class="info" role="cell">
               <div>
                 <Logo
-                  src={project.logo}
-                  alt={project.title}
+                  src={stakedToken.logo}
+                  alt={stakedToken.title}
                   size="medium"
                   framed
                 />
               </div>
-              <span data-tid="project-title">{project.title}</span>
+              <span data-tid="project-title">{stakedToken.title}</span>
             </div>
 
             <div class="maturity" data-tid="project-maturity" role="cell">
               {#if $authSignedInStore}
                 <MaturityWithTooltip
-                  availableMaturity={project?.availableMaturity ?? 0n}
-                  stakedMaturity={project?.stakedMaturity ?? 0n}
+                  availableMaturity={stakedToken?.availableMaturity ?? 0n}
+                  stakedMaturity={stakedToken?.stakedMaturity ?? 0n}
                 />
               {:else}
                 {PRICE_NOT_AVAILABLE_PLACEHOLDER}
@@ -113,23 +113,23 @@
               class="staked-usd"
               data-tid="project-staked-usd"
               role="cell"
-              aria-label={`${project.title} USD: ${project?.stakeInUsd ?? 0}`}
+              aria-label={`${stakedToken.title} USD: ${stakedToken?.stakeInUsd ?? 0}`}
             >
-              ${formatNumber(project?.stakeInUsd ?? 0)}
+              ${formatNumber(stakedToken?.stakeInUsd ?? 0)}
             </div>
             <div
               class="staked-native"
               data-tid="project-staked-native"
               role="cell"
-              aria-label={`${project.title} D: ${project?.stakeInUsd ?? 0}`}
+              aria-label={`${stakedToken.title} D: ${stakedToken?.stakeInUsd ?? 0}`}
             >
-              {project.stake instanceof TokenAmountV2
+              {stakedToken.stake instanceof TokenAmountV2
                 ? formatTokenV2({
-                    value: project.stake,
+                    value: stakedToken.stake,
                     detailed: true,
                   })
                 : PRICE_NOT_AVAILABLE_PLACEHOLDER}
-              {project.stake.token.symbol}
+              {stakedToken.stake.token.symbol}
             </div>
           </div>
         {/each}

--- a/frontend/src/lib/components/portfolio/ProjectsCard.svelte
+++ b/frontend/src/lib/components/portfolio/ProjectsCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import MaturityWithTooltip from "$lib/components/neurons/MaturityWithTooltip.svelte";
   import Card from "$lib/components/portfolio/Card.svelte";
   import Logo from "$lib/components/ui/Logo.svelte";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
@@ -10,7 +11,6 @@
   import { formatTokenV2 } from "$lib/utils/token.utils";
   import { IconNeuronsPage, IconRight } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
-  import MaturityWithTooltip from "../neurons/MaturityWithTooltip.svelte";
 
   export let topProjects: TableProject[];
   export let usdAmount: number;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1201,6 +1201,13 @@
     "tokens_card_list_second_column_mobile": "Balance",
     "tokens_card_list_second_column": "Value Native",
     "tokens_card_list_third_column": "Value $",
-    "tokens_card_info_row": "Store and transfer tokens securely in the NNS wallet — running 100% on the Internet Computer blockchain. Tokens allow you to participate in ICP's onchain governance systems."
+    "tokens_card_info_row": "Store and transfer tokens securely in the NNS wallet — running 100% on the Internet Computer blockchain. Tokens allow you to participate in ICP's onchain governance systems.",
+    "projects_card_title": "Total Staking Balance",
+    "projects_card_link": "Stake neurons",
+    "projects_card_list_first_column": "Top Staked Neurons",
+    "projects_card_list_second_column_mobile": "Balance $/Maturity",
+    "projects_card_list_second_column": "Maturity",
+    "projects_card_list_third_column": "Staked",
+    "projects_card_info_row": "Optimize voting power and earn rewards by increasing your staked neurons."
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1267,6 +1267,13 @@ interface I18nPortfolio {
   tokens_card_list_second_column: string;
   tokens_card_list_third_column: string;
   tokens_card_info_row: string;
+  projects_card_title: string;
+  projects_card_link: string;
+  projects_card_list_first_column: string;
+  projects_card_list_second_column_mobile: string;
+  projects_card_list_second_column: string;
+  projects_card_list_third_column: string;
+  projects_card_info_row: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/components/portfolio/ProjectsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/ProjectsCard.spec.ts
@@ -1,0 +1,203 @@
+import ProjectsCard from "$lib/components/portfolio/ProjectsCard.svelte";
+import type { TableProject } from "$lib/types/staking";
+import type { UserTokenData } from "$lib/types/tokens-page";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { mockCkBTCToken as CkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockCkETHToken as CkETHToken } from "$tests/mocks/cketh-accounts.mock";
+import {
+  ckBTCTokenBase,
+  ckETHTokenBase,
+  createIcpUserToken,
+  createUserToken,
+} from "$tests/mocks/tokens-page.mock";
+import { TokensCardPo } from "$tests/page-objects/TokensCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+import { render } from "@testing-library/svelte";
+
+describe("ProjectsCard", () => {
+  const renderComponent = (props: {
+    topProjects: TableProject[];
+    usdAmount: number;
+  }) => {
+    const { container } = render(ProjectsCard, {
+      props,
+    });
+
+    return TokensCardPo.under(new JestPageObjectElement(container));
+  };
+
+  describe("when not signed in", () => {
+    const mockIcpToken = createIcpUserToken();
+    const mockCkBTCToken = createUserToken(ckBTCTokenBase);
+    const mockCkETHToken = createUserToken(ckETHTokenBase);
+
+    const mockTokens = [
+      mockIcpToken,
+      mockCkBTCToken,
+      mockCkETHToken,
+    ] as UserTokenData[];
+
+    beforeEach(() => {
+      setNoIdentity();
+    });
+
+    it("should show placeholder balance", async () => {
+      const po = renderComponent({
+        topTokens: mockTokens,
+        usdAmount: 0,
+      });
+
+      expect(await po.getAmount()).toBe("$-/-");
+    });
+
+    it("should show list of tokens with name and balance", async () => {
+      const po = renderComponent({
+        topTokens: mockTokens,
+        usdAmount: 0,
+      });
+      const titles = await po.getTokensTitles();
+      const balances = await po.getTokensUsdBalances();
+
+      expect(titles.length).toBe(3);
+      expect(titles).toEqual(["Internet Computer", "ckBTC", "ckETH"]);
+
+      expect(balances.length).toBe(3);
+      expect(balances).toEqual(["$0.00", "$0.00", "$0.00"]);
+    });
+  });
+
+  describe("when signed in", () => {
+    const mockIcpToken = createIcpUserToken();
+    mockIcpToken.balanceInUsd = 100;
+    mockIcpToken.balance = TokenAmountV2.fromUlps({
+      amount: 2160000000n,
+      token: ICPToken,
+    });
+
+    const mockCkBTCToken = createUserToken(ckBTCTokenBase);
+    mockCkBTCToken.balanceInUsd = 200;
+    mockCkBTCToken.balance = TokenAmountV2.fromUlps({
+      amount: 2160000000n,
+      token: CkBTCToken,
+    });
+
+    const mockCkETHToken = createUserToken(ckETHTokenBase);
+    mockCkETHToken.balanceInUsd = 300;
+    mockCkETHToken.balance = TokenAmountV2.fromUlps({
+      amount: 21600000000000000000n,
+      token: CkETHToken,
+    });
+
+    const mockTokens = [
+      mockIcpToken,
+      mockCkBTCToken,
+      mockCkETHToken,
+    ] as UserTokenData[];
+
+    beforeEach(() => {
+      resetIdentity();
+    });
+
+    it("should show the usd amount", async () => {
+      const po = renderComponent({
+        topTokens: mockTokens,
+        usdAmount: 600,
+      });
+
+      expect(await po.getAmount()).toBe("$600.00");
+    });
+
+    it("should show all the tokens with their balance", async () => {
+      const po = renderComponent({
+        topTokens: mockTokens,
+        usdAmount: 600,
+      });
+      const titles = await po.getTokensTitles();
+      const usdBalances = await po.getTokensUsdBalances();
+      const nativeBalances = await po.getTokensNativeBalances();
+
+      expect(titles.length).toBe(3);
+      expect(titles).toEqual(["Internet Computer", "ckBTC", "ckETH"]);
+
+      expect(usdBalances.length).toBe(3);
+      expect(usdBalances).toEqual(["$100.00", "$200.00", "$300.00"]);
+
+      expect(nativeBalances.length).toBe(3);
+      expect(nativeBalances).toEqual([
+        "21.60 ICP",
+        "21.60 ckBTC",
+        "21.60 ckETH",
+      ]);
+    });
+
+    it("should not show info row when tokens length is 3 or more", async () => {
+      const po = renderComponent({
+        topTokens: mockTokens.slice(0, 3),
+        usdAmount: 600,
+      });
+      const titles = await po.getTokensTitles();
+      const balances = await po.getTokensUsdBalances();
+      const nativeBalances = await po.getTokensNativeBalances();
+
+      expect(titles.length).toBe(3);
+      expect(titles).toEqual(["Internet Computer", "ckBTC", "ckETH"]);
+
+      expect(balances.length).toBe(3);
+      expect(balances).toEqual(["$100.00", "$200.00", "$300.00"]);
+
+      expect(nativeBalances.length).toBe(3);
+      expect(nativeBalances).toEqual([
+        "21.60 ICP",
+        "21.60 ckBTC",
+        "21.60 ckETH",
+      ]);
+
+      expect(await po.getInfoRow().isPresent()).toBe(false);
+    });
+
+    it("should show info row when tokens length is 1", async () => {
+      const po = renderComponent({
+        topTokens: mockTokens.slice(0, 1),
+        usdAmount: 100,
+      });
+
+      const titles = await po.getTokensTitles();
+      const balances = await po.getTokensUsdBalances();
+      const nativeBalances = await po.getTokensNativeBalances();
+
+      expect(titles.length).toBe(1);
+      expect(titles).toEqual(["Internet Computer"]);
+
+      expect(balances.length).toBe(1);
+      expect(balances).toEqual(["$100.00"]);
+
+      expect(nativeBalances.length).toBe(1);
+      expect(nativeBalances).toEqual(["21.60 ICP"]);
+
+      expect(await po.getInfoRow().isPresent()).toBe(true);
+    });
+
+    it("should show info row when tokens length is 2", async () => {
+      const po = renderComponent({
+        topTokens: mockTokens.slice(0, 2),
+        usdAmount: 300,
+      });
+
+      const titles = await po.getTokensTitles();
+      const balances = await po.getTokensUsdBalances();
+      const nativeBalances = await po.getTokensNativeBalances();
+
+      expect(titles.length).toBe(2);
+      expect(titles).toEqual(["Internet Computer", "ckBTC"]);
+
+      expect(balances.length).toBe(2);
+      expect(balances).toEqual(["$100.00", "$200.00"]);
+
+      expect(nativeBalances.length).toBe(2);
+      expect(nativeBalances).toEqual(["21.60 ICP", "21.60 ckBTC"]);
+
+      expect(await po.getInfoRow().isPresent()).toBe(true);
+    });
+  });
+});

--- a/frontend/src/tests/lib/components/portfolio/ProjectsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/ProjectsCard.spec.ts
@@ -12,19 +12,19 @@ import { render } from "@testing-library/svelte";
 
 describe("ProjectsCard", () => {
   const renderComponent = ({
-    topProjects = [],
+    topStakedTokens = [],
     usdAmount = 0,
-    numberOfTopTokens = 0,
+    numberOfTopHeldTokens = 0,
   }: {
-    topProjects?: TableProject[];
+    topStakedTokens?: TableProject[];
     usdAmount?: number;
-    numberOfTopTokens?: number;
+    numberOfTopHeldTokens?: number;
   } = {}) => {
     const { container } = render(ProjectsCard, {
       props: {
-        topProjects,
+        topStakedTokens,
         usdAmount,
-        numberOfTopTokens,
+        numberOfTopHeldTokens,
       },
     });
 
@@ -80,7 +80,7 @@ describe("ProjectsCard", () => {
 
     it("should list of tokens with placeholders", async () => {
       const po = renderComponent({
-        topProjects: mockProjects,
+        topStakedTokens: mockProjects,
       });
       const titles = await po.getProjectsTitle();
       const maturities = await po.getProjectsMaturity();
@@ -179,7 +179,7 @@ describe("ProjectsCard", () => {
 
     it("should show all the projects with their maturity, staked in usd and staked in native currency", async () => {
       const po = renderComponent({
-        topProjects: mockProjects,
+        topStakedTokens: mockProjects,
       });
 
       const titles = await po.getProjectsTitle();
@@ -211,10 +211,10 @@ describe("ProjectsCard", () => {
       ]);
     });
 
-    it("should not show info row when numberOfTopTokens is the same as the number of topProjects", async () => {
+    it("should not show info row when numberOfTopHeldTokens is the same as the number of topStakedTokens", async () => {
       const po = renderComponent({
-        topProjects: mockProjects.slice(0, 3),
-        numberOfTopTokens: 3,
+        topStakedTokens: mockProjects.slice(0, 3),
+        numberOfTopHeldTokens: 3,
       });
 
       const titles = await po.getProjectsTitle();
@@ -242,10 +242,10 @@ describe("ProjectsCard", () => {
       expect(await po.getInfoRow().isPresent()).toBe(false);
     });
 
-    it("should not show info row when the number of topProjects is less than numberOfTopTokens like 1", async () => {
+    it("should not show info row when the number of topStakedTokens is less than numberOfTopHeldTokens like 1", async () => {
       const po = renderComponent({
-        topProjects: mockProjects.slice(0, 2),
-        numberOfTopTokens: 4,
+        topStakedTokens: mockProjects.slice(0, 2),
+        numberOfTopHeldTokens: 4,
       });
 
       const titles = await po.getProjectsTitle();
@@ -269,10 +269,10 @@ describe("ProjectsCard", () => {
       expect(await po.getInfoRow().isPresent()).toBe(true);
     });
 
-    it("should not show info row when the number of topProjects is less than numberOfTopTokens like 2", async () => {
+    it("should not show info row when the number of topStakedTokens is less than numberOfTopHeldTokens like 2", async () => {
       const po = renderComponent({
-        topProjects: mockProjects.slice(0, 1),
-        numberOfTopTokens: 3,
+        topStakedTokens: mockProjects.slice(0, 1),
+        numberOfTopHeldTokens: 3,
       });
 
       const titles = await po.getProjectsTitle();

--- a/frontend/src/tests/page-objects/ProjectsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsCard.page-object.ts
@@ -1,0 +1,62 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+class ProjectsCardRoPo extends BasePageObject {
+  private static readonly TID = "card-row";
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<ProjectsCardRoPo[]> {
+    const rows = await element.allByTestId(ProjectsCardRoPo.TID);
+    return rows.map((el) => new ProjectsCardRoPo(el));
+  }
+
+  getTokenTitle(): Promise<string> {
+    return this.getText("token-title");
+  }
+
+  getTokenNativeBalance(): Promise<string> {
+    return this.getText("token-native-balance");
+  }
+
+  getTokenUsdBalance(): Promise<string> {
+    return this.getText("token-usd-balance");
+  }
+}
+
+export class TokensCardPo extends BasePageObject {
+  private static readonly TID = "tokens-card";
+
+  static under(element: PageObjectElement): TokensCardPo {
+    return new TokensCardPo(element.byTestId(TokensCardPo.TID));
+  }
+
+  async getRows(): Promise<ProjectsCardRoPo[]> {
+    return ProjectsCardRoPo.allUnder(this.root);
+  }
+
+  getAmount(): Promise<string> {
+    return this.getText("amount");
+  }
+
+  getInfoRow(): PageObjectElement {
+    return this.getElement("info-row");
+  }
+
+  async getTokensTitles(): Promise<string[]> {
+    const rowsPos = await this.getRows();
+    return Promise.all(rowsPos.map((po) => po.getTokenTitle()));
+  }
+
+  async getTokensUsdBalances(): Promise<string[]> {
+    const rows = await this.getRows();
+
+    return Promise.all(rows.map((row) => row.getTokenUsdBalance()));
+  }
+
+  async getTokensNativeBalances(): Promise<string[]> {
+    const rows = await this.getRows();
+
+    return Promise.all(rows.map((row) => row.getTokenNativeBalance()));
+  }
+}

--- a/frontend/src/tests/page-objects/ProjectsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsCard.page-object.ts
@@ -1,8 +1,10 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { nonNullish } from "@dfinity/utils";
+import { MaturityWithTooltipPo } from "./MaturityWithTooltip.page-object";
 
 class ProjectsCardRoPo extends BasePageObject {
-  private static readonly TID = "card-row";
+  private static readonly TID = "project-card-row";
 
   static async allUnder(
     element: PageObjectElement
@@ -12,23 +14,31 @@ class ProjectsCardRoPo extends BasePageObject {
   }
 
   getTokenTitle(): Promise<string> {
-    return this.getText("token-title");
+    return this.getText("project-title");
   }
 
-  getTokenNativeBalance(): Promise<string> {
-    return this.getText("token-native-balance");
+  async getProjectMaturity(): Promise<string> {
+    const maturityWithTooltipPo = MaturityWithTooltipPo.under(this.root);
+    const totalMaturity = await maturityWithTooltipPo.getTotalMaturity();
+
+    if (nonNullish(totalMaturity)) return totalMaturity;
+    return this.getText("project-maturity");
   }
 
-  getTokenUsdBalance(): Promise<string> {
-    return this.getText("token-usd-balance");
+  getProjectStakeInUsd(): Promise<string> {
+    return this.getText("project-staked-usd");
+  }
+
+  getProjectStakeInNativeCurrency(): Promise<string> {
+    return this.getText("project-staked-native");
   }
 }
 
-export class TokensCardPo extends BasePageObject {
-  private static readonly TID = "tokens-card";
+export class ProjectsCardPo extends BasePageObject {
+  private static readonly TID = "projects-card";
 
-  static under(element: PageObjectElement): TokensCardPo {
-    return new TokensCardPo(element.byTestId(TokensCardPo.TID));
+  static under(element: PageObjectElement): ProjectsCardPo {
+    return new ProjectsCardPo(element.byTestId(ProjectsCardPo.TID));
   }
 
   async getRows(): Promise<ProjectsCardRoPo[]> {
@@ -43,20 +53,25 @@ export class TokensCardPo extends BasePageObject {
     return this.getElement("info-row");
   }
 
-  async getTokensTitles(): Promise<string[]> {
+  async getProjectsTitle(): Promise<string[]> {
     const rowsPos = await this.getRows();
     return Promise.all(rowsPos.map((po) => po.getTokenTitle()));
   }
 
-  async getTokensUsdBalances(): Promise<string[]> {
+  async getProjectsMaturity(): Promise<string[]> {
     const rows = await this.getRows();
-
-    return Promise.all(rows.map((row) => row.getTokenUsdBalance()));
+    return Promise.all(rows.map((row) => row.getProjectMaturity()));
   }
 
-  async getTokensNativeBalances(): Promise<string[]> {
+  async getProjectsStakeInUsd(): Promise<string[]> {
     const rows = await this.getRows();
+    return Promise.all(rows.map((row) => row.getProjectStakeInUsd()));
+  }
 
-    return Promise.all(rows.map((row) => row.getTokenNativeBalance()));
+  async getProjectsStakeInNativeCurrency(): Promise<string[]> {
+    const rows = await this.getRows();
+    return Promise.all(
+      rows.map((row) => row.getProjectStakeInNativeCurrency())
+    );
   }
 }

--- a/frontend/src/tests/page-objects/ProjectsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsCard.page-object.ts
@@ -1,7 +1,7 @@
+import { MaturityWithTooltipPo } from "$tests/page-objects/MaturityWithTooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
-import { MaturityWithTooltipPo } from "./MaturityWithTooltip.page-object";
 
 class ProjectsCardRoPo extends BasePageObject {
   private static readonly TID = "project-card-row";


### PR DESCRIPTION
# Motivation

The `ProjectsCard` component on the Portfolio page displays the total USD amount of staked in projects and a list of up to four projects. If there is a difference of 1 or more with the number of top Tokens it shows a information message.

Related PRs:
- Get top tokens #6159 

# Changes

- Adds the `ProjectsCard` component.

# Tests

- Unit tests for the component  
-  New page object for the component 
- Manually tested in [E2E environment](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary