### PR TITLE
Rename periodic confirmation related utils

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -9,7 +9,7 @@
     isNeuronFollowingResetVPE,
     isNeuronLosingRewardsVPE,
     secondsUntilLosingRewardsVPE,
-    shouldDisplayRewardLossNotificationVPE,
+    shouldDisplayMissingRewardNotification,
   } from "$lib/utils/neuron.utils";
   import {
     IconCheckCircleFill,
@@ -43,7 +43,7 @@
   let isLosingRewardsSoon = false;
   $: isLosingRewardsSoon =
     !isLosingRewards &&
-    shouldDisplayRewardLossNotificationVPE({
+    shouldDisplayMissingRewardNotification({
       neuron,
       startReducingVotingPowerAfterSeconds:
         $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -9,7 +9,7 @@
     isNeuronFollowingResetVPE,
     isNeuronLosingRewardsVPE,
     secondsUntilLosingRewardsVPE,
-    shouldDisplayRewardLossNotificationVPE,
+    shouldDisplayRewardLossNotification,
   } from "$lib/utils/neuron.utils";
   import {
     IconCheckCircleFill,
@@ -43,7 +43,7 @@
   let isLosingRewardsSoon = false;
   $: isLosingRewardsSoon =
     !isLosingRewards &&
-    shouldDisplayRewardLossNotificationVPE({
+    shouldDisplayRewardLossNotification({
       neuron,
       startReducingVotingPowerAfterSeconds:
         $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -7,7 +7,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
     isNeuronFollowingResetVPE,
-    isNeuronLosingRewardsVPE,
+    isNeuronMissingReward,
     secondsUntilLosingRewardsVPE,
     shouldDisplayMissingRewardNotification,
   } from "$lib/utils/neuron.utils";
@@ -34,7 +34,7 @@
   });
 
   let isLosingRewards = false;
-  $: isLosingRewards = isNeuronLosingRewardsVPE({
+  $: isLosingRewards = isNeuronMissingReward({
     neuron,
     startReducingVotingPowerAfterSeconds:
       $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -6,7 +6,7 @@
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
-    isNeuronFollowingResetVPE,
+    isNeuronFollowingReset,
     isNeuronMissingReward,
     secondsUntilLosingRewardsVPE,
     shouldDisplayMissingRewardNotification,
@@ -26,7 +26,7 @@
   export let neuron: NeuronInfo;
 
   let isFollowingReset = false;
-  $: isFollowingReset = isNeuronFollowingResetVPE({
+  $: isFollowingReset = isNeuronFollowingReset({
     neuron,
     startReducingVotingPowerAfterSeconds:
       $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -9,7 +9,7 @@
     isNeuronFollowingResetVPE,
     isNeuronLosingRewardsVPE,
     secondsUntilLosingRewardsVPE,
-    shouldDisplayRewardLossNotification,
+    shouldDisplayRewardLossNotificationVPE,
   } from "$lib/utils/neuron.utils";
   import {
     IconCheckCircleFill,
@@ -43,7 +43,7 @@
   let isLosingRewardsSoon = false;
   $: isLosingRewardsSoon =
     !isLosingRewards &&
-    shouldDisplayRewardLossNotification({
+    shouldDisplayRewardLossNotificationVPE({
       neuron,
       startReducingVotingPowerAfterSeconds:
         $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -8,7 +8,7 @@
   import {
     isNeuronFollowingReset,
     isNeuronMissingReward,
-    secondsUntilLosingRewardsVPE,
+    secondsUntilMissingReward,
     shouldDisplayMissingRewardNotification,
   } from "$lib/utils/neuron.utils";
   import {
@@ -80,7 +80,7 @@
 
     const timeUntilLoss = secondsToDuration({
       seconds: BigInt(
-        secondsUntilLosingRewardsVPE({
+        secondsUntilMissingReward({
           neuron,
           startReducingVotingPowerAfterSeconds,
         })

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -4,7 +4,7 @@
   import Banner from "$lib/components/ui/Banner.svelte";
   import BannerIcon from "$lib/components/ui/BannerIcon.svelte";
   import {
-    isNeuronLosingRewardsVPE,
+    isNeuronMissingReward,
     secondsUntilLosingRewardsVPE,
   } from "$lib/utils/neuron.utils";
   import { soonLosingRewardNeuronsStore } from "$lib/derived/neurons.derived";
@@ -27,7 +27,7 @@
     neuron: NeuronInfo;
     startReducingVotingPowerAfterSeconds: bigint;
   }) =>
-    isNeuronLosingRewardsVPE({ neuron, startReducingVotingPowerAfterSeconds })
+    isNeuronMissingReward({ neuron, startReducingVotingPowerAfterSeconds })
       ? $i18n.losing_rewards_banner.rewards_missing_title
       : replacePlaceholders($i18n.losing_rewards_banner.days_left_title, {
           $timeLeft: secondsToDuration({

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -5,7 +5,7 @@
   import BannerIcon from "$lib/components/ui/BannerIcon.svelte";
   import {
     isNeuronMissingReward,
-    secondsUntilLosingRewardsVPE,
+    secondsUntilMissingReward,
   } from "$lib/utils/neuron.utils";
   import { soonLosingRewardNeuronsStore } from "$lib/derived/neurons.derived";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -32,7 +32,7 @@
       : replacePlaceholders($i18n.losing_rewards_banner.days_left_title, {
           $timeLeft: secondsToDuration({
             seconds: BigInt(
-              secondsUntilLosingRewardsVPE({
+              secondsUntilMissingReward({
                 neuron,
                 startReducingVotingPowerAfterSeconds,
               })

--- a/frontend/src/lib/derived/neurons.derived.ts
+++ b/frontend/src/lib/derived/neurons.derived.ts
@@ -2,7 +2,7 @@ import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   hasValidStake,
-  shouldDisplayRewardLossNotificationVPE,
+  shouldDisplayRewardLossNotification,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
 } from "$lib/utils/neuron.utils";
@@ -25,7 +25,7 @@ export const soonLosingRewardNeuronsStore: Readable<NeuronInfo[]> = derived(
   ($definedNeuronsStore) =>
     sortNeuronsByVotingPowerRefreshedTimeout(
       $definedNeuronsStore.filter((neuron) =>
-        shouldDisplayRewardLossNotificationVPE({
+        shouldDisplayRewardLossNotification({
           neuron,
           startReducingVotingPowerAfterSeconds: get(
             startReducingVotingPowerAfterSecondsStore

--- a/frontend/src/lib/derived/neurons.derived.ts
+++ b/frontend/src/lib/derived/neurons.derived.ts
@@ -2,7 +2,7 @@ import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   hasValidStake,
-  shouldDisplayRewardLossNotification,
+  shouldDisplayRewardLossNotificationVPE,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
 } from "$lib/utils/neuron.utils";
@@ -25,7 +25,7 @@ export const soonLosingRewardNeuronsStore: Readable<NeuronInfo[]> = derived(
   ($definedNeuronsStore) =>
     sortNeuronsByVotingPowerRefreshedTimeout(
       $definedNeuronsStore.filter((neuron) =>
-        shouldDisplayRewardLossNotification({
+        shouldDisplayRewardLossNotificationVPE({
           neuron,
           startReducingVotingPowerAfterSeconds: get(
             startReducingVotingPowerAfterSecondsStore

--- a/frontend/src/lib/derived/neurons.derived.ts
+++ b/frontend/src/lib/derived/neurons.derived.ts
@@ -2,7 +2,7 @@ import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   hasValidStake,
-  shouldDisplayRewardLossNotificationVPE,
+  shouldDisplayMissingRewardNotification,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
 } from "$lib/utils/neuron.utils";
@@ -25,7 +25,7 @@ export const soonLosingRewardNeuronsStore: Readable<NeuronInfo[]> = derived(
   ($definedNeuronsStore) =>
     sortNeuronsByVotingPowerRefreshedTimeout(
       $definedNeuronsStore.filter((neuron) =>
-        shouldDisplayRewardLossNotificationVPE({
+        shouldDisplayMissingRewardNotification({
           neuron,
           startReducingVotingPowerAfterSeconds: get(
             startReducingVotingPowerAfterSecondsStore

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -38,7 +38,7 @@
     getNeuronById,
     isSpawning,
     neuronVoting,
-    shouldDisplayRewardLossNotification,
+    shouldDisplayRewardLossNotificationVPE,
   } from "$lib/utils/neuron.utils";
   import { Island } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
@@ -156,7 +156,7 @@
   $: isConfirmFollowingVisible =
     $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION &&
     nonNullish(neuron) &&
-    shouldDisplayRewardLossNotification({
+    shouldDisplayRewardLossNotificationVPE({
       neuron,
       startReducingVotingPowerAfterSeconds:
         $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -38,7 +38,7 @@
     getNeuronById,
     isSpawning,
     neuronVoting,
-    shouldDisplayRewardLossNotificationVPE,
+    shouldDisplayRewardLossNotification,
   } from "$lib/utils/neuron.utils";
   import { Island } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
@@ -156,7 +156,7 @@
   $: isConfirmFollowingVisible =
     $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION &&
     nonNullish(neuron) &&
-    shouldDisplayRewardLossNotificationVPE({
+    shouldDisplayRewardLossNotification({
       neuron,
       startReducingVotingPowerAfterSeconds:
         $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -38,7 +38,7 @@
     getNeuronById,
     isSpawning,
     neuronVoting,
-    shouldDisplayRewardLossNotificationVPE,
+    shouldDisplayMissingRewardNotification,
   } from "$lib/utils/neuron.utils";
   import { Island } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
@@ -156,7 +156,7 @@
   $: isConfirmFollowingVisible =
     $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION &&
     nonNullish(neuron) &&
-    shouldDisplayRewardLossNotificationVPE({
+    shouldDisplayMissingRewardNotification({
       neuron,
       startReducingVotingPowerAfterSeconds:
         $startReducingVotingPowerAfterSecondsStore,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -556,7 +556,7 @@ const getNeuronTagsUnrelatedToController = ({
     get(ENABLE_PERIODIC_FOLLOWING_CONFIRMATION)
   ) {
     if (
-      isNeuronLosingRewardsVPE({ neuron, startReducingVotingPowerAfterSeconds })
+      isNeuronMissingReward({ neuron, startReducingVotingPowerAfterSeconds })
     ) {
       tags.push({
         text: i18n.neurons.missing_rewards,
@@ -1327,7 +1327,7 @@ export const isNeuronFollowingResetVPE = ({
 
 /** If the voting power economics are not available,
  *  we assume that the neuron is not losing rewards. */
-export const isNeuronLosingRewardsVPE = ({
+export const isNeuronMissingReward = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
 }: {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -563,7 +563,7 @@ const getNeuronTagsUnrelatedToController = ({
         status: "danger",
       });
     } else if (
-      shouldDisplayRewardLossNotificationVPE({
+      shouldDisplayMissingRewardNotification({
         neuron,
         startReducingVotingPowerAfterSeconds,
       })
@@ -1345,7 +1345,7 @@ export const isNeuronLosingRewardsVPE = ({
  * e.g. "Neuron will start losing rewards in 30 days"
  * If the voting power economics are not available,
  * we assume that the neuron is not losing rewards. */
-export const shouldDisplayRewardLossNotificationVPE = ({
+export const shouldDisplayMissingRewardNotification = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
 }: {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -563,7 +563,7 @@ const getNeuronTagsUnrelatedToController = ({
         status: "danger",
       });
     } else if (
-      shouldDisplayRewardLossNotification({
+      shouldDisplayRewardLossNotificationVPE({
         neuron,
         startReducingVotingPowerAfterSeconds,
       })
@@ -1345,7 +1345,7 @@ export const isNeuronLosingRewardsVPE = ({
  * e.g. "Neuron will start losing rewards in 30 days"
  * If the voting power economics are not available,
  * we assume that the neuron is not losing rewards. */
-export const shouldDisplayRewardLossNotification = ({
+export const shouldDisplayRewardLossNotificationVPE = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
 }: {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1303,7 +1303,7 @@ export const secondsUntilLosingRewardsVPE = ({
 
 /** If the voting power economics are not available,
  *  we assume that the neuron's following is not reset. */
-export const isNeuronFollowingResetVPE = ({
+export const isNeuronFollowingReset = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
   clearFollowingAfterSeconds,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -572,7 +572,7 @@ const getNeuronTagsUnrelatedToController = ({
         text: replacePlaceholders(i18n.neurons.missing_rewards_soon, {
           $timeLeft: secondsToMissingRewardsDuration({
             seconds: BigInt(
-              secondsUntilLosingRewardsVPE({
+              secondsUntilMissingReward({
                 neuron,
                 startReducingVotingPowerAfterSeconds,
               })
@@ -1283,11 +1283,11 @@ export const isPublicNeuron = (neuronInfo: NeuronInfo): boolean => {
 export const getVotingPowerRefreshedTimestampSeconds = ({
   fullNeuron,
 }: NeuronInfo): bigint =>
-  // When the fullNeuron is not presented, we assume that the neuron is not losing rewards
+  // When the fullNeuron is not presented, we assume that the neuron is not missing rewards
   // to avoid unnecessary notifications.
   fullNeuron?.votingPowerRefreshedTimestampSeconds ?? BigInt(nowInSeconds());
 
-export const secondsUntilLosingRewardsVPE = ({
+export const secondsUntilMissingReward = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
 }: {
@@ -1326,7 +1326,7 @@ export const isNeuronFollowingReset = ({
 };
 
 /** If the voting power economics are not available,
- *  we assume that the neuron is not losing rewards. */
+ *  we assume that the neuron is not missing rewards. */
 export const isNeuronMissingReward = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
@@ -1336,15 +1336,15 @@ export const isNeuronMissingReward = ({
 }): boolean =>
   isNullish(startReducingVotingPowerAfterSeconds)
     ? false
-    : secondsUntilLosingRewardsVPE({
+    : secondsUntilMissingReward({
         neuron,
         startReducingVotingPowerAfterSeconds,
       }) <= 0;
 
 /**
- * e.g. "Neuron will start losing rewards in 30 days"
+ * e.g. "Neuron will start missing rewards in 30 days"
  * If the voting power economics are not available,
- * we assume that the neuron is not losing rewards. */
+ * we assume that the neuron is not missing rewards. */
 export const shouldDisplayMissingRewardNotification = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
@@ -1354,7 +1354,7 @@ export const shouldDisplayMissingRewardNotification = ({
 }): boolean =>
   isNullish(startReducingVotingPowerAfterSeconds)
     ? false
-    : secondsUntilLosingRewardsVPE({
+    : secondsUntilMissingReward({
         neuron,
         startReducingVotingPowerAfterSeconds,
       }) <= daysToSeconds(NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS);

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -563,7 +563,7 @@ const getNeuronTagsUnrelatedToController = ({
         status: "danger",
       });
     } else if (
-      shouldDisplayRewardLossNotificationVPE({
+      shouldDisplayRewardLossNotification({
         neuron,
         startReducingVotingPowerAfterSeconds,
       })
@@ -1345,7 +1345,7 @@ export const isNeuronLosingRewardsVPE = ({
  * e.g. "Neuron will start losing rewards in 30 days"
  * If the voting power economics are not available,
  * we assume that the neuron is not losing rewards. */
-export const shouldDisplayRewardLossNotificationVPE = ({
+export const shouldDisplayRewardLossNotification = ({
   neuron,
   startReducingVotingPowerAfterSeconds,
 }: {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -70,7 +70,7 @@ import {
   neuronVotingPower,
   neuronsVotingPower,
   secondsUntilLosingRewardsVPE,
-  shouldDisplayRewardLossNotificationVPE,
+  shouldDisplayMissingRewardNotification,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
   topicsToFollow,
@@ -3751,10 +3751,10 @@ describe("neuron-utils", () => {
       });
     });
 
-    describe("shouldDisplayRewardLossNotificationVPE", () => {
+    describe("shouldDisplayMissingRewardNotification", () => {
       it("should return false by default", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayMissingRewardNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: {
               ...mockNeuron,
@@ -3766,7 +3766,7 @@ describe("neuron-utils", () => {
 
       it("should return true after notification period starts", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayMissingRewardNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3775,7 +3775,7 @@ describe("neuron-utils", () => {
           })
         ).toBe(true);
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayMissingRewardNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3787,7 +3787,7 @@ describe("neuron-utils", () => {
 
       it("should return false w/o voting economics", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayMissingRewardNotification({
             startReducingVotingPowerAfterSeconds: undefined,
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3799,7 +3799,7 @@ describe("neuron-utils", () => {
 
       it("should return false before notification period", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayMissingRewardNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -69,7 +69,7 @@ import {
   neuronStakedMaturity,
   neuronVotingPower,
   neuronsVotingPower,
-  secondsUntilLosingRewardsVPE,
+  secondsUntilMissingReward,
   shouldDisplayMissingRewardNotification,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
@@ -3589,10 +3589,10 @@ describe("neuron-utils", () => {
     const losingRewardsPeriod = SECONDS_IN_HALF_YEAR;
     const notificationPeriod = 30 * SECONDS_IN_DAY;
 
-    describe("secondsUntilLosingRewardsVPE", () => {
+    describe("secondsUntilMissingReward", () => {
       it("should return future date when no fullNeuron", () => {
         expect(
-          secondsUntilLosingRewardsVPE({
+          secondsUntilMissingReward({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: {
               ...mockNeuron,
@@ -3604,7 +3604,7 @@ describe("neuron-utils", () => {
 
       it("should return seconds until losing rewards", () => {
         expect(
-          secondsUntilLosingRewardsVPE({
+          secondsUntilMissingReward({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: 0,
@@ -3612,7 +3612,7 @@ describe("neuron-utils", () => {
           })
         ).toBe(SECONDS_IN_HALF_YEAR);
         expect(
-          secondsUntilLosingRewardsVPE({
+          secondsUntilMissingReward({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -53,7 +53,7 @@ import {
   isNeuronControllable,
   isNeuronControllableByUser,
   isNeuronControlledByHardwareWallet,
-  isNeuronFollowingResetVPE,
+  isNeuronFollowingReset,
   isNeuronMissingReward,
   isPublicNeuron,
   isSpawning,
@@ -3677,10 +3677,10 @@ describe("neuron-utils", () => {
       });
     });
 
-    describe("isNeuronFollowingResetVPE", () => {
+    describe("isNeuronFollowingReset", () => {
       it("should return false by default", () => {
         expect(
-          isNeuronFollowingResetVPE({
+          isNeuronFollowingReset({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             clearFollowingAfterSeconds: BigInt(SECONDS_IN_MONTH),
             neuron: {
@@ -3693,7 +3693,7 @@ describe("neuron-utils", () => {
 
       it("should return false w/o voting power economics", () => {
         expect(
-          isNeuronFollowingResetVPE({
+          isNeuronFollowingReset({
             startReducingVotingPowerAfterSeconds: undefined,
             clearFollowingAfterSeconds: BigInt(SECONDS_IN_MONTH),
             neuron: neuronWithRefreshedTimestamp({
@@ -3703,7 +3703,7 @@ describe("neuron-utils", () => {
           })
         ).toBe(false);
         expect(
-          isNeuronFollowingResetVPE({
+          isNeuronFollowingReset({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             clearFollowingAfterSeconds: undefined,
             neuron: neuronWithRefreshedTimestamp({
@@ -3716,7 +3716,7 @@ describe("neuron-utils", () => {
 
       it("should return true after the followings have been reset", () => {
         expect(
-          isNeuronFollowingResetVPE({
+          isNeuronFollowingReset({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             clearFollowingAfterSeconds: BigInt(SECONDS_IN_MONTH),
             neuron: neuronWithRefreshedTimestamp({
@@ -3726,7 +3726,7 @@ describe("neuron-utils", () => {
           })
         ).toBe(true);
         expect(
-          isNeuronFollowingResetVPE({
+          isNeuronFollowingReset({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             clearFollowingAfterSeconds: BigInt(SECONDS_IN_MONTH),
             neuron: neuronWithRefreshedTimestamp({
@@ -3739,7 +3739,7 @@ describe("neuron-utils", () => {
 
       it("should return false", () => {
         expect(
-          isNeuronFollowingResetVPE({
+          isNeuronFollowingReset({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             clearFollowingAfterSeconds: BigInt(SECONDS_IN_MONTH),
             neuron: neuronWithRefreshedTimestamp({

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -70,7 +70,7 @@ import {
   neuronVotingPower,
   neuronsVotingPower,
   secondsUntilLosingRewardsVPE,
-  shouldDisplayRewardLossNotificationVPE,
+  shouldDisplayRewardLossNotification,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
   topicsToFollow,
@@ -3751,10 +3751,10 @@ describe("neuron-utils", () => {
       });
     });
 
-    describe("shouldDisplayRewardLossNotificationVPE", () => {
+    describe("shouldDisplayRewardLossNotification", () => {
       it("should return false by default", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayRewardLossNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: {
               ...mockNeuron,
@@ -3766,7 +3766,7 @@ describe("neuron-utils", () => {
 
       it("should return true after notification period starts", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayRewardLossNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3775,7 +3775,7 @@ describe("neuron-utils", () => {
           })
         ).toBe(true);
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayRewardLossNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3787,7 +3787,7 @@ describe("neuron-utils", () => {
 
       it("should return false w/o voting economics", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayRewardLossNotification({
             startReducingVotingPowerAfterSeconds: undefined,
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3799,7 +3799,7 @@ describe("neuron-utils", () => {
 
       it("should return false before notification period", () => {
         expect(
-          shouldDisplayRewardLossNotificationVPE({
+          shouldDisplayRewardLossNotification({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -54,7 +54,7 @@ import {
   isNeuronControllableByUser,
   isNeuronControlledByHardwareWallet,
   isNeuronFollowingResetVPE,
-  isNeuronLosingRewardsVPE,
+  isNeuronMissingReward,
   isPublicNeuron,
   isSpawning,
   isValidInputAmount,
@@ -3622,10 +3622,10 @@ describe("neuron-utils", () => {
       });
     });
 
-    describe("isNeuronLosingRewardsVPE", () => {
+    describe("isNeuronMissingReward", () => {
       it("should return false by default", () => {
         expect(
-          isNeuronLosingRewardsVPE({
+          isNeuronMissingReward({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: {
               ...mockNeuron,
@@ -3637,7 +3637,7 @@ describe("neuron-utils", () => {
 
       it("should return false w/o voting power economics", () => {
         expect(
-          isNeuronLosingRewardsVPE({
+          isNeuronMissingReward({
             startReducingVotingPowerAfterSeconds: undefined,
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod,
@@ -3648,7 +3648,7 @@ describe("neuron-utils", () => {
 
       it("should return true after the reward loss has started", () => {
         expect(
-          isNeuronLosingRewardsVPE({
+          isNeuronMissingReward({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod,
@@ -3656,7 +3656,7 @@ describe("neuron-utils", () => {
           })
         ).toBe(true);
         expect(
-          isNeuronLosingRewardsVPE({
+          isNeuronMissingReward({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod + 1,
@@ -3667,7 +3667,7 @@ describe("neuron-utils", () => {
 
       it("should return false", () => {
         expect(
-          isNeuronLosingRewardsVPE({
+          isNeuronMissingReward({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs: losingRewardsPeriod - 1,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -70,7 +70,7 @@ import {
   neuronVotingPower,
   neuronsVotingPower,
   secondsUntilLosingRewardsVPE,
-  shouldDisplayRewardLossNotification,
+  shouldDisplayRewardLossNotificationVPE,
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
   topicsToFollow,
@@ -3751,10 +3751,10 @@ describe("neuron-utils", () => {
       });
     });
 
-    describe("shouldDisplayRewardLossNotification", () => {
+    describe("shouldDisplayRewardLossNotificationVPE", () => {
       it("should return false by default", () => {
         expect(
-          shouldDisplayRewardLossNotification({
+          shouldDisplayRewardLossNotificationVPE({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: {
               ...mockNeuron,
@@ -3766,7 +3766,7 @@ describe("neuron-utils", () => {
 
       it("should return true after notification period starts", () => {
         expect(
-          shouldDisplayRewardLossNotification({
+          shouldDisplayRewardLossNotificationVPE({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3775,7 +3775,7 @@ describe("neuron-utils", () => {
           })
         ).toBe(true);
         expect(
-          shouldDisplayRewardLossNotification({
+          shouldDisplayRewardLossNotificationVPE({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3787,7 +3787,7 @@ describe("neuron-utils", () => {
 
       it("should return false w/o voting economics", () => {
         expect(
-          shouldDisplayRewardLossNotification({
+          shouldDisplayRewardLossNotificationVPE({
             startReducingVotingPowerAfterSeconds: undefined,
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:
@@ -3799,7 +3799,7 @@ describe("neuron-utils", () => {
 
       it("should return false before notification period", () => {
         expect(
-          shouldDisplayRewardLossNotification({
+          shouldDisplayRewardLossNotificationVPE({
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
             neuron: neuronWithRefreshedTimestamp({
               votingPowerRefreshedTimestampAgeSecs:


### PR DESCRIPTION
# Motivation

During the migration to the voting power economics API, two versions of the same utilities existed (e.g., isNeuronLosingRewards and isNeuronLosingRewards**VPE**). The obsolete, constant-based utilities have been removed.

To keep the codebase clean, this PR removes the **VPE** postfix from these functions. Additionally, we replace the word "losing" with "missing" to reflect a shift in terminology during feature development. Other renamings will follow in upcoming PRs.

# Changes

- Rename periodic confirmation related neuron utils.

# Tests

- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.