### PR TITLE
Disable FORCE_CALL_STRATEGY for 100% of sessions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+- Proceed with rollout of re-enabling of certification of certain calls from `30%` to `100%`.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -15,7 +15,7 @@ export const DEV = import.meta.env.DEV;
 //
 // Whether we do query+update calls remains fixed for the duration of the
 // sessions, by which we mean until the next time the app/page is reloaded.
-const RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE: number = 30;
+const RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE: number = 100;
 
 const getForceCallStrategyForPercentage = (
   percentage: number


### PR DESCRIPTION
# Motivation

With https://github.com/dfinity/nns-dapp/pull/6205 we changed the deployment of disabling `FORCE_CALL_STRATEGY` from 10% to 30%.
The [proposal](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=134977) for the release with this change was executed today at 11:23 CET.

Looking at graphs for the [SNS subnet](https://grafana.mainnet.dfinity.network/d/ic-health/ic-health?orgId=1&var-period=$__auto&from=2025-01-27T08:23:00.000Z&to=2025-01-27T14:23:00.000Z&timezone=utc&var-datasource=PE62C54679EC3C073&var-ic=mercury&var-ic_subnet=x33ed-h457x-bsgyx-oqxqf-6pzwv-wkhzr-rm2j3-npodi-purzm-n66cg-gae&var-dc=$__all&var-instance=$__all&var-instance_host=$__all) and the [NNS subnet](https://grafana.mainnet.dfinity.network/d/ic-health/ic-health?orgId=1&var-period=$__auto&from=2025-01-27T08:23:00.000Z&to=2025-01-27T14:23:00.000Z&timezone=utc&var-datasource=PE62C54679EC3C073&var-ic=mercury&var-ic_subnet=tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe&var-dc=$__all&var-instance=$__all&var-instance_host=$__all) from 3 hours before to 3 hours after the execution, I do not notice any difference in any of the graph starting at or soon after 11:23.

So if the change had any effect on these subnets, it's not very noticeable.

Therefore, let's proceed to 100%.

# Changes

1. Increase `RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE` from 30 to 100.

# Tests

Looked at graph.

# Todos

- [ ] Add entry to changelog (if necessary).
