### PR TITLE
fix(scripts): enhance import checker to include local imports

### DIFF
--- a/frontend/src/lib/canisters/ic-management/ic-management.canister.ts
+++ b/frontend/src/lib/canisters/ic-management/ic-management.canister.ts
@@ -1,4 +1,8 @@
 import { toCanisterDetails } from "$lib/canisters/ic-management/converters";
+import type {
+  CanisterDetails,
+  CanisterSettings,
+} from "$lib/canisters/ic-management/ic-management.canister.types";
 import { mapError } from "$lib/canisters/ic-management/ic-management.errors";
 import type { ICManagementCanisterOptions } from "@dfinity/ic-management";
 import {
@@ -6,10 +10,6 @@ import {
   type CanisterStatusResponse,
 } from "@dfinity/ic-management";
 import type { Principal } from "@dfinity/principal";
-import type {
-  CanisterDetails,
-  CanisterSettings,
-} from "./ic-management.canister.types";
 
 /**
  * The ICManagementCanister was initially implemented here, but it has since been moved to ic-js and packaged as a standalone library.

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -1,12 +1,5 @@
 import type { NNSDappCanisterOptions } from "$lib/canisters/nns-dapp/nns-dapp.canister.types";
 import { idlFactory as certifiedIdlFactory } from "$lib/canisters/nns-dapp/nns-dapp.certified.idl";
-import type { NNSDappService } from "$lib/canisters/nns-dapp/nns-dapp.idl";
-import { idlFactory } from "$lib/canisters/nns-dapp/nns-dapp.idl";
-import { Actor } from "@dfinity/agent";
-import { AccountIdentifier } from "@dfinity/ledger-icp";
-import type { ProposalId } from "@dfinity/nns";
-import type { Principal } from "@dfinity/principal";
-import { nonNullish, toNullable } from "@dfinity/utils";
 import {
   AccountNotFoundError,
   CanisterAlreadyAttachedError,
@@ -21,7 +14,9 @@ import {
   SubAccountLimitExceededError,
   TooManyImportedTokensError,
   UnknownProposalPayloadError,
-} from "./nns-dapp.errors";
+} from "$lib/canisters/nns-dapp/nns-dapp.errors";
+import type { NNSDappService } from "$lib/canisters/nns-dapp/nns-dapp.idl";
+import { idlFactory } from "$lib/canisters/nns-dapp/nns-dapp.idl";
 import type {
   AccountDetails,
   CanisterDetails,
@@ -34,7 +29,12 @@ import type {
   RenameSubAccountRequest,
   RenameSubAccountResponse,
   SubAccountDetails,
-} from "./nns-dapp.types";
+} from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { Actor } from "@dfinity/agent";
+import { AccountIdentifier } from "@dfinity/ledger-icp";
+import type { ProposalId } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import { nonNullish, toNullable } from "@dfinity/utils";
 
 export class NNSDappCanister {
   private constructor(

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -2,8 +2,8 @@ import { loadActionableProposals } from "$lib/services/actionable-proposals.serv
 import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
 import { initAccounts } from "$lib/services/icp-accounts.services";
 import { loadImportedTokens } from "$lib/services/imported-tokens.services";
+import { loadNetworkEconomicsParameters } from "$lib/services/network-economics.services";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
-import { loadNetworkEconomicsParameters } from "./network-economics.services";
 
 export const initAppPrivateData = async (): Promise<void> => {
   const initNetworkEconomicsParameters: Promise<void>[] = [

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -19,6 +19,12 @@ import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import {
+  getAccountIdentity,
+  getAccountIdentityByPrincipal,
+  loadBalance,
+  transferICP,
+} from "$lib/services/icp-accounts.services";
 import { assertLedgerVersion } from "$lib/services/icp-ledger.services";
 import {
   queryAndUpdate,
@@ -76,12 +82,6 @@ import {
 import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
-import {
-  getAccountIdentity,
-  getAccountIdentityByPrincipal,
-  loadBalance,
-  transferICP,
-} from "./icp-accounts.services";
 
 const getIdentityAndNeuronHelper = async (
   neuronId: NeuronId

--- a/frontend/src/lib/services/utils.services.ts
+++ b/frontend/src/lib/services/utils.services.ts
@@ -1,10 +1,10 @@
-import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { Identity } from "@dfinity/agent";
 import {
   getAnonymousIdentity,
   getAuthenticatedIdentity,
   getCurrentIdentity,
-} from "./auth.services";
+} from "$lib/services/auth.services";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
+import type { Identity } from "@dfinity/agent";
 
 export type QueryAndUpdateOnResponse<R> = (options: {
   certified: boolean;

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -1,3 +1,17 @@
+import {
+  snsAggregatorStore,
+  type SnsAggregatorStore,
+} from "$lib/stores/sns-aggregator.store";
+import {
+  snsDerivedStateStore,
+  type SnsDerivedStateData,
+  type SnsDerivedStateStore,
+} from "$lib/stores/sns-derived-state.store";
+import {
+  snsLifecycleStore,
+  type SnsLifecycleData,
+  type SnsLifecycleStore,
+} from "$lib/stores/sns-lifecycle.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { convertDtoToSnsSummary } from "$lib/utils/sns-aggregator-converters.utils";
@@ -13,20 +27,6 @@ import {
   nonNullish,
 } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
-import {
-  snsAggregatorStore,
-  type SnsAggregatorStore,
-} from "./sns-aggregator.store";
-import {
-  snsDerivedStateStore,
-  type SnsDerivedStateData,
-  type SnsDerivedStateStore,
-} from "./sns-derived-state.store";
-import {
-  snsLifecycleStore,
-  type SnsLifecycleData,
-  type SnsLifecycleStore,
-} from "./sns-lifecycle.store";
 
 // ************** Proposals for Launchpad **************
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -30,6 +30,10 @@ import type {
   NeuronVisibilityRowData,
   UncontrolledNeuronDetailsData,
 } from "$lib/types/neuron-visibility-row";
+import {
+  getAccountByPrincipal,
+  isAccountHardwareWallet,
+} from "$lib/utils/accounts.utils";
 import { daysToSeconds, nowInSeconds } from "$lib/utils/date.utils";
 import {
   formatNumber,
@@ -77,10 +81,6 @@ import {
 } from "@dfinity/utils";
 import type { ComponentType } from "svelte";
 import { get } from "svelte/store";
-import {
-  getAccountByPrincipal,
-  isAccountHardwareWallet,
-} from "./accounts.utils";
 
 export type StateInfo = {
   Icon?: ComponentType;

--- a/frontend/src/tests/mocks/nns-dapp.canister.mock.ts
+++ b/frontend/src/tests/mocks/nns-dapp.canister.mock.ts
@@ -4,12 +4,12 @@ import type {
   RegisterHardwareWalletRequest,
   SubAccountDetails,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { AccountIdentifier } from "@dfinity/ledger-icp";
 import {
   mockAccountDetails,
   mockMainAccount,
   mockSubAccountDetails,
-} from "./icp-accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
+import { AccountIdentifier } from "@dfinity/ledger-icp";
 
 // eslint-disable-next-line
 // @ts-ignore: test file

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -1,5 +1,19 @@
 import type { SnsSummarySwap } from "$lib/types/sns";
 import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
+import {
+  mockDerived,
+  mockInit,
+  mockQueryMetadataResponse,
+  mockQueryTokenResponse,
+  principal,
+  summaryForLifecycle,
+} from "$tests/mocks/sns-projects.mock";
+import {
+  governanceCanisterIdMock,
+  indexCanisterIdMock,
+  ledgerCanisterIdMock,
+  swapCanisterIdMock,
+} from "$tests/mocks/sns.api.mock";
 import type { IcrcTokenMetadataResponse } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
 import type {
@@ -8,20 +22,6 @@ import type {
   SnsSwapLifecycle,
 } from "@dfinity/sns";
 import { nonNullish, toNullable } from "@dfinity/utils";
-import {
-  mockDerived,
-  mockInit,
-  mockQueryMetadataResponse,
-  mockQueryTokenResponse,
-  principal,
-  summaryForLifecycle,
-} from "./sns-projects.mock";
-import {
-  governanceCanisterIdMock,
-  indexCanisterIdMock,
-  ledgerCanisterIdMock,
-  swapCanisterIdMock,
-} from "./sns.api.mock";
 
 const swapToQuerySwap = (swap: SnsSummarySwap): [SnsSwap] => [
   {

--- a/frontend/src/tests/page-objects/IcpExchangeRate.page-object.ts
+++ b/frontend/src/tests/page-objects/IcpExchangeRate.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipIconPo } from "./TooltipIcon.page-object";
 
 export class IcpExchangeRatePo extends BasePageObject {
   private static readonly TID = "icp-exchange-rate-component";

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -1,9 +1,9 @@
 import { HeldTokensCardPo } from "$tests/page-objects/HeldTokensCard.page-object";
 import { NoStakedTokensCardPo } from "$tests/page-objects/NoStakedTokensCard.page-object";
+import { StakedTokensCardPo } from "$tests/page-objects/StakedTokensCard.page-object";
 import { TotalAssetsCardPo } from "$tests/page-objects/TotalAssetsCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { StakedTokensCardPo } from "./StakedTokensCard.page-object";
 
 export class PortfolioPagePo extends BasePageObject {
   private static readonly TID = "portfolio-page-component";

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -1,10 +1,10 @@
 import { ResponsiveTablePo } from "$tests/page-objects/ResponsiveTable.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
-import { isNullish } from "@dfinity/utils";
 import {
   TokensTableRowPo,
   type TokensTableRowData,
-} from "./TokensTableRow.page-object";
+} from "$tests/page-objects/TokensTableRow.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { isNullish } from "@dfinity/utils";
 
 export class TokensTablePo extends ResponsiveTablePo {
   private static readonly TID = "tokens-table-component";

--- a/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/UsdValueBanner.page-object.ts
@@ -1,7 +1,7 @@
+import { IcpExchangeRatePo } from "$tests/page-objects/IcpExchangeRate.page-object";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { IcpExchangeRatePo } from "./IcpExchangeRate.page-object";
 
 export class UsdValueBannerPo extends BasePageObject {
   private static readonly TID = "usd-value-banner-component";

--- a/scripts/check-relative-imports
+++ b/scripts/check-relative-imports
@@ -9,7 +9,7 @@ cd "$TOP_DIR/frontend"
 # 1. The $types import: SvelteKit generates virtual types for each page/layout that has to be imported like `./$types`
 # 2. The home page route: Special case in our app that requires relative imports due to SvelteKit's routing structure
 # 3. Imports in the style section of Svelte components
-if git grep -n "from ['\"]\.\./" -- "src/**/*.svelte" "src/**/*.ts" |
+if git grep -n "from ['\"]\." -- "src/**/*.svelte" "src/**/*.ts" |
   # 1. Skip $types imports
   grep -v "/\$types" |
   # 2. Skip home page route


### PR DESCRIPTION
# Motivation

We don't want to have relative imports in our codebase. The reason is to avoid issues related to how different tools sort Svelte imports. 

The initial version of the script was not checking for local relative imports `./` 

Follow up of #6146

# Changes

- Change the regex to match files to `.`
- Fix existing cases
- Run `./scripts/fmt-frontend` to sort imports based on rules

# Tests

- The [first commit](https://github.com/dfinity/nns-dapp/pull/6193/commits/ae1bec126f2137e119496ed894167f7d4bff2994) [highlights previously unnoticed issues](https://github.com/dfinity/nns-dapp/actions/runs/12868009402/job/35873823334?pr=6193). 
- The [second commit](https://github.com/dfinity/nns-dapp/pull/6193/commits/885790f6f83d5f3d2648493fd8e3508bda8558cb) addresses those issues -> green pipeline

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary