### PR TITLE
refactor(ui): extract IcpExchangeRate into standalone component

### DIFF
--- a/frontend/src/lib/components/ui/IcpExchangeRate.svelte
+++ b/frontend/src/lib/components/ui/IcpExchangeRate.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+
+  export let hasError: boolean;
+  export let placeholderValue: string = PRICE_NOT_AVAILABLE_PLACEHOLDER;
+
+  let icpPrice: number | undefined;
+  $: icpPrice =
+    isNullish($icpSwapUsdPricesStore) || $icpSwapUsdPricesStore === "error"
+      ? undefined
+      : $icpSwapUsdPricesStore[LEDGER_CANISTER_ID.toText()];
+
+  let icpPriceFormatted: string;
+  $: icpPriceFormatted = nonNullish(icpPrice)
+    ? formatNumber(icpPrice)
+    : placeholderValue;
+</script>
+
+<div class="exchange-rate" data-tid="icp-exchange-rate-component">
+  <img
+    src={IC_LOGO_ROUNDED}
+    alt={$i18n.auth.ic_logo}
+    class="icp-icon desktop-only"
+  />
+  <span class="desktop-only">
+    1 {$i18n.core.icp} = $<span data-tid="icp-price">{icpPriceFormatted}</span>
+  </span>
+  <TooltipIcon>
+    {#if hasError}
+      {$i18n.accounts.token_price_error}
+    {:else}
+      <div class="mobile-only">
+        1 {$i18n.core.icp} = ${icpPriceFormatted}
+      </div><div>
+        {$i18n.accounts.token_price_source}
+      </div>
+    {/if}
+  </TooltipIcon>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  .exchange-rate {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+    .icp-icon {
+      width: 20px;
+      height: 20px;
+    }
+  }
+  .desktop-only {
+    display: none;
+  }
+  @include media.min-width(medium) {
+    .desktop-only {
+      display: initial;
+    }
+    .mobile-only {
+      display: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/ui/IcpExchangeRate.svelte
+++ b/frontend/src/lib/components/ui/IcpExchangeRate.svelte
@@ -1,29 +1,26 @@
 <script lang="ts">
   import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
-  import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
-  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { i18n } from "$lib/stores/i18n";
   import { formatNumber } from "$lib/utils/format.utils";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
 
+  export let icpPrice: number | undefined;
   export let hasError: boolean;
-  export let placeholderValue: string = PRICE_NOT_AVAILABLE_PLACEHOLDER;
-
-  let icpPrice: number | undefined;
-  $: icpPrice =
-    isNullish($icpSwapUsdPricesStore) || $icpSwapUsdPricesStore === "error"
-      ? undefined
-      : $icpSwapUsdPricesStore[LEDGER_CANISTER_ID.toText()];
+  export let absentValue: string = PRICE_NOT_AVAILABLE_PLACEHOLDER;
 
   let icpPriceFormatted: string;
   $: icpPriceFormatted = nonNullish(icpPrice)
     ? formatNumber(icpPrice)
-    : placeholderValue;
+    : absentValue;
 </script>
 
-<div class="exchange-rate" data-tid="icp-exchange-rate-component">
+<div
+  class="exchange-rate"
+  data-tid="icp-exchange-rate-component"
+  class:has-error={hasError}
+>
   <img
     src={IC_LOGO_ROUNDED}
     alt={$i18n.auth.ic_logo}
@@ -55,16 +52,21 @@
       width: 20px;
       height: 20px;
     }
-  }
-  .desktop-only {
-    display: none;
-  }
-  @include media.min-width(medium) {
-    .desktop-only {
-      display: initial;
+
+    &.has-error {
+      --tooltip-icon-color: var(--tag-failed-text);
     }
-    .mobile-only {
+
+    .desktop-only {
       display: none;
+    }
+    @include media.min-width(medium) {
+      .desktop-only {
+        display: flex;
+      }
+      .mobile-only {
+        display: none;
+      }
     }
   }
 </style>

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+  import IcpExchangeRate from "$lib/components/ui/IcpExchangeRate.svelte";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { i18n } from "$lib/stores/i18n";
   import { formatNumber } from "$lib/utils/format.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import IcpExchangeRate from "./IcpExchangeRate.svelte";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean;

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { i18n } from "$lib/stores/i18n";
   import { formatNumber } from "$lib/utils/format.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
+  import IcpExchangeRate from "./IcpExchangeRate.svelte";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean;
@@ -28,11 +28,6 @@
       ? undefined
       : $icpSwapUsdPricesStore[LEDGER_CANISTER_ID.toText()];
 
-  let icpPriceFormatted: string;
-  $: icpPriceFormatted = nonNullish(icpPrice)
-    ? formatNumber(icpPrice)
-    : absentValue;
-
   let icpAmount: number | undefined;
   $: icpAmount = icpPrice && usdAmount && usdAmount / icpPrice;
 
@@ -42,11 +37,7 @@
     : absentValue;
 </script>
 
-<div
-  class="wrapper"
-  data-tid="usd-value-banner-component"
-  class:has-error={hasError}
->
+<div class="wrapper" data-tid="usd-value-banner-component">
   <div class="table-banner-icon">
     <slot name="icon" />
   </div>
@@ -67,29 +58,7 @@
         {$i18n.core.icp}
       </div>
     </div>
-    <div class="exchange-rate">
-      <img
-        src={IC_LOGO_ROUNDED}
-        alt={$i18n.auth.ic_logo}
-        class="icp-icon desktop-only"
-      />
-      <span class="desktop-only">
-        1 {$i18n.core.icp} = $<span data-tid="icp-price"
-          >{icpPriceFormatted}</span
-        >
-      </span>
-      <TooltipIcon>
-        {#if hasError}
-          {$i18n.accounts.token_price_error}
-        {:else}
-          <div class="mobile-only">
-            1 {$i18n.core.icp} = ${icpPriceFormatted}
-          </div><div>
-            {$i18n.accounts.token_price_source}
-          </div>
-        {/if}
-      </TooltipIcon>
-    </div>
+    <IcpExchangeRate {icpPrice} {hasError} {absentValue} />
   </div>
 </div>
 
@@ -134,34 +103,6 @@
         display: flex;
         flex-direction: column;
       }
-
-      .exchange-rate {
-        display: flex;
-        align-items: center;
-        gap: var(--padding-0_5x);
-
-        .icp-icon {
-          width: 20px;
-          height: 20px;
-        }
-      }
-    }
-
-    &.has-error {
-      --tooltip-icon-color: var(--tag-failed-text);
-    }
-  }
-
-  .desktop-only {
-    display: none;
-  }
-
-  @include media.min-width(medium) {
-    .desktop-only {
-      display: initial;
-    }
-    .mobile-only {
-      display: none;
     }
   }
 </style>

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -617,10 +617,7 @@ describe("ProjectsTable", () => {
         await po.getUsdValueBannerPo().getTotalsTooltipIconPo().isPresent()
       ).toBe(false);
       expect(
-        await po
-          .getUsdValueBannerPo()
-          .getExchangeRateTooltipIconPo()
-          .getTooltipText()
+        await po.getUsdValueBannerPo().getIcpExchangeRatePo().getTooltipText()
       ).toBe(
         "1 ICP = $10.00 Token prices are in ckUSDC based on data provided by ICPSwap."
       );
@@ -683,10 +680,7 @@ describe("ProjectsTable", () => {
       expect(await po.getUsdValueBannerPo().isPresent()).toBe(true);
       expect(await po.getUsdValueBannerPo().getPrimaryAmount()).toBe("$-/-");
       expect(
-        await po
-          .getUsdValueBannerPo()
-          .getExchangeRateTooltipIconPo()
-          .getTooltipText()
+        await po.getUsdValueBannerPo().getIcpExchangeRatePo().getTooltipText()
       ).toBe(
         "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment."
       );

--- a/frontend/src/tests/lib/components/ui/IcpExchangeRate.spec.ts
+++ b/frontend/src/tests/lib/components/ui/IcpExchangeRate.spec.ts
@@ -1,77 +1,72 @@
 import IcpExchangeRate from "$lib/components/ui/IcpExchangeRate.svelte";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import en from "$tests/mocks/i18n.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { IcpExchangeRatePo } from "$tests/page-objects/IcpExchangeRate.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("IcpExchangeRate", () => {
   const renderComponent = ({
+    icpPrice,
     hasError,
-    placeholderValue,
+    absentValue,
   }: {
+    icpPrice: number;
     hasError: boolean;
-    placeholderValue?: string;
+    absentValue?: string;
   }) => {
     const { container } = render(IcpExchangeRate, {
+      icpPrice,
       hasError,
-      placeholderValue,
+      absentValue,
     });
 
     return IcpExchangeRatePo.under(new JestPageObjectElement(container));
   };
 
-  const setIcpPrice = (icpPrice: number) => {
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: String(icpPrice),
-      },
-    ]);
-  };
-
   it("displays default placeholder when price is not available", async () => {
-    const usdPrice = undefined;
-    setIcpPrice(usdPrice);
+    const icpPrice = undefined;
+    const hasError = false;
 
-    const po = renderComponent({ hasError: false });
+    const po = renderComponent({ icpPrice, hasError });
 
     expect(await po.getIcpPrice()).toEqual("-/-");
   });
 
   it("displays provided placeholder when price is not available", async () => {
-    const usdPrice = undefined;
-    setIcpPrice(usdPrice);
+    const icpPrice = undefined;
+    const absentValue = "N/A";
+    const hasError = false;
 
-    const po = renderComponent({ hasError: false, placeholderValue: "N/A" });
+    const po = renderComponent({ icpPrice, absentValue, hasError });
 
     expect(await po.getIcpPrice()).toEqual("N/A");
   });
 
   it("displays formatted price when available", async () => {
-    const usdPrice = 10;
-    setIcpPrice(usdPrice);
+    const icpPrice = 10;
+    const hasError = false;
 
-    const po = renderComponent({ hasError: false });
+    const po = renderComponent({ icpPrice, hasError });
 
     expect(await po.getIcpPrice()).toEqual("10.00");
   });
 
   it("shows error message in tooltip when hasError is true", async () => {
-    const po = renderComponent({ hasError: true });
+    const icpPrice = undefined;
+    const hasError = true;
+
+    const po = renderComponent({ icpPrice, hasError });
+
     const message = en.accounts.token_price_error;
 
     expect(await po.getTooltipText()).toEqual(message);
   });
 
   it("shows price source message in tooltip when hasError is false", async () => {
-    const usdPrice = 10;
-    setIcpPrice(usdPrice);
+    const icpPrice = 10;
+    const hasError = false;
 
-    const po = renderComponent({ hasError: false });
+    const po = renderComponent({ icpPrice, hasError });
     const message = `1 ICP = $10.00 ${en.accounts.token_price_source}`;
 
     expect(await po.getTooltipText()).toEqual(message);

--- a/frontend/src/tests/lib/components/ui/IcpExchangeRate.spec.ts
+++ b/frontend/src/tests/lib/components/ui/IcpExchangeRate.spec.ts
@@ -1,0 +1,79 @@
+import IcpExchangeRate from "$lib/components/ui/IcpExchangeRate.svelte";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import en from "$tests/mocks/i18n.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { IcpExchangeRatePo } from "$tests/page-objects/IcpExchangeRate.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("IcpExchangeRate", () => {
+  const renderComponent = ({
+    hasError,
+    placeholderValue,
+  }: {
+    hasError: boolean;
+    placeholderValue?: string;
+  }) => {
+    const { container } = render(IcpExchangeRate, {
+      hasError,
+      placeholderValue,
+    });
+
+    return IcpExchangeRatePo.under(new JestPageObjectElement(container));
+  };
+
+  const setIcpPrice = (icpPrice: number) => {
+    icpSwapTickersStore.set([
+      {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+        last_price: String(icpPrice),
+      },
+    ]);
+  };
+
+  it("displays default placeholder when price is not available", async () => {
+    const usdPrice = undefined;
+    setIcpPrice(usdPrice);
+
+    const po = renderComponent({ hasError: false });
+
+    expect(await po.getIcpPrice()).toEqual("-/-");
+  });
+
+  it("displays provided placeholder when price is not available", async () => {
+    const usdPrice = undefined;
+    setIcpPrice(usdPrice);
+
+    const po = renderComponent({ hasError: false, placeholderValue: "N/A" });
+
+    expect(await po.getIcpPrice()).toEqual("N/A");
+  });
+
+  it("displays formatted price when available", async () => {
+    const usdPrice = 10;
+    setIcpPrice(usdPrice);
+
+    const po = renderComponent({ hasError: false });
+
+    expect(await po.getIcpPrice()).toEqual("10.00");
+  });
+
+  it("shows error message in tooltip when hasError is true", async () => {
+    const po = renderComponent({ hasError: true });
+    const message = en.accounts.token_price_error;
+
+    expect(await po.getTooltipText()).toEqual(message);
+  });
+
+  it("shows price source message in tooltip when hasError is false", async () => {
+    const usdPrice = 10;
+    setIcpPrice(usdPrice);
+
+    const po = renderComponent({ hasError: false });
+    const message = `1 ICP = $10.00 ${en.accounts.token_price_source}`;
+
+    expect(await po.getTooltipText()).toEqual(message);
+  });
+});

--- a/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
@@ -1,6 +1,7 @@
 import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import en from "$tests/mocks/i18n.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -92,10 +93,9 @@ describe("UsdValueBanner", () => {
     setIcpPrice(icpPrice);
 
     const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+    const message = `1 ICP = $10.00 ${en.accounts.token_price_source}`;
 
-    expect(await po.getExchangeRateTooltipIconPo().getTooltipText()).toEqual(
-      "1 ICP = $10.00 Token prices are in ckUSDC based on data provided by ICPSwap."
-    );
+    expect(await po.getIcpExchangeRatePo().getTooltipText()).toEqual(message);
   });
 
   it("should not have an error by default", async () => {
@@ -116,11 +116,10 @@ describe("UsdValueBanner", () => {
     setIcpPrice(icpPrice);
 
     const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+    const message = en.accounts.token_price_error;
 
     expect(await po.hasError()).toBe(true);
-    expect(await po.getExchangeRateTooltipIconPo().getTooltipText()).toEqual(
-      "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment."
-    );
+    expect(await po.getIcpExchangeRatePo().getTooltipText()).toEqual(message);
   });
 
   it("should show a tooltip about unpriced tokens", async () => {

--- a/frontend/src/tests/page-objects/IcpExchangeRate.page-object.ts
+++ b/frontend/src/tests/page-objects/IcpExchangeRate.page-object.ts
@@ -1,0 +1,24 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TooltipIconPo } from "./TooltipIcon.page-object";
+
+export class IcpExchangeRatePo extends BasePageObject {
+  private static readonly TID = "icp-exchange-rate-component";
+
+  static under(element: PageObjectElement): IcpExchangeRatePo {
+    return new IcpExchangeRatePo(element.byTestId(IcpExchangeRatePo.TID));
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
+  }
+
+  getIcpPrice(): Promise<string> {
+    return this.getText("icp-price");
+  }
+
+  getTooltipText(): Promise<string> {
+    const tooltipIconPo = this.getTooltipIconPo();
+    return tooltipIconPo.getTooltipText();
+  }
+}

--- a/frontend/src/tests/page-objects/IcpExchangeRate.page-object.ts
+++ b/frontend/src/tests/page-objects/IcpExchangeRate.page-object.ts
@@ -21,4 +21,9 @@ export class IcpExchangeRatePo extends BasePageObject {
     const tooltipIconPo = this.getTooltipIconPo();
     return tooltipIconPo.getTooltipText();
   }
+
+  async hasError(): Promise<boolean> {
+    const classNames = await this.root.getClasses();
+    return classNames.includes("has-error");
+  }
 }

--- a/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
@@ -1,6 +1,7 @@
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { IcpExchangeRatePo } from "./IcpExchangeRate.page-object";
 
 export class UsdValueBannerPo extends BasePageObject {
   private static readonly TID = "usd-value-banner-component";
@@ -13,8 +14,8 @@ export class UsdValueBannerPo extends BasePageObject {
     return TooltipIconPo.under(this.root.querySelector(".totals"));
   }
 
-  getExchangeRateTooltipIconPo(): TooltipIconPo {
-    return TooltipIconPo.under(this.root.querySelector(".exchange-rate"));
+  getIcpExchangeRatePo(): IcpExchangeRatePo {
+    return IcpExchangeRatePo.under(this.root);
   }
 
   getPrimaryAmount(): Promise<string> {
@@ -30,7 +31,6 @@ export class UsdValueBannerPo extends BasePageObject {
   }
 
   async hasError(): Promise<boolean> {
-    const classNames = await this.root.getClasses();
-    return classNames.includes("has-error");
+    return this.getIcpExchangeRatePo().hasError();
   }
 }


### PR DESCRIPTION
# Motivation

Extracts the Icp exchange rate section from the `UsdValueBanner` component for reuse in other components, such as the Portfolio `TotalAssetsCard`.

# Changes

- New `IcpExchangeRate` component.
- Introduces `IcpExchangeRate` in `UsdValueBanner` 

# Tests

- Unit tests for the new component
- Updates existing tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary