### PR TITLE
Voting power economics derived stores

### DIFF
--- a/frontend/src/lib/derived/network-economics.derived.ts
+++ b/frontend/src/lib/derived/network-economics.derived.ts
@@ -1,0 +1,19 @@
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
+import { derived, type Readable } from "svelte/store";
+
+export const startReducingVotingPowerAfterSecondsStore: Readable<
+  bigint | undefined
+> = derived(
+  networkEconomicsStore,
+  ($networkEconomicsStore) =>
+    $networkEconomicsStore.parameters?.votingPowerEconomics
+      ?.startReducingVotingPowerAfterSeconds
+);
+
+export const clearFollowingAfterSecondsStore: Readable<bigint | undefined> =
+  derived(
+    networkEconomicsStore,
+    ($networkEconomicsStore) =>
+      $networkEconomicsStore.parameters?.votingPowerEconomics
+        ?.clearFollowingAfterSeconds
+  );

--- a/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
@@ -1,0 +1,39 @@
+import {
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_MONTH,
+} from "$lib/constants/constants";
+import {
+  clearFollowingAfterSecondsStore,
+  startReducingVotingPowerAfterSecondsStore,
+} from "$lib/derived/network-economics.derived";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
+import { get } from "svelte/store";
+
+describe("network-economics-derived", () => {
+  it("should return start reducing voting power", () => {
+    expect(get(startReducingVotingPowerAfterSecondsStore)).toEqual(undefined);
+
+    networkEconomicsStore.setParameters({
+      parameters: mockNetworkEconomics,
+      certified: true,
+    });
+
+    expect(get(startReducingVotingPowerAfterSecondsStore)).toEqual(
+      BigInt(SECONDS_IN_HALF_YEAR)
+    );
+  });
+
+  it("should return start reducing voting power", () => {
+    expect(get(clearFollowingAfterSecondsStore)).toEqual(undefined);
+
+    networkEconomicsStore.setParameters({
+      parameters: mockNetworkEconomics,
+      certified: true,
+    });
+
+    expect(get(clearFollowingAfterSecondsStore)).toEqual(
+      BigInt(SECONDS_IN_MONTH)
+    );
+  });
+});


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, they may change in the future. Therefore, we want to retrieve them from the API. 

In this PR, we add derived stores to retrieve values related to periodic confirmation.

# Changes

- New strores.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.