### PR TITLE
refactor(ui): extract UsdValueBanner logic into headless component

### DIFF
--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -6,6 +6,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { formatNumber } from "$lib/utils/format.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
+  import IcpExchangeRate from "./IcpExchangeRate.svelte";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean;

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import IcpExchangeRate from "$lib/components/ui/IcpExchangeRate.svelte";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import UsdValueHeadless from "$lib/components/ui/UsdValueHeadless.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import UsdValueHeadless from "./UsdValueHeadless.svelte";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean;

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -6,7 +6,6 @@
   import { i18n } from "$lib/stores/i18n";
   import { formatNumber } from "$lib/utils/format.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import IcpExchangeRate from "./IcpExchangeRate.svelte";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean;

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -1,66 +1,48 @@
 <script lang="ts">
   import IcpExchangeRate from "$lib/components/ui/IcpExchangeRate.svelte";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
-  import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { formatNumber } from "$lib/utils/format.utils";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import UsdValueHeadless from "./UsdValueHeadless.svelte";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean;
 
   const absentValue = "-/-";
-
-  let hasError: boolean;
-  $: hasError = $icpSwapUsdPricesStore === "error";
-
-  let hasPrices: boolean;
-  $: hasPrices = !hasError && nonNullish($icpSwapUsdPricesStore);
-
-  let usdAmountFormatted: string;
-  $: usdAmountFormatted =
-    nonNullish(usdAmount) && hasPrices ? formatNumber(usdAmount) : absentValue;
-
-  let icpPrice: number | undefined;
-  $: icpPrice =
-    isNullish($icpSwapUsdPricesStore) || $icpSwapUsdPricesStore === "error"
-      ? undefined
-      : $icpSwapUsdPricesStore[LEDGER_CANISTER_ID.toText()];
-
-  let icpAmount: number | undefined;
-  $: icpAmount = icpPrice && usdAmount && usdAmount / icpPrice;
-
-  let icpAmountFormatted: string;
-  $: icpAmountFormatted = nonNullish(icpAmount)
-    ? formatNumber(icpAmount)
-    : absentValue;
 </script>
 
-<div class="wrapper" data-tid="usd-value-banner-component">
-  <div class="table-banner-icon">
-    <slot name="icon" />
-  </div>
-  <div class="text-content">
-    <div class="totals">
-      <div class="primary-amount-row">
-        <span class="primary-amount" data-tid="primary-amount">
-          ${usdAmountFormatted}
-        </span>
-        {#if hasPrices && hasUnpricedTokens}
-          <TooltipIcon>
-            {$i18n.accounts.unpriced_tokens_warning}
-          </TooltipIcon>
-        {/if}
-      </div>
-      <div class="secondary-amount" data-tid="secondary-amount">
-        {icpAmountFormatted}
-        {$i18n.core.icp}
-      </div>
+<UsdValueHeadless
+  {usdAmount}
+  {hasUnpricedTokens}
+  let:icpPrice
+  let:usdAmountFormatted
+  let:icpAmountFormatted
+  let:hasError
+  let:hasPricesAndUnpricedTokens
+  ><div class="wrapper" data-tid="usd-value-banner-component">
+    <div class="table-banner-icon">
+      <slot name="icon" />
     </div>
-    <IcpExchangeRate {icpPrice} {hasError} {absentValue} />
+    <div class="text-content">
+      <div class="totals">
+        <div class="primary-amount-row">
+          <span class="primary-amount" data-tid="primary-amount">
+            ${usdAmountFormatted}
+          </span>
+          {#if hasPricesAndUnpricedTokens}
+            <TooltipIcon>
+              {$i18n.accounts.unpriced_tokens_warning}
+            </TooltipIcon>
+          {/if}
+        </div>
+        <div class="secondary-amount" data-tid="secondary-amount">
+          {icpAmountFormatted}
+          {$i18n.core.icp}
+        </div>
+      </div>
+      <IcpExchangeRate {icpPrice} {hasError} {absentValue} />
+    </div>
   </div>
-</div>
+</UsdValueHeadless>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/lib/components/ui/UsdValueHeadless.svelte
+++ b/frontend/src/lib/components/ui/UsdValueHeadless.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+
+  export let usdAmount: number | undefined;
+  export let hasUnpricedTokens: boolean = false;
+
+  let hasError: boolean;
+  $: hasError = $icpSwapUsdPricesStore === "error";
+
+  let hasPrices: boolean;
+  $: hasPrices = !hasError && nonNullish($icpSwapUsdPricesStore);
+
+  let hasPricesAndUnpricedTokens: boolean;
+  $: hasPricesAndUnpricedTokens = hasPrices && hasUnpricedTokens;
+
+  let usdAmountFormatted: string;
+  $: usdAmountFormatted =
+    nonNullish(usdAmount) && hasPrices
+      ? formatNumber(usdAmount)
+      : PRICE_NOT_AVAILABLE_PLACEHOLDER;
+
+  let icpPrice: number | undefined;
+  $: icpPrice =
+    isNullish($icpSwapUsdPricesStore) || $icpSwapUsdPricesStore === "error"
+      ? undefined
+      : $icpSwapUsdPricesStore[LEDGER_CANISTER_ID.toText()];
+
+  let icpAmount: number | undefined;
+  $: icpAmount = icpPrice && usdAmount && usdAmount / icpPrice;
+
+  let icpAmountFormatted: string;
+  $: icpAmountFormatted = nonNullish(icpAmount)
+    ? formatNumber(icpAmount)
+    : PRICE_NOT_AVAILABLE_PLACEHOLDER;
+</script>
+
+<slot
+  {icpPrice}
+  {usdAmountFormatted}
+  {icpAmountFormatted}
+  {hasPricesAndUnpricedTokens}
+  {hasError}
+/>

--- a/frontend/src/lib/components/ui/UsdValueHeadless.svelte
+++ b/frontend/src/lib/components/ui/UsdValueHeadless.svelte
@@ -7,6 +7,7 @@
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean = false;
+  export let absentValue: string = PRICE_NOT_AVAILABLE_PLACEHOLDER;
 
   let hasError: boolean;
   $: hasError = $icpSwapUsdPricesStore === "error";
@@ -19,9 +20,7 @@
 
   let usdAmountFormatted: string;
   $: usdAmountFormatted =
-    nonNullish(usdAmount) && hasPrices
-      ? formatNumber(usdAmount)
-      : PRICE_NOT_AVAILABLE_PLACEHOLDER;
+    nonNullish(usdAmount) && hasPrices ? formatNumber(usdAmount) : absentValue;
 
   let icpPrice: number | undefined;
   $: icpPrice =
@@ -35,7 +34,7 @@
   let icpAmountFormatted: string;
   $: icpAmountFormatted = nonNullish(icpAmount)
     ? formatNumber(icpAmount)
-    : PRICE_NOT_AVAILABLE_PLACEHOLDER;
+    : absentValue;
 </script>
 
 <slot

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
@@ -10,13 +10,16 @@ describe("UsdValueHeadless", () => {
   const renderComponent = ({
     usdAmount,
     hasUnpricedTokens,
+    absentValue,
   }: {
     usdAmount: number;
     hasUnpricedTokens: boolean;
+    absentValue?: string;
   }) => {
     const { container } = render(UsdValueHeadlessTest, {
       usdAmount,
       hasUnpricedTokens,
+      absentValue,
     });
 
     return UsdValueHeadlessPo.under(new JestPageObjectElement(container));
@@ -31,6 +34,35 @@ describe("UsdValueHeadless", () => {
       },
     ]);
   };
+
+  it("should handle undefined usdAmount", async () => {
+    setIcpPrice(100);
+
+    const po = renderComponent({
+      usdAmount: undefined,
+      hasUnpricedTokens: false,
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("-/-");
+    expect(await po.getIcpAmountFormatted()).toBe("-/-");
+    expect(await po.getHasError()).toBe("false");
+    expect(await po.getHasPricesAndUnpricedTokens()).toBe("false");
+  });
+
+  it("should handle override absent value", async () => {
+    setIcpPrice(100);
+
+    const po = renderComponent({
+      usdAmount: undefined,
+      hasUnpricedTokens: false,
+      absentValue: "N/A",
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("N/A");
+    expect(await po.getIcpAmountFormatted()).toBe("N/A");
+    expect(await po.getHasError()).toBe("false");
+    expect(await po.getHasPricesAndUnpricedTokens()).toBe("false");
+  });
 
   it("should display formatted values when prices are available", async () => {
     setIcpPrice(100);
@@ -72,20 +104,6 @@ describe("UsdValueHeadless", () => {
     expect(await po.getIcpAmountFormatted()).toBe("10.00");
     expect(await po.getHasError()).toBe("false");
     expect(await po.getHasPricesAndUnpricedTokens()).toBe("true");
-  });
-
-  it("should handle undefined usdAmount", async () => {
-    setIcpPrice(100);
-
-    const po = renderComponent({
-      usdAmount: undefined,
-      hasUnpricedTokens: false,
-    });
-
-    expect(await po.getUsdAmountFormatted()).toBe("-/-");
-    expect(await po.getIcpAmountFormatted()).toBe("-/-");
-    expect(await po.getHasError()).toBe("false");
-    expect(await po.getHasPricesAndUnpricedTokens()).toBe("false");
   });
 
   it("should handle price updates", async () => {

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
@@ -1,0 +1,107 @@
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import UsdValueHeadlessTest from "$tests/lib/components/ui/UsdValueHeadlessTest.svelte";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { UsdValueHeadlessPo } from "$tests/page-objects/UsdValueHeadless.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("UsdValueHeadless", () => {
+  const renderComponent = ({
+    usdAmount,
+    hasUnpricedTokens,
+  }: {
+    usdAmount: number;
+    hasUnpricedTokens: boolean;
+  }) => {
+    const { container } = render(UsdValueHeadlessTest, {
+      usdAmount,
+      hasUnpricedTokens,
+    });
+
+    return UsdValueHeadlessPo.under(new JestPageObjectElement(container));
+  };
+
+  const setIcpPrice = (icpPrice: number) => {
+    icpSwapTickersStore.set([
+      {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+        last_price: String(icpPrice),
+      },
+    ]);
+  };
+
+  it("should display formatted values when prices are available", async () => {
+    setIcpPrice(100);
+
+    const po = renderComponent({
+      usdAmount: 1000,
+      hasUnpricedTokens: false,
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("1’000.00");
+    expect(await po.getIcpAmountFormatted()).toBe("10.00");
+    expect(await po.getHasError()).toBe("false");
+    expect(await po.getHasPricesAndUnpricedTokens()).toBe("false");
+  });
+
+  it("should handle error state", async () => {
+    icpSwapTickersStore.set("error");
+
+    const po = renderComponent({
+      usdAmount: 1000,
+      hasUnpricedTokens: false,
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("-/-");
+    expect(await po.getIcpAmountFormatted()).toBe("-/-");
+    expect(await po.getHasError()).toBe("true");
+    expect(await po.getHasPricesAndUnpricedTokens()).toBe("false");
+  });
+
+  it("should handle unpriced tokens", async () => {
+    setIcpPrice(100);
+
+    const po = renderComponent({
+      usdAmount: 1000,
+      hasUnpricedTokens: true,
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("1’000.00");
+    expect(await po.getIcpAmountFormatted()).toBe("10.00");
+    expect(await po.getHasError()).toBe("false");
+    expect(await po.getHasPricesAndUnpricedTokens()).toBe("true");
+  });
+
+  it("should handle undefined usdAmount", async () => {
+    setIcpPrice(100);
+
+    const po = renderComponent({
+      usdAmount: undefined,
+      hasUnpricedTokens: false,
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("-/-");
+    expect(await po.getIcpAmountFormatted()).toBe("-/-");
+    expect(await po.getHasError()).toBe("false");
+    expect(await po.getHasPricesAndUnpricedTokens()).toBe("false");
+  });
+
+  it("should handle price updates", async () => {
+    setIcpPrice(100);
+
+    const po = renderComponent({
+      usdAmount: 1000,
+      hasUnpricedTokens: false,
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("1’000.00");
+    expect(await po.getIcpAmountFormatted()).toBe("10.00");
+
+    setIcpPrice(200);
+
+    expect(await po.getUsdAmountFormatted()).toBe("1’000.00");
+    expect(await po.getIcpAmountFormatted()).toBe("5.00");
+  });
+});

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadlessTest.svelte
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadlessTest.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import UsdValueHeadless from "$lib/components/ui/UsdValueHeadless.svelte";
+
+  export let usdAmount: number | undefined;
+  export let hasUnpricedTokens: boolean = false;
+</script>
+
+<UsdValueHeadless
+  {usdAmount}
+  {hasUnpricedTokens}
+  let:usdAmountFormatted
+  let:icpAmountFormatted
+  let:hasPricesAndUnpricedTokens
+  let:hasError
+>
+  <div data-tid="usd-value-headless-consumer">
+    <span data-tid="usd-amount">{usdAmountFormatted}</span>
+    <span data-tid="icp-amount">{icpAmountFormatted}</span>
+    <span data-tid="has-prices-ans-unpriced-tokens"
+      >{hasPricesAndUnpricedTokens.toString()}</span
+    >
+    <span data-tid="has-error">{hasError.toString()}</span>
+  </div></UsdValueHeadless
+>

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadlessTest.svelte
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadlessTest.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
   import UsdValueHeadless from "$lib/components/ui/UsdValueHeadless.svelte";
+  import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean = false;
+  export let absentValue: string = PRICE_NOT_AVAILABLE_PLACEHOLDER;
 </script>
 
 <UsdValueHeadless
   {usdAmount}
   {hasUnpricedTokens}
+  {absentValue}
   let:usdAmountFormatted
   let:icpAmountFormatted
   let:hasPricesAndUnpricedTokens

--- a/frontend/src/tests/page-objects/UsdValueHeadless.page-object.ts
+++ b/frontend/src/tests/page-objects/UsdValueHeadless.page-object.ts
@@ -1,0 +1,26 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class UsdValueHeadlessPo extends BasePageObject {
+  private static readonly TID = "usd-value-headless-consumer";
+
+  static under(element: PageObjectElement): UsdValueHeadlessPo {
+    return new UsdValueHeadlessPo(element.byTestId(UsdValueHeadlessPo.TID));
+  }
+
+  getUsdAmountFormatted(): Promise<string> {
+    return this.getText("usd-amount");
+  }
+
+  getIcpAmountFormatted(): Promise<string> {
+    return this.getText("icp-amount");
+  }
+
+  getHasError(): Promise<string> {
+    return this.getText("has-error");
+  }
+
+  getHasPricesAndUnpricedTokens(): Promise<string> {
+    return this.getText("has-prices-ans-unpriced-tokens");
+  }
+}


### PR DESCRIPTION
# Motivation

Extract the logic from the `UsdValueBanner` component into a headless component for use with different UIs. This will be utilized by the total assets card on the Portfolio page.

# Changes

- New `UsdValueHeadless` component.
- Introduces `UsdValueHeadless` in `UsdValueBanner` 

# Tests

- Unit tests for the new component
- Updates existing tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary