### PR TITLE
Rename periodic confirmation related labels

### DIFF
--- a/frontend/src/lib/components/accounts/LedgerNeuronHotkeyWarning.svelte
+++ b/frontend/src/lib/components/accounts/LedgerNeuronHotkeyWarning.svelte
@@ -25,7 +25,7 @@
     <Banner
       isClosable
       on:nnsClose={dismissBanner}
-      htmlText={$i18n.losing_rewards.hw_hotkey_warning}
+      htmlText={$i18n.missing_rewards.hw_hotkey_warning}
     >
       <BannerIcon slot="icon">
         <IconInfo />

--- a/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
@@ -9,7 +9,7 @@
   import { nonNullish } from "@dfinity/utils";
 
   let title: string;
-  $: title = $i18n.losing_rewards_banner.confirm_title;
+  $: title = $i18n.missing_rewards_banner.confirm_title;
 </script>
 
 {#if nonNullish($startReducingVotingPowerAfterSecondsStore)}

--- a/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
@@ -16,7 +16,7 @@
   <Banner
     testId="confirm-following-banner-component"
     {title}
-    text={replacePlaceholders($i18n.losing_rewards.description, {
+    text={replacePlaceholders($i18n.missing_rewards.description, {
       $period: secondsToDissolveDelayDuration(
         $startReducingVotingPowerAfterSecondsStore
       ),

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -62,7 +62,7 @@
     isFollowingReset || isLosingRewards
       ? $i18n.neuron_detail.reward_status_inactive
       : isLosingRewardsSoon
-        ? $i18n.neuron_detail.reward_status_losing_soon
+        ? $i18n.neuron_detail.reward_status_missing_soon
         : $i18n.neuron_detail.reward_status_active;
 
   const getDescription = ({

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -99,7 +99,7 @@
 {#if nonNullish($startReducingVotingPowerAfterSecondsStore) && nonNullish($clearFollowingAfterSecondsStore)}
   <CommonItemAction
     testId="nns-neuron-reward-status-action-component"
-    tooltipText={replacePlaceholders($i18n.losing_rewards.description, {
+    tooltipText={replacePlaceholders($i18n.missing_rewards.description, {
       $period: secondsToDissolveDelayDuration(
         $startReducingVotingPowerAfterSecondsStore
       ),

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -88,7 +88,7 @@
       i18n: $i18n.time,
     });
     return replacePlaceholders(
-      $i18n.neuron_detail.reward_status_losing_soon_description,
+      $i18n.neuron_detail.reward_status_missing_soon_description,
       {
         $time: timeUntilLoss,
       }

--- a/frontend/src/lib/components/neuron-detail/actions/ConfirmFollowingActionButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/ConfirmFollowingActionButton.svelte
@@ -13,5 +13,5 @@
     openNnsNeuronModal({
       type: "confirm-following",
       data: { neuron },
-    })}>{$i18n.losing_rewards.confirm}</button
+    })}>{$i18n.missing_rewards.confirm}</button
 >

--- a/frontend/src/lib/components/neuron-detail/actions/ConfirmFollowingButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/ConfirmFollowingButton.svelte
@@ -13,7 +13,7 @@
   const onClick = async () => {
     startBusy({
       initiator: "refresh-voting-power",
-      labelKey: "losing_rewards.confirming",
+      labelKey: "missing_rewards.confirming",
     });
 
     const totalCount = neuronIds.length;
@@ -28,5 +28,5 @@
   on:click={onClick}
   class="secondary"
   data-tid="confirm-following-button-component"
-  >{$i18n.losing_rewards.confirm}</button
+  >{$i18n.missing_rewards.confirm}</button
 >

--- a/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -34,7 +34,7 @@
 
 <div class="wrapper" data-tid="add-principal-to-hotkeys-modal">
   {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION}
-    <Banner htmlText={$i18n.losing_rewards.hw_create_neuron_warning}>
+    <Banner htmlText={$i18n.missing_rewards.hw_create_neuron_warning}>
       <BannerIcon slot="icon">
         <IconInfo />
       </BannerIcon>

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -28,8 +28,8 @@
     startReducingVotingPowerAfterSeconds: bigint;
   }) =>
     isNeuronLosingRewardsVPE({ neuron, startReducingVotingPowerAfterSeconds })
-      ? $i18n.losing_rewards_banner.rewards_missing_title
-      : replacePlaceholders($i18n.losing_rewards_banner.days_left_title, {
+      ? $i18n.missing_rewards_banner.rewards_missing_title
+      : replacePlaceholders($i18n.missing_rewards_banner.days_left_title, {
           $timeLeft: secondsToDuration({
             seconds: BigInt(
               secondsUntilLosingRewardsVPE({

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -52,7 +52,7 @@
         startReducingVotingPowerAfterSeconds:
           $startReducingVotingPowerAfterSecondsStore,
       })}
-      text={replacePlaceholders($i18n.losing_rewards.description, {
+      text={replacePlaceholders($i18n.missing_rewards.description, {
         // TODO(mstr): Rename to secondsToRoundedDuration
         $period: secondsToDissolveDelayDuration(
           $startReducingVotingPowerAfterSecondsStore
@@ -67,7 +67,7 @@
           data-tid="confirm-button"
           class="danger"
           on:click={() => (isModalVisible = true)}
-          >{$i18n.losing_rewards.confirm}</button
+          >{$i18n.missing_rewards.confirm}</button
         >
       </div>
     </Banner>

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -39,7 +39,7 @@
   testId="nns-loosing-rewards-neuron-card-component"
   role={isClickable ? "button" : undefined}
   noMargin
-  ariaLabel={$i18n.losing_rewards_modal.goto_neuron}
+  ariaLabel={$i18n.missing_rewards_modal.goto_neuron}
   on:click={onClick}
 >
   <div class="wrapper">
@@ -67,7 +67,7 @@
       </div>
     {:else}
       <p data-tid="no-following" class="no-following">
-        {$i18n.losing_rewards_modal.no_following}
+        {$i18n.missing_rewards_modal.no_following}
       </p>
     {/if}
   </div>

--- a/frontend/src/lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte
@@ -10,7 +10,7 @@
       data-tid="badge"
       class="badge"
       role="status"
-      aria-label={$i18n.losing_rewards.badge_label}
+      aria-label={$i18n.missing_rewards.badge_label}
     ></span>
   {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -400,7 +400,7 @@
     "days_left_title": "$timeLeft left to confirm your neuron following",
     "rewards_missing_title": "One or more of your neurons are missing voting rewards"
   },
-  "losing_rewards_modal": {
+  "missing_rewards_modal": {
     "goto_neuron": "Go to neuron details",
     "title": "Review following",
     "label": "Neuron(s)",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -395,7 +395,7 @@
     "hw_create_neuron_warning": "It is recommended to <strong>Add Hotkey</strong> now, otherwise the NNS dapp will not be able to warn you if this neuron starts missing voting rewards due to inactivity.",
     "hw_hotkey_warning": "You may have neurons that are not added to the NNS dapp. If you want to view your neurons and get alerts in case they start missing voting rewards, you can add them by clicking <strong>Show Neurons > Add to NNS Dapp</strong>."
   },
-  "losing_rewards_banner": {
+  "missing_rewards_banner": {
     "confirm_title": "Confirm following or vote manually to avoid missing rewards",
     "days_left_title": "$timeLeft left to confirm your neuron following",
     "rewards_missing_title": "One or more of your neurons are missing voting rewards"

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -777,7 +777,7 @@
     "created": "Date Created",
     "reward_status_active": "Active neuron",
     "reward_status_losing_soon": "Missing rewards soon",
-    "reward_status_losing_soon_description": "$time to confirm following",
+    "reward_status_missing_soon_description": "$time to confirm following",
     "reward_status_inactive": "Inactive neuron",
     "reward_status_inactive_description": "Confirm following or vote manually to continue receiving rewards",
     "reward_status_inactive_reset_description": "Following has been reset. Confirm following or vote manually to continue receiving rewards",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -776,7 +776,7 @@
     "amount_maturity": "$amount maturity",
     "created": "Date Created",
     "reward_status_active": "Active neuron",
-    "reward_status_losing_soon": "Missing rewards soon",
+    "reward_status_missing_soon": "Missing rewards soon",
     "reward_status_missing_soon_description": "$time to confirm following",
     "reward_status_inactive": "Inactive neuron",
     "reward_status_inactive_description": "Confirm following or vote manually to continue receiving rewards",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -387,7 +387,7 @@
     "create_as_public_tooltip": "Public neurons reveal more information about themselves including how they vote on proposals.",
     "create_as_public_neuron_failure": "Making your neuron public has failed, so it was created as a private neuron. You can change neuron visibility at any time under \"Advanced Details & Settings\""
   },
-  "losing_rewards": {
+  "missing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",
     "confirming": "Confirming following. This may take a moment.",
     "confirm": "Confirm Following",

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -49,7 +49,7 @@
 
 <Modal on:nnsClose testId="losing-reward-neurons-modal-component">
   <svelte:fragment slot="title">
-    {$i18n.losing_rewards_modal.title}
+    {$i18n.missing_rewards_modal.title}
   </svelte:fragment>
 
   <div class="wrapper">
@@ -63,7 +63,7 @@
       </p>
     {/if}
 
-    <h3 class="label">{$i18n.losing_rewards_modal.label}</h3>
+    <h3 class="label">{$i18n.missing_rewards_modal.label}</h3>
     <ul class="cards">
       {#each neurons as neuron (neuron.neuronId)}
         <li>

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -55,7 +55,7 @@
   <div class="wrapper">
     {#if nonNullish($startReducingVotingPowerAfterSecondsStore)}
       <p class="description" data-tid="losing-rewards-description">
-        {replacePlaceholders($i18n.losing_rewards.description, {
+        {replacePlaceholders($i18n.missing_rewards.description, {
           $period: secondsToDissolveDelayDuration(
             BigInt($startReducingVotingPowerAfterSecondsStore)
           ),

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -401,7 +401,7 @@ interface I18nNeurons {
   create_as_public_neuron_failure: string;
 }
 
-interface I18nLosing_rewards {
+interface I18nMissing_rewards {
   description: string;
   confirming: string;
   confirm: string;
@@ -410,7 +410,7 @@ interface I18nLosing_rewards {
   hw_hotkey_warning: string;
 }
 
-interface I18nmissing_rewards_banner {
+interface I18nMissing_rewards_banner {
   confirm_title: string;
   days_left_title: string;
   rewards_missing_title: string;
@@ -1516,8 +1516,8 @@ interface I18n {
   neuron_types: I18nNeuron_types;
   staking: I18nStaking;
   neurons: I18nNeurons;
-  losing_rewards: I18nLosing_rewards;
-  missing_rewards_banner: I18nmissing_rewards_banner;
+  missing_rewards: I18nMissing_rewards;
+  missing_rewards_banner: I18nMissing_rewards_banner;
   missing_rewards_modal: I18nMissing_rewards_modal;
   new_followee: I18nNew_followee;
   follow_neurons: I18nFollow_neurons;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -410,7 +410,7 @@ interface I18nLosing_rewards {
   hw_hotkey_warning: string;
 }
 
-interface I18nLosing_rewards_banner {
+interface I18nmissing_rewards_banner {
   confirm_title: string;
   days_left_title: string;
   rewards_missing_title: string;
@@ -1517,7 +1517,7 @@ interface I18n {
   staking: I18nStaking;
   neurons: I18nNeurons;
   losing_rewards: I18nLosing_rewards;
-  losing_rewards_banner: I18nLosing_rewards_banner;
+  missing_rewards_banner: I18nmissing_rewards_banner;
   missing_rewards_modal: I18nMissing_rewards_modal;
   new_followee: I18nNew_followee;
   follow_neurons: I18nFollow_neurons;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -806,7 +806,7 @@ interface I18nNeuron_detail {
   amount_maturity: string;
   created: string;
   reward_status_active: string;
-  reward_status_losing_soon: string;
+  reward_status_missing_soon: string;
   reward_status_missing_soon_description: string;
   reward_status_inactive: string;
   reward_status_inactive_description: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -807,7 +807,7 @@ interface I18nNeuron_detail {
   created: string;
   reward_status_active: string;
   reward_status_losing_soon: string;
-  reward_status_losing_soon_description: string;
+  reward_status_missing_soon_description: string;
   reward_status_inactive: string;
   reward_status_inactive_description: string;
   reward_status_inactive_reset_description: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -416,7 +416,7 @@ interface I18nLosing_rewards_banner {
   rewards_missing_title: string;
 }
 
-interface I18nLosing_rewards_modal {
+interface I18nMissing_rewards_modal {
   goto_neuron: string;
   title: string;
   label: string;
@@ -1518,7 +1518,7 @@ interface I18n {
   neurons: I18nNeurons;
   losing_rewards: I18nLosing_rewards;
   losing_rewards_banner: I18nLosing_rewards_banner;
-  losing_rewards_modal: I18nLosing_rewards_modal;
+  missing_rewards_modal: I18nMissing_rewards_modal;
   new_followee: I18nNew_followee;
   follow_neurons: I18nFollow_neurons;
   voting: I18nVoting;


### PR DESCRIPTION
# Motivation

To keep the codebase clean, this PR renames the labels. The word "losing" has been replaced with "missing" to reflect a shift in terminology during feature development.

# Changes

- Label keys rename.

# Tests

- No changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.