### PR TITLE
feat(portfolio): update token cards with new icons

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -10,7 +10,7 @@
   import { formatNumber } from "$lib/utils/format.utils";
   import { shouldShowInfoRow } from "$lib/utils/portfolio.utils";
   import { formatTokenV2 } from "$lib/utils/token.utils";
-  import { IconAccountsPage } from "@dfinity/gix-components";
+  import { IconAccountsPage, IconHeldTokens } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
 
   export let topHeldTokens: UserTokenData[];
@@ -48,7 +48,7 @@
       linkText={$i18n.portfolio.held_tokens_card_link}
     >
       <svelte:fragment slot="icon">
-        <IconAccountsPage />
+        <IconHeldTokens />
       </svelte:fragment>
     </TokensCardHeader>
     <div class="body" role="table">

--- a/frontend/src/lib/components/portfolio/LoginCard.svelte
+++ b/frontend/src/lib/components/portfolio/LoginCard.svelte
@@ -2,13 +2,13 @@
   import SignIn from "$lib/components/common/SignIn.svelte";
   import Card from "$lib/components/portfolio/Card.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { IconAccountsPage } from "@dfinity/gix-components";
+  import { IconUserLogin } from "@dfinity/gix-components";
 </script>
 
 <Card testId="portfolio-login-card">
   <div class="wrapper">
     <div class="icon">
-      <IconAccountsPage />
+      <IconUserLogin />
     </div>
     <div class="content">
       <h2>{$i18n.portfolio.login_title}</h2>

--- a/frontend/src/lib/components/portfolio/NoStakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/NoStakedTokensCard.svelte
@@ -2,7 +2,7 @@
   import Card from "$lib/components/portfolio/Card.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { i18n } from "$lib/stores/i18n";
-  import { IconNeuronsPage } from "@dfinity/gix-components";
+  import { IconStakedTokens } from "@dfinity/gix-components";
 
   export let primaryCard = false;
   const href = AppPath.Staking;
@@ -11,7 +11,7 @@
 <Card testId="no-staked-tokens-card">
   <div class="wrapper">
     <div class="icon">
-      <IconNeuronsPage />
+      <IconStakedTokens />
     </div>
     <div class="text">
       <p>{$i18n.portfolio.no_neurons_card_description}</p>

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -11,7 +11,7 @@
   import { formatNumber } from "$lib/utils/format.utils";
   import { shouldShowInfoRow } from "$lib/utils/portfolio.utils";
   import { formatTokenV2 } from "$lib/utils/token.utils";
-  import { IconNeuronsPage } from "@dfinity/gix-components";
+  import { IconNeuronsPage, IconStakedTokens } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
 
   export let topStakedTokens: TableProject[];
@@ -48,7 +48,7 @@
       linkText={$i18n.portfolio.staked_tokens_card_link}
     >
       <svelte:fragment slot="icon">
-        <IconNeuronsPage />
+        <IconStakedTokens />
       </svelte:fragment>
     </TokensCardHeader>
     <div class="body" role="table">

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -48,7 +48,7 @@
       linkText={$i18n.portfolio.staked_tokens_card_link}
     >
       <svelte:fragment slot="icon">
-        <IconStakedTokens />
+        <IconNeuronsPage />
       </svelte:fragment>
     </TokensCardHeader>
     <div class="body" role="table">
@@ -121,7 +121,7 @@
           <div class="info-row desktop-only" role="note" data-tid="info-row">
             <div class="content">
               <div class="icon" aria-hidden="true">
-                <IconNeuronsPage />
+                <IconStakedTokens />
               </div>
               <div class="message">
                 {$i18n.portfolio.staked_tokens_card_info_row}


### PR DESCRIPTION
# Motivation

We have new icons for the Portfolio page:

<img width="1556" alt="Screenshot 2025-01-20 at 16 55 59" src="https://github.com/user-attachments/assets/4d1f6133-18eb-4f12-a562-864fa4221141" />

<img width="1555" alt="Screenshot 2025-01-20 at 16 56 15" src="https://github.com/user-attachments/assets/b255d2c4-b7fb-4071-a365-990133ba03d6" />

<img width="1834" alt="Screenshot 2025-01-20 at 17 22 26" src="https://github.com/user-attachments/assets/ff57afb3-cc3d-4ca4-8468-731e99d8ca9a" />

# Changes

- Updated the icons in the header of the `HeldTokensCard` and `StakedTokensCard`.  
- Updated the icon in the `LoginCard`.

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary