### PR TITLE
fix(styles): IcpExchangeRate specificity conflict

### DIFF
--- a/frontend/src/lib/components/ui/IcpExchangeRate.svelte
+++ b/frontend/src/lib/components/ui/IcpExchangeRate.svelte
@@ -56,17 +56,17 @@
     &.has-error {
       --tooltip-icon-color: var(--tag-failed-text);
     }
+  }
 
+  .desktop-only {
+    display: none;
+  }
+  @include media.min-width(medium) {
     .desktop-only {
-      display: none;
+      display: flex;
     }
-    @include media.min-width(medium) {
-      .desktop-only {
-        display: flex;
-      }
-      .mobile-only {
-        display: none;
-      }
+    .mobile-only {
+      display: none;
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

The `display: none` rule wasn't working because, when nested inside `.exchange-rate`, Svelte's CSS scoping created a more specific selector. This interfered with the media query's ability to toggle the visibility of utility classes effectively.

# Changes

- Fix the style by moving it out from the parents scope

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary