### PR TITLE
fix(portfolio): change native token price precision to 2 digits

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -91,7 +91,7 @@
               {heldToken.balance instanceof TokenAmountV2
                 ? formatTokenV2({
                     value: heldToken.balance,
-                    detailed: true,
+                    detailed: false,
                   })
                 : PRICE_NOT_AVAILABLE_PLACEHOLDER}
               <span class="symbol">

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -110,7 +110,7 @@
               {stakedToken.stake instanceof TokenAmountV2
                 ? formatTokenV2({
                     value: stakedToken.stake,
-                    detailed: true,
+                    detailed: false,
                   })
                 : PRICE_NOT_AVAILABLE_PLACEHOLDER}
               {stakedToken.stake.token.symbol}

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -135,7 +135,7 @@ describe("HeldTokensCard", () => {
       expect(nativeBalances).toEqual([
         "21.60 ICP",
         "21.60 ckBTC",
-        "21.606 ckETH",
+        "21.61 ckETH",
       ]);
     });
 
@@ -159,7 +159,7 @@ describe("HeldTokensCard", () => {
       expect(nativeBalances).toEqual([
         "21.60 ICP",
         "21.60 ckBTC",
-        "21.606 ckETH",
+        "21.61 ckETH",
       ]);
 
       expect(await po.getInfoRow().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -93,7 +93,7 @@ describe("HeldTokensCard", () => {
     const mockCkETHToken = createUserToken(ckETHTokenBase);
     mockCkETHToken.balanceInUsd = 300;
     mockCkETHToken.balance = TokenAmountV2.fromUlps({
-      amount: 21600000000000000000n,
+      amount: 21606000000000000000n,
       token: CkETHToken,
     });
 
@@ -135,7 +135,7 @@ describe("HeldTokensCard", () => {
       expect(nativeBalances).toEqual([
         "21.60 ICP",
         "21.60 ckBTC",
-        "21.60 ckETH",
+        "21.606 ckETH",
       ]);
     });
 
@@ -159,7 +159,7 @@ describe("HeldTokensCard", () => {
       expect(nativeBalances).toEqual([
         "21.60 ICP",
         "21.60 ckBTC",
-        "21.60 ckETH",
+        "21.606 ckETH",
       ]);
 
       expect(await po.getInfoRow().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
@@ -153,7 +153,7 @@ describe("StakedTokensCard", () => {
       stakeInUsd: 400,
       domKey: "/staking/3",
       stake: TokenAmountV2.fromUlps({
-        amount: 1000_000n,
+        amount: 1100_000n,
         token: mockToken,
       }),
     };
@@ -207,7 +207,7 @@ describe("StakedTokensCard", () => {
         "0.01 ICP",
         "0.01 TET",
         "0.01 TET",
-        "0.01 TET",
+        "0.011 TET",
       ]);
     });
 

--- a/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
@@ -207,7 +207,7 @@ describe("StakedTokensCard", () => {
         "0.01 ICP",
         "0.01 TET",
         "0.01 TET",
-        "0.011 TET",
+        "0.01 TET",
       ]);
     });
 


### PR DESCRIPTION
# Motivation

We want to display two digits of precision for the native price of a token, similar to how it appears in the Tokens and Staging routes.

# Changes

- Calls `formatTokenV2` with `detailed: false` to round the amount to the nearest digit.

# Tests

- Adds a test to verify that rounding is applied correctly.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary