### PR TITLE
refactor(portfolio): extract TokensCard header into standalone component

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
+  import TokensCardHeader from "$lib/components/portfolio/TokensCardHeader.svelte";
   import Logo from "$lib/components/ui/Logo.svelte";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -39,35 +40,11 @@
     role="region"
     aria-label={$i18n.portfolio.held_tokens_card_title}
   >
-    <div class="header">
-      <div class="header-wrapper">
-        <div class="icon" aria-hidden="true">
-          <IconAccountsPage />
-        </div>
-        <div class="text-content">
-          <h5 class="title">{$i18n.portfolio.held_tokens_card_title}</h5>
-          <p
-            class="amount"
-            data-tid="amount"
-            aria-label={`${$i18n.portfolio.held_tokens_card_title}: ${usdAmount}`}
-          >
-            ${usdAmountFormatted}
-          </p>
-        </div>
-      </div>
-      <a
-        {href}
-        class="button secondary"
-        aria-label={$i18n.portfolio.held_tokens_card_link}
-      >
-        <span class="mobile-only">
-          <IconRight />
-        </span>
-        <span class="tablet-up">
-          {$i18n.portfolio.held_tokens_card_link}
-        </span>
-      </a>
-    </div>
+    <TokensCardHeader {href} {usdAmount} {usdAmountFormatted}>
+      <svelte:fragment slot="icon">
+        <IconAccountsPage />
+      </svelte:fragment>
+    </TokensCardHeader>
     <div class="body" role="table">
       <div class="header" role="row">
         <span role="columnheader"
@@ -144,46 +121,12 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
+
   .wrapper {
     display: flex;
     flex-direction: column;
     height: 100%;
     background-color: var(--card-background-tint);
-
-    .header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: var(--padding-3x) var(--padding-2x);
-
-      .header-wrapper {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--padding-2x);
-
-        .icon {
-          width: 50px;
-          height: 50px;
-        }
-
-        .text-content {
-          display: flex;
-          flex-direction: column;
-          gap: var(--padding-0_5x);
-
-          .title {
-            font-size: 0.875rem;
-            font-weight: bold;
-            color: var(--text-description);
-            margin: 0;
-            padding: 0;
-          }
-          .amount {
-            font-size: 1.5rem;
-          }
-        }
-      }
-    }
 
     .body {
       display: flex;

--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -40,7 +40,13 @@
     role="region"
     aria-label={$i18n.portfolio.held_tokens_card_title}
   >
-    <TokensCardHeader {href} {usdAmount} {usdAmountFormatted}>
+    <TokensCardHeader
+      {href}
+      {usdAmount}
+      {usdAmountFormatted}
+      title={$i18n.portfolio.held_tokens_card_title}
+      linkText={$i18n.portfolio.held_tokens_card_link}
+    >
       <svelte:fragment slot="icon">
         <IconAccountsPage />
       </svelte:fragment>

--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -10,7 +10,7 @@
   import { formatNumber } from "$lib/utils/format.utils";
   import { shouldShowInfoRow } from "$lib/utils/portfolio.utils";
   import { formatTokenV2 } from "$lib/utils/token.utils";
-  import { IconAccountsPage, IconRight } from "@dfinity/gix-components";
+  import { IconAccountsPage } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
 
   export let topHeldTokens: UserTokenData[];

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -40,7 +40,13 @@
     role="region"
     aria-label={$i18n.portfolio.staked_tokens_card_title}
   >
-    <TokensCardHeader {href} {usdAmount} {usdAmountFormatted}>
+    <TokensCardHeader
+      {href}
+      {usdAmount}
+      {usdAmountFormatted}
+      title={$i18n.portfolio.staked_tokens_card_title}
+      linkText={$i18n.portfolio.staked_tokens_card_link}
+    >
       <svelte:fragment slot="icon">
         <IconNeuronsPage />
       </svelte:fragment>

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import MaturityWithTooltip from "$lib/components/neurons/MaturityWithTooltip.svelte";
   import Card from "$lib/components/portfolio/Card.svelte";
+  import TokensCardHeader from "$lib/components/portfolio/TokensCardHeader.svelte";
   import Logo from "$lib/components/ui/Logo.svelte";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -10,7 +11,7 @@
   import { formatNumber } from "$lib/utils/format.utils";
   import { shouldShowInfoRow } from "$lib/utils/portfolio.utils";
   import { formatTokenV2 } from "$lib/utils/token.utils";
-  import { IconNeuronsPage, IconRight } from "@dfinity/gix-components";
+  import { IconNeuronsPage } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
 
   export let topStakedTokens: TableProject[];
@@ -39,35 +40,11 @@
     role="region"
     aria-label={$i18n.portfolio.staked_tokens_card_title}
   >
-    <div class="header">
-      <div class="header-wrapper">
-        <div class="icon" aria-hidden="true">
-          <IconNeuronsPage />
-        </div>
-        <div class="text-content">
-          <h5 class="title">{$i18n.portfolio.staked_tokens_card_title}</h5>
-          <p
-            class="amount"
-            data-tid="amount"
-            aria-label={`${$i18n.portfolio.staked_tokens_card_title}: ${usdAmount}`}
-          >
-            ${usdAmountFormatted}
-          </p>
-        </div>
-      </div>
-      <a
-        {href}
-        class="button secondary"
-        aria-label={$i18n.portfolio.staked_tokens_card_link}
-      >
-        <span class="mobile-only">
-          <IconRight />
-        </span>
-        <span class="tablet-up">
-          {$i18n.portfolio.staked_tokens_card_link}
-        </span>
-      </a>
-    </div>
+    <TokensCardHeader {href} {usdAmount} {usdAmountFormatted}>
+      <svelte:fragment slot="icon">
+        <IconNeuronsPage />
+      </svelte:fragment>
+    </TokensCardHeader>
     <div class="body" role="table">
       <div class="header" role="row">
         <span role="columnheader"
@@ -158,41 +135,6 @@
     flex-direction: column;
     height: 100%;
     background-color: var(--card-background-tint);
-
-    .header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: var(--padding-3x) var(--padding-2x);
-
-      .header-wrapper {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--padding-2x);
-
-        .icon {
-          width: 50px;
-          height: 50px;
-        }
-
-        .text-content {
-          display: flex;
-          flex-direction: column;
-          gap: var(--padding-0_5x);
-
-          .title {
-            font-size: 0.875rem;
-            font-weight: bold;
-            color: var(--text-description);
-            margin: 0;
-            padding: 0;
-          }
-          .amount {
-            font-size: 1.5rem;
-          }
-        }
-      }
-    }
 
     .body {
       display: flex;

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -20,10 +20,7 @@
       </p>
     </div>
   </div>
-  <a
-    {href}
-    class="button link"
-  >
+  <a {href} class="button link" aria-label={linkText}>
     <span class="icon">
       <IconRight />
     </span>
@@ -35,7 +32,6 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
-  @use "@dfinity/gix-components/dist/styles/mixins/button";
 
   .header {
     display: flex;
@@ -72,17 +68,26 @@
     }
 
     .link {
-      /* @include button.secondary; */
-
       width: 35px;
       height: 35px;
       border-radius: 50%;
 
+      // TODO: This is necessary because using the button mixins from GIX generates warnings about unused styles.
+      // The styles in question relate to the disabled attribute, which does not apply to the anchor element.
+      // This is a temporary fix until those mixins are updated to include the disabled state as an additional mixin.
+      color: var(--button-secondary-color);
+      border: solid var(--button-border-size) var(--primary);
       @include media.min-width(medium) {
-        height: auto;
         width: auto;
-        @include button.base;
-        @include button.secondary;
+        height: auto;
+        padding: var(--padding) var(--padding-2x);
+        border-radius: var(--border-radius);
+        position: relative;
+        min-height: var(--button-min-height);
+        font-weight: var(--font-weight-bold);
+        &:focus {
+          filter: contrast(1.25);
+        }
       }
 
       .icon {

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { IconRight } from "@dfinity/gix-components";
+
+  export let usdAmount: number;
+  export let usdAmountFormatted: string;
+  export let href: string;
+</script>
+
+<div class="header">
+  <div class="header-wrapper">
+    <div class="icon" aria-hidden="true">
+      <slot name="icon" />
+    </div>
+    <div class="text-content">
+      <h5 class="title">{$i18n.portfolio.held_tokens_card_title}</h5>
+      <p
+        class="amount"
+        data-tid="amount"
+        aria-label={`${$i18n.portfolio.held_tokens_card_title}: ${usdAmount}`}
+      >
+        ${usdAmountFormatted}
+      </p>
+    </div>
+  </div>
+  <a {href} class="link" aria-label={$i18n.portfolio.held_tokens_card_link}>
+    <span class="icon">
+      <IconRight />
+    </span>
+    <span class="text">
+      {$i18n.portfolio.held_tokens_card_link}
+    </span>
+  </a>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/button";
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--padding-3x) var(--padding-2x);
+
+    .header-wrapper {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--padding-2x);
+
+      .icon {
+        width: 50px;
+        height: 50px;
+      }
+
+      .text-content {
+        display: flex;
+        flex-direction: column;
+        gap: var(--padding-0_5x);
+
+        .title {
+          font-size: 0.875rem;
+          font-weight: bold;
+          color: var(--text-description);
+          margin: 0;
+          padding: 0;
+        }
+        .amount {
+          font-size: 1.5rem;
+        }
+      }
+    }
+
+    .link {
+      @include button.secondary;
+
+      width: 35px;
+      height: 35px;
+      border-radius: 50%;
+
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      box-sizing: border-box;
+
+      text-decoration: none;
+
+      @include media.min-width(medium) {
+        height: auto;
+        width: auto;
+        @include button.base;
+        @include button.secondary;
+      }
+
+      .icon {
+        display: flex;
+
+        @include media.min-width(medium) {
+          display: none;
+        }
+      }
+
+      .text {
+        display: none;
+        @include media.min-width(medium) {
+          display: inline;
+        }
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
   import { IconRight } from "@dfinity/gix-components";
 
   export let usdAmount: number;
   export let usdAmountFormatted: string;
   export let href: string;
+  export let title: string;
+  export let linkText: string;
 </script>
 
 <div class="header">
@@ -13,12 +14,8 @@
       <slot name="icon" />
     </div>
     <div class="text-content">
-      <h5 class="title">{$i18n.portfolio.held_tokens_card_title}</h5>
-      <p
-        class="amount"
-        data-tid="amount"
-        aria-label={`${$i18n.portfolio.held_tokens_card_title}: ${usdAmount}`}
-      >
+      <h5 class="title">{title}</h5>
+      <p class="amount" data-tid="amount" aria-label={`${title}: ${usdAmount}`}>
         ${usdAmountFormatted}
       </p>
     </div>
@@ -26,13 +23,12 @@
   <a
     {href}
     class="button link"
-    aria-label={$i18n.portfolio.held_tokens_card_link}
   >
     <span class="icon">
       <IconRight />
     </span>
     <span class="text">
-      {$i18n.portfolio.held_tokens_card_link}
+      {linkText}
     </span>
   </a>
 </div>

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -23,7 +23,11 @@
       </p>
     </div>
   </div>
-  <a {href} class="link" aria-label={$i18n.portfolio.held_tokens_card_link}>
+  <a
+    {href}
+    class="button link"
+    aria-label={$i18n.portfolio.held_tokens_card_link}
+  >
     <span class="icon">
       <IconRight />
     </span>
@@ -72,19 +76,11 @@
     }
 
     .link {
-      @include button.secondary;
+      /* @include button.secondary; */
 
       width: 35px;
       height: 35px;
       border-radius: 50%;
-
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-
-      box-sizing: border-box;
-
-      text-decoration: none;
 
       @include media.min-width(medium) {
         height: auto;
@@ -95,7 +91,6 @@
 
       .icon {
         display: flex;
-
         @include media.min-width(medium) {
           display: none;
         }


### PR DESCRIPTION
# Motivation

The header of the `HeldTokensCard` and `StakedTokensCard` can be extracted into a small component to simplify their implementations. Additionally, this is useful because the designs require a special type of link for mobile viewports.

[Design](https://www.figma.com/design/3P3MBRLwECLuxN5b5iuWiA/NNS-Portfolio-Overview?node-id=111-77539&t=deMCSzrYqw1lOvRL-4)

https://github.com/user-attachments/assets/de13179f-d3c2-481d-a89d-8ddc3de2787d

# Changes

- Extracts common markup and styles from the `HeldTokensCard` and `StakedTokensCard` into this new component.
- Overrides mobile styles for the `button` and `secondary` classes to make it look like the design.

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary