### PR TITLE
Migrate getNeuronTags to voting power economics

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -19,6 +19,7 @@
   } from "$lib/utils/neuron.utils";
   import type { NeuronInfo } from "@dfinity/nns";
   import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuron: NeuronInfo;
 
@@ -39,6 +40,8 @@
     identity: $authStore.identity,
     accounts: $icpAccountsStore,
     i18n: $i18n,
+    startReducingVotingPowerAfterSeconds:
+      $startReducingVotingPowerAfterSecondsStore,
   });
 </script>
 

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -13,6 +13,7 @@
   import { Card, IconRight } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuron: NeuronInfo;
   export let onClick: (() => void) | undefined;
@@ -26,6 +27,8 @@
     identity: $authStore.identity,
     accounts: $icpAccountsStore,
     i18n: $i18n,
+    startReducingVotingPowerAfterSeconds:
+      $startReducingVotingPowerAfterSecondsStore,
   });
 
   let followees: FolloweesNeuron[];

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -5,6 +5,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { getNeuronTags, type NeuronTagData } from "$lib/utils/neuron.utils";
   import type { NeuronInfo } from "@dfinity/nns";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuron: NeuronInfo;
   export let tagName: "p" | "h3" = "p";
@@ -15,6 +16,8 @@
     identity: $authStore.identity,
     accounts: $icpAccountsStore,
     i18n: $i18n,
+    startReducingVotingPowerAfterSeconds:
+      $startReducingVotingPowerAfterSecondsStore,
   });
 </script>
 

--- a/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
@@ -14,6 +14,7 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let defaultSelectedNeuron: NeuronInfo | null = null;
   export let makePublic: boolean;
@@ -126,6 +127,8 @@
                   identity: $authStore.identity,
                   accounts: $icpAccountsStore,
                   i18n: $i18n,
+                  startReducingVotingPowerAfterSeconds:
+                    $startReducingVotingPowerAfterSecondsStore,
                 })}
                 checked={isNeuronSelected(n)}
                 on:nnsChange={() => handleCheckboxChange(n)}
@@ -153,6 +156,8 @@
                   identity: $authStore.identity,
                   accounts: $icpAccountsStore,
                   i18n: $i18n,
+                  startReducingVotingPowerAfterSeconds:
+                    $startReducingVotingPowerAfterSecondsStore,
                 })}
                 disabled
               />

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -20,6 +20,7 @@
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
   import { IconNeuronsPage, Spinner } from "@dfinity/gix-components";
   import { onMount } from "svelte";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;
@@ -35,6 +36,8 @@
     i18n: $i18n,
     neuronInfos: $definedNeuronsStore,
     icpSwapUsdPrices: $icpSwapUsdPricesStore,
+    startReducingVotingPowerAfterSeconds:
+      $startReducingVotingPowerAfterSecondsStore,
   });
 
   let totalStakeInUsd: number;

--- a/frontend/src/lib/stores/neurons-table-order-sorted-neuron-ids-store.ts
+++ b/frontend/src/lib/stores/neurons-table-order-sorted-neuron-ids-store.ts
@@ -1,5 +1,6 @@
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 import { definedNeuronsStore } from "$lib/derived/neurons.derived";
 import { authStore } from "$lib/stores/auth.store";
 import { i18n } from "$lib/stores/i18n";
@@ -18,6 +19,7 @@ const tableNeuronsToSortStore = derived(
     i18n,
     definedNeuronsStore,
     icpSwapUsdPricesStore,
+    startReducingVotingPowerAfterSecondsStore,
   ],
   ([
     $authStore,
@@ -25,6 +27,7 @@ const tableNeuronsToSortStore = derived(
     $i18n,
     $definedNeuronsStore,
     $icpSwapUsdPricesStore,
+    $startReducingVotingPowerAfterSecondsStore,
   ]) => {
     const tableNeurons = tableNeuronsFromNeuronInfos({
       identity: $authStore.identity,
@@ -32,6 +35,8 @@ const tableNeuronsToSortStore = derived(
       i18n: $i18n,
       neuronInfos: $definedNeuronsStore,
       icpSwapUsdPrices: $icpSwapUsdPricesStore,
+      startReducingVotingPowerAfterSeconds:
+        $startReducingVotingPowerAfterSecondsStore,
     });
     return tableNeurons.sort(compareById);
   }

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -47,12 +47,14 @@ export const tableNeuronsFromNeuronInfos = ({
   accounts,
   icpSwapUsdPrices,
   i18n,
+  startReducingVotingPowerAfterSeconds,
 }: {
   neuronInfos: NeuronInfo[];
   identity?: Identity | undefined | null;
   accounts: IcpAccountsStoreData;
   icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
   i18n: I18n;
+  startReducingVotingPowerAfterSeconds: bigint | undefined;
 }): TableNeuron[] => {
   return neuronInfos.map((neuronInfo) => {
     const { neuronId, dissolveDelaySeconds } = neuronInfo;
@@ -91,6 +93,7 @@ export const tableNeuronsFromNeuronInfos = ({
         identity,
         accounts,
         i18n,
+        startReducingVotingPowerAfterSeconds,
       }),
       isPublic: isPublicNeuron(neuronInfo),
     };

--- a/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
@@ -1,5 +1,10 @@
 import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
+import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsLosingRewardsNeuronCardPo } from "$tests/page-objects/NnsLosingRewardsNeuronCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -26,6 +31,9 @@ describe("NnsLosingRewardsNeuronCard", () => {
           followees: [followNeuronId1],
         },
       ],
+      votingPowerRefreshedTimestampSeconds: BigInt(
+        nowInSeconds() - SECONDS_IN_YEAR
+      ),
     },
   };
 
@@ -57,6 +65,20 @@ describe("NnsLosingRewardsNeuronCard", () => {
     await po.click();
 
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render 'Missing rewards' tag", async () => {
+    overrideFeatureFlagsStore.setFlag(
+      "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+      true
+    );
+    networkEconomicsStore.setParameters({
+      parameters: mockNetworkEconomics,
+      certified: true,
+    });
+
+    const po = await renderComponent({ neuron });
+    expect(await po.getNeuronTags()).toEqual(["Missing rewards"]);
   });
 
   it("should render following", async () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1531,6 +1531,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([hotkeyTag]);
     });
@@ -1550,6 +1551,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithoutHw,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([hotkeyTag]);
     });
@@ -1569,6 +1571,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([hwTag]);
     });
@@ -1588,6 +1591,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([]);
     });
@@ -1607,6 +1611,7 @@ describe("neuron-utils", () => {
           identity: null,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([]);
     });
@@ -1625,6 +1630,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([nfTag]);
     });
@@ -1645,6 +1651,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([nfTag, hotkeyTag]);
     });
@@ -1665,6 +1672,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([nfTag, hwTag]);
     });
@@ -1684,6 +1692,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([seedTag]);
     });
@@ -1703,6 +1712,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([ectTag]);
     });
@@ -1725,6 +1735,7 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
           accounts: accountsWithHW,
           i18n: en,
+          startReducingVotingPowerAfterSeconds: undefined,
         })
       ).toEqual([seedTag, nfTag, hwTag]);
     });
@@ -1782,6 +1793,8 @@ describe("neuron-utils", () => {
               identity: mockIdentity,
               accounts: accountsWithHW,
               i18n: en,
+              startReducingVotingPowerAfterSeconds:
+                BigInt(SECONDS_IN_HALF_YEAR),
             })
           ).toEqual([
             {
@@ -1834,8 +1847,26 @@ describe("neuron-utils", () => {
             identity: mockIdentity,
             accounts: accountsWithHW,
             i18n: en,
+            startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
           })
         ).toEqual([missingRewardsTag]);
+      });
+
+      it("returns no 'Missing rewards' tag when no voting power economics", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+
+        expect(
+          getNeuronTags({
+            neuron: losingRewardNeuron,
+            identity: mockIdentity,
+            accounts: accountsWithHW,
+            i18n: en,
+            startReducingVotingPowerAfterSeconds: undefined,
+          })
+        ).toEqual([]);
       });
 
       it("returns no 'Missing rewards' tag without feature flag", () => {
@@ -1850,6 +1881,7 @@ describe("neuron-utils", () => {
             identity: mockIdentity,
             accounts: accountsWithHW,
             i18n: en,
+            startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
           })
         ).toEqual([]);
       });
@@ -1866,8 +1898,26 @@ describe("neuron-utils", () => {
             identity: mockIdentity,
             accounts: accountsWithHW,
             i18n: en,
+            startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
           })
         ).toEqual([missingRewardsSoonTag]);
+      });
+
+      it("returns no 'Missing rewards soon' tag w/o voting power economics", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+
+        expect(
+          getNeuronTags({
+            neuron: losingRewardSoonNeuron,
+            identity: mockIdentity,
+            accounts: accountsWithHW,
+            i18n: en,
+            startReducingVotingPowerAfterSeconds: undefined,
+          })
+        ).toEqual([]);
       });
 
       it("returns no 'Missing rewards soon' tag without feature flag", () => {
@@ -1882,6 +1932,7 @@ describe("neuron-utils", () => {
             identity: mockIdentity,
             accounts: accountsWithHW,
             i18n: en,
+            startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
           })
         ).toEqual([]);
       });
@@ -3325,6 +3376,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result).toEqual({
         neuronId: neuron.neuronId.toString(),
@@ -3344,6 +3396,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.tags).toEqual([{ text: "Seed" }]);
     });
@@ -3358,6 +3411,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.tags).toEqual([{ text: "Early Contributor Token" }]);
     });
@@ -3372,6 +3426,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.tags).toEqual([{ text: "Neurons' fund" }]);
     });
@@ -3392,6 +3447,7 @@ describe("neuron-utils", () => {
           hardwareWallets: [mockHardwareWalletAccount],
         },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.uncontrolledNeuronDetails).toEqual({
         type: "hardwareWallet",
@@ -3415,6 +3471,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.uncontrolledNeuronDetails).toEqual({
         type: "hotkey",
@@ -3435,6 +3492,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.uncontrolledNeuronDetails).toBeUndefined();
     });
@@ -3455,6 +3513,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.stake).toEqual(
         TokenAmountV2.fromUlps({
@@ -3484,6 +3543,7 @@ describe("neuron-utils", () => {
           hardwareWallets: [mockHardwareWalletAccount],
         },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.stake).toBeUndefined();
       expect(result.uncontrolledNeuronDetails).toEqual({
@@ -3510,6 +3570,7 @@ describe("neuron-utils", () => {
         identity: mockIdentity,
         accounts: { main: mockMainAccount },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(result.stake).toBeUndefined();
     });

--- a/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
@@ -78,6 +78,7 @@ describe("neurons-table.utils", () => {
           [LEDGER_CANISTER_ID.toText()]: icpPrice,
         },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
 
     it("should convert default neuronInfo to tableNeuron", () => {
@@ -244,6 +245,7 @@ describe("neurons-table.utils", () => {
           [LEDGER_CANISTER_ID.toText()]: icpPrice,
         },
         i18n: en,
+        startReducingVotingPowerAfterSeconds: undefined,
       });
       expect(tableNeurons).toEqual([
         {

--- a/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsLosingRewardsNeuronCard.page-object.ts
@@ -1,5 +1,6 @@
 import { CardPo } from "$tests/page-objects/Card.page-object";
 import { FolloweePo } from "$tests/page-objects/Followee.page-object";
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsLosingRewardsNeuronCardPo extends CardPo {
@@ -29,5 +30,14 @@ export class NnsLosingRewardsNeuronCardPo extends CardPo {
 
   async getNeuronId(): Promise<string> {
     return this.getElement("neuron-id").getText();
+  }
+
+  getNeuronTagPos(): Promise<NeuronTagPo[]> {
+    return NeuronTagPo.allUnder(this.root);
+  }
+
+  async getNeuronTags(): Promise<string[]> {
+    const pos = await this.getNeuronTagPos();
+    return Promise.all(pos.map((po) => po.getText()));
   }
 }


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, actual values are already being retrieved from the API (they are the same for now but may be updated in the future). The general idea is that if the parameters are unavailable, we consider the neuron active.

In this PR, we migrate the getNeuronTags function (and its callers) to the voting power economics utilities.

# Changes

- Switch to ...VPE utils in getNeuronTags ([changes](https://github.com/dfinity/nns-dapp/pull/6241/files#diff-b570daeb2a65094f5bd1d1b823bcf3025de7af68555903e0c2061d2f8b029e8fR555-R581)).
- Update all callers to provide startReducingVotingPowerAfterSeconds argument.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.