### PR TITLE
feat(portfolio): integrate staked tokens card into Portfolio page

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -3,11 +3,15 @@
   import LoginCard from "$lib/components/portfolio/LoginCard.svelte";
   import NoHeldTokensCard from "$lib/components/portfolio/NoHeldTokensCard.svelte";
   import NoStakedTokensCard from "$lib/components/portfolio/NoStakedTokensCard.svelte";
+  import StakedTokensCard from "$lib/components/portfolio/StakedTokensCard.svelte";
   import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import type { TableProject } from "$lib/types/staking";
   import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
-  import { getTopHeldTokens } from "$lib/utils/portfolio.utils";
+  import {
+    getTopHeldTokens,
+    getTopStakedTokens,
+  } from "$lib/utils/portfolio.utils";
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
@@ -48,7 +52,7 @@
   $: showNoHeldTokensCard = $authSignedInStore && totalTokensBalanceInUsd === 0;
 
   let showNoStakedTokensCard: boolean;
-  $: showNoStakedTokensCard = !$authSignedInStore || totalStakedInUsd === 0;
+  $: showNoStakedTokensCard = $authSignedInStore && totalStakedInUsd === 0;
 
   // The Card should display a Primary Action when it is the only available option.
   // This occurs when there are tokens but no stake.
@@ -58,6 +62,12 @@
   let topHeldTokens: UserTokenData[];
   $: topHeldTokens = getTopHeldTokens({
     userTokens: userTokens,
+    isSignedIn: $authSignedInStore,
+  });
+
+  let topStakedTokens: TableProject[];
+  $: topStakedTokens = getTopStakedTokens({
+    projects: tableProjects,
     isSignedIn: $authSignedInStore,
   });
 </script>
@@ -80,6 +90,12 @@
     {/if}
     {#if showNoStakedTokensCard}
       <NoStakedTokensCard primaryCard={hasNoStakedTokensCardAPrimaryAction} />
+    {:else}
+      <StakedTokensCard
+        {topStakedTokens}
+        usdAmount={totalStakedInUsd}
+        numberOfTopHeldTokens={topHeldTokens.length}
+      />
     {/if}
   </div>
 </main>

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -3,6 +3,7 @@ import Portfolio from "$lib/pages/Portfolio.svelte";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken } from "$lib/types/tokens-page";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
@@ -10,7 +11,7 @@ import { mockTableProject } from "$tests/mocks/staking.mock";
 import { createUserToken } from "$tests/mocks/tokens-page.mock";
 import { PortfolioPagePo } from "$tests/page-objects/PortfolioPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { TokenAmountV2 } from "@dfinity/utils";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("Portfolio page", () => {
@@ -39,7 +40,7 @@ describe("Portfolio page", () => {
       expect(await po.getLoginCard().isPresent()).toBe(true);
     });
 
-    it("should show the TokensCard default data", async () => {
+    it("should show the HeldTokensCard default data", async () => {
       const po = renderPage();
 
       const tokensCardPo = po.getHeldTokensCardPo();
@@ -49,16 +50,119 @@ describe("Portfolio page", () => {
       expect(await tokensCardPo.getInfoRow().isPresent()).toBe(false);
     });
 
-    it("should show the NoStakedTokensCard with secondary action", async () => {
+    it("should show the StakedTokensCard default data", async () => {
       const po = renderPage();
 
-      expect(await po.getNoStakedTokensCarPo().isPresent()).toBe(true);
-      // TODO: This will change once the StakedTokensCard is introduced
-      // expect(await po.getNoStakedTokensCarPo().hasSecondaryAction()).toBe(true);
+      const stakedTokensCardPo = po.getStakedTokensCardPo();
+
+      expect(await po.getNoStakedTokensCarPo().isPresent()).toBe(false);
+      expect(await stakedTokensCardPo.isPresent()).toBe(true);
+      expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(false);
     });
   });
 
   describe("when logged in", () => {
+    const token1 = createUserToken({
+      balanceInUsd: 100,
+      universeId: principal(1),
+      title: "Token1",
+      balance: TokenAmountV2.fromUlps({
+        amount: 2160000000n,
+        token: mockToken,
+      }),
+    });
+    const token2 = createUserToken({
+      balanceInUsd: 200,
+      universeId: principal(2),
+      title: "Token2",
+      balance: TokenAmountV2.fromUlps({
+        amount: 2160000000n,
+        token: mockToken,
+      }),
+    });
+    const token3 = createUserToken({
+      balanceInUsd: 300,
+      universeId: principal(3),
+      title: "Token3",
+      balance: TokenAmountV2.fromUlps({
+        amount: 2160000000n,
+        token: mockToken,
+      }),
+    });
+    const token4 = createUserToken({
+      balanceInUsd: 400,
+      universeId: principal(4),
+      title: "Token4",
+      balance: TokenAmountV2.fromUlps({
+        amount: 2160000000n,
+        token: mockToken,
+      }),
+    });
+    const token5 = createUserToken({
+      balanceInUsd: 500,
+      universeId: principal(5),
+      title: "Token5",
+      balance: TokenAmountV2.fromUlps({
+        amount: 2160000000n,
+        token: mockToken,
+      }),
+    });
+
+    const icpProject: TableProject = {
+      ...mockTableProject,
+      stakeInUsd: 100,
+      domKey: "/staking/icp",
+      stake: TokenAmountV2.fromUlps({
+        amount: 1000_000n,
+        token: ICPToken,
+      }),
+      availableMaturity: 1_000_000_000n,
+      stakedMaturity: 1_000_000_000n,
+    };
+    const tableProject1: TableProject = {
+      ...mockTableProject,
+      title: "Project 1",
+      stakeInUsd: 200,
+      domKey: "/staking/1",
+      universeId: principal(1).toText(),
+      stake: TokenAmountV2.fromUlps({
+        amount: 1000_000n,
+        token: mockToken,
+      }),
+    };
+    const tableProject2: TableProject = {
+      ...mockTableProject,
+      title: "Project 2",
+      stakeInUsd: 300,
+      domKey: "/staking/2",
+
+      universeId: principal(2).toText(),
+      stake: TokenAmountV2.fromUlps({
+        amount: 1000_000n,
+        token: mockToken,
+      }),
+    };
+    const tableProject3: TableProject = {
+      ...mockTableProject,
+      title: "Project 3",
+      stakeInUsd: 400,
+      domKey: "/staking/3",
+      universeId: principal(3).toText(),
+      availableMaturity: 100_000_000n,
+      stake: TokenAmountV2.fromUlps({
+        amount: 0n,
+        token: mockToken,
+      }),
+    };
+    const tableProject4: TableProject = {
+      ...mockTableProject,
+      title: "Project 4",
+      stakeInUsd: undefined,
+      domKey: "/staking/4",
+      universeId: principal(5).toText(),
+      stake: new UnavailableTokenAmount(mockToken),
+    };
+
     beforeEach(() => {
       resetIdentity();
 
@@ -77,7 +181,7 @@ describe("Portfolio page", () => {
       expect(await po.getLoginCard().isPresent()).toBe(false);
     });
 
-    describe("NoTokensCard", () => {
+    describe("NoHeldTokensCard", () => {
       it("should display the card when the tokens accounts balance is zero", async () => {
         const po = renderPage();
 
@@ -99,53 +203,7 @@ describe("Portfolio page", () => {
       });
     });
 
-    describe("TokensCard", () => {
-      const token1 = createUserToken({
-        balanceInUsd: 100,
-        rowHref: "/tokens/1",
-        title: "Token1",
-        balance: TokenAmountV2.fromUlps({
-          amount: 2160000000n,
-          token: mockToken,
-        }),
-      });
-      const token2 = createUserToken({
-        balanceInUsd: 200,
-        rowHref: "/tokens/2",
-        title: "Token2",
-        balance: TokenAmountV2.fromUlps({
-          amount: 2160000000n,
-          token: mockToken,
-        }),
-      });
-      const token3 = createUserToken({
-        balanceInUsd: 300,
-        rowHref: "/tokens/3",
-        title: "Token3",
-        balance: TokenAmountV2.fromUlps({
-          amount: 2160000000n,
-          token: mockToken,
-        }),
-      });
-      const token4 = createUserToken({
-        balanceInUsd: 400,
-        rowHref: "/tokens/4",
-        title: "Token4",
-        balance: TokenAmountV2.fromUlps({
-          amount: 2160000000n,
-          token: mockToken,
-        }),
-      });
-      const token5 = createUserToken({
-        balanceInUsd: 500,
-        rowHref: "/tokens/5",
-        title: "Token5",
-        balance: TokenAmountV2.fromUlps({
-          amount: 2160000000n,
-          token: mockToken,
-        }),
-      });
-
+    describe("HeldTokensCard", () => {
       it("should display the top four tokens by balanceInUsd", async () => {
         const po = renderPage({
           userTokens: [token1, token2, token3, token4, token5],
@@ -207,6 +265,90 @@ describe("Portfolio page", () => {
       });
     });
 
+    describe("StakedTokensCard", () => {
+      it("should display the top staked tokens by staked balance in Usd with InternetComputer as first", async () => {
+        const po = renderPage({
+          tableProjects: [
+            tableProject1,
+            tableProject2,
+            tableProject3,
+            tableProject4,
+            icpProject,
+          ],
+        });
+        const stakedTokensCardPo = po.getStakedTokensCardPo();
+
+        const titles = await stakedTokensCardPo.getStakedTokensTitle();
+        const maturities = await stakedTokensCardPo.getStakedTokensMaturity();
+        const stakesInUsd =
+          await stakedTokensCardPo.getStakedTokensStakeInUsd();
+        const stakesInNativeCurrency =
+          await stakedTokensCardPo.getStakedTokensStakeInNativeCurrency();
+
+        expect(await po.getNoStakedTokensCarPo().isPresent()).toBe(false);
+
+        expect(titles.length).toBe(4);
+        expect(titles).toEqual([
+          "Internet Computer",
+          "Project 3",
+          "Project 2",
+          "Project 1",
+        ]);
+
+        expect(maturities.length).toBe(4);
+        expect(maturities).toEqual(["20.00", "1.00", "0", "0"]);
+
+        expect(stakesInUsd.length).toBe(4);
+        expect(stakesInUsd).toEqual([
+          "$100.00",
+          "$400.00",
+          "$300.00",
+          "$200.00",
+        ]);
+
+        expect(stakesInNativeCurrency.length).toBe(4);
+        expect(stakesInNativeCurrency).toEqual([
+          "0.01 ICP",
+          "0 TET",
+          "0.01 TET",
+          "0.01 TET",
+        ]);
+
+        expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(false);
+      });
+
+      it("should display the information row when the staked tokens card has less items than the held tokens card", async () => {
+        const po = renderPage({
+          tableProjects: [tableProject1, tableProject2],
+          userTokens: [token1, token2, token3, token4],
+        });
+        const stakedTokensCardPo = po.getStakedTokensCardPo();
+
+        const titles = await stakedTokensCardPo.getStakedTokensTitle();
+        const maturities = await stakedTokensCardPo.getStakedTokensMaturity();
+        const stakesInUsd =
+          await stakedTokensCardPo.getStakedTokensStakeInUsd();
+        const stakesInNativeCurrency =
+          await stakedTokensCardPo.getStakedTokensStakeInNativeCurrency();
+
+        expect(await po.getNoStakedTokensCarPo().isPresent()).toBe(false);
+
+        expect(titles.length).toBe(2);
+        expect(titles).toEqual(["Project 2", "Project 1"]);
+
+        expect(maturities.length).toBe(2);
+        expect(maturities).toEqual(["0", "0"]);
+
+        expect(stakesInUsd.length).toBe(2);
+        expect(stakesInUsd).toEqual(["$300.00", "$200.00"]);
+
+        expect(stakesInNativeCurrency.length).toBe(2);
+        expect(stakesInNativeCurrency).toEqual(["0.01 TET", "0.01 TET"]);
+
+        expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(true);
+      });
+    });
+
     describe("NoStakedTokensCard", () => {
       it("should display the card when the total balance is zero", async () => {
         const po = renderPage();
@@ -253,30 +395,30 @@ describe("Portfolio page", () => {
       const token1 = createUserToken({
         universeId: principal(1),
         balanceInUsd: 5,
-        rowHref: "/token/1",
       });
       const token2 = createUserToken({
-        universeId: principal(1),
+        universeId: principal(2),
         balanceInUsd: 7,
-        rowHref: "/token/2",
       });
       const token3 = createUserToken({
-        universeId: principal(1),
+        universeId: principal(3),
         balanceInUsd: undefined,
-        rowHref: "/token/3",
       });
 
       const tableProject1: TableProject = {
         ...mockTableProject,
         stakeInUsd: 2,
+        domKey: "/project/1",
       };
       const tableProject2: TableProject = {
         ...mockTableProject,
         stakeInUsd: 10.5,
+        domKey: "/project/2",
       };
       const tableProject3: TableProject = {
         ...mockTableProject,
         stakeInUsd: undefined,
+        domKey: "/project/3",
       };
 
       it("should display total assets", async () => {

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -3,6 +3,7 @@ import { NoStakedTokensCardPo } from "$tests/page-objects/NoStakedTokensCard.pag
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { StakedTokensCardPo } from "./StakedTokensCard.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
   private static readonly TID = "portfolio-page-component";
@@ -29,5 +30,9 @@ export class PortfolioPagePo extends BasePageObject {
 
   getHeldTokensCardPo(): HeldTokensCardPo {
     return HeldTokensCardPo.under(this.root);
+  }
+
+  getStakedTokensCardPo(): StakedTokensCardPo {
+    return StakedTokensCardPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

We want to show the top staked tokens card in the Portfolio page.

# Changes

- Calls `getTopStakedTokens` on the Portfolio page to retrieve the list of top staked tokens  
- Renders the `StakedTokensCard` on the Portfolio page with the top staked tokens.

# Tests

- Unit test to verify the presence of the component when the user has staked tokens.  
- Unit test to check the contents of the `StakeTokensCard` when the user has tokens.
- Unit test to check that the `StakedTokensCard` shows an informational row when it has less items than the `HeltTokensCard`

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary