### PR TITLE
test(porfolio): enable ENABLE_PORTFOLIO_PAGE in missing e2e test

### DIFF
--- a/frontend/src/tests/e2e/multi-tab-auth.spec.ts
+++ b/frontend/src/tests/e2e/multi-tab-auth.spec.ts
@@ -48,7 +48,7 @@ test("Test multi-tab auth", async ({ page: page1, context }) => {
   await expectSignedInAccountsPage(appPo2);
 
   // When signed in, the landing page shows the tokens page.
-  await page1.goto("/");
+  await page1.goto("/accounts");
   await expectSignedInTokensPage(appPo1);
 
   await step("Sign out");

--- a/frontend/src/tests/e2e/multi-tab-auth.spec.ts
+++ b/frontend/src/tests/e2e/multi-tab-auth.spec.ts
@@ -1,9 +1,9 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
-    setFeatureFlag,
-    signInWithNewUser,
-    step,
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
 } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 

--- a/frontend/src/tests/e2e/multi-tab-auth.spec.ts
+++ b/frontend/src/tests/e2e/multi-tab-auth.spec.ts
@@ -1,6 +1,10 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+    setFeatureFlag,
+    signInWithNewUser,
+    step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 const expectSignedOut = async (appPo: AppPo) => {
@@ -15,11 +19,12 @@ const expectSignedInAccountsPage = async (appPo: AppPo) => {
   expect(await appPo.getSignInPo().isPresent()).toBe(false);
 };
 
-const expectSignedInTokensPage = async (appPo: AppPo) => {
-  await appPo.getTokensPo().getTokensPagePo().waitFor();
-  expect(await appPo.getTokensPo().getSignInTokensPagePo().isPresent()).toBe(
-    false
-  );
+const expectSignedInPortfolioPage = async (appPo: AppPo) => {
+  await appPo.getPortfolioPo().getPortfolioPagePo().waitFor();
+
+  expect(
+    await appPo.getPortfolioPo().getPortfolioPagePo().getLoginCard().isPresent()
+  ).toBe(false);
 };
 
 test("Test multi-tab auth", async ({ page: page1, context }) => {
@@ -47,9 +52,20 @@ test("Test multi-tab auth", async ({ page: page1, context }) => {
   await page2.reload();
   await expectSignedInAccountsPage(appPo2);
 
-  // When signed in, the landing page shows the tokens page.
-  await page1.goto("/accounts");
-  await expectSignedInTokensPage(appPo1);
+  // When signed in, the landing page shows the portfolio page.
+  await page1.goto("/");
+
+  //TODO: Remove once the the feature flag is in PROD
+  await expect(page1).toHaveTitle(/.*\s\/\sNNS Dapp/);
+
+  await setFeatureFlag({
+    page: page1,
+    featureFlag: "ENABLE_PORTFOLIO_PAGE",
+    value: true,
+  });
+
+  await page1.reload();
+  await expectSignedInPortfolioPage(appPo1);
 
   await step("Sign out");
   await appPo1.getAccountMenuPo().openMenu();

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -22,6 +22,7 @@ import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { isNullish } from "@dfinity/utils";
 import { expect } from "@playwright/test";
+import { PortfolioRoutePo } from "./PortfolioRoute.page-object";
 
 export class AppPo extends BasePageObject {
   getSignInPo(): SignInPo {
@@ -38,6 +39,10 @@ export class AppPo extends BasePageObject {
 
   getSignInAccountsPo(): SignInAccountsPo {
     return SignInAccountsPo.under(this.root);
+  }
+
+  getPortfolioPo(): PortfolioRoutePo {
+    return PortfolioRoutePo.under(this.root);
   }
 
   getTokensPo(): TokensRoutePo {

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -9,6 +9,7 @@ import { LaunchpadPo } from "$tests/page-objects/Launchpad.page-object";
 import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
+import { PortfolioRoutePo } from "$tests/page-objects/PortfolioRoute.page-object";
 import { ProjectDetailPo } from "$tests/page-objects/ProjectDetail.page-object";
 import { ProposalDetailPo } from "$tests/page-objects/ProposalDetail.page-object";
 import { ProposalsPo } from "$tests/page-objects/Proposals.page-object";
@@ -22,7 +23,6 @@ import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { isNullish } from "@dfinity/utils";
 import { expect } from "@playwright/test";
-import { PortfolioRoutePo } from "./PortfolioRoute.page-object";
 
 export class AppPo extends BasePageObject {
   getSignInPo(): SignInPo {


### PR DESCRIPTION
# Motivation

In #6199, we will change the root page from the `tokens` page to the `portfolio`.  
In #6225, we modified tests that were redirecting to `/` by enabling the feature flag and reloading the page to ensure they function correctly. 

This PR addresses  one missing case from #6225.

# Changes

- Updated the expectations for navigating to `/`.
- Extended the `AppPo` to return the `PortfolioPo`.

# Tests

- Should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary