### PR TITLE
feat(portfolio): adds a loading state to the total assets card

### DIFF
--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -3,10 +3,13 @@
   import IcpExchangeRate from "$lib/components/ui/IcpExchangeRate.svelte";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import UsdValueHeadless from "$lib/components/ui/UsdValueHeadless.svelte";
+  import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
   import { i18n } from "$lib/stores/i18n";
+  import { Spinner } from "@dfinity/gix-components";
 
   export let usdAmount: number | undefined;
   export let hasUnpricedTokens: boolean = false;
+  export let isLoading: boolean = false;
 </script>
 
 <UsdValueHeadless
@@ -24,17 +27,27 @@
       <div class="pricing">
         <div class="totals">
           <div class="primary-amount-row">
-            <span class="primary-amount" data-tid="primary-amount">
-              ${usdAmountFormatted}
-            </span>
-            {#if hasPricesAndUnpricedTokens}
-              <TooltipIcon>
-                {$i18n.accounts.unpriced_tokens_warning}
-              </TooltipIcon>
+            {#if !isLoading}
+              <span class="primary-amount" data-tid="primary-amount">
+                ${usdAmountFormatted}
+              </span>
+              {#if hasPricesAndUnpricedTokens}
+                <TooltipIcon>
+                  {$i18n.accounts.unpriced_tokens_warning}
+                </TooltipIcon>
+              {/if}
+            {:else}
+              <div>
+                <Spinner inline size="small" />
+              </div>
             {/if}
           </div>
           <div class="secondary-amount" data-tid="secondary-amount">
-            {icpAmountFormatted}
+            {#if !isLoading}
+              {icpAmountFormatted}
+            {:else}
+              {PRICE_NOT_AVAILABLE_PLACEHOLDER}
+            {/if}
             {$i18n.core.icp}
           </div>
         </div>
@@ -77,15 +90,22 @@
         flex-direction: column;
         gap: var(--padding);
 
-        .primary-amount {
-          font-size: 1.875rem; // 32px
+        .primary-amount-row {
+          display: flex;
+          gap: var(--padding);
 
-          @include media.min-width(medium) {
-            font-size: 2.5rem; // 40px
+          min-height: 45px;
+
+          .primary-amount {
+            font-size: 1.875rem; // 32px
+
+            @include media.min-width(medium) {
+              font-size: 2.5rem; // 40px
+            }
           }
-        }
-        .secondary-amount {
-          color: var(--text-description);
+          .secondary-amount {
+            color: var(--text-description);
+          }
         }
       }
     }

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -153,8 +153,8 @@ describe("UsdValueBanner", () => {
     );
   });
 
-  it("should show a spinner instead of the USD price and placeholder text for the ICP when isLoading is true", async () => {
-    const usdAmount = undefined;
+  it("should show a spinner instead of the USD price and a placeholder text for the ICP", async () => {
+    const usdAmount = 100;
     const icpPrice = 10;
     const isLoading = true;
 
@@ -168,5 +168,21 @@ describe("UsdValueBanner", () => {
     expect(await po.hasSpinner()).toEqual(true);
     expect(await po.getPrimaryAmount()).toBeNull();
     expect(await po.getSecondaryAmount()).toEqual("-/- ICP");
+  });
+
+  it("should not show a spinner", async () => {
+    const usdAmount = 100;
+    const icpPrice = 10;
+    const isLoading = false;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({
+      usdAmount,
+      isLoading,
+    });
+
+    expect(await po.hasSpinner()).toEqual(false);
+    expect(await po.getPrimaryAmount()).toEqual("$100.00");
   });
 });

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -11,13 +11,16 @@ describe("UsdValueBanner", () => {
   const renderComponent = ({
     usdAmount,
     hasUnpricedTokens,
+    isLoading,
   }: {
     usdAmount: number;
-    hasUnpricedTokens: boolean;
+    hasUnpricedTokens?: boolean;
+    isLoading?: boolean;
   }) => {
     const { container } = render(TotalAssetsCard, {
       usdAmount,
       hasUnpricedTokens,
+      isLoading,
     });
     return TotalAssetsCardPo.under(new JestPageObjectElement(container));
   };
@@ -148,5 +151,22 @@ describe("UsdValueBanner", () => {
     expect(await po.getTotalsTooltipIconPo().isPresent()).toBe(
       hasUnpricedTokens
     );
+  });
+
+  it("should show a spinner instead of the USD price and placeholder text for the ICP when isLoading is true", async () => {
+    const usdAmount = undefined;
+    const icpPrice = 10;
+    const isLoading = true;
+
+    setIcpPrice(icpPrice);
+
+    const po = renderComponent({
+      usdAmount,
+      isLoading,
+    });
+
+    expect(await po.hasSpinner()).toEqual(true);
+    expect(await po.getPrimaryAmount()).toBeNull();
+    expect(await po.getSecondaryAmount()).toEqual("-/- ICP");
   });
 });

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -7,7 +7,7 @@ import { TotalAssetsCardPo } from "$tests/page-objects/TotalAssetsCard.page-obje
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
 
-describe("UsdValueBanner", () => {
+describe("TotalAssetsCard", () => {
   const renderComponent = ({
     usdAmount,
     hasUnpricedTokens,
@@ -154,35 +154,24 @@ describe("UsdValueBanner", () => {
   });
 
   it("should show a spinner instead of the USD price and a placeholder text for the ICP", async () => {
-    const usdAmount = 100;
-    const icpPrice = 10;
     const isLoading = true;
 
-    setIcpPrice(icpPrice);
-
     const po = renderComponent({
-      usdAmount,
+      usdAmount: undefined,
       isLoading,
     });
 
     expect(await po.hasSpinner()).toEqual(true);
-    expect(await po.getPrimaryAmount()).toBeNull();
-    expect(await po.getSecondaryAmount()).toEqual("-/- ICP");
   });
 
   it("should not show a spinner", async () => {
-    const usdAmount = 100;
-    const icpPrice = 10;
     const isLoading = false;
 
-    setIcpPrice(icpPrice);
-
     const po = renderComponent({
-      usdAmount,
+      usdAmount: undefined,
       isLoading,
     });
 
     expect(await po.hasSpinner()).toEqual(false);
-    expect(await po.getPrimaryAmount()).toEqual("$100.00");
   });
 });

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -155,20 +155,27 @@ describe("TotalAssetsCard", () => {
 
   it("should show a spinner instead of the USD price and a placeholder text for the ICP", async () => {
     const isLoading = true;
+    const usdAmount = undefined;
+    const hasUnpricedTokens = true;
 
     const po = renderComponent({
-      usdAmount: undefined,
+      usdAmount,
       isLoading,
+      hasUnpricedTokens,
     });
 
     expect(await po.hasSpinner()).toEqual(true);
+    expect(await po.getPrimaryAmount()).toBeNull();
+    expect(await po.getSecondaryAmount()).toEqual("-/- ICP");
+    expect(await po.getTotalsTooltipIconPo().isPresent()).toBe(false);
   });
 
   it("should not show a spinner", async () => {
     const isLoading = false;
+    const usdAmount = undefined;
 
     const po = renderComponent({
-      usdAmount: undefined,
+      usdAmount,
       isLoading,
     });
 

--- a/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
@@ -30,6 +30,10 @@ export class TotalAssetsCardPo extends BasePageObject {
     return this.getText("icp-price");
   }
 
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
+  }
+
   async hasError(): Promise<boolean> {
     return this.getIcpExchangeRatePo().hasError();
   }


### PR DESCRIPTION
# Motivation

We want to inform users that something is loading by displaying a spinner in the asset cards.

https://github.com/user-attachments/assets/22743f6c-2df8-4a9d-86d5-d651713eda01


# Changes

- Added a prop `isLoading` to control the display of the `Spinner`.  
- Updated styles to ensure the `Spinner` fits properly.

# Tests

- Unit tests to verify that the `Spinner` displays correctly based on the new prop.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.