### PR TITLE
Use page objects in FollowSnsTopicSection.spec.ts

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
   import Hash from "$lib/components/ui/Hash.svelte";
   import NewSnsFolloweeModal from "$lib/modals/sns/neurons/NewSnsFolloweeModal.svelte";
@@ -56,40 +57,43 @@
   };
 </script>
 
-<FollowTopicSection
-  on:nnsOpen={openModal}
-  count={followees.length}
-  id={nsFunction.id.toString()}
->
-  <svelte:fragment slot="title">{nsFunction.name}</svelte:fragment>
-  <svelte:fragment slot="subtitle"
-    >{fromNullable(nsFunction.description)}</svelte:fragment
+<TestIdWrapper testId="follow-sns-topic-section-component">
+  <FollowTopicSection
+    on:nnsOpen={openModal}
+    count={followees.length}
+    id={nsFunction.id.toString()}
   >
-  <ul>
-    {#each followees as followee (subaccountToHexString(followee.id))}
-      {@const followeeIdHex = subaccountToHexString(followee.id)}
-      <li data-tid="current-followee-item">
-        <Value>
-          <Hash text={followeeIdHex} id={followeeIdHex} tagName="span" />
-        </Value>
-        <button
-          class="text"
-          aria-label={$i18n.core.remove}
-          on:click={() => removeCurrentFollowee(followee)}><IconClose /></button
-        >
-      </li>
-    {/each}
-  </ul>
-</FollowTopicSection>
+    <svelte:fragment slot="title">{nsFunction.name}</svelte:fragment>
+    <svelte:fragment slot="subtitle"
+      >{fromNullable(nsFunction.description)}</svelte:fragment
+    >
+    <ul>
+      {#each followees as followee (subaccountToHexString(followee.id))}
+        {@const followeeIdHex = subaccountToHexString(followee.id)}
+        <li data-tid="current-followee-item">
+          <Value>
+            <Hash text={followeeIdHex} id={followeeIdHex} tagName="span" />
+          </Value>
+          <button
+            class="text"
+            aria-label={$i18n.core.remove}
+            on:click={() => removeCurrentFollowee(followee)}
+            ><IconClose /></button
+          >
+        </li>
+      {/each}
+    </ul>
+  </FollowTopicSection>
 
-{#if showModal}
-  <NewSnsFolloweeModal
-    {rootCanisterId}
-    {neuron}
-    functionId={nsFunction.id}
-    on:nnsClose={closeModal}
-  />
-{/if}
+  {#if showModal}
+    <NewSnsFolloweeModal
+      {rootCanisterId}
+      {neuron}
+      functionId={nsFunction.id}
+      on:nnsClose={closeModal}
+    />
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/card";

--- a/frontend/src/lib/modals/sns/neurons/NewSnsFolloweeModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/NewSnsFolloweeModal.svelte
@@ -45,7 +45,7 @@
   };
 </script>
 
-<Modal on:nnsClose>
+<Modal testId="new-sns-followee-modal-component" on:nnsClose>
   <svelte:fragment slot="title">{$i18n.new_followee.title}</svelte:fragment>
 
   <form on:submit|preventDefault={add}>

--- a/frontend/src/tests/page-objects/FollowSnsTopicSection.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsTopicSection.page-object.ts
@@ -1,0 +1,45 @@
+import { FollowTopicSectionPo } from "$tests/page-objects/FollowTopicSection.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { NewSnsFolloweeModalPo } from "$tests/page-objects/NewSnsFolloweeModal.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class FollowSnsTopicSectionPo extends BasePageObject {
+  private static readonly TID = "follow-sns-topic-section-component";
+
+  static under(element: PageObjectElement): FollowSnsTopicSectionPo {
+    return new FollowSnsTopicSectionPo(
+      element.byTestId(FollowSnsTopicSectionPo.TID)
+    );
+  }
+
+  async getFollowTopicSectionPo(): Promise<FollowTopicSectionPo> {
+    const article = this.root.querySelector("article");
+    const testId = await article.getAttribute("data-tid");
+    const topic = Number(testId.match(/follow-topic-(\d+)-section/)[1]);
+    return FollowTopicSectionPo.under({
+      element: this.root,
+      topic,
+    });
+  }
+
+  getHashPos(): Promise<HashPo[]> {
+    return HashPo.allUnder(this.root);
+  }
+
+  getNewSnsFolloweeModalPo(): NewSnsFolloweeModalPo {
+    return NewSnsFolloweeModalPo.under(this.root);
+  }
+
+  async removeFollowee(followeeId: string): Promise<void> {
+    const listItems = await this.root.allByTestId("current-followee-item");
+    for (const listItem of listItems) {
+      const hashPo = HashPo.under(listItem);
+      if ((await hashPo.getFullText()) === followeeId) {
+        listItem.querySelector("button").click();
+        return;
+      }
+    }
+    throw new Error(`Followee with id ${followeeId} not found`);
+  }
+}

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -10,6 +10,11 @@ export class HashPo extends BasePageObject {
     return new HashPo(element.byTestId(HashPo.TID));
   }
 
+  static async allUnder(element: PageObjectElement): Promise<HashPo[]> {
+    return Array.from(await element.allByTestId(HashPo.TID)).map(
+      (el) => new HashPo(el)
+    );
+  }
   getTooltipPo(): TooltipPo {
     return TooltipPo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/NewSnsFolloweeModal.page-object.ts
+++ b/frontend/src/tests/page-objects/NewSnsFolloweeModal.page-object.ts
@@ -1,0 +1,12 @@
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NewSnsFolloweeModalPo extends ModalPo {
+  private static readonly TID = "new-sns-followee-modal-component";
+
+  static under(element: PageObjectElement): NewSnsFolloweeModalPo {
+    return new NewSnsFolloweeModalPo(
+      element.byTestId(NewSnsFolloweeModalPo.TID)
+    );
+  }
+}


### PR DESCRIPTION
# Motivation

Make the test easier to read and maintain.

# Changes

1. Add test IDs and page objects for components.
2. Change `FollowSnsTopicSection.spec.ts` to use page objects.

# Tests

1. Test still passes.
2. Test now also passes with the change from https://github.com/dfinity/nns-dapp/pull/6263

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary