### PR TITLE
Economics based periodic confirmation utils

### DIFF
--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -41,6 +41,7 @@ export const TOPICS_TO_FOLLOW_NNS = [
 // Inactivity means no manual votes cast and no updates to the list of followed neurons (followees).
 // Draft ic pr: https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L582)
 // TODO(mstr): replace with the actual ic link.
+// @deprecated
 export const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
 
 // After a neuron has experienced voting power reduction for this amount of time,
@@ -48,6 +49,7 @@ export const START_REDUCING_VOTING_POWER_AFTER_SECONDS = SECONDS_IN_HALF_YEAR;
 // 1. Deciding voting power reaches 0.
 // 2. Its following on topics other than NeuronManagement are cleared.
 // https://github.com/dfinity/ic/blob/c2da5aca97a07bae4fcbf5d72a8c0448b40599d7/rs/nns/governance/canister/governance.did#L584
+// @deprecated
 export const CLEAR_FOLLOWING_AFTER_SECONDS = SECONDS_IN_MONTH;
 
 // To notify users that their rewards will start decreasing in 30 days.


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, they may change in the future. Therefore, we want to retrieve them from the API.

In this PR, we mark the current periodic confirmation utilities as deprecated and add sibling utilities that expect the voting power economics properties to be in the argument. The utilities will be replaced in upcoming PRs.

# Changes

- Add sibling utils. The only logic change is that the new utilities assume the neuron is active when a voting power parameter is not available.

# Tests

- Added. They are similar to the old version utilities.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.