### PR TITLE
Stop resetting some SNS related stores in beforeEach

### DIFF
--- a/frontend/src/tests/lib/derived/sns-aggregator.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-aggregator.derived.spec.ts
@@ -4,10 +4,6 @@ import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { get } from "svelte/store";
 
 describe("snsAggregatorDerived", () => {
-  beforeEach(() => {
-    snsAggregatorIncludingAbortedProjectsStore.reset();
-  });
-
   it("should create a derived store", () => {
     const rootCanisterId = "3uikt-kqsgq-aaaaa-aaaaa-cai";
     const ledgerCanisterId = "zjv33-2isgu-aaaaa-aaaaa-cai";

--- a/frontend/src/tests/lib/derived/sns-parameters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-parameters.derived.spec.ts
@@ -12,10 +12,6 @@ import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
 describe("SNS Parameters store", () => {
-  beforeEach(() => {
-    snsAggregatorIncludingAbortedProjectsStore.reset();
-  });
-
   describe("snsParametersStore", () => {
     it("should set parameters for a project", () => {
       snsAggregatorIncludingAbortedProjectsStore.setData([

--- a/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
@@ -16,10 +16,6 @@ describe("sns swap canisters accounts store", () => {
     },
   };
 
-  beforeEach(() => {
-    snsAggregatorIncludingAbortedProjectsStore.reset();
-  });
-
   it("should convert swap canisters to accounts for a given controller", () => {
     snsAggregatorIncludingAbortedProjectsStore.setData([aggregatorData]);
 

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -19,7 +19,6 @@ describe("selected-project-new-transaction-data derived store", () => {
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
       resetSnsProjects();
-      snsSwapCommitmentsStore.reset();
     });
 
     it("returns undefined when nns", () => {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -12,7 +12,6 @@ import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
 import { getOrCreateSnsFinalizationStatusStore } from "$lib/stores/sns-finalization-status.store";
-import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { userCountryStore } from "$lib/stores/user-country.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
@@ -83,7 +82,6 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
   beforeEach(() => {
     resetSnsProjects();
-    snsSwapCommitmentsStore.reset();
     userCountryStore.set(NOT_LOADED);
 
     vi.clearAllTimers();

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -104,7 +104,6 @@ describe("SNS public services", () => {
 
   describe("loadSnsProjects", () => {
     beforeEach(() => {
-      snsAggregatorIncludingAbortedProjectsStore.reset();
       clearWrapperCache();
       resetIdentity();
     });

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -46,9 +46,7 @@ describe("sns-services", () => {
     resetIdentity();
     vi.useFakeTimers();
     vi.clearAllTimers();
-    snsSwapCommitmentsStore.reset();
     resetSnsProjects();
-    snsDerivedStateStore.reset();
   });
 
   describe("getSwapAccount", () => {

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -9,10 +9,6 @@ import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("sns-aggregator store", () => {
-  beforeEach(() => {
-    snsAggregatorIncludingAbortedProjectsStore.reset();
-  });
-
   describe("snsAggregatorIncludingAbortedProjectsStore", () => {
     it("should set aggregator data", () => {
       snsAggregatorIncludingAbortedProjectsStore.setData(

--- a/frontend/src/tests/lib/stores/sns-derived-state.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-derived-state.store.spec.ts
@@ -4,10 +4,6 @@ import type { SnsGetDerivedStateResponse } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns derived state store", () => {
-  beforeEach(() => {
-    snsDerivedStateStore.reset();
-  });
-
   it("should store derived state", () => {
     const rootCanisterId = principal(0);
 

--- a/frontend/src/tests/lib/stores/sns-lifecycle.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-lifecycle.store.spec.ts
@@ -12,10 +12,6 @@ describe("sns lifecycle store", () => {
     lifecycle: [SnsSwapLifecycle.Committed],
   };
 
-  beforeEach(() => {
-    snsLifecycleStore.reset();
-  });
-
   it("should create a store for a given root canister id and store lifecycle", () => {
     const rootCanisterId = principal(0);
 

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -31,12 +31,6 @@ import {
 import { get } from "svelte/store";
 
 describe("sns.store", () => {
-  beforeEach(() => {
-    snsAggregatorIncludingAbortedProjectsStore.reset();
-    snsDerivedStateStore.reset();
-    snsLifecycleStore.reset();
-  });
-
   describe("snsSwapStatesStore", () => {
     it("should store swap states", () => {
       const swapCommitment = mockSnsSwapCommitment(


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of a few stores at a time.

This PR does so for `snsAggregatorIncludingAbortedProjectsStore`, `snsDerivedStateStore`, `snsLifecycleStore` and `snsSwapCommitmentsStore`.

# Changes

1. Remove resetting of `snsAggregatorIncludingAbortedProjectsStore`, `snsDerivedStateStore`, `snsLifecycleStore` and `snsSwapCommitmentsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary