### PR TITLE
Stop resetting importedTokensStore and failedImportedTokenLedgerIdsStore in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -46,7 +46,6 @@ describe("ImportTokenModal", () => {
   let queryIcrcTokenSpy: MockInstance;
 
   beforeEach(() => {
-    importedTokensStore.reset();
     resetIdentity();
     resetSnsProjects();
     busyStore.resetForTesting();

--- a/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
@@ -13,11 +13,6 @@ describe("icrcCanistersStore", () => {
   const ledgerCanisterId2 = principal(2);
   const ledgerCanisterId3 = principal(3);
 
-  beforeEach(() => {
-    importedTokensStore.reset();
-    failedImportedTokenLedgerIdsStore.reset();
-  });
-
   it("returns empty object when no icrc tokens are present", () => {
     expect(get(icrcCanistersStore)).toEqual({});
   });

--- a/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
@@ -20,11 +20,6 @@ describe("imported tokens derived stores", () => {
     indexCanisterId: undefined,
   };
 
-  beforeEach(() => {
-    importedTokensStore.reset();
-    failedImportedTokenLedgerIdsStore.reset();
-  });
-
   describe("failedExistentImportedTokenLedgerIdsStore", () => {
     it("should contain failed imported tokens", () => {
       expect(get(failedExistentImportedTokenLedgerIdsStore)).toEqual([]);

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -117,7 +117,6 @@ describe("IcrcWallet", () => {
     vi.useRealTimers();
     resetIdentity();
     busyStore.resetForTesting();
-    importedTokensStore.reset();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -94,7 +94,6 @@ describe("Wallet", () => {
   const importedTokenId = principal(123);
   beforeEach(() => {
     resetIdentity();
-    importedTokensStore.reset();
     setCkETHCanisters();
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -47,8 +47,6 @@ describe("icrc-accounts-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    importedTokensStore.reset();
-    failedImportedTokenLedgerIdsStore.reset();
     resetSnsProjects();
 
     vi.spyOn(ledgerApi, "queryIcrcToken").mockResolvedValue(mockToken);

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -43,8 +43,6 @@ describe("imported-tokens-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    importedTokensStore.reset();
-    failedImportedTokenLedgerIdsStore.reset();
     busyStore.resetForTesting();
     vi.spyOn(console, "error").mockReturnValue();
     vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);

--- a/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
@@ -7,11 +7,6 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("imported-tokens-store", () => {
-  beforeEach(() => {
-    importedTokensStore.reset();
-    failedImportedTokenLedgerIdsStore.reset();
-  });
-
   describe("importedTokensStore", () => {
     const importedTokenA: ImportedTokenData = {
       ledgerCanisterId: principal(0),

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -137,8 +137,6 @@ describe("Tokens route", () => {
 
   describe("when feature flag enabled", () => {
     beforeEach(() => {
-      importedTokensStore.reset();
-      failedImportedTokenLedgerIdsStore.reset();
       ckBTCBalanceE8s = ckBTCDefaultBalanceE8s;
       ckETHBalanceUlps = ckETHDefaultBalanceUlps;
       tetrisBalanceE8s = tetrisDefaultBalanceE8s;


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of a few stores at a time.

This PR does so for `importedTokensStore` and `failedImportedTokenLedgerIdsStore`.

# Changes

1. Remove resetting of `importedTokensStore` and `failedImportedTokenLedgerIdsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary