### PR TITLE
Stop resetting some btc related stores in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
@@ -8,10 +8,6 @@ import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
 
 describe("BitcoinEstimatedAmountReceived", () => {
-  beforeEach(() => {
-    ckBTCInfoStore.reset();
-  });
-
   describe("should display zero as estimated received amount", () => {
     const zeroBtc = `${formatEstimatedFee(0n)} ${en.ckbtc.btc}`;
 

--- a/frontend/src/tests/lib/components/accounts/BitcoinKYTFee.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinKYTFee.spec.ts
@@ -11,10 +11,6 @@ describe("BitcoinKYTFee", () => {
     universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
   };
 
-  beforeEach(() => {
-    ckBTCInfoStore.reset();
-  });
-
   describe("display fee", () => {
     const result = 789n;
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCInfoCard.spec.ts
@@ -37,8 +37,6 @@ describe("CkBTCInfoCard", () => {
 
   beforeEach(() => {
     resetIdentity();
-    bitcoinAddressStore.reset();
-    ckBTCInfoStore.reset();
 
     page.mock({
       data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -60,8 +60,6 @@ describe("CkBTCTransactionList", () => {
   };
 
   beforeEach(() => {
-    ckbtcPendingUtxosStore.reset();
-    ckbtcRetrieveBtcStatusesStore.reset();
     vi.useFakeTimers().setSystemTime(new Date());
   });
 

--- a/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
@@ -38,8 +38,6 @@ describe("BtcCkBTCReceiveModal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    bitcoinAddressStore.reset();
-    ckBTCInfoStore.reset();
     page.reset();
   });
 
@@ -88,8 +86,6 @@ describe("BtcCkBTCReceiveModal", () => {
   describe("with btc", () => {
     describe("without BTC address", () => {
       beforeEach(() => {
-        bitcoinAddressStore.reset();
-
         vi.spyOn(minterApi, "getBTCAddress").mockResolvedValue(undefined);
       });
 

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -84,7 +84,6 @@ describe("CkBTCTransactionModal", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    ckBTCInfoStore.reset();
 
     vi.mocked(transferTokens).mockResolvedValue({ blockIndex: undefined });
     resetIdentity();

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -10,8 +10,6 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { WALLET_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/wallet.constants";
 import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
 import * as services from "$lib/services/icrc-accounts.services";
-import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
-import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { ckbtcRetrieveBtcStatusesStore } from "$lib/stores/ckbtc-retrieve-btc-statuses.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -115,9 +113,6 @@ describe("CkBTCWallet", () => {
   beforeEach(() => {
     vi.clearAllTimers();
     vi.useRealTimers();
-    ckBTCInfoStore.reset();
-    bitcoinAddressStore.reset();
-    ckbtcRetrieveBtcStatusesStore.reset();
     resetIdentity();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({

--- a/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
@@ -19,7 +19,6 @@ import { get } from "svelte/store";
 
 describe("ckbtc-info-services", () => {
   beforeEach(() => {
-    ckBTCInfoStore.reset();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -34,7 +34,6 @@ import { get } from "svelte/store";
 describe("ckbtc-minter-services", () => {
   beforeEach(() => {
     resetIdentity();
-    ckbtcRetrieveBtcStatusesStore.reset();
     vi.spyOn(minterApi, "updateBalance").mockResolvedValue(mockUpdateBalanceOk);
   });
 

--- a/frontend/src/tests/lib/stores/bitcoin.store.spec.ts
+++ b/frontend/src/tests/lib/stores/bitcoin.store.spec.ts
@@ -7,8 +7,6 @@ import { get } from "svelte/store";
 
 describe("bitcoin-store", () => {
   describe("Bitcoin address store", () => {
-    beforeEach(() => bitcoinAddressStore.reset());
-
     const data = {
       identifier: mockCkBTCMainAccount.identifier,
       btcAddress: mockBTCAddressTestnet,

--- a/frontend/src/tests/lib/stores/ckbtc-info.store.spec.ts
+++ b/frontend/src/tests/lib/stores/ckbtc-info.store.spec.ts
@@ -7,8 +7,6 @@ import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import { get } from "svelte/store";
 
 describe("ckBTC info store", () => {
-  beforeEach(() => ckBTCInfoStore.reset());
-
   const ckBtcData = {
     canisterId: CKBTC_UNIVERSE_CANISTER_ID,
     info: mockCkBTCMinterInfo,

--- a/frontend/src/tests/lib/stores/ckbtc-pending-utxos.store.spec.ts
+++ b/frontend/src/tests/lib/stores/ckbtc-pending-utxos.store.spec.ts
@@ -3,10 +3,6 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("ckBTC pending UTXOs store", () => {
-  beforeEach(() => {
-    ckbtcPendingUtxosStore.reset();
-  });
-
   const ckbtcUniverseId = principal(0);
   const cktestbtcUniverseId = principal(1);
 

--- a/frontend/src/tests/lib/stores/ckbtc-retrieve-btc-statuses.store.spec.ts
+++ b/frontend/src/tests/lib/stores/ckbtc-retrieve-btc-statuses.store.spec.ts
@@ -3,10 +3,6 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("ckBTC retrieve BTC statuses store", () => {
-  beforeEach(() => {
-    ckbtcRetrieveBtcStatusesStore.reset();
-  });
-
   const ckbtcUniverseId = principal(0);
   const cktestbtcUniverseId = principal(1);
 


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of a few stores at a time.

This PR does so for `ckBTCInfoStore`, `bitcoinAddressStore`, `ckbtcRetrieveBtcStatusesStore` and `ckbtcPendingUtxosStore`.

# Changes

1. Remove resetting of `ckBTCInfoStore`, `bitcoinAddressStore`, `ckbtcRetrieveBtcStatusesStore` and `ckbtcPendingUtxosStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary