### PR TITLE
Decode unused neuron accounts as candid::Reserved

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -6,9 +6,8 @@ use candid::CandidType;
 use dfn_candid::Candid;
 use histogram::AccountsStoreHistogram;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_nns_common::types::NeuronId;
 use ic_stable_structures::{storable::Bound, Storable};
-use icp_ledger::{AccountIdentifier, BlockIndex, Memo, Subaccount};
+use icp_ledger::{AccountIdentifier, BlockIndex, Subaccount};
 use itertools::Itertools;
 use on_wire::{FromWire, IntoWire};
 use serde::Deserialize;
@@ -229,14 +228,6 @@ pub enum SetImportedTokensResponse {
 pub enum GetImportedTokensResponse {
     Ok(ImportedTokens),
     AccountNotFound,
-}
-
-#[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
-pub struct NeuronDetails {
-    account_identifier: AccountIdentifier,
-    principal: PrincipalId,
-    memo: Memo,
-    neuron_id: Option<NeuronId>,
 }
 
 #[derive(CandidType, Debug, PartialEq)]
@@ -782,7 +773,7 @@ impl StableState for AccountsStore {
             HashMap<AccountIdentifier, AccountWrapper>,
             candid::Reserved,
             candid::Reserved,
-            HashMap<AccountIdentifier, NeuronDetails>,
+            candid::Reserved,
             Option<BlockIndex>,
             MultiPartTransactionsProcessor,
             u64,


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/5739 we removed `neuron_accounts` from `AccountsStore` and stopped encoding it onto stable memory.
We also decoded its slot from stable memory into `candid::Reserved` which should be able to decode any type.
But this failed during canister upgrade because of the decoding skipping quota which exists to prevent attacks with requests with large amounts of unparsed data.

So in https://github.com/dfinity/nns-dapp/pull/5805 we changed it to decode into the original type `HashMap<AccountIdentifier, NeuronDetails>`.

Now that we no longer have a large map in stable memory, it is safe to decode into `candid::Reserved` as we do with other unused fields.

# Changes

1. Decode unused neuron accounts as `candid::Reserved` once again.
2. Remove unused type `NeuronDetails`.

# Tests

1. Used the golden state test with [these changes](https://github.com/dfinity/ic/pull/2657) to make sure the golden state can still be decoded.
2. Changed the type from `candid::Reserved` to `u64` to make sure the golden state test fails.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary