### PR TITLE
Stop resetting snsProposalsStore and snsFiltersStore in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -16,8 +16,6 @@ describe("Proposals", () => {
   let queryProposalsSpy;
 
   beforeEach(() => {
-    snsProposalsStore.reset();
-
     queryProposalsSpy = vi
       .spyOn(api, "queryProposals")
       .mockResolvedValue([mockProposalInfo]);

--- a/frontend/src/tests/lib/derived/sns/sns-filtered-actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-filtered-actionable-proposals.derived.spec.ts
@@ -25,8 +25,6 @@ describe("snsFilteredActionableProposalsStore", () => {
   };
 
   beforeEach(() => {
-    snsProposalsStore.reset();
-
     const decisionStatus = [
       {
         id: "1",

--- a/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
@@ -28,10 +28,6 @@ describe("snsFilteredProposalsStore", () => {
     id: [{ id: 3n }],
   };
 
-  beforeEach(() => {
-    snsFiltersStore.reset();
-    snsProposalsStore.reset();
-  });
   it("should return undefined if filter store is not loaded", () => {
     const proposals: SnsProposalData[] = [
       snsProposal1,

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
@@ -9,9 +9,6 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SnsFilterStatusModal", () => {
-  beforeEach(() => {
-    snsFiltersStore.reset();
-  });
   const filters: Filter<SnsProposalDecisionStatus>[] = [
     {
       id: "1",

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
@@ -8,9 +8,6 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SnsFilterTypesModal", () => {
-  beforeEach(() => {
-    snsFiltersStore.reset();
-  });
   const filters: Filter<SnsProposalTypeFilterId>[] = [
     {
       id: "1",

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -74,7 +74,6 @@ describe("SnsProposalDetail", () => {
     page.reset();
     resetSnsProjects();
     actionableProposalsSegmentStore.resetForTesting();
-    snsProposalsStore.reset();
   });
 
   describe("not logged in", () => {

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -2,7 +2,6 @@ import SnsProposals from "$lib/pages/SnsProposals.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
-import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { page } from "$mocks/$app/stores";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import {
@@ -46,8 +45,6 @@ describe("SnsProposals", () => {
   const projectName = "🪙";
 
   beforeEach(() => {
-    snsProposalsStore.reset();
-    snsFiltersStore.reset();
     // Reset to default value
     page.mock({ data: { universe: rootCanisterId.toText() } });
     setSnsProjects([

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -35,8 +35,6 @@ import { get } from "svelte/store";
 
 describe("sns-proposals services", () => {
   beforeEach(() => {
-    snsFiltersStore.reset();
-    snsProposalsStore.reset();
     vi.spyOn(console, "error").mockRestore();
   });
   const proposal1: SnsProposalData = {
@@ -63,8 +61,6 @@ describe("sns-proposals services", () => {
 
     describe("not logged in", () => {
       beforeEach(() => {
-        snsFiltersStore.reset();
-        snsProposalsStore.reset();
         setNoIdentity();
       });
       it("should call queryProposals with the default params", async () => {
@@ -226,7 +222,6 @@ describe("sns-proposals services", () => {
 
     describe("logged in", () => {
       beforeEach(() => {
-        snsProposalsStore.reset();
         resetIdentity();
       });
 

--- a/frontend/src/tests/lib/services/sns-filters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-filters.services.spec.ts
@@ -14,9 +14,6 @@ describe("sns-filters services", () => {
     get(snsFiltersStore)[mockPrincipal.toText()];
 
   describe("loadSnsFilters", () => {
-    beforeEach(() => {
-      snsFiltersStore.reset();
-    });
     it("should load the sns decision status filters store but not Unspecified", async () => {
       expect(getFiltersStoreData()?.decisionStatus).toBeUndefined();
       await loadSnsFilters({

--- a/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
@@ -52,10 +52,6 @@ describe("sns-filters store", () => {
   );
 
   describe("snsFiltersStore", () => {
-    beforeEach(() => {
-      snsFiltersStore.reset();
-    });
-
     it("should setDecisionStatus in different projects", () => {
       snsFiltersStore.setDecisionStatus({ rootCanisterId, decisionStatus });
 
@@ -206,10 +202,6 @@ describe("sns-filters store", () => {
   });
 
   describe("snsSelectedFiltersStore", () => {
-    beforeEach(() => {
-      snsFiltersStore.reset();
-    });
-
     it("should return the selected decision status filters", () => {
       // Project rootCanisterId
       snsFiltersStore.setDecisionStatus({

--- a/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
@@ -19,7 +19,6 @@ describe("SNS Proposals stores", () => {
     id: [{ id: 3n }],
   };
   describe("snsProposalsStore", () => {
-    beforeEach(() => snsProposalsStore.reset());
     it("should set proposals for a project", () => {
       const proposals: SnsProposalData[] = [
         snsProposal1,


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of a few stores at a time.

This PR does so for `snsProposalsStore` and `snsFiltersStore`.

# Changes

1. Remove resetting of `snsProposalsStore` and `snsFiltersStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary