### PR TITLE
Migrate ConfirmFollowingBanner to voting power economics

### DIFF
--- a/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
@@ -4,21 +4,26 @@
   import Banner from "$lib/components/ui/Banner.svelte";
   import BannerIcon from "$lib/components/ui/BannerIcon.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { START_REDUCING_VOTING_POWER_AFTER_SECONDS } from "$lib/constants/neurons.constants";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
+  import { nonNullish } from "@dfinity/utils";
 
   let title: string;
   $: title = $i18n.losing_rewards_banner.confirm_title;
-
-  const text = replacePlaceholders($i18n.losing_rewards.description, {
-    $period: secondsToDissolveDelayDuration(
-      BigInt(START_REDUCING_VOTING_POWER_AFTER_SECONDS)
-    ),
-  });
 </script>
 
-<Banner testId="confirm-following-banner-component" {title} {text}>
-  <BannerIcon slot="icon" status="error">
-    <IconErrorOutline />
-  </BannerIcon>
-</Banner>
+{#if nonNullish($startReducingVotingPowerAfterSecondsStore)}
+  <Banner
+    testId="confirm-following-banner-component"
+    {title}
+    text={replacePlaceholders($i18n.losing_rewards.description, {
+      $period: secondsToDissolveDelayDuration(
+        $startReducingVotingPowerAfterSecondsStore
+      ),
+    })}
+  >
+    <BannerIcon slot="icon" status="error">
+      <IconErrorOutline />
+    </BannerIcon>
+  </Banner>
+{/if}

--- a/frontend/src/tests/lib/components/neuron-detail/ConfirmFollowingBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/ConfirmFollowingBanner.spec.ts
@@ -1,0 +1,31 @@
+import ConfirmFollowingBanner from "$lib/components/neuron-detail/ConfirmFollowingBanner.svelte";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
+import { ConfirmFollowingBannerPo } from "$tests/page-objects/ConfirmFollowingBanner.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("ConfirmFollowingBanner", () => {
+  const renderComponent = () => {
+    const { container } = render(ConfirmFollowingBanner, {});
+
+    return ConfirmFollowingBannerPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should be hidden w/o voting economics", async () => {
+    const po = renderComponent();
+
+    expect(await po.isPresent()).toBe(false);
+  });
+
+  it("should be rendered with voting economics available", async () => {
+    networkEconomicsStore.setParameters({
+      parameters: mockNetworkEconomics,
+      certified: true,
+    });
+
+    const po = renderComponent();
+
+    expect(await po.isPresent()).toBe(true);
+  });
+});


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, actual values are already being retrieved from the API (they are the same for now but may be updated in the future). The general idea is that if the parameters are unavailable, we consider the neuron active.

In this PR, we migrate `ConfirmFollowingBanner` from constants to the voting power economics store.

# Changes

- Switch from constants to related stores.
- Do not show the component without voting power economics available (it is loaded on dapp initialisation).

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.