### PR TITLE
Stop resetting some more SNS related stores in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -33,7 +33,6 @@ describe("ParticipateButton", () => {
   describe("signed in", () => {
     beforeEach(() => {
       resetIdentity();
-      snsTicketsStore.reset();
       userCountryStore.set(NOT_LOADED);
     });
 

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -16,7 +16,6 @@ import { waitFor } from "@testing-library/svelte";
 
 describe("ProjectStatusSection", () => {
   beforeEach(() => {
-    snsTicketsStore.reset();
     resetIdentity();
   });
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -12,8 +12,6 @@ import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
 import { getOrCreateSnsFinalizationStatusStore } from "$lib/stores/sns-finalization-status.store";
-import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
-import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { userCountryStore } from "$lib/stores/user-country.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
@@ -86,8 +84,6 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
   beforeEach(() => {
     resetSnsProjects();
     snsSwapCommitmentsStore.reset();
-    snsSwapMetricsStore.reset();
-    snsTicketsStore.reset();
     userCountryStore.set(NOT_LOADED);
 
     vi.clearAllTimers();

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -133,7 +133,6 @@ describe("sns-api", () => {
 
     vi.useFakeTimers();
 
-    snsTicketsStore.reset();
     resetAccountsForTesting();
 
     vi.spyOn(agentApi, "createAgent").mockImplementation(async () =>
@@ -189,10 +188,6 @@ describe("sns-api", () => {
   });
 
   describe("loadOpenTicket", () => {
-    beforeEach(() => {
-      snsTicketsStore.reset();
-    });
-
     describe("when polling is enabled", () => {
       beforeEach(() => {
         vi.clearAllTimers();

--- a/frontend/src/tests/lib/services/sns-swap-metrics.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-swap-metrics.services.spec.ts
@@ -6,10 +6,6 @@ import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
 describe("sns-swap-metrics", () => {
-  beforeEach(() => {
-    snsSwapMetricsStore.reset();
-  });
-
   describe("loadSnsSwapMetrics", () => {
     const rootCanisterId = mockPrincipal;
     const swapCanisterId = Principal.fromText("aaaaa-aa");

--- a/frontend/src/tests/lib/stores/sns-swap-metrics.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-swap-metrics.store.spec.ts
@@ -7,8 +7,6 @@ describe("snsSwapMetricsStore", () => {
     saleBuyerCount: 123,
   };
 
-  beforeEach(() => snsSwapMetricsStore.reset());
-
   it("should set metrics", () => {
     snsSwapMetricsStore.setMetrics({
       rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/stores/sns-ticket.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-ticket.store.spec.ts
@@ -11,8 +11,6 @@ describe("snsTicketsStore", () => {
     owner: mockPrincipal,
   });
 
-  beforeEach(() => snsTicketsStore.reset());
-
   it("should set ticket", () => {
     snsTicketsStore.setTicket({
       rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -40,10 +40,6 @@ import type {
 import { get } from "svelte/store";
 
 describe("sns-utils", () => {
-  beforeEach(() => {
-    snsTicketsStore.reset();
-  });
-
   describe("getSwapCanisterAccount", () => {
     it("should return swap canister account", async () => {
       const expectedAccount = await getSwapCanisterAccount({
@@ -90,9 +86,6 @@ describe("sns-utils", () => {
   });
 
   describe("hasOpenTicketInProcess", () => {
-    beforeEach(() => {
-      snsTicketsStore.reset();
-    });
     const testTicket = snsTicketMock({
       rootCanisterId: rootCanisterIdMock,
       owner: mockPrincipal,


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of a few stores at a time.

This PR does so for `snsTicketsStore` and `snsSwapMetricsStore`.

# Changes

1. Remove resetting of `snsTicketsStore` and `snsSwapMetricsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary