### PR TITLE
feat(navigation): implement fallback navigation for NNS accounts page

### DIFF
--- a/frontend/src/routes/(app)/(u)/(list)/accounts/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/accounts/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
+  import { afterNavigate, goto } from "$app/navigation";
   import Content from "$lib/components/layout/Content.svelte";
   import IslandWidthMain from "$lib/components/layout/IslandWidthMain.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
@@ -7,7 +7,13 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { accountsTitleStore } from "$lib/derived/accounts-title.derived";
 
-  const back = (): Promise<void> => goto(AppPath.Tokens);
+  let previousPath: string | null = null;
+
+  afterNavigate(({ from }) => {
+    if (from) previousPath = from.url.pathname;
+  });
+
+  const back = () => goto(previousPath || AppPath.Tokens);
 </script>
 
 <LayoutList title={$accountsTitleStore}>


### PR DESCRIPTION
# Motivation

The NNS accounts page layout features a back button that, when clicked, navigates the user to the `/token` page. This was accurate until the introduction of #6036, which provided two options for reaching this page:  
-  from the tokens page  
-  from the portfolio page  

# Changes

- NNS accounts layout to determine how to navigate back based on the previous location.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary