### PR TITLE
fix(ui): stack date range options on small screens in the Reporting page

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- Improved the display of date range options in the mobile view of the Reporting page.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -41,6 +41,7 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   fieldset {
     all: unset;
@@ -59,7 +60,11 @@
 
       div {
         display: flex;
+        flex-direction: column;
         gap: var(--padding-3x);
+        @include media.min-width(medium) {
+          flex-direction: row;
+        }
 
         .radio-option {
           display: flex;


### PR DESCRIPTION
# Motivation

On small screens, the date range options are displayed in a row, but they do not look neat. We want to stack them on small screens.

Before:

https://github.com/user-attachments/assets/5a00ef25-9148-48d0-bed0-bb1d75ec6ee5


After:

https://github.com/user-attachments/assets/e40d0354-8284-4e75-bb65-b327f240f08e


# Changes

- Changes the layout of the radio options from a row to a column.

# Tests

- Manually tested

# Todos

- [x] Add entry to changelog (if necessary).
