### PR TITLE
refactor: integrate test $on in render utils

### DIFF
--- a/frontend/src/tests/lib/components/ContextWrapperTest.svelte
+++ b/frontend/src/tests/lib/components/ContextWrapperTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { SvelteComponent, setContext } from "svelte";
 
-  export let Component: SvelteComponent;
+  export let Component: typeof SvelteComponent;
   export let contextKey: symbol;
   export let contextValue: unknown;
   export let props: object = {};

--- a/frontend/src/tests/lib/components/ContextWrapperTest.svelte
+++ b/frontend/src/tests/lib/components/ContextWrapperTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { SvelteComponent, setContext } from "svelte";
 
-  export let Component: typeof SvelteComponent;
+  export let Component: SvelteComponent;
   export let contextKey: symbol;
   export let contextValue: unknown;
   export let props: object = {};

--- a/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
@@ -5,6 +5,7 @@ import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { mockBTCAddressMainnet } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { render as renderUtils } from "$tests/utils/svelte.test-utils";
 import { fireEvent, render } from "@testing-library/svelte";
 
 describe("AddressInput", () => {
@@ -43,10 +44,12 @@ describe("AddressInput", () => {
     });
 
     it("should trigger the event on click on qr code scanner button", () => {
-      const { getByTestId, component } = render(AddressInput, { props });
-
       const openSpy = vi.fn();
-      component.$on("nnsOpenQRCodeReader", openSpy);
+
+      const { getByTestId } = renderUtils(AddressInput, {
+        props,
+        events: { nnsOpenQRCodeReader: openSpy },
+      });
 
       const button = getByTestId(
         "address-qr-code-scanner"

--- a/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
@@ -11,14 +11,17 @@ describe("ImportTokenForm", () => {
     indexCanisterId: Principal | undefined;
     addIndexCanisterMode?: boolean | undefined;
   }) => {
+    const nnsSubmit = vi.fn();
+    const nnsClose = vi.fn();
+
     const { container, component } = render(ImportTokenForm, {
       props,
+      events: {
+        nnsSubmit: nnsSubmit,
+        nnsClose: nnsClose,
+      },
     });
 
-    const nnsSubmit = vi.fn();
-    component.$on("nnsSubmit", nnsSubmit);
-    const nnsClose = vi.fn();
-    component.$on("nnsClose", nnsClose);
     const getPropLedgerCanisterId = () =>
       component.$$.ctx[component.$$.props["ledgerCanisterId"]];
     const getPropIndexCanisterId = () =>

--- a/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
@@ -5,6 +5,7 @@ import { ImportTokenRemoveConfirmationPo } from "$tests/page-objects/ImportToken
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
 import type { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
 
 describe("ImportTokenRemoveConfirmation", () => {
   const ledgerCanisterId = principal(1);
@@ -24,15 +25,14 @@ describe("ImportTokenRemoveConfirmation", () => {
     onClose?: () => void;
     onConfirm?: () => void;
   }) => {
-    const { container, component } = render(ImportTokenRemoveConfirmation, {
+    const { container } = render(ImportTokenRemoveConfirmation, {
       props: { tokenToRemove },
+      events: {
+        ...(nonNullish(onClose) && { nnsClose: onClose }),
+        ...(nonNullish(onConfirm) && { nnsConfirm: onConfirm }),
+      },
     });
-    if (onClose) {
-      component.$on("nnsClose", onClose);
-    }
-    if (onConfirm) {
-      component.$on("nnsConfirm", onConfirm);
-    }
+
     return ImportTokenRemoveConfirmationPo.under(
       new JestPageObjectElement(container)
     );

--- a/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
@@ -17,14 +17,16 @@ describe("ImportTokenReview", () => {
     indexCanisterId: Principal | undefined;
     tokenMetaData: IcrcTokenMetadata;
   }) => {
-    const { container, component } = render(ImportTokenReview, {
-      props,
-    });
-
-    const onConfirm = vi.fn();
-    component.$on("nnsConfirm", onConfirm);
     const onBack = vi.fn();
-    component.$on("nnsBack", onBack);
+    const onConfirm = vi.fn();
+
+    const { container } = render(ImportTokenReview, {
+      props,
+      events: {
+        nnsConfirm: onConfirm,
+        nnsBack: onBack,
+      },
+    });
 
     return {
       po: ImportTokenReviewPo.under(new JestPageObjectElement(container)),

--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -6,7 +6,7 @@ import {
 import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
-import { render } from "@testing-library/svelte";
+import { render as renderUtils } from "$tests/utils/svelte.test-utils";
 import type { Mock } from "vitest";
 
 describe("NnsDestinationAddress", () => {
@@ -36,10 +36,15 @@ describe("NnsDestinationAddress", () => {
   });
 
   const renderComponent = () => {
-    const { container, component } = render(NnsDestinationAddress);
-    component.$on("nnsAddress", (event) => {
-      onAccountSelectedSpy(event.detail);
+    const { container } = renderUtils(NnsDestinationAddress, {
+      props: {},
+      events: {
+        nnsAddress: (event) => {
+          onAccountSelectedSpy(event.detail);
+        },
+      },
     });
+
     return NnsDestinationAddressPo.under(new JestPageObjectElement(container));
   };
 

--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -6,7 +6,7 @@ import {
 import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
-import { render as renderUtils } from "$tests/utils/svelte.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import type { Mock } from "vitest";
 
 describe("NnsDestinationAddress", () => {
@@ -36,7 +36,7 @@ describe("NnsDestinationAddress", () => {
   });
 
   const renderComponent = () => {
-    const { container } = renderUtils(NnsDestinationAddress, {
+    const { container } = render(NnsDestinationAddress, {
       props: {},
       events: {
         nnsAddress: (event) => {

--- a/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -1,10 +1,10 @@
 import SelectCyclesCanister from "$lib/components/canisters/SelectCyclesCanister.svelte";
 import SelectCyclesCanisterTest from "$tests/lib/components/canisters/SelectCyclesCanisterTest.svelte";
 import en from "$tests/mocks/i18n.mock";
-import { render as renderUtils } from "$tests/utils/svelte.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
 
 vitest.mock("$lib/services/canisters.services", () => {
   return {
@@ -91,15 +91,12 @@ describe("SelectCyclesCanister", () => {
   it("dispatches nnsSelectAmount event on click", async () => {
     const fn = vitest.fn();
 
-    const { container, queryByTestId } = renderUtils(
-      SelectCyclesCanister,
-      {
-        props,
-        events: {
-          nnsSelectAmount: fn,
-        },
-      }
-    );
+    const { container, queryByTestId } = render(SelectCyclesCanister, {
+      props,
+      events: {
+        nnsSelectAmount: fn,
+      },
+    });
 
     const icpInputElement = container.querySelector<HTMLInputElement>(
       'input[name="icp-amount"]'

--- a/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -1,6 +1,7 @@
 import SelectCyclesCanister from "$lib/components/canisters/SelectCyclesCanister.svelte";
 import SelectCyclesCanisterTest from "$tests/lib/components/canisters/SelectCyclesCanisterTest.svelte";
 import en from "$tests/mocks/i18n.mock";
+import { render as renderUtils } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
@@ -88,9 +89,16 @@ describe("SelectCyclesCanister", () => {
   });
 
   it("dispatches nnsSelectAmount event on click", async () => {
-    const { container, component, queryByTestId } = render(
+    const fn = vitest.fn();
+
+    const { container, queryByTestId } = renderUtils(
       SelectCyclesCanister,
-      { props }
+      {
+        props,
+        events: {
+          nnsSelectAmount: fn,
+        },
+      }
     );
 
     const icpInputElement = container.querySelector<HTMLInputElement>(
@@ -103,8 +111,6 @@ describe("SelectCyclesCanister", () => {
         target: { value: 2 },
       }));
 
-    const fn = vitest.fn();
-    component.$on("nnsSelectAmount", fn);
     await clickByTestId(queryByTestId, "select-cycles-button");
 
     await waitFor(() => expect(fn).toBeCalled());

--- a/frontend/src/tests/lib/components/common/MaxButton.spec.ts
+++ b/frontend/src/tests/lib/components/common/MaxButton.spec.ts
@@ -1,6 +1,6 @@
 import MaxButton from "$lib/components/common/MaxButton.svelte";
-import { render as renderUtils } from "$tests/utils/svelte.test-utils";
-import { fireEvent, render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
+import { fireEvent } from "@testing-library/svelte";
 
 describe("MaxButton", () => {
   it("should render a button", () => {
@@ -15,7 +15,7 @@ describe("MaxButton", () => {
 
   it("should trigger on click event", () =>
     new Promise<void>((done) => {
-      const { container } = renderUtils(MaxButton, {
+      const { container } = render(MaxButton, {
         props: {},
         events: {
           click: () => done(),

--- a/frontend/src/tests/lib/components/common/MaxButton.spec.ts
+++ b/frontend/src/tests/lib/components/common/MaxButton.spec.ts
@@ -1,4 +1,5 @@
 import MaxButton from "$lib/components/common/MaxButton.svelte";
+import { render as renderUtils } from "$tests/utils/svelte.test-utils";
 import { fireEvent, render } from "@testing-library/svelte";
 
 describe("MaxButton", () => {
@@ -14,8 +15,12 @@ describe("MaxButton", () => {
 
   it("should trigger on click event", () =>
     new Promise<void>((done) => {
-      const { container, component } = render(MaxButton);
-      component.$on("click", () => done());
+      const { container } = renderUtils(MaxButton, {
+        props: {},
+        events: {
+          click: () => done(),
+        },
+      });
       const buttonElement = container.querySelector("button");
       buttonElement && fireEvent.click(buttonElement);
     }));

--- a/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
+++ b/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
@@ -1,9 +1,8 @@
 import TextInputFormTest from "$tests/lib/components/common/TextInputFormTest.svelte";
 import { TextInputFormPo } from "$tests/page-objects/TextInputForm.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { render as renderUtils } from "$tests/utils/svelte.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
-import { render } from "@testing-library/svelte";
 
 describe("TextInputForm", () => {
   const mandatoryProps = {
@@ -66,7 +65,7 @@ describe("TextInputForm", () => {
   it("should trigger nnsClose when cancel is clicked", () => {
     const callback = vi.fn();
 
-    const { getByTestId } = renderUtils(TextInputFormTest, {
+    const { getByTestId } = render(TextInputFormTest, {
       props: mandatoryProps,
       events: {
         nnsClose: callback,
@@ -80,7 +79,7 @@ describe("TextInputForm", () => {
   it("should trigger nnsConfirmText when confirm is clicked", () => {
     const callback = vi.fn();
 
-    const { getByTestId } = renderUtils(TextInputFormTest, {
+    const { getByTestId } = render(TextInputFormTest, {
       props: mandatoryProps,
       events: {
         nnsConfirmText: callback,

--- a/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
+++ b/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
@@ -1,6 +1,7 @@
 import TextInputFormTest from "$tests/lib/components/common/TextInputFormTest.svelte";
 import { TextInputFormPo } from "$tests/page-objects/TextInputForm.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render as renderUtils } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { render } from "@testing-library/svelte";
 
@@ -63,23 +64,29 @@ describe("TextInputForm", () => {
   });
 
   it("should trigger nnsClose when cancel is clicked", () => {
-    const { getByTestId, component } = render(TextInputFormTest, {
+    const callback = vi.fn();
+
+    const { getByTestId } = renderUtils(TextInputFormTest, {
       props: mandatoryProps,
+      events: {
+        nnsClose: callback,
+      },
     });
 
-    const callback = vi.fn();
-    component.$on("nnsClose", callback);
     clickByTestId(getByTestId, "cancel");
     expect(callback).toHaveBeenCalled();
   });
 
   it("should trigger nnsConfirmText when confirm is clicked", () => {
-    const { getByTestId, component } = render(TextInputFormTest, {
+    const callback = vi.fn();
+
+    const { getByTestId } = renderUtils(TextInputFormTest, {
       props: mandatoryProps,
+      events: {
+        nnsConfirmText: callback,
+      },
     });
 
-    const callback = vi.fn();
-    component.$on("nnsConfirmText", callback);
     clickByTestId(getByTestId, "confirm-text-input-screen-button");
     expect(callback).toHaveBeenCalled();
   });

--- a/frontend/src/tests/lib/components/header/LinkToCanisters.spec.ts
+++ b/frontend/src/tests/lib/components/header/LinkToCanisters.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "$mocks/$app/navigation";
 import { LinkToCanistersPo } from "$tests/page-objects/LinkToCanisters.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 
 describe("LinkToCanisters", () => {
   beforeEach(() => {
@@ -13,15 +13,19 @@ describe("LinkToCanisters", () => {
   });
 
   const renderComponent = () => {
-    const { container, component } = render(LinkToCanisters);
+    const onNnsClick = vi.fn();
+
+    const { container } = render(LinkToCanisters, {
+      props: {},
+      events: {
+        nnsLink: onNnsClick,
+      },
+    });
     const po = LinkToCanistersPo.under({
       element: new JestPageObjectElement(container),
     });
 
     container.addEventListener("click", mockLinkClickEvent);
-
-    const onNnsClick = vi.fn();
-    component.$on("nnsLink", onNnsClick);
 
     return { po, onNnsClick };
   };

--- a/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
@@ -2,21 +2,24 @@ import StakeItemAction from "$lib/components/neuron-detail/StakeItemAction.svelt
 import { mockToken, mockUniverse } from "$tests/mocks/sns-projects.mock";
 import { StakeItemActionPo } from "$tests/page-objects/StakeItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 
 describe("StakeItemAction", () => {
   const renderComponent = ({
     increaseStakeCallback = () => undefined,
     ...props
   }) => {
-    const { container, component } = render(StakeItemAction, {
-      universe: mockUniverse,
-      token: mockToken,
-      neuronStake: 123456789n,
-      ...props,
+    const { container } = render(StakeItemAction, {
+      props: {
+        universe: mockUniverse,
+        token: mockToken,
+        neuronStake: 123456789n,
+        ...props,
+      },
+      events: {
+        increaseStake: increaseStakeCallback,
+      },
     });
-
-    component.$on("increaseStake", increaseStakeCallback);
 
     return StakeItemActionPo.under(new JestPageObjectElement(container));
   };

--- a/frontend/src/tests/lib/components/neuron-detail/actions/ConfirmFollowingButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/ConfirmFollowingButton.spec.ts
@@ -5,10 +5,10 @@ import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { ConfirmFollowingButtonPo } from "$tests/page-objects/ConfirmFollowingButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore } from "@dfinity/gix-components";
 import { nonNullish } from "@dfinity/utils";
-import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("ConfirmFollowingButton", () => {
@@ -35,10 +35,19 @@ describe("ConfirmFollowingButton", () => {
     vi.spyOn(api, "refreshVotingPower").mockResolvedValue();
   });
 
-  const renderComponent = async ({ nnsComplete = undefined, ...props }) => {
-    const { container, component } = render(ConfirmFollowingButton, props);
-
-    if (nonNullish(nnsComplete)) component.$on("nnsComplete", nnsComplete);
+  const renderComponent = async ({
+    nnsComplete = undefined,
+    ...props
+  }: {
+    neuronIds: bigint[];
+    nnsComplete?: () => void;
+  }) => {
+    const { container } = render(ConfirmFollowingButton, {
+      props,
+      events: {
+        ...(nonNullish(nnsComplete) && { nnsComplete }),
+      },
+    });
 
     return ConfirmFollowingButtonPo.under(new JestPageObjectElement(container));
   };

--- a/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseStakeButton.spec.ts
@@ -1,16 +1,18 @@
 import IncreaseStakeButton from "$lib/components/neuron-detail/actions/IncreaseStakeButton.svelte";
 import { IncreaseStakeButtonPo } from "$tests/page-objects/IncreaseStakeButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 
 describe("IncreaseStakeButton", () => {
   const renderComponent = async ({
     increaseStakeCallback = () => undefined,
-    ...props
   }) => {
-    const { container, component } = render(IncreaseStakeButton, props);
-
-    component.$on("increaseStake", increaseStakeCallback);
+    const { container } = render(IncreaseStakeButton, {
+      props: {},
+      events: {
+        increaseStake: increaseStakeCallback,
+      },
+    });
 
     return IncreaseStakeButtonPo.under(new JestPageObjectElement(container));
   };

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
@@ -1,6 +1,7 @@
 import FollowTopicsSection from "$lib/components/neurons/FollowTopicSection.svelte";
 import FollowTopicsSectionTest from "$tests/lib/components/neurons/FollowTopicSectionTest.svelte";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
+import { fireEvent, waitFor } from "@testing-library/svelte";
 
 describe("FollowTopicsSection", () => {
   const title = "title";
@@ -31,14 +32,18 @@ describe("FollowTopicsSection", () => {
   });
 
   it("triggers open event", async () => {
-    const { queryByTestId, component } = render(FollowTopicsSection, {
+    const openSpy = vi.fn();
+
+    const { queryByTestId } = render(FollowTopicsSection, {
       props: {
         id: "3",
         count: 4,
       },
+      events: {
+        nnsOpen: openSpy,
+      },
     });
-    const openSpy = vi.fn();
-    component.$on("nnsOpen", openSpy);
+
     const button = queryByTestId("open-new-followee-modal");
     button && fireEvent.click(button);
 

--- a/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardNeuronsModal.spec.ts
@@ -12,10 +12,10 @@ import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { LosingRewardNeuronsModalPo } from "$tests/page-objects/LosingRewardNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { nonNullish } from "@dfinity/utils";
-import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("LosingRewardNeuronsModal", () => {
@@ -74,16 +74,15 @@ describe("LosingRewardNeuronsModal", () => {
     withNeuronNavigation?: boolean;
     onClose?: () => void;
   } = {}) => {
-    const { container, component } = render(LosingRewardNeuronsModal, {
+    const { container } = render(LosingRewardNeuronsModal, {
       props: {
         neurons,
         withNeuronNavigation,
       },
+      events: {
+        ...(nonNullish(onClose) && { nnsClose: onClose }),
+      },
     });
-
-    if (nonNullish(onClose)) {
-      component.$on("nnsClose", onClose);
-    }
 
     return LosingRewardNeuronsModalPo.under(
       new JestPageObjectElement(container)

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -17,9 +17,10 @@ import {
   resetAccountsForTesting,
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import type { Neuron } from "@dfinity/nns";
 import { NeuronState, NeuronType } from "@dfinity/nns";
-import { fireEvent, render } from "@testing-library/svelte";
+import { fireEvent } from "@testing-library/svelte";
 
 describe("NnsNeuronCard", () => {
   const nowInSeconds = 1689843195;
@@ -42,12 +43,14 @@ describe("NnsNeuronCard", () => {
 
   it("is clickable", async () => {
     const spyClick = vi.fn();
-    const { container, component } = render(NnsNeuronCard, {
+    const { container } = render(NnsNeuronCard, {
       props: {
         neuron: mockNeuron,
       },
+      events: {
+        click: spyClick,
+      },
     });
-    component.$on("click", spyClick);
 
     const articleElement = container.querySelector("article");
 
@@ -57,7 +60,7 @@ describe("NnsNeuronCard", () => {
   });
 
   it("renders role and aria-label passed", async () => {
-    const role = "link";
+    const role = "button";
     const ariaLabel = "test label";
     const { container } = render(NnsNeuronCard, {
       props: {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -5,7 +5,8 @@ import { formatVotingPower } from "$lib/utils/neuron.utils";
 import { mockVoteRegistration } from "$tests/mocks/proposal.mock";
 import { Vote } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 
 describe("VotingConfirmationToolbar", () => {
   const votingPower = 10_000_000_000n;
@@ -101,10 +102,15 @@ describe("VotingConfirmationToolbar", () => {
   });
 
   it("should hide confirmation and dispatch on confirm", async () => {
-    const { component, container } = render(VotingConfirmationToolbar);
-    let calledVoteType: Vote = Vote.Unspecified;
     const onConfirm = vi.fn((ev) => (calledVoteType = ev?.detail?.voteType));
-    component.$on("nnsConfirm", onConfirm);
+
+    const { container } = render(VotingConfirmationToolbar, {
+      props: {},
+      events: {
+        nnsConfirm: onConfirm
+      }
+    });
+    let calledVoteType: Vote = Vote.Unspecified;
 
     await fireEvent.click(
       container.querySelector('[data-tid="vote-no"]') as Element

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -3,10 +3,10 @@ import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import type { VotingNeuron } from "$lib/types/proposals";
 import { formatVotingPower } from "$lib/utils/neuron.utils";
 import { mockVoteRegistration } from "$tests/mocks/proposal.mock";
+import { render } from "$tests/utils/svelte.test-utils";
 import { Vote } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
 import { waitFor } from "@testing-library/svelte";
-import { render } from "$tests/utils/svelte.test-utils";
 
 describe("VotingConfirmationToolbar", () => {
   const votingPower = 10_000_000_000n;
@@ -107,8 +107,8 @@ describe("VotingConfirmationToolbar", () => {
     const { container } = render(VotingConfirmationToolbar, {
       props: {},
       events: {
-        nnsConfirm: onConfirm
-      }
+        nnsConfirm: onConfirm,
+      },
     });
     let calledVoteType: Vote = Vote.Unspecified;
 

--- a/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
@@ -8,10 +8,11 @@ import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { ReportingNeuronsButtonPo } from "$tests/page-objects/ReportingNeuronsButon.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore } from "@dfinity/gix-components";
 import type { NeuronInfo } from "@dfinity/nns";
-import { render } from "@testing-library/svelte";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/governance.api");
@@ -52,15 +53,19 @@ describe("ReportingNeuronsButton", () => {
   });
 
   const renderComponent = ({ onTrigger }: { onTrigger?: () => void } = {}) => {
-    const { container, component } = render(ReportingNeuronsButton);
+    const { container } = render(ReportingNeuronsButton, {
+      props: {},
+      events: {
+        ...(nonNullish(onTrigger) && {
+          nnsExportNeuronsCsvTriggered: onTrigger,
+        }),
+      },
+    });
 
     const po = ReportingNeuronsButtonPo.under({
       element: new JestPageObjectElement(container),
     });
 
-    if (onTrigger) {
-      component.$on("nnsExportNeuronsCsvTriggered", onTrigger);
-    }
     return po;
   };
 

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -18,10 +18,11 @@ import {
   resetAccountsForTesting,
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore } from "@dfinity/gix-components";
 import type { NeuronInfo } from "@dfinity/nns";
-import { render } from "@testing-library/svelte";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/icp-ledger.api");
@@ -80,16 +81,20 @@ describe("ReportingTransactionsButton", () => {
       period,
     }: { onTrigger?: () => void; period: ReportingPeriod } = { period: "all" }
   ) => {
-    const { container, component } = render(ReportingTransactionsButton, {
-      period,
+    const { container } = render(ReportingTransactionsButton, {
+      props: {
+        period,
+      },
+      events: {
+        ...(nonNullish(onTrigger) && {
+          nnsExportIcpTransactionsCsvTriggered: onTrigger,
+        }),
+      },
     });
     const po = ReportingTransactionsButtonPo.under({
       element: new JestPageObjectElement(container),
     });
 
-    if (onTrigger) {
-      component.$on("nnsExportIcpTransactionsCsvTriggered", onTrigger);
-    }
     return po;
   };
 

--- a/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
@@ -6,9 +6,9 @@ import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { ConfirmSnsDissolveDelayPo } from "$tests/page-objects/ConfirmSnsDissolveDelay.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import { nonNullish } from "@dfinity/utils";
-import { render } from "@testing-library/svelte";
 
 describe("ConfirmSnsDissolveDelay", () => {
   const delayInSeconds = Math.round(12.3 * SECONDS_IN_DAY);
@@ -29,13 +29,14 @@ describe("ConfirmSnsDissolveDelay", () => {
     onNnsBack = null,
     onNnsConfirm = null,
   }) => {
-    const { container, component } = render(ConfirmSnsDissolveDelay, props);
-    if (nonNullish(onNnsBack)) {
-      component.$on("nnsBack", onNnsBack);
-    }
-    if (nonNullish(onNnsConfirm)) {
-      component.$on("nnsConfirm", onNnsConfirm);
-    }
+    const { container } = render(ConfirmSnsDissolveDelay, {
+      props,
+      events: {
+        ...(nonNullish(onNnsBack) && { nnsBack: onNnsBack }),
+        ...(nonNullish(onNnsConfirm) && { nnsConfirm: onNnsConfirm }),
+      },
+    });
+
     return ConfirmSnsDissolveDelayPo.under(
       new JestPageObjectElement(container)
     );

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -28,12 +28,15 @@ describe("ProjectsTable", () => {
   const snsTokenSymbol = "TOK";
 
   const renderComponent = ({ onNnsStakeTokens = null } = {}) => {
-    const { container, component } = render(ProjectsTable);
-    if (nonNullish(onNnsStakeTokens)) {
-      component.$on("nnsStakeTokens", ({ detail }) =>
-        onNnsStakeTokens({ detail })
-      );
-    }
+    const { container } = render(ProjectsTable, {
+      props: {},
+      events: {
+        ...(nonNullish(onNnsStakeTokens) && {
+          nnsStakeTokens: ({ detail }) => onNnsStakeTokens({ detail }),
+        }),
+      },
+    });
+
     return ProjectsTablePo.under(new JestPageObjectElement(container));
   };
 

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -19,8 +19,9 @@ import {
 import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { createActionEvent } from "$tests/utils/actions.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
 
 describe("TokensTable", () => {
@@ -33,11 +34,12 @@ describe("TokensTable", () => {
     firstColumnHeader?: string;
     onAction?: Mock;
   }) => {
-    const { container, component } = render(TokensTable, {
+    const { container } = render(TokensTable, {
       props: { userTokensData, firstColumnHeader },
+      events: {
+        nnsAction: onAction,
+      },
     });
-
-    component.$on("nnsAction", onAction);
 
     return TokensTablePo.under(new JestPageObjectElement(container));
   };

--- a/frontend/src/tests/lib/components/ui/AmountInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/AmountInput.spec.ts
@@ -4,7 +4,8 @@ import en from "$tests/mocks/i18n.mock";
 import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
 import { AmountInputPo } from "$tests/page-objects/AmountInput.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { fireEvent, render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
+import { fireEvent } from "@testing-library/svelte";
 
 describe("AmountInput", () => {
   const props = { amount: 10.25, max: 11 };
@@ -27,8 +28,12 @@ describe("AmountInput", () => {
 
   it("should trigger max value", () =>
     new Promise<void>((done) => {
-      const { container, component } = render(AmountInput, { props });
-      component.$on("nnsMax", () => done());
+      const { container } = render(AmountInput, {
+        props,
+        events: {
+          nnsMax: () => done(),
+        },
+      });
 
       const button: HTMLButtonElement = container.querySelector(
         "button"

--- a/frontend/src/tests/lib/components/ui/Banner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Banner.spec.ts
@@ -2,19 +2,19 @@ import BannerTest from "$tests/lib/components/ui/BannerTest.svelte";
 import { BannerPo } from "$tests/page-objects/Banner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
+import { nonNullish } from "@dfinity/utils";
 
 describe("Banner", () => {
   const renderComponent = ({
     props = {},
     onClose,
   }: { props?: unknown; onClose?: () => void } = {}) => {
-    const { container, component } = render(BannerTest, {
+    const { container } = render(BannerTest, {
       props,
+      events: {
+        ...(nonNullish(onClose) && { nnsClose: onClose }),
+      },
     });
-
-    if (onClose) {
-      component.$on("nnsClose", onClose);
-    }
 
     return BannerPo.under(new JestPageObjectElement(container));
   };

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -1,5 +1,9 @@
 import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
-import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+import type {
+  ResponsiveTableColumn,
+  ResponsiveTableOrder,
+  ResponsiveTableRowData,
+} from "$lib/types/responsive-table";
 import { createAscendingComparator } from "$lib/utils/sort.utils";
 import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
 import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
@@ -79,13 +83,32 @@ describe("ResponsiveTable", () => {
     });
   });
 
-  const renderComponent = ({ onNnsAction = null, ...props }) => {
-    const { container, component } = render(ResponsiveTable, props);
-    if (nonNullish(onNnsAction)) {
-      component.$on("nnsAction", ({ detail }) => {
-        onNnsAction({ detail });
-      });
-    }
+  interface RenderComponentProps {
+    testId?: string;
+    tableData: ResponsiveTableRowData[];
+    columns: ResponsiveTableColumn<TestRowData>[];
+    order?: ResponsiveTableOrder;
+    gridRowsPerTableRow?: number;
+    getRowStyle?: (rowData: ResponsiveTableRowData) => string;
+  }
+
+  const renderComponent = ({
+    onNnsAction = null,
+    ...props
+  }: RenderComponentProps & {
+    onNnsAction?: ({ detail }: { detail: unknown }) => void;
+  }) => {
+    const { container } = render(ResponsiveTable, {
+      props,
+      events: {
+        ...(nonNullish(onNnsAction) && {
+          onNnsAction: ({ detail }) => {
+            onNnsAction({ detail });
+          },
+        }),
+      },
+    });
+
     return ResponsiveTablePo.under(new JestPageObjectElement(container));
   };
 

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -102,7 +102,7 @@ describe("ResponsiveTable", () => {
       props,
       events: {
         ...(nonNullish(onNnsAction) && {
-          onNnsAction: ({ detail }) => {
+          nnsAction: ({ detail }) => {
             onNnsAction({ detail });
           },
         }),

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -10,8 +10,9 @@ import { mockSnsFullProject, principal } from "$tests/mocks/sns-projects.mock";
 import { SelectUniverseListPo } from "$tests/page-objects/SelectUniverseList.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { Principal } from "@dfinity/principal";
-import { render } from "@testing-library/svelte";
+import { nonNullish } from "@dfinity/utils";
 
 describe("SelectUniverseList", () => {
   const projects = [
@@ -24,10 +25,13 @@ describe("SelectUniverseList", () => {
   ];
 
   const renderComponent = ({ onSelect }: { onSelect?: () => void } = {}) => {
-    const { container, component } = render(SelectUniverseList);
-    if (onSelect) {
-      component.$on("nnsSelectUniverse", onSelect);
-    }
+    const { container } = render(SelectUniverseList, {
+      props: {},
+      events: {
+        ...(nonNullish(onSelect) && { nnsSelectUniverse: onSelect }),
+      },
+    });
+
     return SelectUniverseListPo.under(new JestPageObjectElement(container));
   };
 

--- a/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -223,7 +223,6 @@ describe("AddAccountModal", () => {
 
   const shouldAttachWallet = async ({
     getByTestId,
-    component,
   }: RenderResult<SvelteComponent>) => {
     const connect = getByTestId("ledger-connect-button") as HTMLButtonElement;
 
@@ -237,21 +236,25 @@ describe("AddAccountModal", () => {
 
     const attach = getByTestId("ledger-attach-button") as HTMLButtonElement;
 
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
-
     fireEvent.click(attach);
-
-    await waitFor(() => expect(onClose).toBeCalled());
   };
 
   it("should attach wallet to new account ", async () => {
-    const renderResult = await renderModal({ component: AddAccountModal });
+    const onClose = vi.fn();
+
+    const renderResult = await renderModal({
+      component: AddAccountModal,
+      events: {
+        nnsClose: onClose,
+      },
+    });
 
     await shouldNavigateHardwareWalletStep(renderResult);
 
     await shouldNavigateHardwareWalletConnect(renderResult);
 
     await shouldAttachWallet(renderResult);
+
+    await waitFor(() => expect(onClose).toBeCalled());
   });
 });

--- a/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -8,12 +8,13 @@ import type { SvelteComponent } from "svelte";
 describe("AddControllerModal", () => {
   const reloadMock = vi.fn();
 
-  const renderAddControllerModal = async (): Promise<
-    RenderResult<SvelteComponent>
-  > => {
+  const renderAddControllerModal = async (
+    events?: Record<string, ($event: CustomEvent) => void>
+  ): Promise<RenderResult<SvelteComponent>> => {
     return renderModal({
       component: AddControllerModal,
       props: { reloadDetails: reloadMock },
+      events,
     });
   };
 
@@ -31,8 +32,12 @@ describe("AddControllerModal", () => {
 
   it("should call addController service and close modal", async () => {
     const principalString = "aaaaa-aa";
-    const { container, queryByTestId, component } =
-      await renderAddControllerModal();
+    const onClose = vi.fn();
+
+    const { container, queryByTestId } =
+      await renderAddControllerModal({
+        nnsClose: onClose,
+      });
 
     const inputElement = container.querySelector("input[type='text']");
     expect(inputElement).not.toBeNull();
@@ -57,8 +62,6 @@ describe("AddControllerModal", () => {
     );
     expect(confirmButton).not.toBeNull();
 
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
     confirmButton && (await fireEvent.click(confirmButton));
 
     expect(addController).toBeCalled();

--- a/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -34,10 +34,9 @@ describe("AddControllerModal", () => {
     const principalString = "aaaaa-aa";
     const onClose = vi.fn();
 
-    const { container, queryByTestId } =
-      await renderAddControllerModal({
-        nnsClose: onClose,
-      });
+    const { container, queryByTestId } = await renderAddControllerModal({
+      nnsClose: onClose,
+    });
 
     const inputElement = container.querySelector("input[type='text']");
     expect(inputElement).not.toBeNull();

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -107,8 +107,8 @@ describe("AddCyclesModal", () => {
       component: AddCyclesModalTest,
       props,
       events: {
-        nnsClose: done
-      }
+        nnsClose: done,
+      },
     });
     // Wait for the onMount to load the conversion rate
     await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -101,9 +101,14 @@ describe("AddCyclesModal", () => {
   });
 
   const testTopUp = async (selectedAccount = mockMainAccount) => {
-    const { queryByTestId, container, component } = await renderModal({
+    const done = vi.fn();
+
+    const { queryByTestId, container } = await renderModal({
       component: AddCyclesModalTest,
       props,
+      events: {
+        nnsClose: done
+      }
     });
     // Wait for the onMount to load the conversion rate
     await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
@@ -135,9 +140,6 @@ describe("AddCyclesModal", () => {
         queryByTestId("confirm-cycles-canister-screen")
       ).toBeInTheDocument()
     );
-
-    const done = vi.fn();
-    component.$on("nnsClose", done);
 
     expect(get(toastsStore)).toEqual([]);
 

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -78,10 +78,14 @@ describe("CreateCanisterModal", () => {
     canisterName,
     selectedAccount = undefined,
   }) => {
-    const { queryByTestId, container, component, queryByText } =
-      await renderModal({
-        component: CreateCanisterModal,
-      });
+    const done = vi.fn();
+
+    const { queryByTestId, container, queryByText } = await renderModal({
+      component: CreateCanisterModal,
+      events: {
+        nnsClose: done,
+      },
+    });
     await selectAccountGoToNameForm({
       container,
       queryByTestId,
@@ -134,9 +138,6 @@ describe("CreateCanisterModal", () => {
     if (canisterName.length > 0) {
       expect(queryByText(canisterName)).toBeInTheDocument();
     }
-
-    const done = vi.fn();
-    component.$on("nnsClose", done);
 
     expect(get(toastsStore)).toEqual([]);
 

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -45,7 +45,7 @@ describe("LinkCanisterModal", () => {
   it("should attach a canister by id and close modal", async () => {
     const onClose = vi.fn();
 
-    const { queryByTestId, container, component } = await renderModal({
+    const { queryByTestId, container } = await renderModal({
       component: LinkCanisterModal,
       events: {
         nnsClose: onClose,

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -43,8 +43,13 @@ describe("LinkCanisterModal", () => {
   };
 
   it("should attach a canister by id and close modal", async () => {
+    const onClose = vi.fn();
+
     const { queryByTestId, container, component } = await renderModal({
       component: LinkCanisterModal,
+      events: {
+        nnsClose: onClose,
+      },
     });
 
     await fillForm({
@@ -52,9 +57,6 @@ describe("LinkCanisterModal", () => {
       name: "test",
       principalText: "aaaaa-aa",
     });
-
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
 
     expect(attachCanister).not.toBeCalled();
     await clickByTestId(queryByTestId, "link-canister-button");
@@ -80,12 +82,14 @@ describe("LinkCanisterModal", () => {
   });
 
   it("should close modal on cancel", async () => {
-    const { queryByTestId, component } = await renderModal({
-      component: LinkCanisterModal,
-    });
-
     const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
+
+    const { queryByTestId } = await renderModal({
+      component: LinkCanisterModal,
+      events: {
+        nnsClose: onClose,
+      },
+    });
 
     await clickByTestId(queryByTestId, "cancel-button");
     await waitFor(() => expect(onClose).toBeCalled());

--- a/frontend/src/tests/lib/modals/common/ConfirmationModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ConfirmationModal.spec.ts
@@ -1,7 +1,8 @@
 import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
 import ConfirmationModalTest from "$tests/lib/modals/common/ConfirmationModalTest.svelte";
 import en from "$tests/mocks/i18n.mock";
-import { fireEvent, render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
+import { fireEvent } from "@testing-library/svelte";
 
 const yesButtonText = en.core.confirm_yes;
 const noButtonText = en.core.confirm_no;
@@ -20,13 +21,15 @@ describe("ConfirmationModal", () => {
 
   it("should provide custom yesLabel", () => {
     const yesLabel = "yes label for test";
-    const { getByText, component } = render(ConfirmationModal, {
+    const spyNnsConfirm = vi.fn();
+    const { getByText } = render(ConfirmationModal, {
       props: {
         yesLabel,
       },
+      events: {
+        nnsConfirm: spyNnsConfirm,
+      },
     });
-    const spyNnsConfirm = vi.fn();
-    component.$on("nnsConfirm", spyNnsConfirm);
 
     expect(spyNnsConfirm).toBeCalledTimes(0);
     fireEvent.click(getByText(yesLabel));
@@ -35,15 +38,25 @@ describe("ConfirmationModal", () => {
 
   it("should trigger nnsClose", () =>
     new Promise<void>((done) => {
-      const { getByText, component } = render(ConfirmationModal);
-      component.$on("nnsClose", () => done());
+      const { getByText } = render(ConfirmationModal, {
+        props: {},
+        events: {
+          nnsClose: () => done(),
+        },
+      });
+
       fireEvent.click(getByText(noButtonText));
     }));
 
   it("should trigger nnsConfirm", () =>
     new Promise<void>((done) => {
-      const { getByText, component } = render(ConfirmationModal);
-      component.$on("nnsConfirm", () => done());
+      const { getByText } = render(ConfirmationModal, {
+        props: {},
+        events: {
+          nnsConfirm: () => done(),
+        },
+      });
+
       fireEvent.click(getByText(yesButtonText));
     }));
 });

--- a/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
@@ -1,6 +1,7 @@
 import FilterModal from "$lib/modals/common/FilterModal.svelte";
 import FilterModalTest from "$tests/lib/modals/common/FilterModalTest.svelte";
-import { fireEvent, render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
+import { fireEvent } from "@testing-library/svelte";
 
 describe("FilterModal", () => {
   const filters = [
@@ -46,12 +47,11 @@ describe("FilterModal", () => {
 
   it("should forward close modal event", () =>
     new Promise<void>((done) => {
-      const { queryByTestId, component } = render(FilterModal, {
+      const { queryByTestId } = render(FilterModal, {
         props,
-      });
-
-      component.$on("nnsClose", () => {
-        done();
+        events: {
+          nnsClose: () => done(),
+        },
       });
 
       const button = queryByTestId("close");
@@ -60,12 +60,11 @@ describe("FilterModal", () => {
 
   it("should trigger nnsChange event when checkbox is clicked", () =>
     new Promise<void>((done) => {
-      const { container, component } = render(FilterModal, {
+      const { container } = render(FilterModal, {
         props,
-      });
-
-      component.$on("nnsChange", () => {
-        done();
+        events: {
+          nnsChange: () => done(),
+        },
       });
 
       const checkboxes = container.querySelectorAll("input[type=checkbox]");
@@ -74,12 +73,11 @@ describe("FilterModal", () => {
 
   it("should trigger nnsConfirm event when primary button is clicked", () =>
     new Promise<void>((done) => {
-      const { queryByTestId, component } = render(FilterModal, {
+      const { queryByTestId } = render(FilterModal, {
         props,
-      });
-
-      component.$on("nnsConfirm", () => {
-        done();
+        events: {
+          nnsConfirm: () => done(),
+        },
       });
 
       const button = queryByTestId("apply-filters");
@@ -88,12 +86,11 @@ describe("FilterModal", () => {
 
   it("should trigger nnsSelectAll when select all button is clicked", () =>
     new Promise<void>((done) => {
-      const { queryByTestId, component } = render(FilterModal, {
+      const { queryByTestId } = render(FilterModal, {
         props,
-      });
-
-      component.$on("nnsSelectAll", () => {
-        done();
+        events: {
+          nnsSelectAll: () => done(),
+        },
       });
 
       const button = queryByTestId("filter-modal-select-all");
@@ -102,12 +99,11 @@ describe("FilterModal", () => {
 
   it("should trigger nnsClearSelection when clear button is clicked", () =>
     new Promise<void>((done) => {
-      const { queryByTestId, component } = render(FilterModal, {
+      const { queryByTestId } = render(FilterModal, {
         props,
-      });
-
-      component.$on("nnsClearSelection", () => {
-        done();
+        events: {
+          nnsClearSelection: () => done(),
+        },
       });
 
       const button = queryByTestId("filter-modal-clear");

--- a/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
@@ -8,8 +8,8 @@ import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
 import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
 import { ResponsiveTableSortModalPo } from "$tests/page-objects/ResponsiveTableSortModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { advanceTime } from "$tests/utils/timers.test-utils";
-import { render } from "@testing-library/svelte";
 import { get, writable, type Writable } from "svelte/store";
 
 describe("ResponsiveTableSortModal", () => {
@@ -53,12 +53,16 @@ describe("ResponsiveTableSortModal", () => {
     onClose?: () => void;
   }) => {
     const { container, component } = render(ResponsiveTableSortModal, {
-      columns,
-      order,
-    });
-    component.$on("nnsClose", () => {
-      orderStore?.set(component.$$.ctx[component.$$.props["order"]]);
-      onClose?.();
+      props: {
+        columns,
+        order,
+      },
+      events: {
+        nnsClose: () => {
+          orderStore?.set(component.$$.ctx[component.$$.props["order"]]);
+          onClose?.();
+        },
+      },
     });
 
     return ResponsiveTableSortModalPo.under(

--- a/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
@@ -14,7 +14,7 @@ vi.mock("$lib/services/neurons.services", () => {
 });
 
 describe("AddHotkeyModal", () => {
-  const renderAddHotkeyModal = async (): Promise<
+  const renderAddHotkeyModal = async (events?: Record<string, ($event: CustomEvent) => void>): Promise<
     RenderResult<SvelteComponent>
   > => {
     return renderModal({
@@ -80,8 +80,12 @@ describe("AddHotkeyModal", () => {
 
   it("should call addHotkey service and close modal", async () => {
     const principalString = "aaaaa-aa";
-    const { container, queryByTestId, component } =
-      await renderAddHotkeyModal();
+    const onClose = vi.fn();
+
+    const { container, queryByTestId } =
+      await renderAddHotkeyModal({
+        nnsClose: onClose
+      });
 
     const inputElement = container.querySelector("input[type='text']");
     expect(inputElement).not.toBeNull();
@@ -94,8 +98,6 @@ describe("AddHotkeyModal", () => {
     const buttonElement = queryByTestId("add-principal-button");
     expect(buttonElement).not.toBeNull();
 
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
     buttonElement && (await fireEvent.click(buttonElement));
     expect(addHotkey).toBeCalled();
 

--- a/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
@@ -20,7 +20,7 @@ describe("AddHotkeyModal", () => {
     return renderModal({
       component: AddHotkeyModal,
       props: { neuron: mockNeuron },
-      events
+      events,
     });
   };
 

--- a/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
@@ -14,12 +14,13 @@ vi.mock("$lib/services/neurons.services", () => {
 });
 
 describe("AddHotkeyModal", () => {
-  const renderAddHotkeyModal = async (events?: Record<string, ($event: CustomEvent) => void>): Promise<
-    RenderResult<SvelteComponent>
-  > => {
+  const renderAddHotkeyModal = async (
+    events?: Record<string, ($event: CustomEvent) => void>
+  ): Promise<RenderResult<SvelteComponent>> => {
     return renderModal({
       component: AddHotkeyModal,
       props: { neuron: mockNeuron },
+      events
     });
   };
 
@@ -82,10 +83,9 @@ describe("AddHotkeyModal", () => {
     const principalString = "aaaaa-aa";
     const onClose = vi.fn();
 
-    const { container, queryByTestId } =
-      await renderAddHotkeyModal({
-        nnsClose: onClose
-      });
+    const { container, queryByTestId } = await renderAddHotkeyModal({
+      nnsClose: onClose,
+    });
 
     const inputElement = container.querySelector("input[type='text']");
     expect(inputElement).not.toBeNull();

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -14,10 +14,10 @@ import { mockFullNeuron } from "$tests/mocks/neurons.mock";
 import { ChangeBulkNeuronVisibilityFormPo } from "$tests/page-objects/ChangeBulkNeuronVisibilityForm.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { NeuronType, NeuronVisibility, type NeuronInfo } from "@dfinity/nns";
 import { nonNullish } from "@dfinity/utils";
-import { render } from "@testing-library/svelte";
 
 describe("ChangeBulkNeuronVisibilityForm", () => {
   const createMockNeuron = ({
@@ -132,21 +132,20 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
       | null;
     onNnsCancel?: (() => void) | null;
   }) => {
-    const { container, component } = render(ChangeBulkNeuronVisibilityForm, {
+    const { container } = render(ChangeBulkNeuronVisibilityForm, {
       props: {
         defaultSelectedNeuron,
         makePublic: makePublic,
       },
+      events: {
+        ...(nonNullish(onNnsSubmit) && {
+          nnsSubmit: ({ detail }) => {
+            onNnsSubmit({ detail });
+          },
+        }),
+        ...(nonNullish(onNnsCancel) && { nnsCancel: onNnsCancel }),
+      },
     });
-
-    if (nonNullish(onNnsSubmit)) {
-      component.$on("nnsSubmit", ({ detail }) => {
-        onNnsSubmit({ detail });
-      });
-    }
-    if (nonNullish(onNnsCancel)) {
-      component.$on("nnsCancel", onNnsCancel);
-    }
 
     return ChangeBulkNeuronVisibilityFormPo.under(
       new JestPageObjectElement(container)

--- a/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
@@ -79,7 +79,7 @@ describe("ChangeNeuronVisibilityModal", () => {
   const renderComponent = async (neuron = mockNeuron) => {
     const nnsClose = vi.fn();
 
-    const { container, component } = await renderModal({
+    const { container } = await renderModal({
       component: ChangeNeuronVisibilityModal,
       props: {
         defaultSelectedNeuron: neuron,

--- a/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeNeuronVisibilityModal.spec.ts
@@ -77,16 +77,18 @@ describe("ChangeNeuronVisibilityModal", () => {
   let stopBusySpy;
 
   const renderComponent = async (neuron = mockNeuron) => {
+    const nnsClose = vi.fn();
+
     const { container, component } = await renderModal({
       component: ChangeNeuronVisibilityModal,
       props: {
         defaultSelectedNeuron: neuron,
         makePublic: !isPublicNeuron(neuron),
       },
+      events: {
+        nnsClose,
+      },
     });
-
-    const nnsClose = vi.fn();
-    component.$on("nnsClose", nnsClose);
 
     return {
       po: ChangeNeuronVisibilityModalPo.under(

--- a/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
@@ -5,8 +5,9 @@ import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { FollowNeuronsModalPo } from "$tests/page-objects/FollowNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { Topic } from "@dfinity/nns";
-import { render } from "@testing-library/svelte";
+import { nonNullish } from "@dfinity/utils";
 
 describe("FollowNeuronsModal", () => {
   const neuronFollowing = {
@@ -35,14 +36,14 @@ describe("FollowNeuronsModal", () => {
   });
 
   const renderComponent = ({ onClose }: { onClose?: () => void }) => {
-    const { container, component } = render(FollowNeuronsModal, {
+    const { container } = render(FollowNeuronsModal, {
       props: {
         neuronId: neuronFollowing.neuronId,
       },
+      events: {
+        ...(nonNullish(onClose) && { nnsClose: onClose }),
+      },
     });
-    if (onClose) {
-      component.$on("nnsClose", onClose);
-    }
 
     return FollowNeuronsModalPo.under(new JestPageObjectElement(container));
   };

--- a/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
@@ -2,8 +2,8 @@ import NeuronVisibilityRow from "$lib/modals/neurons/NeuronVisibilityRow.svelte"
 import type { NeuronVisibilityRowData } from "$lib/types/neuron-visibility-row";
 import { NeuronVisibilityRowPo } from "$tests/page-objects/NeuronVisibilityRow.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
-import { render } from "@testing-library/svelte";
 
 describe("NeuronVisibilityRow", () => {
   const renderComponent = ({
@@ -16,11 +16,12 @@ describe("NeuronVisibilityRow", () => {
     disabled?: boolean;
   }) => {
     const nnsChangeMock = vi.fn();
-    const { container, component } = render(NeuronVisibilityRow, {
+    const { container } = render(NeuronVisibilityRow, {
       props: { rowData, checked, disabled },
+      events: {
+        nnsChange: nnsChangeMock,
+      },
     });
-
-    component.$on("nnsChange", nnsChangeMock);
 
     const po = NeuronVisibilityRowPo.under({
       element: new JestPageObjectElement(container),

--- a/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
@@ -8,10 +8,10 @@ import {
   mockKnownNeuron,
   mockNeuron,
 } from "$tests/mocks/neurons.mock";
+import { render } from "$tests/utils/svelte.test-utils";
 import { Topic } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
 import { waitFor } from "@testing-library/svelte";
-import { render } from "$tests/utils/svelte.test-utils";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {
@@ -62,8 +62,8 @@ describe("NewFolloweeModal", () => {
     const { container } = render(NewFolloweeModal, {
       props: { neuron: mockNeuron, topic: Topic.Unspecified },
       events: {
-        nnsClose: onClose
-      }
+        nnsClose: onClose,
+      },
     });
 
     const inputElement: HTMLInputElement | null = container.querySelector(
@@ -120,8 +120,8 @@ describe("NewFolloweeModal", () => {
     const { queryAllByTestId } = render(NewFolloweeModal, {
       props: { neuron: mockNeuron, topic: Topic.Unspecified },
       events: {
-        nnsClose: onClose
-      }
+        nnsClose: onClose,
+      },
     });
 
     const knownNeuronElements = queryAllByTestId("known-neuron-item");
@@ -148,8 +148,8 @@ describe("NewFolloweeModal", () => {
     const { queryByTestId } = render(NewFolloweeModal, {
       props: { neuron: followingNeuron, topic: Topic.Unspecified },
       events: {
-        nnsClose: onClose
-      }
+        nnsClose: onClose,
+      },
     });
 
     const knownNeuronElement = queryByTestId(

--- a/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
@@ -10,7 +10,8 @@ import {
 } from "$tests/mocks/neurons.mock";
 import { Topic } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {
@@ -56,8 +57,13 @@ describe("NewFolloweeModal", () => {
   });
 
   it("adds a followee from a valid address", async () => {
-    const { container, component } = render(NewFolloweeModal, {
+    const onClose = vi.fn();
+
+    const { container } = render(NewFolloweeModal, {
       props: { neuron: mockNeuron, topic: Topic.Unspecified },
+      events: {
+        nnsClose: onClose
+      }
     });
 
     const inputElement: HTMLInputElement | null = container.querySelector(
@@ -70,9 +76,6 @@ describe("NewFolloweeModal", () => {
 
     const formElement = container.querySelector("form");
     expect(formElement).toBeInTheDocument();
-
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
 
     formElement && (await fireEvent.submit(formElement));
 
@@ -111,8 +114,14 @@ describe("NewFolloweeModal", () => {
 
   it("follow known neurons", async () => {
     knownNeuronsStore.setNeurons([mockKnownNeuron]);
-    const { queryAllByTestId, component } = render(NewFolloweeModal, {
+
+    const onClose = vi.fn();
+
+    const { queryAllByTestId } = render(NewFolloweeModal, {
       props: { neuron: mockNeuron, topic: Topic.Unspecified },
+      events: {
+        nnsClose: onClose
+      }
     });
 
     const knownNeuronElements = queryAllByTestId("known-neuron-item");
@@ -124,9 +133,6 @@ describe("NewFolloweeModal", () => {
 
     expect(followButton).toBeInTheDocument();
 
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
-
     followButton && (await fireEvent.click(followButton));
 
     expect(addFollowee).toBeCalled();
@@ -137,8 +143,13 @@ describe("NewFolloweeModal", () => {
   it("unfollow known neurons", async () => {
     knownNeuronsStore.setNeurons([mockKnownNeuron]);
 
-    const { queryByTestId, component } = render(NewFolloweeModal, {
+    const onClose = vi.fn();
+
+    const { queryByTestId } = render(NewFolloweeModal, {
       props: { neuron: followingNeuron, topic: Topic.Unspecified },
+      events: {
+        nnsClose: onClose
+      }
     });
 
     const knownNeuronElement = queryByTestId(
@@ -146,9 +157,6 @@ describe("NewFolloweeModal", () => {
     );
 
     expect(knownNeuronElement).toBeInTheDocument();
-
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
 
     const knownNeuronButton = knownNeuronElement?.querySelector("button");
     expect(knownNeuronButton).toBeInTheDocument();

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -39,6 +39,7 @@ import {
 import { LedgerCanister } from "@dfinity/ledger-icp";
 import type { NeuronInfo } from "@dfinity/nns";
 import { GovernanceCanister } from "@dfinity/nns";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -91,12 +92,13 @@ describe("NnsStakeNeuronModal", () => {
   });
 
   const renderComponent = async ({ onClose }: { onClose?: () => void }) => {
-    const { container, component } = await renderModal({
+    const { container } = await renderModal({
       component: NnsStakeNeuronModal,
+      events: {
+        ...(nonNullish(onClose) && { nnsClose: onClose }),
+      },
     });
-    if (onClose) {
-      component.$on("nnsClose", onClose);
-    }
+
     return NnsStakeNeuronModalPo.under(new JestPageObjectElement(container));
   };
 

--- a/frontend/src/tests/lib/modals/neurons/VotingHistoryModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/VotingHistoryModal.spec.ts
@@ -4,7 +4,8 @@ import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
-import { render, waitFor } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
+import { waitFor } from "@testing-library/svelte";
 
 describe("VotingHistoryModal", () => {
   const props = {
@@ -53,10 +54,12 @@ describe("VotingHistoryModal", () => {
 
     it("should close on error", async () => {
       const onClose = vi.fn();
-      const { component } = render(VotingHistoryModal, {
+      render(VotingHistoryModal, {
         props,
+        events: {
+          nnsClose: onClose,
+        },
       });
-      component.$on("nnsClose", onClose);
 
       await waitFor(() => expect(onClose).toBeCalled());
     });

--- a/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
@@ -8,21 +8,16 @@ import { render } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { Topic } from "@dfinity/nns";
 import { fireEvent, waitFor } from "@testing-library/svelte";
-import type { ComponentProps } from "svelte";
 import { get } from "svelte/store";
 
 describe("ProposalsFilterModal", () => {
-  const nestedProps: { props: { props: ProposalsFilterModalProps } } = {
+  const props: { props: ProposalsFilterModalProps } = {
     props: {
-      props: {
-        category: "topics",
-        filters: Topic,
-        selectedFilters: DEFAULT_PROPOSALS_FILTERS.topics,
-      },
+      category: "topics",
+      filters: Topic,
+      selectedFilters: DEFAULT_PROPOSALS_FILTERS.topics,
     },
   };
-
-  const props = nestedProps as unknown as ComponentProps<ProposalsFilterModal>;
 
   it("should display modal", () => {
     const { container } = render(ProposalsFilterModal, {

--- a/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
@@ -4,9 +4,10 @@ import { proposalsFiltersStore } from "$lib/stores/proposals.store";
 import type { ProposalsFilterModalProps } from "$lib/types/proposals";
 import { enumKeys } from "$lib/utils/enum.utils";
 import en from "$tests/mocks/i18n.mock";
+import { render } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { Topic } from "@dfinity/nns";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("ProposalsFilterModal", () => {
@@ -59,12 +60,11 @@ describe("ProposalsFilterModal", () => {
 
   it("should forward close modal event", () =>
     new Promise<void>((done) => {
-      const { container, component } = render(ProposalsFilterModal, {
+      const { container } = render(ProposalsFilterModal, {
         props,
-      });
-
-      component.$on("nnsClose", () => {
-        done();
+        events: {
+          nnsClose: () => done(),
+        },
       });
 
       const button: HTMLButtonElement | null = container.querySelector(

--- a/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
@@ -8,16 +8,21 @@ import { render } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { Topic } from "@dfinity/nns";
 import { fireEvent, waitFor } from "@testing-library/svelte";
+import type { ComponentProps } from "svelte";
 import { get } from "svelte/store";
 
 describe("ProposalsFilterModal", () => {
-  const props: { props: ProposalsFilterModalProps } = {
+  const nestedProps: { props: { props: ProposalsFilterModalProps } } = {
     props: {
-      category: "topics",
-      filters: Topic,
-      selectedFilters: DEFAULT_PROPOSALS_FILTERS.topics,
+      props: {
+        category: "topics",
+        filters: Topic,
+        selectedFilters: DEFAULT_PROPOSALS_FILTERS.topics,
+      },
     },
   };
+
+  const props = nestedProps as unknown as ComponentProps<ProposalsFilterModal>;
 
   it("should display modal", () => {
     const { container } = render(ProposalsFilterModal, {

--- a/frontend/src/tests/lib/modals/sns/neurons/AddSnsHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/AddSnsHotkeyModal.spec.ts
@@ -16,13 +16,14 @@ describe("AddSnsHotkeyModal", () => {
     });
   });
 
-  const renderAddSnsHotkeyModal = async (): Promise<
-    RenderResult<SvelteComponent>
-  > =>
+  const renderAddSnsHotkeyModal = async (
+    events?: Record<string, ($event: CustomEvent) => void>
+  ): Promise<RenderResult<SvelteComponent>> =>
     renderSelectedSnsNeuronContext({
       Component: AddSnsHotkeyModal,
       reload,
       neuron: mockSnsNeuron,
+      events,
     });
 
   it("should display modal", async () => {
@@ -63,8 +64,11 @@ describe("AddSnsHotkeyModal", () => {
 
   it("should call addHotkey service, reload and close modal", async () => {
     const principalString = "aaaaa-aa";
-    const { container, queryByTestId, component } =
-      await renderAddSnsHotkeyModal();
+    const onClose = vi.fn();
+
+    const { container, queryByTestId } = await renderAddSnsHotkeyModal({
+      nnsClose: onClose,
+    });
 
     const inputElement = container.querySelector("input[type='text']");
     expect(inputElement).not.toBeNull();
@@ -77,8 +81,6 @@ describe("AddSnsHotkeyModal", () => {
     const buttonElement = queryByTestId("add-principal-button");
     expect(buttonElement).not.toBeNull();
 
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
     buttonElement && (await fireEvent.click(buttonElement));
     expect(addHotkey).toBeCalled();
 

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsModal.spec.ts
@@ -7,6 +7,7 @@ import { FollowSnsNeuronsModalPo } from "$tests/page-objects/FollowSnsNeuronsMod
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
 
 describe("FollowSnsNeuronsModal", () => {
   const neuron = {
@@ -16,7 +17,7 @@ describe("FollowSnsNeuronsModal", () => {
   const reload = vi.fn();
 
   const renderComponent = ({ onClose }: { onClose?: () => void }) => {
-    const { container, component } = renderSelectedSnsNeuronContext({
+    const { container } = renderSelectedSnsNeuronContext({
       Component: FollowSnsNeuronsModal,
       reload,
       neuron,
@@ -24,10 +25,11 @@ describe("FollowSnsNeuronsModal", () => {
         rootCanisterId,
         neuron,
       },
+      events: {
+        ...(nonNullish(onClose) && { nnsClose: onClose }),
+      },
     });
-    if (onClose) {
-      component.$on("nnsClose", onClose);
-    }
+
     return FollowSnsNeuronsModalPo.under(new JestPageObjectElement(container));
   };
 

--- a/frontend/src/tests/lib/modals/sns/neurons/NewSnsFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/NewSnsFolloweeModal.spec.ts
@@ -19,7 +19,9 @@ describe("NewSnsFolloweeModal", () => {
     });
   });
 
-  const renderNewSnsFolloweeModal = (): RenderResult<SvelteComponent> =>
+  const renderNewSnsFolloweeModal = (
+    events?: Record<string, ($event: CustomEvent) => void>
+  ): RenderResult<SvelteComponent> =>
     renderSelectedSnsNeuronContext({
       Component: NewSnsFolloweeModal,
       reload,
@@ -29,6 +31,7 @@ describe("NewSnsFolloweeModal", () => {
         neuron: mockSnsNeuron,
         functionId,
       },
+      events,
     });
 
   it("should display modal", async () => {
@@ -41,7 +44,11 @@ describe("NewSnsFolloweeModal", () => {
     const followeeHex = subaccountToHexString(
       arrayOfNumberToUint8Array([1, 2, 4])
     );
-    const { container, queryByTestId, component } = renderNewSnsFolloweeModal();
+    const onClose = vi.fn();
+
+    const { container, queryByTestId } = renderNewSnsFolloweeModal({
+      nnsClose: onClose,
+    });
 
     const inputElement = container.querySelector("input[type='text']");
     expect(inputElement).not.toBeNull();
@@ -54,8 +61,6 @@ describe("NewSnsFolloweeModal", () => {
     const buttonElement = queryByTestId("add-followee-button");
     expect(buttonElement).not.toBeNull();
 
-    const onClose = vi.fn();
-    component.$on("nnsClose", onClose);
     buttonElement && (await fireEvent.click(buttonElement));
     expect(addFollowee).toBeCalled();
 

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
@@ -3,9 +3,10 @@ import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import type { Filter } from "$lib/types/filters";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { render } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { SnsProposalDecisionStatus } from "@dfinity/sns";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SnsFilterStatusModal", () => {
@@ -56,12 +57,11 @@ describe("SnsFilterStatusModal", () => {
 
   it("should forward close modal event", () =>
     new Promise<void>((done) => {
-      const { container, component } = render(SnsFilterStatusModal, {
+      const { container } = render(SnsFilterStatusModal, {
         props,
-      });
-
-      component.$on("nnsClose", () => {
-        done();
+        events: {
+          nnsClose: () => done(),
+        },
       });
 
       const button: HTMLButtonElement | null = container.querySelector(

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
@@ -3,8 +3,9 @@ import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { render } from "$tests/utils/svelte.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SnsFilterTypesModal", () => {
@@ -55,12 +56,11 @@ describe("SnsFilterTypesModal", () => {
 
   it("should forward close modal event", () =>
     new Promise<void>((done) => {
-      const { container, component } = render(SnsFilterTypesModal, {
+      const { container } = render(SnsFilterTypesModal, {
         props,
-      });
-
-      component.$on("nnsClose", () => {
-        done();
+        events: {
+          nnsClose: () => done(),
+        },
       });
 
       const button: HTMLButtonElement | null = container.querySelector(

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -44,6 +44,7 @@ describe("TransactionModal", () => {
     mustSelectNetwork = false,
     showLedgerFee,
     skipHardwareWallets,
+    events,
   }: {
     destinationAddress?: string;
     sourceAccount?: Account;
@@ -53,6 +54,7 @@ describe("TransactionModal", () => {
     mustSelectNetwork?: boolean;
     showLedgerFee?: boolean;
     skipHardwareWallets?: boolean;
+    events?: Record<string, ($event: CustomEvent) => void>;
   }) =>
     renderModal({
       component: TransactionModal,
@@ -68,6 +70,7 @@ describe("TransactionModal", () => {
           showLedgerFee,
         },
       },
+      events,
     });
 
   beforeEach(() => {
@@ -106,6 +109,7 @@ describe("TransactionModal", () => {
     sourceAccount,
     mustSelectNetwork = false,
     showLedgerFee,
+    events,
   }: {
     destinationAddress?: string;
     sourceAccount?: Account;
@@ -113,6 +117,7 @@ describe("TransactionModal", () => {
     rootCanisterId?: Principal;
     mustSelectNetwork?: boolean;
     showLedgerFee?: boolean;
+    events?: Record<string, ($event: CustomEvent) => void>;
   }): Promise<RenderResult<SvelteComponent>> => {
     const result = await renderTransactionModal({
       destinationAddress,
@@ -121,6 +126,7 @@ describe("TransactionModal", () => {
       rootCanisterId,
       mustSelectNetwork,
       showLedgerFee,
+      events,
     });
 
     const { getByTestId, container } = result;
@@ -176,12 +182,14 @@ describe("TransactionModal", () => {
     });
 
     it("should trigger close on cancel", async () => {
+      const onClose = vi.fn();
+
       const { getByTestId, component } = await renderTransactionModal({
         rootCanisterId: OWN_CANISTER_ID,
+        events: {
+          nnsClose: onClose,
+        },
       });
-
-      const onClose = vi.fn();
-      component.$on("nnsClose", onClose);
 
       await clickByTestId(getByTestId, "transaction-button-cancel");
 
@@ -335,12 +343,14 @@ describe("TransactionModal", () => {
     });
 
     it("should move to the last step and trigger nnsSubmit event", async () => {
-      const { getByTestId, component } = await renderEnter10ICPAndNext({
-        rootCanisterId: OWN_CANISTER_ID,
-      });
-
       const onSubmit = vi.fn();
-      component.$on("nnsSubmit", onSubmit);
+
+      const { getByTestId } = await renderEnter10ICPAndNext({
+        rootCanisterId: OWN_CANISTER_ID,
+        events: {
+          nnsSubmit: onSubmit,
+        },
+      });
 
       const confirmButton = getByTestId("transaction-button-execute");
 
@@ -455,9 +465,14 @@ describe("TransactionModal", () => {
 
   describe("with sns project id", () => {
     it("should move to the last step and trigger nnsSubmit event", async () => {
-      const { getByTestId, container, component } =
+      const onSubmit = vi.fn();
+
+      const { getByTestId, container } =
         await renderTransactionModal({
           rootCanisterId: mockPrincipal,
+          events: {
+            nnsSubmit: onSubmit
+          }
         });
 
       const participateButton = getByTestId("transaction-button-next");
@@ -489,9 +504,6 @@ describe("TransactionModal", () => {
       expect(
         getByTestId("transaction-summary-total-received")?.textContent
       ).toContain(icpAmount);
-
-      const onSubmit = vi.fn();
-      component.$on("nnsSubmit", onSubmit);
 
       const confirmButton = getByTestId("transaction-button-execute");
 

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -184,7 +184,7 @@ describe("TransactionModal", () => {
     it("should trigger close on cancel", async () => {
       const onClose = vi.fn();
 
-      const { getByTestId, component } = await renderTransactionModal({
+      const { getByTestId } = await renderTransactionModal({
         rootCanisterId: OWN_CANISTER_ID,
         events: {
           nnsClose: onClose,
@@ -467,13 +467,12 @@ describe("TransactionModal", () => {
     it("should move to the last step and trigger nnsSubmit event", async () => {
       const onSubmit = vi.fn();
 
-      const { getByTestId, container } =
-        await renderTransactionModal({
-          rootCanisterId: mockPrincipal,
-          events: {
-            nnsSubmit: onSubmit
-          }
-        });
+      const { getByTestId, container } = await renderTransactionModal({
+        rootCanisterId: mockPrincipal,
+        events: {
+          nnsSubmit: onSubmit,
+        },
+      });
 
       const participateButton = getByTestId("transaction-button-next");
       expect(participateButton?.hasAttribute("disabled")).toBeTruthy();

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -33,10 +33,12 @@ export const renderContextWrapper = <T>({
 }): RenderResult<SvelteComponent> =>
   render(ContextWrapperTest, {
     props: {
-      contextKey,
-      contextValue,
-      Component,
-      props,
+      props: {
+        contextKey,
+        contextValue,
+        Component,
+        props,
+      },
     },
     events,
   });

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -11,9 +11,9 @@ import {
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { render } from "$tests/utils/svelte.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import type { RenderResult } from "@testing-library/svelte";
-import { render } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { writable } from "svelte/store";
 
@@ -22,12 +22,14 @@ export const renderContextWrapper = <T>({
   contextKey,
   contextValue,
   props,
+  events,
 }: {
   Component: typeof SvelteComponent;
   contextKey: symbol;
   contextValue: T;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props?: any;
+  events?: Record<string, ($event: CustomEvent) => void>;
 }): RenderResult<SvelteComponent> =>
   render(ContextWrapperTest, {
     props: {
@@ -36,6 +38,7 @@ export const renderContextWrapper = <T>({
       Component,
       props,
     },
+    events,
   });
 
 export const renderSelectedAccountContext = ({
@@ -61,12 +64,14 @@ export const renderSelectedSnsNeuronContext = ({
   neuron,
   reload,
   props,
+  events,
 }: {
   Component: typeof SvelteComponent;
   neuron: SnsNeuron;
   reload: () => Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props?: any;
+  events?: Record<string, ($event: CustomEvent) => void>;
 }) =>
   renderContextWrapper({
     Component,
@@ -82,4 +87,5 @@ export const renderSelectedSnsNeuronContext = ({
       reload,
     } as SelectedSnsNeuronContext,
     props,
+    events,
   });

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -33,12 +33,10 @@ export const renderContextWrapper = <T>({
 }): RenderResult<SvelteComponent> =>
   render(ContextWrapperTest, {
     props: {
-      props: {
-        contextKey,
-        contextValue,
-        Component,
-        props,
-      },
+      contextKey,
+      contextValue,
+      Component,
+      props,
     },
     events,
   });

--- a/frontend/src/tests/mocks/modal.mock.ts
+++ b/frontend/src/tests/mocks/modal.mock.ts
@@ -4,8 +4,9 @@ import {
   type WalletStore,
 } from "$lib/types/wallet.context";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 import type { RenderResult } from "@testing-library/svelte";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { writable } from "svelte/store";
 
@@ -30,13 +31,16 @@ export const modalToolbarSelector = "div.content";
 export const renderModal = async ({
   component,
   props,
+  events,
 }: {
   component: typeof SvelteComponent;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props?: Record<string, any>;
+  events?: Record<string, ($event: CustomEvent) => void>;
 }): Promise<RenderResult<SvelteComponent>> => {
   const modal = render(component, {
     props,
+    events,
   });
 
   const { container } = modal;

--- a/frontend/src/tests/utils/svelte.test-utils.ts
+++ b/frontend/src/tests/utils/svelte.test-utils.ts
@@ -38,7 +38,7 @@ export const render = <C extends SvelteComponent>(
 
   const allEvents = Object.entries(
     nonNullish(componentOptions) && "events" in componentOptions
-      ? componentOptions.events ?? {}
+      ? (componentOptions.events ?? {})
       : {}
   );
 

--- a/frontend/src/tests/utils/svelte.test-utils.ts
+++ b/frontend/src/tests/utils/svelte.test-utils.ts
@@ -1,16 +1,50 @@
-import { render as svelteRender } from "@testing-library/svelte";
+import { nonNullish } from "@dfinity/utils";
+import {
+  render as svelteRender,
+  type RenderResult,
+} from "@testing-library/svelte";
+import type { ComponentProps, SvelteComponent } from "svelte";
+
+// TestingLibrary internal type
+type ComponentType<C> = C extends SvelteComponent
+  ? new (...args: unknown[]) => C
+  : C;
 
 // Adapted from Svelte render to work around the surprising behavior that render
 // reuses the same container element between different calls from the same test.
-export const render = (
-  component,
-  componentOptions = {},
+export const render = <C extends SvelteComponent>(
+  cmp: ComponentType<C>,
+  componentOptions?:
+    | {
+        props: ComponentProps<C>;
+        events?: Record<string, ($event: CustomEvent) => void>;
+      }
+    | ComponentProps<C>,
   renderOptions = {}
-) => {
+): RenderResult<C> => {
   const container = document.createElement("div");
   document.body.appendChild(container);
-  return svelteRender(component, componentOptions, {
+
+  const props = nonNullish(componentOptions)
+    ? "props" in componentOptions
+      ? componentOptions.props
+      : componentOptions
+    : {};
+
+  const { component, ...rest } = svelteRender(cmp, props, {
     ...renderOptions,
     baseElement: container,
   });
+
+  const allEvents = Object.entries(
+    nonNullish(componentOptions) && "events" in componentOptions
+      ? componentOptions.events
+      : {}
+  );
+
+  allEvents.forEach(([event, fn]) => {
+    component.$on(event, fn);
+  });
+
+  return { component, ...rest };
 };

--- a/frontend/src/tests/utils/svelte.test-utils.ts
+++ b/frontend/src/tests/utils/svelte.test-utils.ts
@@ -38,7 +38,7 @@ export const render = <C extends SvelteComponent>(
 
   const allEvents = Object.entries(
     nonNullish(componentOptions) && "events" in componentOptions
-      ? componentOptions.events
+      ? componentOptions.events ?? {}
       : {}
   );
 

--- a/frontend/src/tests/utils/svelte.test-utils.ts
+++ b/frontend/src/tests/utils/svelte.test-utils.ts
@@ -2,6 +2,7 @@ import { nonNullish } from "@dfinity/utils";
 import {
   render as svelteRender,
   type RenderResult,
+  type SvelteComponentOptions,
 } from "@testing-library/svelte";
 import type { ComponentProps, SvelteComponent } from "svelte";
 
@@ -31,10 +32,14 @@ export const render = <C extends SvelteComponent>(
       : componentOptions
     : {};
 
-  const { component, ...rest } = svelteRender(cmp, props, {
-    ...renderOptions,
-    baseElement: container,
-  });
+  const { component, ...rest } = svelteRender(
+    cmp,
+    { props } as SvelteComponentOptions<C>,
+    {
+      ...renderOptions,
+      baseElement: container,
+    }
+  );
 
   const allEvents = Object.entries(
     nonNullish(componentOptions) && "events" in componentOptions

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -6,9 +6,8 @@ use candid::CandidType;
 use dfn_candid::Candid;
 use histogram::AccountsStoreHistogram;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_nns_common::types::NeuronId;
 use ic_stable_structures::{storable::Bound, Storable};
-use icp_ledger::{AccountIdentifier, BlockIndex, Memo, Subaccount};
+use icp_ledger::{AccountIdentifier, BlockIndex, Subaccount};
 use itertools::Itertools;
 use on_wire::{FromWire, IntoWire};
 use serde::Deserialize;
@@ -227,14 +226,6 @@ pub enum SetImportedTokensResponse {
 pub enum GetImportedTokensResponse {
     Ok(ImportedTokens),
     AccountNotFound,
-}
-
-#[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
-pub struct NeuronDetails {
-    account_identifier: AccountIdentifier,
-    principal: PrincipalId,
-    memo: Memo,
-    neuron_id: Option<NeuronId>,
 }
 
 #[derive(CandidType, Debug, PartialEq)]
@@ -784,7 +775,7 @@ impl StableState for AccountsStore {
             HashMap<AccountIdentifier, AccountWrapper>,
             candid::Reserved,
             candid::Reserved,
-            HashMap<AccountIdentifier, NeuronDetails>,
+            candid::Reserved,
             Option<BlockIndex>,
             candid::Reserved,
             u64,


### PR DESCRIPTION
# Motivation

Using the `$on` callback for testing is deprecated in Svelte v5. To align with the changes made in Gix-components (see PR [#544](https://github.com/dfinity/gix-components/pull/554)), we will adopt the `events` option of the `render` function. 

To facilitate the upgrade and minimize changes in the Svelte v5 PR, we have refactored the test to utilize a utility function.

# Changes

- Extend `render` utility to support events
- Replace all occurences of the keywords `$on()` with the usage of the utilitity

# Summarized

```
component.$on("something", something)

// =>

render(Component, {events: {something}}
```

