### PR TITLE
Add tokensTableOrderStore

### DIFF
--- a/frontend/src/lib/stores/tokens-table.store.ts
+++ b/frontend/src/lib/stores/tokens-table.store.ts
@@ -1,0 +1,24 @@
+import type { TokensTableOrder } from "$lib/types/tokens-page";
+import { writable } from "svelte/store";
+
+const initialTokensTableOrder: TokensTableOrder = [
+  {
+    columnId: "balance",
+  },
+  {
+    columnId: "title",
+  },
+];
+
+const initTokensTableOrderStore = () => {
+  const { subscribe, set } = writable<TokensTableOrder>(
+    initialTokensTableOrder
+  );
+
+  return {
+    subscribe,
+    set,
+  };
+};
+
+export const tokensTableOrderStore = initTokensTableOrderStore();

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -8,7 +8,10 @@
  * - `UserTokenAction` is a list of actions supported by the tokens page and hardcoded in the TokensTable.
  * - `UserToken` is the union of `UserTokenLoading` and `UserTokenData`.
  */
-import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+import type {
+  ResponsiveTableColumn,
+  ResponsiveTableOrder,
+} from "$lib/types/responsive-table";
 import type { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import type { Principal } from "@dfinity/principal";
 import type { Token, TokenAmountV2 } from "@dfinity/utils";
@@ -64,3 +67,7 @@ export type UserTokenData = UserTokenBase & {
 
 export type UserToken = UserTokenLoading | UserTokenFailed | UserTokenData;
 export type TokensTableColumn = ResponsiveTableColumn<UserToken>;
+
+export type TokensTableColumnId = "title" | "balance";
+
+export type TokensTableOrder = ResponsiveTableOrder<TokensTableColumnId>;

--- a/frontend/src/tests/lib/stores/tokens-table.store.spec.ts
+++ b/frontend/src/tests/lib/stores/tokens-table.store.spec.ts
@@ -1,0 +1,31 @@
+import { tokensTableOrderStore } from "$lib/stores/tokens-table.store";
+import { get } from "svelte/store";
+
+describe("tokens-table.store", () => {
+  describe("tokensTableOrderStore", () => {
+    it("should have an initial value", () => {
+      expect(get(tokensTableOrderStore)).toEqual([
+        {
+          columnId: "balance",
+        },
+        {
+          columnId: "title",
+        },
+      ]);
+    });
+
+    it("should set", () => {
+      tokensTableOrderStore.set([
+        {
+          columnId: "title",
+        },
+      ]);
+
+      expect(get(tokensTableOrderStore)).toEqual([
+        {
+          columnId: "title",
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to allow the user to change the order in the tokens table by clicking on the table headers, similar to the neurons table.
To remember the order between navigations (not between sessions) we will use a store, similar to the [neuronsTableOrderStore](https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/stores/neurons-table.store.ts).

# Changes

1. Add `tokensTableOrderStore`.

# Tests

1. Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary