### PR TITLE
Get network economics service

### DIFF
--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -10,7 +10,7 @@ import {
   importedTokensStore,
 } from "$lib/stores/imported-tokens.store";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
-import { networkEconomicsParametersStore } from "$lib/stores/network-economics.store";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   proposalPayloadsStore,
@@ -124,7 +124,7 @@ export const initDebugStore = () =>
       defaultIcrcCanistersStore,
       importedTokensStore,
       failedImportedTokenLedgerIdsStore,
-      networkEconomicsParametersStore,
+      networkEconomicsStore,
     ],
     ([
       $busyStore,

--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -10,6 +10,7 @@ import {
   importedTokensStore,
 } from "$lib/stores/imported-tokens.store";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
+import { networkEconomicsParametersStore } from "$lib/stores/network-economics.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   proposalPayloadsStore,
@@ -123,6 +124,7 @@ export const initDebugStore = () =>
       defaultIcrcCanistersStore,
       importedTokensStore,
       failedImportedTokenLedgerIdsStore,
+      networkEconomicsParametersStore,
     ],
     ([
       $busyStore,
@@ -153,6 +155,7 @@ export const initDebugStore = () =>
       $defaultIcrcCanistersStore,
       $importedTokensStore,
       $failedImportedTokenLedgerIdsStore,
+      $networkEconomicsParametersStore,
     ]) => ({
       busy: $busyStore,
       accounts: $accountsStore,
@@ -182,5 +185,6 @@ export const initDebugStore = () =>
       defaultIcrcCanistersStore: $defaultIcrcCanistersStore,
       importedTokensStore: $importedTokensStore,
       failedImportedTokenLedgerIdsStore: $failedImportedTokenLedgerIdsStore,
+      networkEconomicsParametersStore: $networkEconomicsParametersStore,
     })
   );

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -3,8 +3,12 @@ import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposa
 import { initAccounts } from "$lib/services/icp-accounts.services";
 import { loadImportedTokens } from "$lib/services/imported-tokens.services";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
+import { loadNetworkEconomicsParameters } from "./network-economics.services";
 
 export const initAppPrivateData = async (): Promise<void> => {
+  const initNetworkEconomicsParameters: Promise<void>[] = [
+    loadNetworkEconomicsParameters(),
+  ];
   const initNns: Promise<void>[] = [initAccounts()];
   // Reload the SNS projects even if they were loaded.
   // Get latest data and create wrapper caches for the logged in identity.
@@ -17,6 +21,7 @@ export const initAppPrivateData = async (): Promise<void> => {
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
    */
   await Promise.allSettled([
+    Promise.all(initNetworkEconomicsParameters),
     Promise.all(initNns),
     Promise.all(initImportedTokens),
     Promise.all(initSns),

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -3,12 +3,8 @@ import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposa
 import { initAccounts } from "$lib/services/icp-accounts.services";
 import { loadImportedTokens } from "$lib/services/imported-tokens.services";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
-import { loadNetworkEconomicsParameters } from "./network-economics.services";
 
 export const initAppPrivateData = async (): Promise<void> => {
-  const initNetworkEconomicsParameters: Promise<void>[] = [
-    loadNetworkEconomicsParameters(),
-  ];
   const initNns: Promise<void>[] = [initAccounts()];
   // Reload the SNS projects even if they were loaded.
   // Get latest data and create wrapper caches for the logged in identity.
@@ -21,7 +17,6 @@ export const initAppPrivateData = async (): Promise<void> => {
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
    */
   await Promise.allSettled([
-    Promise.all(initNetworkEconomicsParameters),
     Promise.all(initNns),
     Promise.all(initImportedTokens),
     Promise.all(initSns),

--- a/frontend/src/lib/services/network-economics.services.ts
+++ b/frontend/src/lib/services/network-economics.services.ts
@@ -1,6 +1,6 @@
-import { governanceApiService } from "../api-services/governance.api-service";
-import { networkEconomicsStore } from "../stores/network-economics.store";
-import { getAuthenticatedIdentity } from "./auth.services";
+import { governanceApiService } from "$lib/api-services/governance.api-service";
+import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 
 export const loadNetworkEconomicsParameters = async (): Promise<void> => {
   try {

--- a/frontend/src/lib/services/network-economics.services.ts
+++ b/frontend/src/lib/services/network-economics.services.ts
@@ -5,16 +5,17 @@ import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 export const loadNetworkEconomicsParameters = async (): Promise<void> => {
   try {
     const identity = await getAuthenticatedIdentity();
+    const certified = true;
     const parameters = await governanceApiService.getNetworkEconomicsParameters(
       {
         identity,
-        certified: true,
+        certified,
       }
     );
 
     networkEconomicsStore.setParameters({
       parameters,
-      certified: true,
+      certified,
     });
   } catch (error) {
     console.error(error);

--- a/frontend/src/lib/services/network-economics.services.ts
+++ b/frontend/src/lib/services/network-economics.services.ts
@@ -1,0 +1,22 @@
+import { governanceApiService } from "../api-services/governance.api-service";
+import { networkEconomicsStore } from "../stores/network-economics.store";
+import { getAuthenticatedIdentity } from "./auth.services";
+
+export const loadNetworkEconomicsParameters = async (): Promise<void> => {
+  try {
+    const identity = await getAuthenticatedIdentity();
+    const parameters = await governanceApiService.getNetworkEconomicsParameters(
+      {
+        identity,
+        certified: true,
+      }
+    );
+
+    networkEconomicsStore.setParameters({
+      parameters,
+      certified: true,
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/frontend/src/lib/stores/network-economics.store.ts
+++ b/frontend/src/lib/stores/network-economics.store.ts
@@ -15,16 +15,22 @@ export interface NetworkEconomicsStore
  * A store that contains the [network economics parameters](https://github.com/dfinity/ic/blob/d90e934eb440c730d44d9d9b1ece2cc3f9505d05/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto#L1847).
  */
 const initNetworkEconomicsParametersStore = () => {
-  const { subscribe, set } = writable<NetworkEconomicsStoreData>({
+  const initialStoreData: NetworkEconomicsStoreData = {
     parameters: undefined,
     certified: undefined,
-  });
+  };
+  const { subscribe, set } =
+    writable<NetworkEconomicsStoreData>(initialStoreData);
 
   return {
     subscribe,
 
     setParameters(parameters: NetworkEconomicsStoreData) {
       set(parameters);
+    },
+
+    reset() {
+      set(initialStoreData);
     },
   };
 };

--- a/frontend/src/lib/stores/network-economics.store.ts
+++ b/frontend/src/lib/stores/network-economics.store.ts
@@ -1,0 +1,32 @@
+import type { NetworkEconomics } from "@dfinity/nns";
+import { writable, type Readable } from "svelte/store";
+
+export interface NetworkEconomicsStoreData {
+  parameters: NetworkEconomics | undefined;
+  certified: boolean | undefined;
+}
+
+export interface NetworkEconomicsStore
+  extends Readable<NetworkEconomicsStoreData> {
+  setParameters: (data: NetworkEconomicsStoreData) => void;
+}
+
+/**
+ * A store that contains the [network economics parameters](https://github.com/dfinity/ic/blob/d90e934eb440c730d44d9d9b1ece2cc3f9505d05/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto#L1847).
+ */
+const initNetworkEconomicsParametersStore = () => {
+  const { subscribe, set } = writable<NetworkEconomicsStoreData>({
+    parameters: undefined,
+    certified: undefined,
+  });
+
+  return {
+    subscribe,
+
+    setParameters(parameters: NetworkEconomicsStoreData) {
+      set(parameters);
+    },
+  };
+};
+
+export const networkEconomicsStore = initNetworkEconomicsParametersStore();

--- a/frontend/src/tests/lib/services/network-economics.services.spec.ts
+++ b/frontend/src/tests/lib/services/network-economics.services.spec.ts
@@ -1,0 +1,56 @@
+import * as api from "$lib/api/governance.api";
+import { loadNetworkEconomicsParameters } from "$lib/services/network-economics.services";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
+import { get } from "svelte/store";
+
+describe("network-economics-services", () => {
+  let spyGetNetworkEconomicsParameters;
+
+  beforeEach(() => {
+    resetIdentity();
+    spyGetNetworkEconomicsParameters = vi
+      .spyOn(api, "getNetworkEconomicsParameters")
+      .mockResolvedValue(mockNetworkEconomics);
+  });
+
+  describe("loadNetworkEconomicsParameters", () => {
+    it("should load network economics", async () => {
+      await loadNetworkEconomicsParameters();
+
+      expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledTimes(1);
+      expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: true,
+      });
+    });
+
+    it("should update networkEconomicsStore store", async () => {
+      expect(get(networkEconomicsStore)).toEqual({
+        parameters: undefined,
+        certified: undefined,
+      });
+
+      await loadNetworkEconomicsParameters();
+
+      expect(get(networkEconomicsStore)).toEqual({
+        parameters: mockNetworkEconomics,
+        certified: true,
+      });
+    });
+
+    it("should console log on error", async () => {
+      vi.spyOn(console, "error").mockReturnValue();
+      const error = new Error("test error");
+      spyGetNetworkEconomicsParameters = vi
+        .spyOn(api, "getNetworkEconomicsParameters")
+        .mockRejectedValue(error);
+
+      await loadNetworkEconomicsParameters();
+
+      expect(console.error).toBeCalledWith(error);
+      expect(console.error).toBeCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/tests/lib/stores/network-economics.store.spec.ts
+++ b/frontend/src/tests/lib/stores/network-economics.store.spec.ts
@@ -1,6 +1,6 @@
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { get } from "svelte/store";
-import { networkEconomicsStore } from "../../../lib/stores/network-economics.store";
-import { mockNetworkEconomics } from "../../mocks/network-economics.mock";
 
 describe("network-economics-store", () => {
   it("should set parameters", () => {

--- a/frontend/src/tests/lib/stores/network-economics.store.spec.ts
+++ b/frontend/src/tests/lib/stores/network-economics.store.spec.ts
@@ -1,0 +1,22 @@
+import { get } from "svelte/store";
+import { networkEconomicsStore } from "../../../lib/stores/network-economics.store";
+import { mockNetworkEconomics } from "../../mocks/network-economics.mock";
+
+describe("network-economics-store", () => {
+  it("should set parameters", () => {
+    expect(get(networkEconomicsStore)).toEqual({
+      parameters: undefined,
+      certified: undefined,
+    });
+
+    networkEconomicsStore.setParameters({
+      parameters: mockNetworkEconomics,
+      certified: true,
+    });
+
+    expect(get(networkEconomicsStore)).toEqual({
+      parameters: mockNetworkEconomics,
+      certified: true,
+    });
+  });
+});

--- a/frontend/src/tests/mocks/network-economics.mock.ts
+++ b/frontend/src/tests/mocks/network-economics.mock.ts
@@ -1,0 +1,42 @@
+import {
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_MONTH,
+} from "$lib/constants/constants";
+import type { NetworkEconomics } from "@dfinity/nns";
+
+export const mockNetworkEconomics: NetworkEconomics = {
+  neuronMinimumStake: 100_000_000n,
+  maxProposalsToKeepPerTopic: 1_000,
+  neuronManagementFeePerProposal: 10_000n,
+  rejectCost: 10_000_000n,
+  transactionFee: 1_000n,
+  neuronSpawnDissolveDelaySeconds: 3600n * 24n * 7n,
+  minimumIcpXdrRate: 1n,
+  maximumNodeProviderRewards: 10_000_000_000n,
+  neuronsFundEconomics: {
+    minimumIcpXdrRate: {
+      basisPoints: 123n,
+    },
+    maxTheoreticalNeuronsFundParticipationAmountXdr: {
+      humanReadable: "456",
+    },
+    neuronsFundMatchedFundingCurveCoefficients: {
+      contributionThresholdXdr: {
+        humanReadable: "789",
+      },
+      oneThirdParticipationMilestoneXdr: {
+        humanReadable: "123",
+      },
+      fullParticipationMilestoneXdr: {
+        humanReadable: "456",
+      },
+    },
+    maximumIcpXdrRate: {
+      basisPoints: 456n,
+    },
+  },
+  votingPowerEconomics: {
+    startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+    clearFollowingAfterSeconds: BigInt(SECONDS_IN_MONTH),
+  },
+};


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, they may change in the future. Therefore, we want to retrieve them from the API. In this PR, we add the service and store to use them in the following PRs.

# Changes

- New `networkEconomicsStore` store.
- New `loadNetworkEconomicsParameters` service (intentionally no error toasts, because this doesn't block more important activities).

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.