### PR TITLE
Disable Chrome Playwright tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -45,10 +45,13 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
+    // TODO: Enable Chrome tests again once no more flaky.
+    /*
     {
       name: "Google Chrome",
       use: { ...devices["Desktop Chrome"], channel: "chrome", viewport },
     },
+    */
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'], channel: "firefox", viewport },


### PR DESCRIPTION
# Motivation

Chrome end-to-end tests have become very flaky [(example failure](https://github.com/dfinity/nns-dapp/actions/runs/12892772450/job/35947946500)).
I believe it's because GitHub has update Chrome on some of its runners to a version that no longer supports the headless mode used by the version of Playwright we use.
```
      - [pid=12021][err] [0121/175345.791888:WARNING:chrome_main_linux.cc(80)] Read channel stable from /opt/google/chrome/CHROME_VERSION_EXTRA
      - [pid=12021][err] Old Headless mode has been removed from the Chrome binary. Please use the new Headless mode (https://developer.chrome.com/docs/chromium/new-headless) or the chrome-headless-shell which is a standalone implementation of the old Headless mode (https://developer.chrome.com/blog/chrome-headless-shell).
      - [pid=12021][err] 
```
We should try updating our Playwright version but this seems to cause additional flakiness.
Until we can do this, we should disable Chrome end-to-end tests and rely on just Firefox for now, to unblock development.

# Changes

1. Disable Chrome in `frontend/playwright.config.ts`.

# Tests

Remaining tests should pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary