### PR TITLE
SECFIND-244: Remove irrelevant canister stats

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 - Remove canister creation fallback from backend canister.
 - Stop processing ICP transactions in the nns-dapp canister.
+- Stop exporting stats related to transaction processing.
 
 #### Fixed
 

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -136,16 +136,10 @@ type Stats =
         accounts_count: nat64;
         sub_accounts_count: nat64;
         hardware_wallet_accounts_count: nat64;
-        block_height_synced_up_to: opt nat64;
-        seconds_since_last_ledger_sync: nat64;
-        neurons_topped_up_count: nat64;
-        transactions_to_process_queue_length: nat32;
         performance_counts: vec PerformanceCount;
         stable_memory_size_bytes: opt nat64;
         wasm_memory_size_bytes: opt nat64;
         migration_countdown: opt nat32;
-        exceptional_transactions_count: opt nat32;
-        periodic_tasks_count: opt nat32;
         accounts_db_stats_recomputed_on_upgrade: opt bool;
     };
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -17,7 +17,6 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::ops::RangeBounds;
-use std::time::{Duration, SystemTime};
 
 pub mod constructors;
 pub mod histogram;
@@ -717,25 +716,9 @@ impl AccountsStore {
     }
 
     pub fn get_stats(&self, stats: &mut Stats) {
-        let timestamp_now_nanos = u64::try_from(
-            dfn_core::api::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_else(|err| unreachable!("Hey, we are back in the sixties!  Seriously, if we get here, the system time is before the Unix epoch.  This should be impossible.  Error: {err}"))
-                .as_nanos(),
-        )
-        .unwrap_or_else(|_| {
-            unreachable!("Well, this could kill us if the code is still running in 500 years.  Not impossible.")
-        });
-        let duration_since_last_sync =
-            Duration::from_nanos(timestamp_now_nanos - self.last_ledger_sync_timestamp_nanos);
-
         stats.accounts_count = self.accounts_db.db_accounts_len();
         stats.sub_accounts_count = self.accounts_db_stats.sub_accounts_count;
         stats.hardware_wallet_accounts_count = self.accounts_db_stats.hardware_wallet_accounts_count;
-        stats.block_height_synced_up_to = self.block_height_synced_up_to;
-        stats.seconds_since_last_ledger_sync = duration_since_last_sync.as_secs();
-        stats.neurons_topped_up_count = self.neurons_topped_up_count;
-        stats.transactions_to_process_queue_length = self.multi_part_transactions_processor.get_queue_length();
         stats.migration_countdown = Some(self.accounts_db.migration_countdown());
         stats.accounts_db_stats_recomputed_on_upgrade = self.accounts_db_stats_recomputed_on_upgrade.0;
     }

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1066,7 +1066,6 @@ pub(crate) fn assert_initial_test_store_stats_are_correct(stats: &Stats) {
     assert_eq!(2, stats.accounts_count);
     assert_eq!(0, stats.sub_accounts_count);
     assert_eq!(0, stats.hardware_wallet_accounts_count);
-    assert!(stats.seconds_since_last_ledger_sync > 1_000_000_000);
 }
 
 /// The stats test should reject an empty response when we know that there is data in the accounts store.

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -13,11 +13,3 @@ pub struct MultiPartTransactionsProcessor {
 pub enum MultiPartTransactionToBeProcessed {
     CreateCanisterV2(PrincipalId),
 }
-
-impl MultiPartTransactionsProcessor {
-    #[must_use]
-    pub fn get_queue_length(&self) -> u32 {
-        u32::try_from(self.queue.len())
-            .unwrap_or_else(|err| unreachable!("MultiPartTransactionsProcessor queue length has length greater than u32::MAX.  Transactions are pruned by the periodic_tasks_runner if they consume more than 1Gb of data, so this should never happen. Error: {:?}", err))
-    }
-}

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -54,12 +54,6 @@ impl PerformanceCounts {
     /// Note: The `exceptional_transactions_count` saturates at `u32::MAX`, in the very unlikely event that we reach that limit.
     pub fn get_stats(&self, stats: &mut Stats) {
         stats.performance_counts = self.instruction_counts.iter().cloned().collect();
-        stats.exceptional_transactions_count = Some(
-            self.exceptional_transactions
-                .as_ref()
-                .map_or(0, |x| u32::try_from(x.len()).unwrap_or(u32::MAX)),
-        );
-        stats.periodic_tasks_count = self.periodic_tasks_count;
     }
 
     /// Generates sample data for use in tests

--- a/scripts/nns-dapp/e2e-test-metrics-present.keys
+++ b/scripts/nns-dapp/e2e-test-metrics-present.keys
@@ -1,10 +1,6 @@
 accounts_count
-exceptional_transactions_count
 hardware_wallet_accounts_count
-neurons_topped_up_count
 nns_dapp_migration_countdown
 nns_dapp_stable_memory_size_gib
 nns_dapp_wasm_memory_size_gib
-periodic_tasks_count
-seconds_since_last_ledger_sync
 sub_accounts_count

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -32,7 +32,7 @@ get_transactions_count() {
 
 # Gets stats that should be invariant across upgrades
 get_upgrade_invariant_stats() {
-  dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count,  neurons_topped_up_count, sub_accounts_count}'
+  dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count, sub_accounts_count}'
 }
 
 # Verifies that accounts were not recomputed on upgrade.


### PR DESCRIPTION
# Motivation

Now that the nns-dapp canister no longer process transactions for the purpose of recovering from neuron staking/top-up and canister creation/top-up, a number of exports stats have become irrelevant:
1. `block_height_synced_up_to`: we are no longer syncing any blocks
2. `seconds_since_last_ledger_sync`: same
3. `neurons_topped_up_count`: topping up neurons only happens in the frontend now
4. `transactions_to_process_queue_length`: we no longer have a queue of transactions to process
5. `exceptional_transactions_count`: we don't process transactions so also don't run into transactions we can't parse
6. `periodic_tasks_count`: we don't do any periodic tasks anymore

# Changes

1. Remove the irrelevant stats from the Rust data type.
2. Remove the irrelevant stats from the Candid data type.
3. Stop exporting the irrelevant stats.
4. Remove other code related to exported stats.

# Tests

1. Updated tests to no longer check these stats.

# Todos

- [ ] Add entry to changelog (if necessary).
