### PR TITLE
Fix the inappropriate usage of finally

### DIFF
--- a/frontend/src/lib/modals/neurons/UpdateVotingPowerRefreshedModal.svelte
+++ b/frontend/src/lib/modals/neurons/UpdateVotingPowerRefreshedModal.svelte
@@ -14,7 +14,7 @@
   const toBigInt = (value: number | undefined): bigint | undefined => {
     try {
       if (value !== undefined) return BigInt(value);
-    } finally {
+    } catch (err) {
       // Do nothing
     }
     return undefined;


### PR DESCRIPTION
# Motivation

`finally` was mistakenly used instead of `catch`, which doesn't do anything.

Note: no other instances of incorrect `finally` usage were found.

# Changes

Replace `finally` with `catch`. Implicitly tested by the [e2e test](https://github.com/dfinity/nns-dapp/blob/472b179d3515fed65c4056abac9a76247d8745d7/frontend/src/tests/e2e/periodic.spec.ts).

# Tests

- No tests, because this is a test feature.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.