### PR TITLE
Remove canister creation fallback from backend canister

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+- Remove canister creation fallback from backend canister.
+
 #### Fixed
 
 - Improved the display of date range options in the mobile view of the Reporting page.

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -957,18 +957,13 @@ impl AccountsStore {
     /// `multi_part_transactions_processor` which will work through the required actions in the
     /// background.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::unused_self)]
     fn process_transaction_type(
         &mut self,
-        transaction_type: TransactionType,
-        principal: PrincipalId,
-        block_height: BlockIndex,
+        _transaction_type: TransactionType,
+        _principal: PrincipalId,
+        _block_height: BlockIndex,
     ) {
-        if transaction_type == TransactionType::CreateCanister {
-            self.multi_part_transactions_processor.push(
-                block_height,
-                MultiPartTransactionToBeProcessed::CreateCanisterV2(principal),
-            );
-        };
     }
     fn assert_account_limit(&self) {
         let db_accounts_len = self.accounts_db.db_accounts_len();


### PR DESCRIPTION
# Motivation

Creating a canister takes 3 steps:
1. Transferring ICP to the CMC.
2. Notifying the CMC to create the canister.
3. Attaching the canister to the user account on the NNS dapp.

If the process is interrupted after step 1 or 2, the user might end up without ICP and without canister.
To avoid this we have code in the nns-dapp backend canister to detect transactions from step 1 and perform step 2 and 3.
Since https://github.com/dfinity/nns-dapp/pull/6132 we do this in the frontend so we no longer need to do it in the backend.

This PR stops doing this in the backend.
This allows a lot of code to be removed from the backend canister. This will be done in subsequent PRs.

# Changes

1. Stop pushing `CreateCanisterV2` to `multi_part_transactions_processor` when a canister creation funding transaction is detected.

# Tests

1. No unit test failed so apparently the code that was removed wasn't tested.
2. Tested manually that the backend no longer creates the canister after interrupting the process.
3. Tested manually that the frontend still creates the canister after interrupting the process.

# Todos

- [x] Add entry to changelog (if necessary).
