### PR TITLE
feat(portfolio): add info row visibility utility

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -91,7 +91,7 @@ export const getTopStakedTokens = ({
  * with a message instead of leaving a blank space.
  * Rules for showing the info row:
  * 1. When the other card has more tokens than the current card
- * 2. When the other card is empty (has 0 tokens)
+ * 2. When the other card is empty (has 0 tokens) AND current card has fewer than 4 tokens
  * 3. When both cards have fewer than 3 tokens (for visual balance)
  */
 export const shouldShowInfoRow = ({
@@ -103,7 +103,7 @@ export const shouldShowInfoRow = ({
 }) => {
   return (
     otherCardNumberOfTokens - currentCardNumberOfTokens > 0 ||
-    otherCardNumberOfTokens === 0 ||
+    (otherCardNumberOfTokens === 0 && currentCardNumberOfTokens < 4) ||
     (currentCardNumberOfTokens < 3 && otherCardNumberOfTokens < 3)
   );
 };

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -84,3 +84,24 @@ export const getTopStakedTokens = ({
 
   return topProjects.filter((project) => project?.stakeInUsd ?? 0 > 0);
 };
+
+/**
+ * Determines whether to show an info row in a card based on specific display rules.
+ * Rules for showing the info row:
+ * 1. When the other card has more tokens than the current card
+ * 2. When the other card is empty (has 0 tokens)
+ * 3. When both cards have fewer than 3 tokens (for visual balance)
+ */
+export const shouldShowInfoRow = ({
+  currentCardTokens,
+  otherCardTokens,
+}: {
+  currentCardTokens: number;
+  otherCardTokens: number;
+}) => {
+  return (
+    otherCardTokens - currentCardTokens > 0 ||
+    otherCardTokens === 0 ||
+    (currentCardTokens < 3 && otherCardTokens < 3)
+  );
+};

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -102,7 +102,7 @@ export const shouldShowInfoRow = ({
   otherCardNumberOfTokens: number;
 }) => {
   return (
-    otherCardNumberOfTokens - currentCardNumberOfTokens > 0 ||
+    otherCardNumberOfTokens > currentCardNumberOfTokens ||
     (otherCardNumberOfTokens === 0 && currentCardNumberOfTokens < 4) ||
     (currentCardNumberOfTokens < 3 && otherCardNumberOfTokens < 3)
   );

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -87,21 +87,23 @@ export const getTopStakedTokens = ({
 
 /**
  * Determines whether to show an info row in a card based on specific display rules.
+ * This ensures both cards have consistent heights by filling empty space
+ * with a message instead of leaving a blank space.
  * Rules for showing the info row:
  * 1. When the other card has more tokens than the current card
  * 2. When the other card is empty (has 0 tokens)
  * 3. When both cards have fewer than 3 tokens (for visual balance)
  */
 export const shouldShowInfoRow = ({
-  currentCardTokens,
-  otherCardTokens,
+  currentCardNumberOfTokens,
+  otherCardNumberOfTokens,
 }: {
-  currentCardTokens: number;
-  otherCardTokens: number;
+  currentCardNumberOfTokens: number;
+  otherCardNumberOfTokens: number;
 }) => {
   return (
-    otherCardTokens - currentCardTokens > 0 ||
-    otherCardTokens === 0 ||
-    (currentCardTokens < 3 && otherCardTokens < 3)
+    otherCardNumberOfTokens - currentCardNumberOfTokens > 0 ||
+    otherCardNumberOfTokens === 0 ||
+    (currentCardNumberOfTokens < 3 && otherCardNumberOfTokens < 3)
   );
 };

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -3,16 +3,16 @@ import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken } from "$lib/types/tokens-page";
 import {
-    getTopHeldTokens,
-    getTopStakedTokens,
-    shouldShowInfoRow,
+  getTopHeldTokens,
+  getTopStakedTokens,
+  shouldShowInfoRow,
 } from "$lib/utils/portfolio.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockTableProject } from "$tests/mocks/staking.mock";
 import {
-    createIcpUserToken,
-    createUserToken,
-    createUserTokenLoading,
+  createIcpUserToken,
+  createUserToken,
+  createUserTokenLoading,
 } from "$tests/mocks/tokens-page.mock";
 
 describe("Portfolio utils", () => {
@@ -335,7 +335,6 @@ describe("Portfolio utils", () => {
         })
       ).toBe(true);
     });
-
 
     it("should show info row when other card is empty and current card has less than 4 tokens", () => {
       expect(

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -330,8 +330,8 @@ describe("Portfolio utils", () => {
     it("should show info row when other card has more tokens", () => {
       expect(
         shouldShowInfoRow({
-          currentCardTokens: 1,
-          otherCardTokens: 4,
+          currentCardNumberOfTokens: 1,
+          otherCardNumberOfTokens: 4,
         })
       ).toBe(true);
     });
@@ -339,8 +339,8 @@ describe("Portfolio utils", () => {
     it("should show info row when other card is empty", () => {
       expect(
         shouldShowInfoRow({
-          currentCardTokens: 2,
-          otherCardTokens: 0,
+          currentCardNumberOfTokens: 2,
+          otherCardNumberOfTokens: 0,
         })
       ).toBe(true);
     });
@@ -348,15 +348,15 @@ describe("Portfolio utils", () => {
     it("should show info row when both cards have fewer than 3 tokens", () => {
       expect(
         shouldShowInfoRow({
-          currentCardTokens: 2,
-          otherCardTokens: 2,
+          currentCardNumberOfTokens: 2,
+          otherCardNumberOfTokens: 2,
         })
       ).toBe(true);
 
       expect(
         shouldShowInfoRow({
-          currentCardTokens: 1,
-          otherCardTokens: 2,
+          currentCardNumberOfTokens: 1,
+          otherCardNumberOfTokens: 2,
         })
       ).toBe(true);
     });
@@ -364,15 +364,15 @@ describe("Portfolio utils", () => {
     it("should not show info row when both cards have 3 or more tokens", () => {
       expect(
         shouldShowInfoRow({
-          currentCardTokens: 3,
-          otherCardTokens: 3,
+          currentCardNumberOfTokens: 3,
+          otherCardNumberOfTokens: 3,
         })
       ).toBe(false);
 
       expect(
         shouldShowInfoRow({
-          currentCardTokens: 4,
-          otherCardTokens: 3,
+          currentCardNumberOfTokens: 4,
+          otherCardNumberOfTokens: 3,
         })
       ).toBe(false);
     });

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -5,6 +5,7 @@ import type { UserToken } from "$lib/types/tokens-page";
 import {
   getTopHeldTokens,
   getTopStakedTokens,
+  shouldShowInfoRow,
 } from "$lib/utils/portfolio.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockTableProject } from "$tests/mocks/staking.mock";
@@ -322,6 +323,58 @@ describe("Portfolio utils", () => {
 
         expect(result).toHaveLength(0);
       });
+    });
+  });
+
+  describe("shouldShowInfoRow", () => {
+    it("should show info row when other card has more tokens", () => {
+      expect(
+        shouldShowInfoRow({
+          currentCardTokens: 1,
+          otherCardTokens: 4,
+        })
+      ).toBe(true);
+    });
+
+    it("should show info row when other card is empty", () => {
+      expect(
+        shouldShowInfoRow({
+          currentCardTokens: 2,
+          otherCardTokens: 0,
+        })
+      ).toBe(true);
+    });
+
+    it("should show info row when both cards have fewer than 3 tokens", () => {
+      expect(
+        shouldShowInfoRow({
+          currentCardTokens: 2,
+          otherCardTokens: 2,
+        })
+      ).toBe(true);
+
+      expect(
+        shouldShowInfoRow({
+          currentCardTokens: 1,
+          otherCardTokens: 2,
+        })
+      ).toBe(true);
+    });
+
+    it("should not show info row when both cards have 3 or more tokens", () => {
+      expect(
+        shouldShowInfoRow({
+          currentCardTokens: 3,
+          otherCardTokens: 3,
+        })
+      ).toBe(false);
+
+      expect(
+        shouldShowInfoRow({
+          currentCardTokens: 4,
+          otherCardTokens: 3,
+        })
+      ).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -3,16 +3,16 @@ import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken } from "$lib/types/tokens-page";
 import {
-  getTopHeldTokens,
-  getTopStakedTokens,
-  shouldShowInfoRow,
+    getTopHeldTokens,
+    getTopStakedTokens,
+    shouldShowInfoRow,
 } from "$lib/utils/portfolio.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockTableProject } from "$tests/mocks/staking.mock";
 import {
-  createIcpUserToken,
-  createUserToken,
-  createUserTokenLoading,
+    createIcpUserToken,
+    createUserToken,
+    createUserTokenLoading,
 } from "$tests/mocks/tokens-page.mock";
 
 describe("Portfolio utils", () => {
@@ -336,13 +336,35 @@ describe("Portfolio utils", () => {
       ).toBe(true);
     });
 
-    it("should show info row when other card is empty", () => {
+
+    it("should show info row when other card is empty and current card has less than 4 tokens", () => {
       expect(
         shouldShowInfoRow({
           currentCardNumberOfTokens: 2,
           otherCardNumberOfTokens: 0,
         })
       ).toBe(true);
+
+      expect(
+        shouldShowInfoRow({
+          currentCardNumberOfTokens: 3,
+          otherCardNumberOfTokens: 0,
+        })
+      ).toBe(true);
+
+      expect(
+        shouldShowInfoRow({
+          currentCardNumberOfTokens: 4,
+          otherCardNumberOfTokens: 0,
+        })
+      ).toBe(false);
+
+      expect(
+        shouldShowInfoRow({
+          currentCardNumberOfTokens: 5,
+          otherCardNumberOfTokens: 0,
+        })
+      ).toBe(false);
     });
 
     it("should show info row when both cards have fewer than 3 tokens", () => {


### PR DESCRIPTION
# Motivation

Determines whether to display an info row in a card based on specific rules. The criteria for showing the info row are as follows:  
1. When the other card has more tokens than the current card.  
2. When the other card is empty (has 0 tokens).  
3. When both cards have fewer than 3 tokens (for visual balance).

# Changes

- New `shouldShowInfoRow` utility

# Tests

- Unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary