### PR TITLE
Remove heartbeat from nns-dapp canister

### DIFF
--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -1,5 +1,4 @@
 canister_global_timer
-canister_heartbeat
 canister_init
 canister_post_upgrade
 canister_pre_upgrade

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -1,5 +1,4 @@
 canister_global_timer
-canister_heartbeat
 canister_init
 canister_post_upgrade
 canister_pre_upgrade

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -360,6 +360,7 @@ pub enum DetachCanisterResponse {
 impl AccountsStore {
     /// Determines whether a migration is being performed.
     #[must_use]
+    #[allow(dead_code)]
     pub fn migration_in_progress(&self) -> bool {
         self.accounts_db.migration_in_progress()
     }

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -12,6 +12,7 @@ impl AccountsDbAsProxy {
 
     /// Determines whether a migration is in progress.
     #[must_use]
+    #[allow(dead_code)]
     pub fn migration_in_progress(&self) -> bool {
         self.migration.is_some()
     }


### PR DESCRIPTION
# Motivation

Now that NNS dapp has stopped tracking ICP transactions, the only other thing that's done in the heartbeat is to try to make progress on the accounts migration. The accounts migration finished a long time ago so we should remove the entire heartbeat.

This PR removes the heartbeat from the nns-dapp canister.

The rest of the migration code should be cleaned up in separate PRs.

# Changes

1. Remove `canister_heartbeat`.
2. Mark unused functions with `#[allow(dead_code)]`.


# Tests

1. Existing tests should pass.
2. Updated golden exports with
```
scripts/nns-dapp/test-exports --wasm nns-dapp_production.wasm.gz --update-golden --flavour production
scripts/nns-dapp/test-exports --wasm nns-dapp_test.wasm.gz --update-golden --flavour test
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary