### PR TITLE
Use page objects in SnsNeuronFollowingCard.spec.ts

### DIFF
--- a/frontend/src/tests/page-objects/SnsFollowee.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsFollowee.page-object.ts
@@ -1,5 +1,6 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { TagPo } from "$tests/page-objects/Tag.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsFolloweePo extends BasePageObject {
@@ -9,7 +10,17 @@ export class SnsFolloweePo extends BasePageObject {
     return new SnsFolloweePo(element.byTestId(SnsFolloweePo.TID));
   }
 
+  static async allUnder(element: PageObjectElement): Promise<SnsFolloweePo[]> {
+    return Array.from(await element.allByTestId(SnsFolloweePo.TID)).map(
+      (el) => new SnsFolloweePo(el)
+    );
+  }
+
   getHashPo(): HashPo {
     return HashPo.under(this.root);
+  }
+
+  getTagPos(): Promise<TagPo[]> {
+    return TagPo.allUnder(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronFollowingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronFollowingCard.page-object.ts
@@ -1,3 +1,5 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { SnsFolloweePo } from "$tests/page-objects/SnsFollowee.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,5 +10,17 @@ export class SnsNeuronFollowingCardPo extends BasePageObject {
     return new SnsNeuronFollowingCardPo(
       element.byTestId(SnsNeuronFollowingCardPo.TID)
     );
+  }
+
+  getSnsFolloweePos(): Promise<SnsFolloweePo[]> {
+    return SnsFolloweePo.allUnder(this.root);
+  }
+
+  hasSkeletonFollowees(): Promise<boolean> {
+    return this.isPresent("skeleton-followees");
+  }
+
+  getFollowSnsNeuronsButtonPo(): ButtonPo {
+    return this.getButton("sns-follow-neurons-button");
   }
 }


### PR DESCRIPTION
# Motivation

Make the test easier to read and maintain.

# Changes

1. Update page objects.
2. Change `SnsNeuronFollowingCard.spec.ts` to use page objects.

# Tests

1. Test still passes.
2. Test now also passes with the change from https://github.com/dfinity/nns-dapp/pull/6263

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary