### PR TITLE
Add getNetworkEconomicsParameters api

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -5,6 +5,7 @@ import {
   claimOrRefreshNeuron,
   claimOrRefreshNeuronByMemo,
   disburse,
+  getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
   leaveCommunityFund,
@@ -148,6 +149,9 @@ export const governanceApiService = {
       principalText: params.identity.getPrincipal().toText(),
     };
     return neuronsCache.neurons;
+  },
+  getNetworkEconomicsParameters(params: ApiQueryParams) {
+    return getNetworkEconomicsParameters(params);
   },
 
   // Action calls

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -9,6 +9,7 @@ import type { Agent, Identity } from "@dfinity/agent";
 import type {
   E8s,
   KnownNeuron,
+  NetworkEconomics,
   NeuronId,
   NeuronInfo,
   ProposalId,
@@ -592,4 +593,24 @@ export const changeNeuronVisibility = async ({
   logWithTimestamp(
     `Visibility change complete for ${neuronIds.length} neurons. IDs: ${neuronIds.join(", ")}. New visibility: ${visibility}`
   );
+};
+
+export const getNetworkEconomicsParameters = async ({
+  identity,
+  certified,
+}: ApiQueryParams): Promise<NetworkEconomics> => {
+  logWithTimestamp(
+    `Getting network economics parameters call certified: ${certified}...`
+  );
+
+  const { canister: governance } = await governanceCanister({ identity });
+  const response = await governance.getNetworkEconomicsParameters({
+    certified,
+  });
+
+  logWithTimestamp(
+    `Getting network economics parameters call certified: ${certified} complete.`
+  );
+
+  return response;
 };

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -4,6 +4,7 @@ import {
   changeNeuronVisibility,
   claimOrRefreshNeuronByMemo,
   disburse,
+  getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
   leaveCommunityFund,
@@ -838,6 +839,40 @@ describe("neurons-api", () => {
         memo,
         controller,
       });
+    });
+  });
+
+  describe("getNetworkEconomicsParameters", () => {
+    const identity = mockIdentity;
+
+    it("should call the canister to get the network economics parameters", async () => {
+      const certified = true;
+      await getNetworkEconomicsParameters({
+        certified,
+        identity,
+      });
+      expect(
+        mockGovernanceCanister.getNetworkEconomicsParameters
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockGovernanceCanister.getNetworkEconomicsParameters
+      ).toHaveBeenCalledWith({ certified });
+    });
+
+    it("throws error when call fails", async () => {
+      const error = new Error();
+      mockGovernanceCanister.getNetworkEconomicsParameters.mockImplementation(
+        vi.fn(() => {
+          throw error;
+        })
+      );
+
+      const call = () =>
+        getNetworkEconomicsParameters({
+          identity: mockIdentity,
+          certified: true,
+        });
+      await expect(call).rejects.toThrow(error);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, they may change in the future. Therefore, we want to retrieve them from the API. Here, we add an API to fetch network economics parameters from the NNS governance canister.

# Changes

- Add `getNetworkEconomicsParameters` api.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.