### PR TITLE
feat(portfolio): implement TotalAssetsCard component

### DIFF
--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import Card from "$lib/components/portfolio/Card.svelte";
+  import IcpExchangeRate from "$lib/components/ui/IcpExchangeRate.svelte";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import UsdValueHeadless from "$lib/components/ui/UsdValueHeadless.svelte";
+  import { i18n } from "$lib/stores/i18n";
+
+  export let usdAmount: number | undefined;
+  export let hasUnpricedTokens: boolean = false;
+</script>
+
+<UsdValueHeadless
+  {usdAmount}
+  {hasUnpricedTokens}
+  let:icpPrice
+  let:usdAmountFormatted
+  let:icpAmountFormatted
+  let:hasError
+  let:hasPricesAndUnpricedTokens
+>
+  <Card testId="total-assets-card-component">
+    <div class="wrapper">
+      <h3>{$i18n.portfolio.total_assets_title}</h3>
+      <div class="pricing">
+        <div class="totals">
+          <div class="primary-amount-row">
+            <span class="primary-amount" data-tid="primary-amount">
+              ${usdAmountFormatted}
+            </span>
+            {#if hasPricesAndUnpricedTokens}
+              <TooltipIcon>
+                {$i18n.accounts.unpriced_tokens_warning}
+              </TooltipIcon>
+            {/if}
+          </div>
+          <div class="secondary-amount" data-tid="secondary-amount">
+            {icpAmountFormatted}
+            {$i18n.core.icp}
+          </div>
+        </div>
+        <IcpExchangeRate {hasError} {icpPrice} />
+      </div>
+    </div>
+  </Card>
+</UsdValueHeadless>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+    box-sizing: border-box;
+
+    height: 100%;
+    padding: var(--padding-2x);
+    background-color: var(--card-background-tint);
+
+    @include media.min-width(medium) {
+      gap: var(--padding-1_5x);
+      padding: var(--padding-3x);
+    }
+
+    h3 {
+      margin: 0;
+      padding: 0;
+    }
+
+    .pricing {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+
+      .totals {
+        display: flex;
+        flex-direction: column;
+        gap: var(--padding);
+
+        .primary-amount {
+          font-size: 1.875rem; // 32px
+
+          @include media.min-width(medium) {
+            font-size: 2.5rem; // 40px
+          }
+        }
+        .secondary-amount {
+          color: var(--text-description);
+        }
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1208,6 +1208,7 @@
     "staked_tokens_card_list_second_column_mobile": "Balance $/Maturity",
     "staked_tokens_card_list_second_column": "Maturity",
     "staked_tokens_card_list_third_column": "Staked",
-    "staked_tokens_card_info_row": "Optimize voting power and earn rewards by increasing your staked neurons."
+    "staked_tokens_card_info_row": "Optimize voting power and earn rewards by increasing your staked neurons.",
+    "total_assets_title": "Total Holdings"
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1274,6 +1274,7 @@ interface I18nPortfolio {
   staked_tokens_card_list_second_column: string;
   staked_tokens_card_list_third_column: string;
   staked_tokens_card_info_row: string;
+  total_assets_title: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -1,0 +1,152 @@
+import TotalAssetsCard from "$lib/components/portfolio/TotalAssetsCard.svelte";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import en from "$tests/mocks/i18n.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { TotalAssetsCardPo } from "$tests/page-objects/TotalAssetsCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("UsdValueBanner", () => {
+  const renderComponent = ({
+    usdAmount,
+    hasUnpricedTokens,
+  }: {
+    usdAmount: number;
+    hasUnpricedTokens: boolean;
+  }) => {
+    const { container } = render(TotalAssetsCard, {
+      usdAmount,
+      hasUnpricedTokens,
+    });
+    return TotalAssetsCardPo.under(new JestPageObjectElement(container));
+  };
+
+  const setIcpPrice = (icpPrice: number) => {
+    icpSwapTickersStore.set([
+      {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+        last_price: String(icpPrice),
+      },
+    ]);
+  };
+
+  it("should display the USD amount as absent", async () => {
+    const usdAmount = undefined;
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+
+    expect(await po.getPrimaryAmount()).toEqual("$-/-");
+  });
+
+  it("should display the USD amount", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+
+    expect(await po.getPrimaryAmount()).toEqual("$50.00");
+  });
+
+  it("should display the ICP amount", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+
+    expect(await po.getSecondaryAmount()).toEqual("5.00 ICP");
+  });
+
+  it("should display the ICP amount as absent without exchange rates", async () => {
+    const usdAmount = 50;
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+
+    expect(await po.getSecondaryAmount()).toEqual("-/- ICP");
+  });
+
+  it("should display the ICP price", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+
+    expect(await po.getIcpPrice()).toEqual("10.00");
+  });
+
+  it("should display the ICP price as absent without exchange rates", async () => {
+    const usdAmount = 50;
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+
+    expect(await po.getIcpPrice()).toEqual("-/-");
+  });
+
+  it("should display the ICP price in the tooltip", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+    const message = `1 ICP = $10.00 ${en.accounts.token_price_source}`;
+
+    expect(await po.getIcpExchangeRatePo().getTooltipText()).toEqual(message);
+  });
+
+  it("should not have an error by default", async () => {
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+
+    expect(await po.hasError()).toBe(false);
+  });
+
+  it("should have an error without ICP price", async () => {
+    const usdAmount = 50;
+    const icpPrice = 0;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
+    const message = en.accounts.token_price_error;
+
+    expect(await po.hasError()).toBe(true);
+    expect(await po.getIcpExchangeRatePo().getTooltipText()).toEqual(message);
+  });
+
+  it("should show a tooltip about unpriced tokens", async () => {
+    const hasUnpricedTokens = true;
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens });
+
+    expect(await po.getTotalsTooltipIconPo().isPresent()).toBe(
+      hasUnpricedTokens
+    );
+  });
+
+  it("should not show a tooltip about unpriced tokens", async () => {
+    const hasUnpricedTokens = false;
+    const usdAmount = 50;
+    const icpPrice = 10;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({ usdAmount, hasUnpricedTokens });
+
+    expect(await po.getTotalsTooltipIconPo().isPresent()).toBe(
+      hasUnpricedTokens
+    );
+  });
+});

--- a/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
@@ -1,0 +1,36 @@
+import { IcpExchangeRatePo } from "$tests/page-objects/IcpExchangeRate.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class TotalAssetsCardPo extends BasePageObject {
+  private static readonly TID = "total-assets-card-component";
+
+  static under(element: PageObjectElement): TotalAssetsCardPo {
+    return new TotalAssetsCardPo(element.byTestId(TotalAssetsCardPo.TID));
+  }
+
+  getTotalsTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root.querySelector(".totals"));
+  }
+
+  getIcpExchangeRatePo(): IcpExchangeRatePo {
+    return IcpExchangeRatePo.under(this.root);
+  }
+
+  getPrimaryAmount(): Promise<string> {
+    return this.getText("primary-amount");
+  }
+
+  getSecondaryAmount(): Promise<string> {
+    return this.getText("secondary-amount");
+  }
+
+  getIcpPrice(): Promise<string> {
+    return this.getText("icp-price");
+  }
+
+  async hasError(): Promise<boolean> {
+    return this.getIcpExchangeRatePo().hasError();
+  }
+}


### PR DESCRIPTION
# Motivation

We want to display the total value of the user's portfolio on the Portfolio page.

# Changes

- Adds the `TotalAssetsCard` component.

# Tests

- Unit tests for the component  
-  New page object for the component 
- Manually tested in [E2E environment](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary