### PR TITLE
Fix periodic e2e test flakiness

### DIFF
--- a/frontend/src/lib/api/governace-test.api.ts
+++ b/frontend/src/lib/api/governace-test.api.ts
@@ -1,3 +1,4 @@
+import * as governanceApiService from "$lib/api-services/governance.api-service";
 import { createAgent } from "$lib/api/agent.api";
 import { GOVERNANCE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST } from "$lib/constants/environment.constants";
@@ -26,6 +27,7 @@ export const updateNeuron = async ({
   const canister = await governanceTestCanister(identity);
 
   await canister.updateNeuron(neuron);
+  governanceApiService.clearCache();
 
   return;
 };

--- a/frontend/src/lib/services/nns-neurons-dev.services.ts
+++ b/frontend/src/lib/services/nns-neurons-dev.services.ts
@@ -33,10 +33,7 @@ export const updateVotingPowerRefreshedTimestamp = async ({
       identity,
     });
 
-    // TODO: Switch to `await getAndLoadNeuron(neuron.neuronId);`
-    // after adding the voting_power_refreshed_timestamp_seconds field
-    // to ic-js/oldListNeuronsCertifiedService.
-    await listNeurons();
+    await getAndLoadNeuron(neuron.neuronId);
 
     toastsSuccess({
       labelKey: "neuron_detail.update_neuron_success",

--- a/frontend/src/lib/services/nns-neurons-dev.services.ts
+++ b/frontend/src/lib/services/nns-neurons-dev.services.ts
@@ -1,6 +1,6 @@
 import { updateNeuron } from "$lib/api/governace-test.api";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
-import { getAndLoadNeuron, listNeurons } from "$lib/services/neurons.services";
+import { getAndLoadNeuron } from "$lib/services/neurons.services";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import type { E8s, Neuron, NeuronInfo } from "@dfinity/nns";
 import { isNullish } from "@dfinity/utils";


### PR DESCRIPTION
# Motivation

The periodic confirmation end-to-end test is currently flaky. After a lot of investigation, I found the following:
1. We have a neurons cache in `api-services/governance.api-service.ts`. This cache only caches certified  responses ([link](https://github.com/dfinity/nns-dapp/blob/472b179d3515fed65c4056abac9a76247d8745d7/frontend/src/lib/api-services/governance.api-service.ts#L144)).
2. `updateNeuron`, uses a [test API](https://github.com/dfinity/nns-dapp/blob/472b179d3515fed65c4056abac9a76247d8745d7/frontend/src/lib/api/governace-test.api.ts#L19), which doesn't invalidate the above cache.
3. `listNeurons` by default makes a [query call](https://github.com/dfinity/nns-dapp/blob/472b179d3515fed65c4056abac9a76247d8745d7/frontend/src/lib/services/neurons.services.ts#L287), except for [30 percent](https://github.com/dfinity/nns-dapp/blob/472b179d3515fed65c4056abac9a76247d8745d7/frontend/src/lib/constants/mockable.constants.ts#L18) of the time.
4. Using `console.log` to log a `bigint` results in `undefined` in the Playwright report even if the bigint itself is not undefined. This didn't cause flakiness but not knowing this made it a lot harder to debug.

# Changes

1. Use `getAndLoadNeuron` instead of `listNeurons` in `updateVotingPowerRefreshedTimestamp`.
2. Call `governanceApiService.clearCache()` in `updateNeuron`.

# Tests

With these changes I could run the e2e test 72 times without failure.
Before it would fail more than 10% of the time.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary