### PR TITLE
Switch to shouldDisplayRewardLossNotificationVPE

### DIFF
--- a/frontend/src/lib/derived/neurons.derived.ts
+++ b/frontend/src/lib/derived/neurons.derived.ts
@@ -1,13 +1,14 @@
+import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   hasValidStake,
-  shouldDisplayRewardLossNotification,
+  shouldDisplayRewardLossNotificationVPE,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
 } from "$lib/utils/neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { nonNullish } from "@dfinity/utils";
-import { derived, type Readable } from "svelte/store";
+import { derived, get, type Readable } from "svelte/store";
 
 export const definedNeuronsStore: Readable<NeuronInfo[]> = derived(
   neuronsStore,
@@ -23,7 +24,14 @@ export const soonLosingRewardNeuronsStore: Readable<NeuronInfo[]> = derived(
   definedNeuronsStore,
   ($definedNeuronsStore) =>
     sortNeuronsByVotingPowerRefreshedTimeout(
-      $definedNeuronsStore.filter(shouldDisplayRewardLossNotification)
+      $definedNeuronsStore.filter((neuron) =>
+        shouldDisplayRewardLossNotificationVPE({
+          neuron,
+          startReducingVotingPowerAfterSeconds: get(
+            startReducingVotingPowerAfterSecondsStore
+          ),
+        })
+      )
     )
 );
 

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -38,7 +38,7 @@
     getNeuronById,
     isSpawning,
     neuronVoting,
-    shouldDisplayRewardLossNotification,
+    shouldDisplayRewardLossNotificationVPE,
   } from "$lib/utils/neuron.utils";
   import { Island } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
@@ -47,6 +47,7 @@
   import { writable } from "svelte/store";
   import ConfirmFollowingBanner from "$lib/components/neuron-detail/ConfirmFollowingBanner.svelte";
   import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuronIdText: string | undefined | null;
 
@@ -155,7 +156,11 @@
   $: isConfirmFollowingVisible =
     $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION &&
     nonNullish(neuron) &&
-    shouldDisplayRewardLossNotification(neuron);
+    shouldDisplayRewardLossNotificationVPE({
+      neuron,
+      startReducingVotingPowerAfterSeconds:
+        $startReducingVotingPowerAfterSecondsStore,
+    });
 </script>
 
 <TestIdWrapper testId="nns-neuron-detail-component">

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronsMissingRewardsBadge.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronsMissingRewardsBadge.spec.ts
@@ -1,8 +1,10 @@
 import NnsNeuronsMissingRewardsBadge from "$lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte";
 import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronsMissingRewardsBadgePo } from "$tests/page-objects/NnsNeuronsMissingRewardsBadge.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -40,6 +42,10 @@ describe("NnsNeuronsMissingRewardsBadge", () => {
   beforeEach(() => {
     vi.useFakeTimers({
       now: nowSeconds * 1000,
+    });
+    networkEconomicsStore.setParameters({
+      parameters: mockNetworkEconomics,
+      certified: true,
     });
   });
 

--- a/frontend/src/tests/lib/derived/neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/neurons.derived.spec.ts
@@ -5,8 +5,10 @@ import {
   soonLosingRewardNeuronsStore,
   sortedNeuronStore,
 } from "$lib/derived/neurons.derived";
+import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
+import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { NeuronInfo } from "@dfinity/nns";
 import { get } from "svelte/store";
@@ -147,6 +149,13 @@ describe("neurons-derived", () => {
       },
     };
 
+    beforeEach(() => {
+      networkEconomicsStore.setParameters({
+        parameters: mockNetworkEconomics,
+        certified: true,
+      });
+    });
+
     it("should return empty list when no neurons", () => {
       neuronsStore.setNeurons({
         neurons: [],
@@ -177,6 +186,15 @@ describe("neurons-derived", () => {
         neuron2,
         neuron1,
       ]);
+    });
+
+    it("returns [] w/o voting power economics", () => {
+      networkEconomicsStore.reset();
+      neuronsStore.setNeurons({
+        neurons: [neuron2, neuron1, neuron3],
+        certified: true,
+      });
+      expect(get(soonLosingRewardNeuronsStore)).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Currently, the voting power parameters are hardcoded as half a year and one month. However, actual values are already being retrieved from the API (they are the same for now but may be updated in the future). The general idea is that if the parameters are unavailable, we consider the neuron active.

In this PR, we replace the constants based `shouldDisplayRewardLossNotification` function with `shouldDisplayRewardLossNotificationVPE`.

# Changes

- Replace in `soonLosingRewardNeuronsStore`.
- Replace in NnsNeuronDetail for ConfirmFollowingBanner visibility.

# Tests

- Updated. The NnsNeuronDetail was already covered because of the partly duplicated logic in the ConfirmFollowingBanner [here](https://github.com/dfinity/nns-dapp/pull/6236/files#diff-1cfb1fc9513a792bdab9ae3014a9012736bbf26f57001b3c1adcbddb51d769feR156-R172).
- Update NnsNeuronsMissingRewardsBadge.spec, because the component depends on soonLosingRewardNeuronsStore.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.