### PR TITLE
Stop resetting voteRegistrationStore and checkedNeuronSubaccountsStore in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -4,10 +4,7 @@ import * as proposalsApi from "$lib/api/proposals.api";
 import NnsVotingCard from "$lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte";
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { neuronsStore } from "$lib/stores/neurons.store";
-import {
-  voteRegistrationStore,
-  votingNeuronSelectStore,
-} from "$lib/stores/vote-registration.store";
+import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import {
   SELECTED_PROPOSAL_CONTEXT_KEY,
   type SelectedProposalContext,
@@ -72,8 +69,6 @@ describe("VotingCard", () => {
   };
 
   beforeEach(() => {
-    voteRegistrationStore.reset();
-
     neuronsStore.setNeurons({ neurons: [], certified: true });
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
     resetIdentity();

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -5,7 +5,6 @@ import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { SECONDS_IN_DAY, SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import NnsNeuronDetail from "$lib/pages/NnsNeuronDetail.svelte";
 import * as knownNeuronsServices from "$lib/services/known-neurons.services";
-import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
@@ -46,8 +45,6 @@ describe("NeuronDetail", () => {
     // Ensure the API is called after the first request.
     clearCache();
 
-    voteRegistrationStore.reset();
-    checkedNeuronSubaccountsStore.reset();
     fakeGovernanceApi.addNeuronWith({ neuronId, stake: neuronStake });
     fakeGovernanceApi.addNeuronWith({ neuronId: 1234n });
     fakeGovernanceApi.setLatestRewardEvent({

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -2,7 +2,6 @@ import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
-import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { enumValues } from "$lib/utils/enum.utils";
@@ -57,7 +56,6 @@ describe("SnsNeurons", () => {
   const projectName = "Tetris";
 
   beforeEach(() => {
-    checkedNeuronSubaccountsStore.reset();
     page.mock({ data: { universe: rootCanisterId.toText() } });
     resetIdentity();
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -16,7 +16,6 @@ import {
 import * as services from "$lib/services/neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
 import * as busyStore from "$lib/stores/busy.store";
-import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -160,7 +159,6 @@ describe("neurons-services", () => {
     resetAccountsForTesting();
     resetAccountIdentity();
     resetNeuronsApiService();
-    checkedNeuronSubaccountsStore.reset();
 
     vi.spyOn(icpAccountsServices, "loadBalance").mockReturnValue(undefined);
     vi.spyOn(icpAccountsServices, "transferICP").mockResolvedValue({

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -62,7 +62,6 @@ describe("sns-neurons-check-balances-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    checkedNeuronSubaccountsStore.reset();
     resetSnsProjects();
 
     setSnsProjects([

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -74,7 +74,6 @@ describe("vote-registration-services", () => {
 
   beforeEach(() => {
     // Cleanup:
-    voteRegistrationStore.reset();
     proposalsStore.resetForTesting();
     resetIdentity();
 

--- a/frontend/src/tests/lib/stores/checked-neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/checked-neurons.store.spec.ts
@@ -3,10 +3,6 @@ import { get } from "svelte/store";
 
 describe("checked-neurons.store", () => {
   describe("checkedNeuronSubaccountsStore", () => {
-    beforeEach(() => {
-      checkedNeuronSubaccountsStore.reset();
-    });
-
     it("should initially be empty", () => {
       expect(get(checkedNeuronSubaccountsStore)).toEqual({});
     });

--- a/frontend/src/tests/lib/stores/vote-registration.store.spec.ts
+++ b/frontend/src/tests/lib/stores/vote-registration.store.spec.ts
@@ -19,10 +19,6 @@ describe("voting-store", () => {
     proposalIdString: "2",
   };
 
-  beforeEach(() => {
-    voteRegistrationStore.reset();
-  });
-
   describe("voteRegistrationStore", () => {
     it("should set voting items", () => {
       voteRegistrationStore.add({ ...voteA, canisterId: OWN_CANISTER_ID });


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of a few stores at a time.

This PR does so for `voteRegistrationStore` and `checkedNeuronSubaccountsStore`.

# Changes

1. Remove resetting of `voteRegistrationStore` and `checkedNeuronSubaccountsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary