### PR TITLE
NNS1-3548: Add compare functions for tokens table

### DIFF
--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -4,8 +4,11 @@ import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.
 import type { UserTokenData, UserTokenFailed } from "$lib/types/tokens-page";
 import {
   compareFailedTokensLast,
+  compareTokenHasBalance,
   compareTokensAlphabetically,
+  compareTokensByBalance,
   compareTokensByImportance,
+  compareTokensByUsdBalance,
   compareTokensIcpFirst,
   compareTokensWithBalanceOrImportedFirst,
 } from "$lib/utils/tokens-table.utils";
@@ -116,6 +119,91 @@ describe("tokens-table.utils", () => {
     });
   });
 
+  describe("compareTokensByUsdBalance", () => {
+    const token1 = createUserToken({
+      universeId: principal(1),
+      balanceInUsd: 1,
+    });
+    const token2 = createUserToken({
+      universeId: principal(2),
+      balanceInUsd: 2,
+    });
+
+    it("should compare by USD balance", () => {
+      expect(compareTokensByUsdBalance(token1, token2)).toEqual(1);
+    });
+  });
+
+  describe("compareTokenHasBalance", () => {
+    const token0 = createTokenWithBalance({ id: 0, amount: 0n });
+    const token1 = createTokenWithBalance({ id: 1, amount: 1n });
+    const token2 = createTokenWithBalance({ id: 2, amount: 2n });
+
+    it("should compare by whether the balance is positive", () => {
+      expect(compareTokenHasBalance(token0, token1)).toEqual(1);
+      expect(compareTokenHasBalance(token1, token0)).toEqual(-1);
+      expect(compareTokenHasBalance(token0, token0)).toEqual(0);
+      expect(compareTokenHasBalance(token1, token1)).toEqual(0);
+    });
+
+    it("does not care about the balance if both are positive", () => {
+      expect(compareTokenHasBalance(token1, token2)).toEqual(0);
+      expect(compareTokenHasBalance(token2, token1)).toEqual(0);
+    });
+  });
+
+  describe("compareTokensByBalance", () => {
+    const tokenWithUsdBalance = createUserToken({
+      universeId: principal(1),
+      balanceInUsd: 1,
+    });
+    const tokenWithBalanceWithoutUsd = createTokenWithBalance({
+      id: 2,
+      amount: 2n,
+    });
+    const tokenIcp = createIcpUserToken();
+    const tokenCkbtcWithoutBalance = {
+      ...ckBTCToken,
+      balance: TokenAmountV2.fromUlps({
+        amount: 0n,
+        token: ckBTCToken.balance.token,
+      }),
+    };
+    const tokenImported = createTokenWithBalance({ id: 5, amount: 0n });
+    const tokenNotImported = createTokenWithBalance({ id: 6, amount: 0n });
+
+    it("should compare by balance and tie breaks", () => {
+      const tokens = [
+        tokenWithUsdBalance,
+        tokenWithBalanceWithoutUsd,
+        tokenIcp,
+        tokenCkbtcWithoutBalance,
+        tokenImported,
+        failedImportedToken,
+        tokenNotImported,
+      ];
+
+      const compare = compareTokensByBalance({
+        importedTokenIds: new Set([
+          tokenImported.universeId.toText(),
+          failedImportedToken.universeId.toText(),
+        ]),
+      });
+
+      // Include i and j in the expected value to know what i and j were
+      // when this fails.
+      for (let i = 0; i < tokens.length; i++) {
+        expect([i, compare(tokens[i], tokens[i])]).toEqual([i, 0]);
+      }
+      for (let i = 0; i < tokens.length; i++) {
+        for (let j = i + 1; j < tokens.length; j++) {
+          expect([i, j, compare(tokens[i], tokens[j])]).toEqual([i, j, -1]);
+          expect([i, j, compare(tokens[j], tokens[i])]).toEqual([i, j, 1]);
+        }
+      }
+    });
+  });
+
   describe("compareTokensWithBalanceOrImportedFirst", () => {
     const token0 = createTokenWithBalance({ id: 0, amount: 0n });
     const token1 = createTokenWithBalance({ id: 1, amount: 1n });
@@ -200,6 +288,34 @@ describe("tokens-table.utils", () => {
           importedTokenIds,
         })(createUserTokenLoading(), importedTokenNoBalance)
       ).toEqual(1);
+    });
+  });
+
+  describe("compareTokensIsImported", () => {
+    const token0 = createTokenWithBalance({ id: 0, amount: 0n });
+
+    const importedTokenIds = new Set([
+      importedTokenWithBalance.universeId.toText(),
+      importedTokenNoBalance.universeId.toText(),
+      failedImportedToken.universeId.toText(),
+    ]);
+
+    it("should compare by imported", () => {
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(importedTokenNoBalance, token0)
+      ).toEqual(-1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token0, importedTokenNoBalance)
+      ).toEqual(1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(importedTokenWithBalance, importedTokenNoBalance)
+      ).toEqual(0);
     });
   });
 


### PR DESCRIPTION
# Motivation

We want to allow the user to change the order in the tokens table by clicking on the table headers, similar to the neurons table.
When clicking the "Projects" header, the tokens should be ordered alphabetically by name.
When clicking the "Balance" header, the tokens should be ordered by:
1. USD value of the balance
2. Tokens without exchange rate but positive balance before tokens with zero balance.
3. Within tokens with the same (probably 0) USD value, they should be sorted by:
    1. ICP first
    2. Known ck tokens
    3. Imported tokens
    4. Failed imported tokens
    5. Other tokens
    6. Alphabetically

This PR adds the sorting functions.
It does not add the functionality in the table.

# Changes

1. Add necessary compare functions.

# Tests

1. Unit tests added.
2. Tested manually (with additional changes) at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/tokens/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet