### PR TITLE
refactor(scripts): remove redundant import validation checks

### DIFF
--- a/scripts/check-relative-imports
+++ b/scripts/check-relative-imports
@@ -8,15 +8,11 @@ cd "$TOP_DIR/frontend"
 # We skip three specific cases:
 # 1. The $types import: SvelteKit generates virtual types for each page/layout that has to be imported like `./$types`
 # 2. The home page route: Special case in our app that requires relative imports due to SvelteKit's routing structure
-# 3. Imports in the style section of Svelte components
 if git grep -n "from ['\"]\." -- "src/**/*.svelte" "src/**/*.ts" |
   # 1. Skip $types imports
   grep -v "/\$types" |
   # 2. Skip home page route
-  grep -v "src/routes/(app)/(home)/+page.svelte" |
-  # 3. Skip style section imports
-  grep -v "@use.*\.\." |
-  grep -v "@import.*\.\."; then
+  grep -v "src/routes/(app)/(home)/+page.svelte"; then
   exit 1
 else
   exit 0


### PR DESCRIPTION
# Motivation

We want to avoid relative imports in our codebase to prevent issues with how different tools sort Svelte imports. 

Currently, there are exceptions for `@import` and `@use` declarations, but these are unnecessary since the grep command only searches for JS/TS declarations.

Follow up on #6146.

# Changes

- Removes unnecessary checks for SCSS declarations.

# Tests

- Should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary