### PR TITLE
FOLLOW-1337: Disable FORCE_CALL_STRATEGY for 30% of sessions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 - Change the USD value icon in the token pages
+- Proceed with rollout of re-enabling of certification of certain calls from `10%` to `30%`.
 
 #### Deprecated
 

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -15,7 +15,7 @@ export const DEV = import.meta.env.DEV;
 //
 // Whether we do query+update calls remains fixed for the duration of the
 // sessions, by which we mean until the next time the app/page is reloaded.
-const RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE: number = 10;
+const RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE: number = 30;
 
 const getForceCallStrategyForPercentage = (
   percentage: number


### PR DESCRIPTION
# Motivation

We want to re-enable the update calls that are disabled via FORCE_CALL_STRATEGY.
Because this may result in higher subnet load, we have first rolled it out to 10% of sessions in [this PR](https://github.com/dfinity/nns-dapp/pull/5593).
Just before that rollout, subnets got overloaded for unrelated reasons, but are now back to normal.
So we will proceed to 30% to see if it has any effect on subnet load.

# Changes

1. Initialize `FORCE_CALL_STRATEGY` on app load, to `"query"` 70% of the time and to `undefined` 30% of the time.

# Tests

Not tested.

# Todos

- [x] Add entry to changelog (if necessary).
