### PR TITLE
styles(portfolio): align text right HeldTokensCard on mobile screens

### DIFF
--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -57,7 +57,7 @@
           >{$i18n.portfolio.staked_tokens_card_list_first_column}</span
         >
 
-        <span class="mobile-only justify-end" role="columnheader"
+        <span class="mobile-only justify-end text-right" role="columnheader"
           >{$i18n.portfolio.staked_tokens_card_list_second_column_mobile}</span
         >
         <span class="tablet-up justify-end" role="columnheader"
@@ -277,6 +277,10 @@
 
     .justify-end {
       justify-self: end;
+    }
+
+    .text-right {
+      text-align: right;
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

On very small screens, the staked balance column header spans two lines, and the text is not aligned to the right like the rest of the column.

Before:
<img width="234" alt="Screenshot 2025-01-21 at 10 14 28" src="https://github.com/user-attachments/assets/e920c06e-b703-419c-8527-ff7f56575eab" />

After:
<img width="270" alt="Screenshot 2025-01-21 at 10 14 37" src="https://github.com/user-attachments/assets/47c02e03-8a16-4f22-bbf8-81aa1e6e4fdc" />


# Changes

- Align text to the right in small screens

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary