### PR TITLE
refactor(portfolio): exclude CTS project from token cards

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -16,13 +16,12 @@ import {
 import { isUserTokenData } from "$lib/utils/user-token.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
-const SPECIAL_CANISTER_IDS = [CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID];
 
-const filterSpecialCanister = ({
+const filterCyclesTransferStation = ({
   universeId,
 }: {
   universeId: string;
-}): boolean => !SPECIAL_CANISTER_IDS.includes(universeId);
+}): boolean => CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID !== universeId;
 
 const compareTokensByUsdBalance = createDescendingComparator(
   (token: UserTokenData) => token?.balanceInUsd ?? 0 > 0
@@ -52,7 +51,7 @@ export const getTopHeldTokens = ({
   const topTokens = userTokens
     .filter(isUserTokenData)
     .filter(({ universeId }) =>
-      filterSpecialCanister({ universeId: universeId.toText() })
+      filterCyclesTransferStation({ universeId: universeId.toText() })
     )
     .sort(compareTokens)
     .slice(0, MAX_NUMBER_OF_ITEMS);
@@ -88,7 +87,7 @@ export const getTopStakedTokens = ({
   isSignedIn?: boolean;
 }): TableProject[] => {
   const topProjects = [...projects]
-    .filter(filterSpecialCanister)
+    .filter(filterCyclesTransferStation)
     .sort(compareProjects)
     .slice(0, MAX_NUMBER_OF_ITEMS);
 

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,3 +1,4 @@
+import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
 import {
@@ -15,6 +16,13 @@ import {
 import { isUserTokenData } from "$lib/utils/user-token.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
+const SPECIAL_CANISTER_IDS = [CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID];
+
+const filterSpecialCanister = ({
+  universeId,
+}: {
+  universeId: string;
+}): boolean => !SPECIAL_CANISTER_IDS.includes(universeId);
 
 const compareTokensByUsdBalance = createDescendingComparator(
   (token: UserTokenData) => token?.balanceInUsd ?? 0 > 0
@@ -43,6 +51,9 @@ export const getTopHeldTokens = ({
 }): UserTokenData[] => {
   const topTokens = userTokens
     .filter(isUserTokenData)
+    .filter(({ universeId }) =>
+      filterSpecialCanister({ universeId: universeId.toText() })
+    )
     .sort(compareTokens)
     .slice(0, MAX_NUMBER_OF_ITEMS);
 
@@ -77,6 +88,7 @@ export const getTopStakedTokens = ({
   isSignedIn?: boolean;
 }): TableProject[] => {
   const topProjects = [...projects]
+    .filter(filterSpecialCanister)
     .sort(compareProjects)
     .slice(0, MAX_NUMBER_OF_ITEMS);
 

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -158,27 +158,22 @@ describe("Portfolio utils", () => {
         expect(result).toHaveLength(0);
       });
 
-      it("should filter special tokens", () => {
+      it("should filter CTS token", () => {
         const mockIcpToken = createIcpUserToken({ balanceInUsd: 1000 });
-        const mockSpecialProjectThatShouldBeFilteredOut = createUserToken({
+        const mockCSTProject = createUserToken({
           universeId: Principal.fromText(
             CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID
           ),
           balanceInUsd: 0,
         });
-        const tokens: UserToken[] = [
-          mockSpecialProjectThatShouldBeFilteredOut,
-          mockIcpToken,
-        ];
+        const tokens: UserToken[] = [mockCSTProject, mockIcpToken];
         const result = getTopHeldTokens({
           userTokens: tokens,
           isSignedIn: true,
         });
 
         expect(result).toHaveLength(1);
-        expect(result).not.toContainEqual(
-          mockSpecialProjectThatShouldBeFilteredOut
-        );
+        expect(result).not.toContainEqual(mockCSTProject);
       });
     });
   });
@@ -349,17 +344,14 @@ describe("Portfolio utils", () => {
         expect(result).toHaveLength(0);
       });
 
-      it("should filter special projects", () => {
-        const mockSpecialProjectThatShouldBeFilteredOut: TableProject = {
+      it("should filter CTS project", () => {
+        const mockCTSProject: TableProject = {
           ...mockTableProject,
           stakeInUsd: 1000,
           universeId: CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
         };
 
-        const projects = [
-          mockSpecialProjectThatShouldBeFilteredOut,
-          mockIcpProject,
-        ];
+        const projects = [mockCTSProject, mockIcpProject];
 
         const result = getTopStakedTokens({
           projects,
@@ -367,9 +359,7 @@ describe("Portfolio utils", () => {
         });
 
         expect(result).toHaveLength(1);
-        expect(result).not.toContainEqual(
-          mockSpecialProjectThatShouldBeFilteredOut
-        );
+        expect(result).not.toContainEqual(mockCTSProject);
       });
     });
   });

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -1,3 +1,4 @@
+import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
@@ -14,6 +15,7 @@ import {
   createUserToken,
   createUserTokenLoading,
 } from "$tests/mocks/tokens-page.mock";
+import { Principal } from "@dfinity/principal";
 
 describe("Portfolio utils", () => {
   describe("getTopTokens", () => {
@@ -154,6 +156,29 @@ describe("Portfolio utils", () => {
         });
 
         expect(result).toHaveLength(0);
+      });
+
+      it("should filter special tokens", () => {
+        const mockIcpToken = createIcpUserToken({ balanceInUsd: 1000 });
+        const mockSpecialProjectThatShouldBeFilteredOut = createUserToken({
+          universeId: Principal.fromText(
+            CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID
+          ),
+          balanceInUsd: 0,
+        });
+        const tokens: UserToken[] = [
+          mockSpecialProjectThatShouldBeFilteredOut,
+          mockIcpToken,
+        ];
+        const result = getTopHeldTokens({
+          userTokens: tokens,
+          isSignedIn: true,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result).not.toContainEqual(
+          mockSpecialProjectThatShouldBeFilteredOut
+        );
       });
     });
   });
@@ -322,6 +347,29 @@ describe("Portfolio utils", () => {
         });
 
         expect(result).toHaveLength(0);
+      });
+
+      it("should filter special projects", () => {
+        const mockSpecialProjectThatShouldBeFilteredOut: TableProject = {
+          ...mockTableProject,
+          stakeInUsd: 1000,
+          universeId: CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
+        };
+
+        const projects = [
+          mockSpecialProjectThatShouldBeFilteredOut,
+          mockIcpProject,
+        ];
+
+        const result = getTopStakedTokens({
+          projects,
+          isSignedIn: true,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result).not.toContainEqual(
+          mockSpecialProjectThatShouldBeFilteredOut
+        );
       });
     });
   });


### PR DESCRIPTION
# Motivation

We don't want to display the `CYCLES_TRANSFER_STATION` project in either of the TokenCards shown on the Portfolio page.

# Changes

- Update `getTopHeldTokens` to exclude the `CYCLES_TRANSFER_STATION` project.  
- Update `getTopStakedTokens` to exclude the `CYCLES_TRANSFER_STATION` project.

# Tests

- Updated tests to check that filtering is being applied

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary