### PR TITLE
feat(portfolio): implement page loading states

### DIFF
--- a/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
+
+  export let testId: string;
 </script>
 
-<Card testId="skeleton-tokens-card">
+<Card {testId}>
   <div class="wrapper">
     <div class="header">
       <div class="header-wrapper">

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -123,7 +123,7 @@
   </div>
   <div class="content">
     {#if heldTokensCard === "skeleton"}
-      <SkeletonTokensCard />
+      <SkeletonTokensCard testId="held-tokens-skeleton-card" />
     {:else if heldTokensCard === "empty"}
       <NoHeldTokensCard />
     {:else}
@@ -135,7 +135,7 @@
     {/if}
 
     {#if stakedTokensCard === "skeleton"}
-      <SkeletonTokensCard />
+      <SkeletonTokensCard testId="staked-tokens-skeleton-card" />
     {:else if stakedTokensCard === "empty"}
       <NoStakedTokensCard primaryCard={hasNoStakedTokensCardAPrimaryAction} />
     {:else}

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -10,8 +10,8 @@
   import type { TableProject } from "$lib/types/staking";
   import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
   import {
-      getTopHeldTokens,
-      getTopStakedTokens,
+    getTopHeldTokens,
+    getTopStakedTokens,
   } from "$lib/utils/portfolio.utils";
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
@@ -58,18 +58,16 @@
   // - 'full': Shows card with data (or when user is not signed in, visitor data)
   // - 'loading': Shows skeleton while data is being fetched
   // - 'empty': Shows empty state when user has no tokens
-  type TokensCardStatus = "empty" | "loading" | "full";
+  type TokensCardType = "empty" | "skeleton" | "full";
 
-
-  let heldTokensCard: TokensCardStatus;
+  let heldTokensCard: TokensCardType;
   $: heldTokensCard = !$authSignedInStore
     ? "full"
     : areHeldTokensLoading
-      ? "loading"
+      ? "skeleton"
       : totalTokensBalanceInUsd === 0
         ? "empty"
         : "full";
-
 
   let areStakedTokensLoading: boolean;
   $: areStakedTokensLoading = tableProjects.some(
@@ -78,11 +76,11 @@
 
   // Determines the display state of the staked tokens card
   // Similar logic to heldTokensCard but for staked tokens
-  let stakedTokensCard: TokensCardStatus;
+  let stakedTokensCard: TokensCardType;
   $: stakedTokensCard = !$authSignedInStore
     ? "full"
     : areStakedTokensLoading
-      ? "loading"
+      ? "skeleton"
       : totalStakedInUsd === 0
         ? "empty"
         : "full";
@@ -124,7 +122,7 @@
     />
   </div>
   <div class="content">
-    {#if heldTokensCard === "loading"}
+    {#if heldTokensCard === "skeleton"}
       <SkeletonTokensCard />
     {:else if heldTokensCard === "empty"}
       <NoHeldTokensCard />
@@ -136,7 +134,7 @@
       />
     {/if}
 
-    {#if stakedTokensCard === "loading"}
+    {#if stakedTokensCard === "skeleton"}
       <SkeletonTokensCard />
     {:else if stakedTokensCard === "empty"}
       <NoStakedTokensCard primaryCard={hasNoStakedTokensCardAPrimaryAction} />

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -90,7 +90,7 @@
   // This helps guide users to stake their tokens when possible
   let hasNoStakedTokensCardAPrimaryAction: boolean;
   $: hasNoStakedTokensCardAPrimaryAction =
-    stakedTokensCard === "empty" && heldTokensCard !== "empty";
+    stakedTokensCard === "empty" && heldTokensCard === "full";
 
   // Global loading state that tracks if either held or staked tokens are loading
   // TotalAssetsCard will show this if either held or staked are loading

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -17,7 +17,7 @@
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
 
-  export let userTokens: UserToken[];
+  export let userTokens: UserToken[] = [];
   export let tableProjects: TableProject[];
 
   let totalTokensBalanceInUsd: number;
@@ -58,7 +58,10 @@
   // - 'full': Shows card with data (or when user is not signed in, visitor data)
   // - 'loading': Shows skeleton while data is being fetched
   // - 'empty': Shows empty state when user has no tokens
-  let heldTokensCard: "empty" | "loading" | "full";
+  type TokensCardStatus = "empty" | "loading" | "full";
+
+
+  let heldTokensCard: TokensCardStatus;
   $: heldTokensCard = !$authSignedInStore
     ? "full"
     : areHeldTokensLoading
@@ -67,6 +70,7 @@
         ? "empty"
         : "full";
 
+
   let areStakedTokensLoading: boolean;
   $: areStakedTokensLoading = tableProjects.some(
     (project) => project.isStakeLoading
@@ -74,12 +78,12 @@
 
   // Determines the display state of the staked tokens card
   // Similar logic to heldTokensCard but for staked tokens
-  let stakedTokensCard: "empty" | "loading" | "full";
+  let stakedTokensCard: TokensCardStatus;
   $: stakedTokensCard = !$authSignedInStore
     ? "full"
-    : areHeldTokensLoading
+    : areStakedTokensLoading
       ? "loading"
-      : totalTokensBalanceInUsd === 0
+      : totalStakedInUsd === 0
         ? "empty"
         : "full";
 
@@ -87,7 +91,8 @@
   // Primary action is shown when there are tokens but no stakes
   // This helps guide users to stake their tokens when possible
   let hasNoStakedTokensCardAPrimaryAction: boolean;
-  $: hasNoStakedTokensCardAPrimaryAction = stakedTokensCard !== "empty";
+  $: hasNoStakedTokensCardAPrimaryAction =
+    stakedTokensCard === "empty" && heldTokensCard !== "empty";
 
   // Global loading state that tracks if either held or staked tokens are loading
   // TotalAssetsCard will show this if either held or staked are loading
@@ -121,7 +126,7 @@
   <div class="content">
     {#if heldTokensCard === "loading"}
       <SkeletonTokensCard />
-    {:else if stakedTokensCard === "empty"}
+    {:else if heldTokensCard === "empty"}
       <NoHeldTokensCard />
     {:else}
       <HeldTokensCard

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -542,15 +542,25 @@ describe("Portfolio page", () => {
     });
 
     describe("Loading States", () => {
-      it("should show loading states while tokens are loading", async () => {
-        const loadingToken = createUserTokenLoading({});
-        const loadingProject: TableProject = {
-          ...mockTableProject,
-          isStakeLoading: true,
-        };
+      const loadingToken = createUserTokenLoading({});
+      const loadingProject: TableProject = {
+        ...mockTableProject,
+        isStakeLoading: true,
+      };
 
-        // Test Case 1: Initial loading state - both tokens and projects loading
-        let po = renderPage({
+      const loadedToken = createUserToken({
+        balanceInUsd: 100,
+        universeId: principal(1),
+      });
+
+      const loadedProject: TableProject = {
+        ...mockTableProject,
+        stakeInUsd: 100,
+        isStakeLoading: false,
+      };
+
+      it("should show the inital loading state - both tokens and projects loading", async () => {
+        const po = renderPage({
           userTokens: [loadingToken],
           tableProjects: [loadingProject],
         });
@@ -562,14 +572,15 @@ describe("Portfolio page", () => {
         );
         expect(await po.getHeldTokensCardPo().isPresent()).toEqual(false);
         expect(await po.getStakedTokensCardPo().isPresent()).toEqual(false);
+      });
 
+      it("should show a partial loading state - tokens loaded, projects still loading", async () => {
         const loadedToken = createUserToken({
           balanceInUsd: 100,
           universeId: principal(1),
         });
 
-        // Test Case 2: Partial loading state - tokens loaded, projects still loading
-        po = renderPage({
+        const po = renderPage({
           userTokens: [loadedToken],
           tableProjects: [loadingProject],
         });
@@ -581,15 +592,11 @@ describe("Portfolio page", () => {
         );
         expect(await po.getHeldTokensCardPo().isPresent()).toEqual(true);
         expect(await po.getStakedTokensCardPo().isPresent()).toEqual(false);
+      });
 
-        const loadedProject: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 100,
-          isStakeLoading: false,
-        };
-
-        // Test Case 3: Partial loading state - projects loaded, tokens still loading
-        po = renderPage({
+      it("should show a partial loading state - projects loaded, tokens still loading", async () => {
+        // Test Case 3:
+        const po = renderPage({
           userTokens: [loadingToken],
           tableProjects: [loadedProject],
         });
@@ -601,9 +608,10 @@ describe("Portfolio page", () => {
         );
         expect(await po.getHeldTokensCardPo().isPresent()).toEqual(false);
         expect(await po.getStakedTokensCardPo().isPresent()).toEqual(true);
+      });
 
-        // Test Case 4: Fully loaded state - both tokens and projects loaded
-        po = renderPage({
+      it("should show a fully loaded state - both tokens and projects loaded", async () => {
+        const po = renderPage({
           userTokens: [loadedToken],
           tableProjects: [loadedProject],
         });

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -467,6 +467,20 @@ describe("Portfolio page", () => {
           "$0.00"
         );
       });
+
+      it("should not display a primary action when the staked tokens card loads before the held tokens card", async () => {
+        const loadingToken = createUserTokenLoading({});
+
+        const po = renderPage({
+          userTokens: [loadingToken],
+          tableProjects: [],
+        });
+
+        expect(await po.getNoStakedTokensCarPo().isPresent()).toEqual(true);
+        expect(await po.getNoStakedTokensCarPo().hasPrimaryAction()).toEqual(
+          false
+        );
+      });
     });
 
     describe("TotalAssetsCard", () => {

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -122,7 +122,8 @@ describe("Portfolio page", () => {
       });
 
       expect(await po.getTotalAssetsCardPo().hasSpinner()).toEqual(false);
-      expect(await po.getNumberOfSkeletonCards()).toEqual(0);
+      expect(await po.getHeldTokensSkeletonCard().isPresent()).toEqual(false);
+      expect(await po.getStakedTokensSkeletonCard().isPresent()).toEqual(false);
     });
   });
 
@@ -540,9 +541,12 @@ describe("Portfolio page", () => {
         });
 
         expect(await po.getTotalAssetsCardPo().hasSpinner()).toEqual(true);
-        expect(await po.getNumberOfSkeletonCards()).toEqual(2);
-        expect(await po.getHeldTokensCardPo().isPresent()).toBe(false);
-        expect(await po.getStakedTokensCardPo().isPresent()).toBe(false);
+        expect(await po.getHeldTokensSkeletonCard().isPresent()).toEqual(true);
+        expect(await po.getStakedTokensSkeletonCard().isPresent()).toEqual(
+          true
+        );
+        expect(await po.getHeldTokensCardPo().isPresent()).toEqual(false);
+        expect(await po.getStakedTokensCardPo().isPresent()).toEqual(false);
 
         const loadedToken = createUserToken({
           balanceInUsd: 100,
@@ -554,9 +558,12 @@ describe("Portfolio page", () => {
         });
 
         expect(await po.getTotalAssetsCardPo().hasSpinner()).toEqual(true);
-        expect(await po.getNumberOfSkeletonCards()).toEqual(1);
-        expect(await po.getHeldTokensCardPo().isPresent()).toBe(true);
-        expect(await po.getStakedTokensCardPo().isPresent()).toBe(false);
+        expect(await po.getHeldTokensSkeletonCard().isPresent()).toEqual(false);
+        expect(await po.getStakedTokensSkeletonCard().isPresent()).toEqual(
+          true
+        );
+        expect(await po.getHeldTokensCardPo().isPresent()).toEqual(true);
+        expect(await po.getStakedTokensCardPo().isPresent()).toEqual(false);
 
         const loadedProject: TableProject = {
           ...mockTableProject,
@@ -570,9 +577,12 @@ describe("Portfolio page", () => {
         });
 
         expect(await po.getTotalAssetsCardPo().hasSpinner()).toEqual(false);
-        expect(await po.getNumberOfSkeletonCards()).toEqual(0);
-        expect(await po.getHeldTokensCardPo().isPresent()).toBe(true);
-        expect(await po.getStakedTokensCardPo().isPresent()).toBe(true);
+        expect(await po.getHeldTokensSkeletonCard().isPresent()).toEqual(false);
+        expect(await po.getStakedTokensSkeletonCard().isPresent()).toEqual(
+          false
+        );
+        expect(await po.getHeldTokensCardPo().isPresent()).toEqual(true);
+        expect(await po.getStakedTokensCardPo().isPresent()).toEqual(true);
       });
     });
   });

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -575,11 +575,6 @@ describe("Portfolio page", () => {
       });
 
       it("should show a partial loading state - tokens loaded, projects still loading", async () => {
-        const loadedToken = createUserToken({
-          balanceInUsd: 100,
-          universeId: principal(1),
-        });
-
         const po = renderPage({
           userTokens: [loadedToken],
           tableProjects: [loadingProject],
@@ -595,7 +590,6 @@ describe("Portfolio page", () => {
       });
 
       it("should show a partial loading state - projects loaded, tokens still loading", async () => {
-        // Test Case 3:
         const po = renderPage({
           userTokens: [loadingToken],
           tableProjects: [loadedProject],

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -527,10 +527,8 @@ describe("Portfolio page", () => {
     });
 
     describe("Loading States", () => {
-      it("should show skeleton when tokens are loading", async () => {
-        // First render with loading state
+      it("should show loading states while tokens are loading", async () => {
         const loadingToken = createUserTokenLoading({});
-
         const loadingProject: TableProject = {
           ...mockTableProject,
           isStakeLoading: true,

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -535,6 +535,7 @@ describe("Portfolio page", () => {
           isStakeLoading: true,
         };
 
+        // Test Case 1: Initial loading state - both tokens and projects loading
         let po = renderPage({
           userTokens: [loadingToken],
           tableProjects: [loadingProject],
@@ -552,6 +553,8 @@ describe("Portfolio page", () => {
           balanceInUsd: 100,
           universeId: principal(1),
         });
+
+        // Test Case 2: Partial loading state - tokens loaded, projects still loading
         po = renderPage({
           userTokens: [loadedToken],
           tableProjects: [loadingProject],
@@ -571,6 +574,21 @@ describe("Portfolio page", () => {
           isStakeLoading: false,
         };
 
+        // Test Case 3: Partial loading state - projects loaded, tokens still loading
+        po = renderPage({
+          userTokens: [loadingToken],
+          tableProjects: [loadedProject],
+        });
+
+        expect(await po.getTotalAssetsCardPo().hasSpinner()).toEqual(true);
+        expect(await po.getHeldTokensSkeletonCard().isPresent()).toEqual(true);
+        expect(await po.getStakedTokensSkeletonCard().isPresent()).toEqual(
+          false
+        );
+        expect(await po.getHeldTokensCardPo().isPresent()).toEqual(false);
+        expect(await po.getStakedTokensCardPo().isPresent()).toEqual(true);
+
+        // Test Case 4: Fully loaded state - both tokens and projects loaded
         po = renderPage({
           userTokens: [loadedToken],
           tableProjects: [loadedProject],

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -36,8 +36,11 @@ export class PortfolioPagePo extends BasePageObject {
     return StakedTokensCardPo.under(this.root);
   }
 
-  async getNumberOfSkeletonCards(): Promise<number> {
-    const skeletons = await this.root.allByTestId("skeleton-tokens-card");
-    return skeletons.length;
+  getHeldTokensSkeletonCard(): PageObjectElement {
+    return this.getElement("held-tokens-skeleton-card");
+  }
+
+  getStakedTokensSkeletonCard(): PageObjectElement {
+    return this.getElement("staked-tokens-skeleton-card");
   }
 }

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -35,4 +35,9 @@ export class PortfolioPagePo extends BasePageObject {
   getStakedTokensCardPo(): StakedTokensCardPo {
     return StakedTokensCardPo.under(this.root);
   }
+
+  async getNumberOfSkeletonCards(): Promise<number> {
+    const skeletons = await this.root.allByTestId("skeleton-tokens-card");
+    return skeletons.length;
+  }
 }


### PR DESCRIPTION
# Motivation

Loading all the information for the Portfolio page may take some time. We want to display loading indicators to enhance the user experience.

https://github.com/user-attachments/assets/807d6d1f-8742-4ec0-a642-409eef735e8f

# Changes

- Logic to decide the type of card to display: `empty`, `skeleton`, or `full`, depending on the data.  
- Provide boolean to the total assets card if any content is loading.

# Tests

- Added unit test for the transition between not signed in, loading and loaded
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary