### PR TITLE
Make logMessage mandatory in queryAndUpdate

### DIFF
--- a/frontend/src/lib/services/ckbtc-info.services.ts
+++ b/frontend/src/lib/services/ckbtc-info.services.ts
@@ -66,5 +66,6 @@ export const loadCkBTCInfo = async ({
 
       handleError?.();
     },
+    logMessage: "loadCkBTCInfo",
   });
 };

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -119,6 +119,7 @@ export const loadIcrcToken = ({
       // Hide unproven data
       tokensStore.resetUniverse(ledgerCanisterId);
     },
+    logMessage: "loadIcrcToken",
   });
 };
 

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -309,6 +309,7 @@ export const listNeurons = async ({
         err: error,
       });
     },
+    logMessage: "listNeurons",
   });
 };
 
@@ -1017,6 +1018,7 @@ export const loadNeuron = ({
       }
       catchError(error);
     },
+    logMessage: "loadNeuron",
   });
 };
 

--- a/frontend/src/lib/services/public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/public/sns-proposals.services.ts
@@ -177,6 +177,7 @@ export const loadSnsProposals = async ({
         err,
       });
     },
+    logMessage: "loadSnsProposals",
   });
 };
 
@@ -225,5 +226,6 @@ export const getSnsProposalById = async ({
       });
       handleError?.(err);
     },
+    logMessage: "getSnsProposalById",
   });
 };

--- a/frontend/src/lib/services/utils.services.ts
+++ b/frontend/src/lib/services/utils.services.ts
@@ -43,7 +43,7 @@ export const queryAndUpdate = async <R, E>({
 }: {
   request: (options: { certified: boolean; identity: Identity }) => Promise<R>;
   onLoad: QueryAndUpdateOnResponse<R>;
-  logMessage?: string;
+  logMessage: string;
   onError?: QueryAndUpdateOnError<E>;
   strategy?: QueryAndUpdateStrategy;
   identityType?: QueryAndUpdateIdentity;
@@ -77,7 +77,7 @@ export const queryAndUpdate = async <R, E>({
     if (currentStrategy !== "query_and_update") {
       return;
     }
-    logPrefix = logPrefix ?? `[${lastIndex++}] ${logMessage ?? ""}`;
+    logPrefix = logPrefix ?? `[${lastIndex++}] ${logMessage}`;
     logWithTimestamp(`${logPrefix} calls${postfix}`);
   };
 

--- a/frontend/src/tests/lib/services/utils.services.spec.ts
+++ b/frontend/src/tests/lib/services/utils.services.spec.ts
@@ -30,6 +30,7 @@ describe("api-utils", () => {
             onError,
             identityType: "current",
             strategy: "query_and_update",
+            logMessage: "test-log",
           });
 
         expect(call).rejects.toThrowError();
@@ -48,6 +49,7 @@ describe("api-utils", () => {
           onLoad,
           onError,
           identityType: "current",
+          logMessage: "test-log",
         });
 
         expect(onLoad).toHaveBeenCalledTimes(1);
@@ -75,6 +77,7 @@ describe("api-utils", () => {
           request,
           onLoad,
           onError,
+          logMessage: "test-log",
         });
 
         expect(request).toHaveBeenCalledTimes(2);
@@ -103,6 +106,7 @@ describe("api-utils", () => {
           request,
           onLoad,
           onError,
+          logMessage: "test-log",
         });
 
         await tick();
@@ -125,6 +129,7 @@ describe("api-utils", () => {
         await queryAndUpdate<number, unknown>({
           request,
           onLoad,
+          logMessage: "test-log",
         });
 
         expect(requestCertified.sort()).toEqual([false, true]);
@@ -144,6 +149,7 @@ describe("api-utils", () => {
           request,
           onLoad,
           strategy: "query",
+          logMessage: "test-log",
         });
 
         expect(requestCertified.sort()).toEqual([false]);
@@ -169,6 +175,7 @@ describe("api-utils", () => {
           request,
           onLoad,
           strategy: "update",
+          logMessage: "test-log",
         });
 
         expect(requestCertified.sort()).toEqual([true]);
@@ -191,6 +198,7 @@ describe("api-utils", () => {
           request,
           onLoad,
           onError,
+          logMessage: "test-log",
         });
 
         expect(onLoad).not.toBeCalled();
@@ -226,6 +234,7 @@ describe("api-utils", () => {
           request,
           onLoad,
           onError,
+          logMessage: "test-log",
         });
         await runResolvedPromises();
 
@@ -263,6 +272,7 @@ describe("api-utils", () => {
           request,
           onLoad,
           onError,
+          logMessage: "test-log",
         });
         await runResolvedPromises();
 
@@ -305,6 +315,7 @@ describe("api-utils", () => {
         await queryAndUpdate<number, unknown>({
           request,
           onLoad,
+          logMessage: "test-log",
         });
         expect(updateDone).toBeTruthy();
         expect(queryDone).toBe(false);


### PR DESCRIPTION
# Motivation

While debugging end-to-end test flakiness I had difficulty understanding which calls were being made because not all calls to `queryAndUpdate` define a log message.

# Changes

1. Make the `logMessage` parameter of `queryAndUpdate` non-optional.
2. Specify a log message for all calls missing a log message.

# Tests

1. Update the tests to specify a log message in every call.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary