### PR TITLE
feat(portfolio): adds a loading state to the tokens cards

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -16,6 +16,7 @@
   export let topHeldTokens: UserTokenData[];
   export let usdAmount: number;
   export let numberOfTopStakedTokens: number;
+  export let isLoading: boolean = false;
 
   const href = AppPath.Tokens;
 
@@ -44,6 +45,7 @@
       {href}
       {usdAmount}
       {usdAmountFormatted}
+      {isLoading}
       title={$i18n.portfolio.held_tokens_card_title}
       linkText={$i18n.portfolio.held_tokens_card_link}
     >

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -17,6 +17,7 @@
   export let topStakedTokens: TableProject[];
   export let usdAmount: number;
   export let numberOfTopHeldTokens: number;
+  export let isLoading: boolean;
 
   const href = AppPath.Staking;
   let usdAmountFormatted: string;
@@ -44,6 +45,7 @@
       {href}
       {usdAmount}
       {usdAmountFormatted}
+      {isLoading}
       title={$i18n.portfolio.staked_tokens_card_title}
       linkText={$i18n.portfolio.staked_tokens_card_link}
     >

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -17,7 +17,7 @@
   export let topStakedTokens: TableProject[];
   export let usdAmount: number;
   export let numberOfTopHeldTokens: number;
-  export let isLoading: boolean;
+  export let isLoading: boolean = false;
 
   const href = AppPath.Staking;
   let usdAmountFormatted: string;

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { IconRight } from "@dfinity/gix-components";
+  import { IconRight, Spinner } from "@dfinity/gix-components";
 
   export let usdAmount: number;
   export let usdAmountFormatted: string;
   export let href: string;
   export let title: string;
   export let linkText: string;
+  export let isLoading: boolean = false;
 </script>
 
 <div class="header">
@@ -15,9 +16,19 @@
     </div>
     <div class="text-content">
       <h5 class="title">{title}</h5>
-      <p class="amount" data-tid="amount" aria-label={`${title}: ${usdAmount}`}>
-        ${usdAmountFormatted}
-      </p>
+      {#if !isLoading}
+        <p
+          class="amount"
+          data-tid="amount"
+          aria-label={`${title}: ${usdAmount}`}
+        >
+          ${usdAmountFormatted}
+        </p>
+      {:else}
+        <div>
+          <Spinner inline size="small" />
+        </div>
+      {/if}
     </div>
   </div>
   <a {href} class="button link" aria-label={linkText}>

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -16,19 +16,13 @@
     </div>
     <div class="text-content">
       <h5 class="title">{title}</h5>
-      {#if !isLoading}
-        <p
-          class="amount"
-          data-tid="amount"
-          aria-label={`${title}: ${usdAmount}`}
-        >
+      <p class="amount" data-tid="amount" aria-label={`${title}: ${usdAmount}`}>
+        {#if !isLoading}
           ${usdAmountFormatted}
-        </p>
-      {:else}
-        <div>
+        {:else}
           <Spinner inline size="small" />
-        </div>
-      {/if}
+        {/if}
+      </p>
     </div>
   </div>
   <a {href} class="button link" aria-label={linkText}>
@@ -74,6 +68,7 @@
         }
         .amount {
           font-size: 1.5rem;
+          align-self: flex-start;
         }
       }
     }

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -19,16 +19,19 @@ describe("HeldTokensCard", () => {
     topHeldTokens = [],
     usdAmount = 0,
     numberOfTopStakedTokens = 0,
+    isLoading = false,
   }: {
     topHeldTokens?: UserTokenData[];
     usdAmount?: number;
     numberOfTopStakedTokens?: number;
+    isLoading?: boolean;
   }) => {
     const { container } = render(HeldTokensCard, {
       props: {
         topHeldTokens,
         usdAmount,
         numberOfTopStakedTokens,
+        isLoading,
       },
     });
 
@@ -54,9 +57,22 @@ describe("HeldTokensCard", () => {
       const po = renderComponent({
         topHeldTokens: mockTokens,
         usdAmount: 0,
+        isLoading: false,
       });
 
       expect(await po.getAmount()).toBe("$-/-");
+      expect(await po.hasSpinner()).toBe(false);
+    });
+
+    it("should show a spinner instead of placeholder balance", async () => {
+      const po = renderComponent({
+        topHeldTokens: mockTokens,
+        usdAmount: 0,
+        isLoading: true,
+      });
+
+      expect(await po.getAmount()).toBeNull();
+      expect(await po.hasSpinner()).toBe(true);
     });
 
     it("should show list of tokens with name and balance", async () => {

--- a/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
@@ -15,16 +15,19 @@ describe("StakedTokensCard", () => {
     topStakedTokens = [],
     usdAmount = 0,
     numberOfTopHeldTokens = 0,
+    isLoading = false,
   }: {
     topStakedTokens?: TableProject[];
     usdAmount?: number;
     numberOfTopHeldTokens?: number;
+    isLoading?: boolean;
   } = {}) => {
     const { container } = render(StakedTokensCard, {
       props: {
         topStakedTokens,
         usdAmount,
         numberOfTopHeldTokens,
+        isLoading,
       },
     });
 
@@ -76,6 +79,16 @@ describe("StakedTokensCard", () => {
       const po = renderComponent();
 
       expect(await po.getAmount()).toBe("$-/-");
+      expect(await po.hasSpinner()).toEqual(false);
+    });
+
+    it("should show placeholder balance", async () => {
+      const po = renderComponent({
+        isLoading: true,
+      });
+
+      expect(await po.getAmount()).toBeNull();
+      expect(await po.hasSpinner()).toEqual(true);
     });
 
     it("should list of tokens with placeholders", async () => {

--- a/frontend/src/tests/page-objects/HeldTokensCard.page-object.ts
+++ b/frontend/src/tests/page-objects/HeldTokensCard.page-object.ts
@@ -43,6 +43,10 @@ export class HeldTokensCardPo extends BasePageObject {
     return this.getElement("info-row");
   }
 
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
+  }
+
   async getHeldTokensTitles(): Promise<string[]> {
     const rowsPos = await this.getRows();
     return Promise.all(rowsPos.map((po) => po.getHeldTokenTitle()));

--- a/frontend/src/tests/page-objects/StakedTokensCard.page-object.ts
+++ b/frontend/src/tests/page-objects/StakedTokensCard.page-object.ts
@@ -53,6 +53,10 @@ export class StakedTokensCardPo extends BasePageObject {
     return this.getElement("info-row");
   }
 
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
+  }
+
   async getStakedTokensTitle(): Promise<string[]> {
     const rowsPos = await this.getRows();
     return Promise.all(rowsPos.map((po) => po.getStakedTokenTitle()));


### PR DESCRIPTION
# Motivation

We want to inform users that something is loading by displaying a spinner in the asset cards.

https://github.com/user-attachments/assets/41bac40d-dda1-4f74-a4f6-156440deb179

# Changes

- Added a `Spinner` to the `TokensCardHeader` based on prop `isLoading`
- Exposed `isLoading` prop by the consumers of `TokensCardHeader`
- Updated styles to ensure the Spinner fits properly.

# Tests

- Unit tests to verify that the `Spinner` displays correctly based on the new prop.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev. PR: #6210 