### PR TITLE
Import token by url

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -965,7 +965,8 @@
     "is_duplication": "You have already imported this token, you can find it in the token list.",
     "is_sns": "You cannot import SNS tokens, they are added by the NNS.",
     "is_important": "This token is already in the token list.",
-    "is_icp": "You cannot import ICP."
+    "is_icp": "You cannot import ICP.",
+    "invalid_canister_id": "\"$canisterId\" is not a valid canister ID."
   },
   "error__sns": {
     "undefined_project": "The requested project is invalid or throws an error.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -966,7 +966,7 @@
     "is_sns": "You cannot import SNS tokens, they are added by the NNS.",
     "is_important": "This token is already in the token list.",
     "is_icp": "You cannot import ICP.",
-    "invalid_canister_id": "\"$canisterId\" is not a valid canister ID."
+    "invalid_canister_id": "Importing the token was unsuccessful because \"$canisterId\" is not a valid canister ID. Please verify the ID and retry."
   },
   "error__sns": {
     "undefined_project": "The requested project is invalid or throws an error.",

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -68,6 +68,7 @@
         substitutions: { $canisterId: canisterIdText },
       });
       close();
+      // Navigate to clear all query parameters.
       goto(AppPath.Tokens);
     }
   };

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -56,9 +56,11 @@
   let indexCanisterId: Principal | undefined;
   let tokenMetaData: IcrcTokenMetadata | undefined;
 
-  const validateCanisterIdText = (canisterIdText: string): boolean => {
+  const getCanisterIdFromText = (
+    canisterIdText: string
+  ): Principal | undefined => {
     try {
-      return Boolean(Principal.fromText(canisterIdText));
+      return Principal.fromText(canisterIdText);
     } catch (err) {
       console.error(err);
       toastsError({
@@ -67,27 +69,24 @@
       });
       close();
       goto(AppPath.Tokens);
-      return false;
     }
   };
   $: {
-    const ledgerId = $pageStore.importTokenLedgerId;
     if (
-      nonNullish(ledgerId) &&
+      $ENABLE_IMPORT_TOKEN_BY_URL &&
       isNullish(ledgerCanisterId) &&
-      validateCanisterIdText(ledgerId)
+      nonNullish($pageStore.importTokenLedgerId)
     ) {
-      ledgerCanisterId = Principal.fromText(ledgerId);
+      ledgerCanisterId = getCanisterIdFromText($pageStore.importTokenLedgerId);
     }
   }
   $: {
-    const indexId = $pageStore.importTokenIndexId;
     if (
-      nonNullish(indexId) &&
+      $ENABLE_IMPORT_TOKEN_BY_URL &&
       isNullish(indexCanisterId) &&
-      validateCanisterIdText(indexId)
+      nonNullish($pageStore.importTokenIndexId)
     ) {
-      indexCanisterId = Principal.fromText(indexId);
+      indexCanisterId = getCanisterIdFromText($pageStore.importTokenIndexId);
     }
   }
 

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -14,7 +14,7 @@
   } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import { toastsError, toastsShow } from "$lib/stores/toasts.store";
+  import { toastsError } from "$lib/stores/toasts.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { isImportantCkToken } from "$lib/utils/icrc-tokens.utils";
   import { isImportedToken } from "$lib/utils/imported-tokens.utils";
@@ -72,16 +72,25 @@
   };
   $: {
     const ledgerId = $pageStore.importTokenLedgerId;
-    if (nonNullish(ledgerId) && validateCanisterIdText(ledgerId)) {
+    if (
+      nonNullish(ledgerId) &&
+      isNullish(ledgerCanisterId) &&
+      validateCanisterIdText(ledgerId)
+    ) {
       ledgerCanisterId = Principal.fromText(ledgerId);
     }
   }
   $: {
     const indexId = $pageStore.importTokenIndexId;
-    if (nonNullish(indexId) && validateCanisterIdText(indexId)) {
+    if (
+      nonNullish(indexId) &&
+      isNullish(indexCanisterId) &&
+      validateCanisterIdText(indexId)
+    ) {
       indexCanisterId = Principal.fromText(indexId);
     }
   }
+
   let isAutoSubmitDone = false;
   $: if (
     $ENABLE_IMPORT_TOKEN_BY_URL &&

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -8,7 +8,10 @@
   import { matchLedgerIndexPair } from "$lib/services/icrc-index.services";
   import { addImportedToken } from "$lib/services/imported-tokens.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
-  import { DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING } from "$lib/stores/feature-flags.store";
+  import {
+    DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING,
+    ENABLE_IMPORT_TOKEN_BY_URL,
+  } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { toastsError, toastsShow } from "$lib/stores/toasts.store";
@@ -26,7 +29,6 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
   import { get } from "svelte/store";
-  import { authSignedInStore } from "$lib/derived/auth.derived";
   import { AppPath } from "$lib/constants/routes.constants";
   import { pageStore } from "$lib/derived/page.derived";
 
@@ -82,7 +84,7 @@
   }
   let isAutoSubmitDone = false;
   $: if (
-    $authSignedInStore &&
+    $ENABLE_IMPORT_TOKEN_BY_URL &&
     !isAutoSubmitDone &&
     // Wait for the imported tokens to be loaded (for successful validation).
     nonNullish($importedTokensStore?.importedTokens)

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1008,6 +1008,7 @@ interface I18nError__imported_tokens {
   is_sns: string;
   is_important: string;
   is_icp: string;
+  invalid_canister_id: string;
 }
 
 interface I18nError__sns {

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -554,5 +554,39 @@ describe("ImportTokenModal", () => {
         "You have already imported this token, you can find it in the token list."
       );
     });
+
+    it("should navigate to tokens on close w/o query params", async () => {
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [],
+      });
+      vi.spyOn(importedTokensApi, "setImportedTokens").mockResolvedValue();
+
+      importedTokensStore.set({
+        importedTokens: [],
+        certified: true,
+      });
+
+      const po = renderComponent();
+      const formPo = po.getImportTokenFormPo();
+      const reviewPo = po.getImportTokenReviewPo();
+
+      await runResolvedPromises();
+
+      expect(get(pageStore)).toMatchObject({
+        importTokenLedgerId: ledgerCanisterId.toText(),
+        importTokenIndexId: indexCanisterId.toText(),
+        path: AppPath.Tokens,
+      });
+
+      expect(await formPo.isPresent()).toEqual(false);
+      expect(await reviewPo.isPresent()).toEqual(true);
+
+      await po.closeModal();
+      expect(get(pageStore)).toMatchObject({
+        importTokenLedgerId: undefined,
+        importTokenIndexId: undefined,
+        path: AppPath.Tokens,
+      });
+    });
   });
 });

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -452,7 +452,7 @@ describe("ImportTokenModal", () => {
     expect(get(pageStore).path).toEqual(AppPath.Tokens);
   });
 
-  describe.only("Import token by URL", () => {
+  describe("Import token by URL", () => {
     beforeEach(() => {
       page.mock({
         routeId: AppPath.Tokens,
@@ -513,6 +513,29 @@ describe("ImportTokenModal", () => {
           },
         ],
       });
+    });
+
+    it("does not auto validate when feature flag disabled", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_IMPORT_TOKEN_BY_URL", false);
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [],
+      });
+      vi.spyOn(importedTokensApi, "setImportedTokens").mockResolvedValue();
+
+      importedTokensStore.set({
+        importedTokens: [],
+        certified: true,
+      });
+
+      const po = renderComponent();
+      const formPo = po.getImportTokenFormPo();
+      const reviewPo = po.getImportTokenReviewPo();
+
+      await runResolvedPromises();
+
+      // Should stay as form step
+      expect(await formPo.isPresent()).toEqual(true);
+      expect(await reviewPo.isPresent()).toEqual(false);
     });
 
     it("should wait for imported tokens to be loaded before validation", async () => {

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -1,3 +1,4 @@
+import * as ledgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
@@ -8,6 +9,7 @@ import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { UserTokenData } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
@@ -327,6 +329,12 @@ describe("Tokens page", () => {
       });
 
       it("opens import token modal when ledger canister id in URL", async () => {
+        vi.spyOn(ledgerApi, "queryIcrcToken").mockResolvedValue({
+          name: "Tetris",
+          symbol: "TET",
+          logo: "https://tetris.tet/logo.png",
+        } as IcrcTokenMetadata);
+
         page.mock({
           routeId: AppPath.Tokens,
           data: {


### PR DESCRIPTION
# Motivation

To simplify the token import process, the user can import a custom CK token by clicking a link, and the import token form will be pre-filled with the parameters from the URL (e.g. //nns.ic0.app/tokens/?import-ledger-id=m7h5t-euaaa-aaaaa-qabia-cai&import-index-id=myg3h-jmaaa-aaaaa-qabiq-cai). Having the ledger canister ID is sufficient to add an imported token.

In this PR, we fill in the form and automatically start validation.

1. Validate the canister IDs provided in the URL.
2. If the ID(s) are valid, fill in the form.
3. Start validation.

**Out of scope:**
- Additional handling of same tokens import.
- Sign-out flow.

# Changes

- Add logic to start the import token process by URL.

# Tests

- Added.
- Tested locally.

https://github.com/user-attachments/assets/22143018-db80-45eb-a4ab-336dfd12de89

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.