### PR TITLE
Register resetNeuronsApiService cleanup

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -46,6 +46,7 @@ import {
 } from "$lib/api/governance.api";
 import { SECONDS_IN_MINUTE } from "$lib/constants/constants";
 import { nowInSeconds } from "$lib/utils/date.utils";
+import { registerCleanupForTesting } from "$lib/utils/test-support.utils";
 import type { Identity } from "@dfinity/agent";
 import type { KnownNeuron, NeuronInfo } from "@dfinity/nns";
 import { isNullish, nonNullish } from "@dfinity/utils";
@@ -109,7 +110,7 @@ const clearCacheAfter = async <R>(promise: Promise<R>) => {
 };
 
 // Should be called in between tests to clean up state.
-export const resetNeuronsApiService = () => {
+const resetNeuronsApiService = () => {
   clearCache();
 };
 
@@ -219,3 +220,5 @@ export const governanceApiService = {
     return clearCacheAfter(changeNeuronVisibility(params));
   },
 };
+
+registerCleanupForTesting(resetNeuronsApiService);

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -1,7 +1,4 @@
-import {
-  governanceApiService,
-  resetNeuronsApiService,
-} from "$lib/api-services/governance.api-service";
+import { governanceApiService } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
 import {
   createMockIdentity,
@@ -154,10 +151,6 @@ const shouldInvalidateCacheOnFailure = async <P, R>({
 
 describe("neurons api-service", () => {
   const neuronId = 12n;
-
-  beforeEach(() => {
-    resetNeuronsApiService();
-  });
 
   // Read calls
 

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
 import { mergeNeurons } from "$lib/api/governance.api";
 import MergeNeuronsModal from "$lib/modals/neurons/MergeNeuronsModal.svelte";
@@ -47,7 +46,6 @@ describe("MergeNeuronsModal", () => {
       testIdentity
     );
     resetAccountsForTesting();
-    resetNeuronsApiService();
   });
 
   const selectAndTestTwoNeurons = async ({ po, neurons }) => {

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
@@ -30,10 +29,6 @@ describe("NnsNeurons", () => {
       maturityE8sEquivalent: 0n,
     },
   };
-
-  beforeEach(() => {
-    resetNeuronsApiService();
-  });
 
   const renderComponent = async () => {
     const { container } = render(NnsNeurons);

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
 import * as proposalsApi from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
@@ -55,7 +54,6 @@ describe("NnsProposalDetail", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetNeuronsApiService();
     vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue(testNeurons);
 
     actionableProposalsSegmentStore.set("all");

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
 import * as proposalsApi from "$lib/api/proposals.api";
 import { DEFAULT_LIST_PAGINATION_LIMIT } from "$lib/constants/constants";
@@ -49,7 +48,6 @@ describe("NnsProposals", () => {
 
   beforeEach(() => {
     proposalsStore.resetForTesting();
-    resetNeuronsApiService();
     proposalsFiltersStore.reset();
     actionableProposalsSegmentStore.resetForTesting();
 

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as canistersApi from "$lib/api/canisters.api";
 import * as governanceApi from "$lib/api/governance.api";
 import * as indexApi from "$lib/api/icp-index.api";
@@ -90,7 +89,6 @@ describe("NnsWallet", () => {
     vi.clearAllTimers();
     cancelPollAccounts();
     resetAccountsForTesting();
-    resetNeuronsApiService();
     icpTransactionsStore.reset();
     resetIdentity();
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
 import * as icpLedgerApi from "$lib/api/icp-ledger.api";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
@@ -158,7 +157,6 @@ describe("neurons-services", () => {
     spyConsoleError = vi.spyOn(console, "error");
     resetAccountsForTesting();
     resetAccountIdentity();
-    resetNeuronsApiService();
 
     vi.spyOn(icpAccountsServices, "loadBalance").mockReturnValue(undefined);
     vi.spyOn(icpAccountsServices, "transferICP").mockResolvedValue({

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
 import * as proposalsApi from "$lib/api/proposals.api";
 import { queryProposal } from "$lib/api/proposals.api";
@@ -45,7 +44,6 @@ let resolveUncertifiedPromise;
 
 describe("Proposal detail page when not logged in user", () => {
   beforeEach(() => {
-    resetNeuronsApiService();
     resolveCertifiedPromise = undefined;
     resolveUncertifiedPromise = undefined;
     // we don't display actionable proposals for non-logged in users

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -1,4 +1,3 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
 import * as proposalsApi from "$lib/api/proposals.api";
 import { queryProposals } from "$lib/api/proposals.api";
@@ -28,8 +27,6 @@ describe('NnsProposals when "all proposals" selected', () => {
     DEFAULT_PROPOSALS_FILTERS;
 
   beforeEach(() => {
-    resetNeuronsApiService();
-
     actionableProposalsSegmentStore.set("all");
 
     vi.spyOn(proposalsApi, "queryProposals").mockResolvedValue([proposal]);


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/6114 added `registerCleanupForTesting` to make test cleanup more robust.

# Changes

1. Use `registerCleanupForTesting` to register `resetNeuronsApiService` as cleanup function.
2. Stop exporting `resetNeuronsApiService`.
3. Stop calling `resetNeuronsApiService` in individual tests.

# Tests

1. Existing tests pass.
2. Verified that without registering the cleanup function, tests fail.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary