### PR TITLE
Periodic confirmation e2e test

### DIFF
--- a/frontend/src/lib/modals/neurons/UpdateVotingPowerRefreshedModal.svelte
+++ b/frontend/src/lib/modals/neurons/UpdateVotingPowerRefreshedModal.svelte
@@ -82,7 +82,11 @@
 </script>
 
 <!-- ONLY FOR TESTNET. NO UNIT TESTS -->
-<Modal role="alert" on:nnsClose>
+<Modal
+  role="alert"
+  on:nnsClose
+  testId="update-voting-power-refreshed-modal-component"
+>
   <span slot="title">Voting Power Refreshed Timestamp</span>
 
   <form
@@ -112,6 +116,7 @@
       <span class="label">Value in seconds</span>
 
       <Input
+        testId="update-voting-power-refreshed-seconds-input"
         placeholderLabelKey="core.amount"
         name="seconds"
         inputType="number"
@@ -123,8 +128,8 @@
   </form>
 
   <button
-    data-tid="confirm-add-maturity-button"
-    form="get-maturity-form"
+    data-tid="confirm-update-voting-power-refreshed-button"
+    form="dev-update-voting-power-refreshed"
     class="primary"
     slot="footer"
     disabled={isNullish(toBigInt(secondsValue)) || updating}

--- a/frontend/src/tests/e2e/periodic.spec.ts
+++ b/frontend/src/tests/e2e/periodic.spec.ts
@@ -39,6 +39,8 @@ test("Test periodic confirmation", async ({ page, context }) => {
 
   step("Review missing rewards banner");
   await appPo.goToStaking();
+  // The test is flaky whithout this wait
+  await losingRewardsBannerPo.getBannerPo().waitFor();
   expect(await losingRewardsBannerPo.isVisible()).toBe(true);
 
   step("Confirm following");

--- a/frontend/src/tests/e2e/periodic.spec.ts
+++ b/frontend/src/tests/e2e/periodic.spec.ts
@@ -1,0 +1,60 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+const SECONDS_IN_6_MONTHS = ((4 * 365 + 1) * (60 * 60 * 24)) / 4;
+
+test("Test periodic confirmation", async ({ page, context }) => {
+  const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
+
+  await page.goto("/tokens");
+  await expect(page).toHaveTitle("Tokens / NNS Dapp");
+
+  step("Sign in");
+  await signInWithNewUser({ page, context });
+
+  step("Get some tokens");
+  await appPo.getIcpTokens(21);
+
+  step("Stake a neuron");
+  await appPo.goToStaking();
+  await appPo
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: 10, dissolveDelayDays: "max" });
+
+  const neuronIds = await appPo.getNeuronsPo().getNnsNeuronsPo().getNeuronIds();
+  const neuronDetail = appPo.getNeuronDetailPo().getNnsNeuronDetailPo();
+  await appPo.goToNeuronDetails(neuronIds[0]);
+
+  step("Make the neuron inactive");
+  await neuronDetail.updateVotingPowerRefreshedTimestamp(
+    Math.round(Date.now() / 1000 - SECONDS_IN_6_MONTHS)
+  );
+
+  step("Review missing rewards banner");
+  await appPo.goToStaking();
+  const losingRewardsBannerPo = appPo.getStakingPo().getLosingRewardsBannerPo();
+  expect(await losingRewardsBannerPo.isVisible()).toBe(true);
+
+  step("Confirm following");
+  await losingRewardsBannerPo.clickConfirm();
+  // Review the modal
+  const losingRewardNeuronsModalPo = appPo
+    .getStakingPo()
+    .getLosingRewardsBannerPo()
+    .getLosingRewardNeuronsModalPo();
+  const cards =
+    await losingRewardNeuronsModalPo.getNnsLosingRewardsNeuronCardPos();
+  expect(cards.length).toBe(1);
+  expect(await cards[0].getNeuronId()).toEqual(neuronIds[0]);
+
+  // Confirm
+  await losingRewardNeuronsModalPo.clickConfirmFollowing();
+  await appPo
+    .getStakingPo()
+    .getLosingRewardsBannerPo()
+    .getBannerPo()
+    .waitForAbsent();
+  expect(await losingRewardsBannerPo.isVisible()).toBe(false);
+});

--- a/frontend/src/tests/e2e/periodic.spec.ts
+++ b/frontend/src/tests/e2e/periodic.spec.ts
@@ -3,7 +3,9 @@ import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page
 import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
-const SECONDS_IN_6_MONTHS = ((4 * 365 + 1) * (60 * 60 * 24)) / 4;
+const SECONDS_IN_DAY = 24 * 60 * 60;
+const AVERAGE_DAYS_PER_YEAR = 365.25;
+const SECONDS_IN_6_MONTHS = (AVERAGE_DAYS_PER_YEAR / 2) * SECONDS_IN_DAY;
 
 test("Test periodic confirmation", async ({ page, context }) => {
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));

--- a/frontend/src/tests/e2e/periodic.spec.ts
+++ b/frontend/src/tests/e2e/periodic.spec.ts
@@ -23,6 +23,9 @@ test("Test periodic confirmation", async ({ page, context }) => {
     .getStakingPo()
     .stakeFirstNnsNeuron({ amount: 10, dissolveDelayDays: "max" });
 
+  const losingRewardsBannerPo = appPo.getStakingPo().getLosingRewardsBannerPo();
+  expect(await losingRewardsBannerPo.isVisible()).toBe(false);
+
   const neuronIds = await appPo.getNeuronsPo().getNnsNeuronsPo().getNeuronIds();
   const neuronDetail = appPo.getNeuronDetailPo().getNnsNeuronDetailPo();
   await appPo.goToNeuronDetails(neuronIds[0]);
@@ -34,7 +37,6 @@ test("Test periodic confirmation", async ({ page, context }) => {
 
   step("Review missing rewards banner");
   await appPo.goToStaking();
-  const losingRewardsBannerPo = appPo.getStakingPo().getLosingRewardsBannerPo();
   expect(await losingRewardsBannerPo.isVisible()).toBe(true);
 
   step("Confirm following");

--- a/frontend/src/tests/e2e/periodic.spec.ts
+++ b/frontend/src/tests/e2e/periodic.spec.ts
@@ -39,7 +39,7 @@ test("Test periodic confirmation", async ({ page, context }) => {
 
   step("Review missing rewards banner");
   await appPo.goToStaking();
-  // The test is flaky whithout this wait
+  // The test is flaky without this wait, presumably because of a delayed store update.
   await losingRewardsBannerPo.getBannerPo().waitFor();
   expect(await losingRewardsBannerPo.isVisible()).toBe(true);
 

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -136,6 +136,16 @@ export class NnsNeuronDetailPo extends BasePageObject {
       .addMaturity(amount);
   }
 
+  async updateVotingPowerRefreshedTimestamp(timestamp: number): Promise<void> {
+    await this.getNnsNeuronTestnetFunctionsCardPo().clickUpdateVotingPowerRefreshedTimestamp();
+    await this.getNnsNeuronModalsPo()
+      .getUpdateVotingPowerRefreshedModalPo()
+      .waitFor();
+    await this.getNnsNeuronModalsPo()
+      .getUpdateVotingPowerRefreshedModalPo()
+      .updateTimestampSeconds(timestamp);
+  }
+
   async spawnNeuron({ percentage }: { percentage: number }): Promise<void> {
     await this.getMaturitySectionPo()
       .getAvailableMaturityItemActionPo()

--- a/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
@@ -6,6 +6,7 @@ import { JoinCommunityFundModalPo } from "$tests/page-objects/JoinCommunityFundM
 import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 import { NnsAddMaturityModalPo } from "$tests/page-objects/NnsAddMaturityModal.page-object";
 import { SpawnNeuronModalPo } from "$tests/page-objects/SpawnNeuronModal.page-object";
+import { UpdateVotingPowerRefreshedModalPo } from "$tests/page-objects/UpdateVotingPowerRefreshedModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -38,6 +39,10 @@ export class NnsNeuronModalsPo extends BasePageObject {
 
   getNnsAddMaturityModalPo(): NnsAddMaturityModalPo {
     return NnsAddMaturityModalPo.under(this.root);
+  }
+
+  getUpdateVotingPowerRefreshedModalPo(): UpdateVotingPowerRefreshedModalPo {
+    return UpdateVotingPowerRefreshedModalPo.under(this.root);
   }
 
   getSpawnNeuronModalPo(): SpawnNeuronModalPo {

--- a/frontend/src/tests/page-objects/NnsNeuronTestnetFunctionsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronTestnetFunctionsCard.page-object.ts
@@ -13,4 +13,8 @@ export class NnsNeuronTestnetFunctionsCardPo extends BasePageObject {
   clickAddMaturity(): Promise<void> {
     return this.click("add-maturity-button");
   }
+
+  clickUpdateVotingPowerRefreshedTimestamp(): Promise<void> {
+    return this.click("update-voting-power-refreshed-button");
+  }
 }

--- a/frontend/src/tests/page-objects/UpdateVotingPowerRefreshedModal.page-object.ts
+++ b/frontend/src/tests/page-objects/UpdateVotingPowerRefreshedModal.page-object.ts
@@ -1,0 +1,32 @@
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import { TextInputPo } from "$tests/page-objects/TextInput.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class UpdateVotingPowerRefreshedModalPo extends ModalPo {
+  private static TID = "update-voting-power-refreshed-modal-component";
+
+  static under(element: PageObjectElement): UpdateVotingPowerRefreshedModalPo {
+    return new UpdateVotingPowerRefreshedModalPo(
+      element.byTestId(UpdateVotingPowerRefreshedModalPo.TID)
+    );
+  }
+
+  getTimestampSecondsInputPo(): TextInputPo {
+    return TextInputPo.under({
+      element: this.root,
+      testId: "update-voting-power-refreshed-seconds-input",
+    });
+  }
+
+  async getTimestampSeconds(): Promise<number> {
+    return Number(await this.getTimestampSecondsInputPo().getValue());
+  }
+
+  async updateTimestampSeconds(seconds: number): Promise<void> {
+    await this.root
+      .byTestId("update-voting-power-refreshed-seconds-input")
+      .typeText(seconds.toString());
+    await this.click("confirm-update-voting-power-refreshed-button");
+    await this.waitForClosed();
+  }
+}


### PR DESCRIPTION
# Motivation

To ensure that the user can confirm following and does not miss voting rewards, we have added an end-to-end (e2e) test that attempts to confirm the following of an inactive neuron.

# Changes

- Update page objects.
- Added an e2e test.

# Tests

- Yes

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.