### PR TITLE
Fix preventing global fetch in tests

### DIFF
--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -27,6 +27,11 @@ describe("CanisterDetail", () => {
   beforeEach(() => {
     authStore.setForTesting(mockIdentity);
     canistersStore.setCanisters({ canisters: undefined, certified: true });
+
+    vi.spyOn(icpIndexApi, "getTransactions").mockResolvedValue({
+      balance: 0n,
+      transactions: [],
+    });
   });
 
   const canisterId = mockCanisterId;

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -292,6 +292,8 @@ describe("proposals-services", () => {
     beforeEach(() => {
       vi.spyOn(console, "error").mockReturnValue();
       setNoIdentity();
+
+      vi.spyOn(api, "queryProposals").mockResolvedValue(mockProposals);
     });
 
     it("should use anonymous identity", () => {

--- a/frontend/src/tests/routes/app/home/page.spec.ts
+++ b/frontend/src/tests/routes/app/home/page.spec.ts
@@ -1,11 +1,16 @@
+import * as icpSwapApi from "$lib/api/icp-swap.api";
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import HomeRoute from "$routes/(app)/(home)/+page.svelte";
 import { setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { render } from "@testing-library/svelte";
 
 describe("Home page", () => {
   beforeEach(() => {
     setNoIdentity();
+    vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue([]);
+    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockCkBTCToken);
   });
 
   it("should render sign-in button", () => {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -134,19 +134,18 @@ setDefaultTestConstants({
 failTestsThatLogToConsole();
 
 // Avoid using fetch in tests.
-// NOTE: This doesn't seem to work when all tests are run but works when
-// individual tests are run. Not sure why. Still it seems better to have it than
-// not to have it.
 let usedGlobalFetch = false;
 beforeEach(() => {
   usedGlobalFetch = false;
+  vi.spyOn(global, "fetch").mockImplementation(() => {
+    usedGlobalFetch = true;
+    // Also log in case the error is caught by the code under test.
+    console.log("global.fetch is not allowed in tests", new Error().stack);
+    throw new Error("global.fetch is not allowed in tests");
+  });
 });
 afterEach(async () => {
   expect(usedGlobalFetch).toBe(false);
-});
-vi.spyOn(global, "fetch").mockImplementation(() => {
-  usedGlobalFetch = true;
-  throw new Error("global.fetch is not allowed in tests");
 });
 
 // testing-library setup


### PR DESCRIPTION
# Motivation

We have code to prevent tests from doing `fetch`. When `fetch` happens during tests it typically means that they should have mocked an API call that's being used.

But this code wasn't working because it uses mocking and `vi.restoreAllMocks()` was being called after the setup was done.

# Changes

1. Mock `global.fetch` in `beforeEach` instead of directly in `vitest.setup.ts`.

# Tests

1. Add missing API mocking in tests that started failing.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary