### PR TITLE
Load network economics

### DIFF
--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -3,8 +3,12 @@ import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposa
 import { initAccounts } from "$lib/services/icp-accounts.services";
 import { loadImportedTokens } from "$lib/services/imported-tokens.services";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
+import { loadNetworkEconomicsParameters } from "./network-economics.services";
 
 export const initAppPrivateData = async (): Promise<void> => {
+  const initNetworkEconomicsParameters: Promise<void>[] = [
+    loadNetworkEconomicsParameters(),
+  ];
   const initNns: Promise<void>[] = [initAccounts()];
   // Reload the SNS projects even if they were loaded.
   // Get latest data and create wrapper caches for the logged in identity.
@@ -17,6 +21,7 @@ export const initAppPrivateData = async (): Promise<void> => {
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
    */
   await Promise.allSettled([
+    Promise.all(initNetworkEconomicsParameters),
     Promise.all(initNns),
     Promise.all(initImportedTokens),
     Promise.all(initSns),

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -1,5 +1,6 @@
 import { clearSnsAggregatorCache } from "$lib/api-services/sns-aggregator.api-service";
 import * as agent from "$lib/api/agent.api";
+import * as governanceApi from "$lib/api/governance.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import * as actionableProposalsServices from "$lib/services/actionable-proposals.services";
@@ -7,8 +8,9 @@ import * as actionableSnsProposalsServices from "$lib/services/actionable-sns-pr
 import { initAppPrivateData } from "$lib/services/app.services";
 import * as importedTokensServices from "$lib/services/imported-tokens.services";
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
@@ -132,6 +134,23 @@ describe("app-services", () => {
     expect(spyLoadImportedTokens).toHaveBeenCalledTimes(1);
     expect(spyLoadImportedTokens).toHaveBeenCalledWith({
       ignoreAccountNotFoundError: true,
+    });
+  });
+
+  it("should load network economics", async () => {
+    const spyGetNetworkEconomicsParameters = vi
+      .spyOn(governanceApi, "getNetworkEconomicsParameters")
+      .mockResolvedValue(mockNetworkEconomics);
+
+    expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledTimes(0);
+
+    initAppPrivateData();
+    await runResolvedPromises();
+
+    expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledTimes(1);
+    expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      certified: true,
     });
   });
 });


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, they may change in the future. Therefore, we want to retrieve them from the API. In this PR, we load the network parameters on app init.

# Changes

- Load network parameters on app init.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.