### PR TITLE
feat(navigation): add accounts page entry point store

### DIFF
--- a/frontend/src/lib/stores/accounts-navigation-entry-point.store.ts
+++ b/frontend/src/lib/stores/accounts-navigation-entry-point.store.ts
@@ -3,7 +3,7 @@ import { writable } from "svelte/store";
 
 type AccountsEntryPoint = AppPath.Portfolio | AppPath.Tokens;
 
-const initTokensTableOrderStore = () => {
+const initAccountsNavigationEntryPoint = () => {
   const { subscribe, set } = writable<AccountsEntryPoint>(AppPath.Tokens);
 
   return {
@@ -12,4 +12,5 @@ const initTokensTableOrderStore = () => {
   };
 };
 
-export const accountsNavigationEntryPointStore = initTokensTableOrderStore();
+export const accountsNavigationEntryPointStore =
+  initAccountsNavigationEntryPoint();

--- a/frontend/src/lib/stores/accounts-navigation-entry-point.store.ts
+++ b/frontend/src/lib/stores/accounts-navigation-entry-point.store.ts
@@ -1,0 +1,15 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { writable } from "svelte/store";
+
+type AccountsEntryPoint = AppPath.Portfolio | AppPath.Tokens;
+
+const initTokensTableOrderStore = () => {
+  const { subscribe, set } = writable<AccountsEntryPoint>(AppPath.Tokens);
+
+  return {
+    subscribe,
+    set,
+  };
+};
+
+export const accountsNavigationEntryPoint = initTokensTableOrderStore();

--- a/frontend/src/lib/stores/accounts-navigation-entry-point.store.ts
+++ b/frontend/src/lib/stores/accounts-navigation-entry-point.store.ts
@@ -12,4 +12,4 @@ const initTokensTableOrderStore = () => {
   };
 };
 
-export const accountsNavigationEntryPoint = initTokensTableOrderStore();
+export const accountsNavigationEntryPointStore = initTokensTableOrderStore();

--- a/frontend/src/tests/lib/stores/accounts-navigation-entry-point.store.spec.ts
+++ b/frontend/src/tests/lib/stores/accounts-navigation-entry-point.store.spec.ts
@@ -1,0 +1,15 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { accountsNavigationEntryPoint } from "$lib/stores/accounts-navigation-entry-point.store";
+import { get } from "svelte/store";
+
+describe("accounts-navigation-entry-point.store", () => {
+  it("should have an initial value", () => {
+    expect(get(accountsNavigationEntryPoint)).toEqual(AppPath.Tokens);
+  });
+
+  it("should set", () => {
+    accountsNavigationEntryPoint.set(AppPath.Portfolio);
+
+    expect(get(accountsNavigationEntryPoint)).toEqual(AppPath.Portfolio);
+  });
+});

--- a/frontend/src/tests/lib/stores/accounts-navigation-entry-point.store.spec.ts
+++ b/frontend/src/tests/lib/stores/accounts-navigation-entry-point.store.spec.ts
@@ -1,15 +1,15 @@
 import { AppPath } from "$lib/constants/routes.constants";
-import { accountsNavigationEntryPoint } from "$lib/stores/accounts-navigation-entry-point.store";
+import { accountsNavigationEntryPointStore } from "$lib/stores/accounts-navigation-entry-point.store";
 import { get } from "svelte/store";
 
 describe("accounts-navigation-entry-point.store", () => {
   it("should have an initial value", () => {
-    expect(get(accountsNavigationEntryPoint)).toEqual(AppPath.Tokens);
+    expect(get(accountsNavigationEntryPointStore)).toEqual(AppPath.Tokens);
   });
 
   it("should set", () => {
-    accountsNavigationEntryPoint.set(AppPath.Portfolio);
+    accountsNavigationEntryPointStore.set(AppPath.Portfolio);
 
-    expect(get(accountsNavigationEntryPoint)).toEqual(AppPath.Portfolio);
+    expect(get(accountsNavigationEntryPointStore)).toEqual(AppPath.Portfolio);
   });
 });


### PR DESCRIPTION
# Motivation

The Accounts page features a custom back button that currently redirects users to the Tokens page. This is no longer always accurate, as users can now access this page from the Portfolio page. 

Since users can also navigate from the Accounts page to the Wallet page, we cannot rely on a local solution because the Accounts layout will be unmounted, resulting in the loss of this information. 

A follow-up PR will utilize the store in the Accounts layout to track how users enter the page and determine where to navigate back when they click the custom back button.

Note: We don't want to rely on the browser's history stack. If the user directly enters the Accounts page, we want to navigate them back to the Tokens page as we currently do.

# Changes

- New store `accountsNavigationEntryPointStore`

# Tests

- Unit tests for the store

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary