### PR TITLE
Remove last_ledger_sync_timestamp_nanos from AccountsStore

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -48,7 +48,6 @@ pub struct AccountsStore {
 
     accounts_db_stats: AccountsDbStats,
     accounts_db_stats_recomputed_on_upgrade: IgnoreEq<Option<bool>>,
-    last_ledger_sync_timestamp_nanos: u64,
     neurons_topped_up_count: u64,
 }
 
@@ -72,11 +71,8 @@ impl fmt::Debug for AccountsStore {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "AccountsStore{{accounts_db: {:?}, accounts_db_stats: {:?}, last_ledger_sync_timestamp_nanos: {:?}, neurons_topped_up_count: {:?}}}",
-            self.accounts_db,
-            self.accounts_db_stats,
-            self.last_ledger_sync_timestamp_nanos,
-            self.neurons_topped_up_count,
+            "AccountsStore{{accounts_db: {:?}, accounts_db_stats: {:?}, neurons_topped_up_count: {:?}}}",
+            self.accounts_db, self.accounts_db_stats, self.neurons_topped_up_count,
         )
     }
 }
@@ -741,7 +737,9 @@ impl StableState for AccountsStore {
             // TODO: Change to an arbitrary value after we've deployed to
             // mainnet. Then remove the MultiPartTransactionsProcessor.
             MultiPartTransactionsProcessor::default(),
-            &self.last_ledger_sync_timestamp_nanos,
+            // last_ledger_sync_timestamp_nanos is unused but we need to encode
+            // it for backwards compatibility.
+            0u64,
             &self.neurons_topped_up_count,
             Some(&self.accounts_db_stats),
         ))
@@ -763,7 +761,7 @@ impl StableState for AccountsStore {
             _neuron_accounts,
             _block_height_synced_up_to,
             _multi_part_transactions_processor,
-            last_ledger_sync_timestamp_nanos,
+            _last_ledger_sync_timestamp_nanos,
             neurons_topped_up_count,
             accounts_db_stats_maybe,
         ): (
@@ -778,7 +776,7 @@ impl StableState for AccountsStore {
             candid::Reserved,
             candid::Reserved,
             candid::Reserved,
-            u64,
+            candid::Reserved,
             u64,
             Option<AccountsDbStats>,
         ) = Candid::from_bytes(bytes).map(|c| c.0)?;
@@ -795,7 +793,6 @@ impl StableState for AccountsStore {
             accounts_db: AccountsDbAsProxy::default(),
             accounts_db_stats,
             accounts_db_stats_recomputed_on_upgrade,
-            last_ledger_sync_timestamp_nanos,
             neurons_topped_up_count,
         })
     }


### PR DESCRIPTION
# Motivation

The nns-dapp canister no longer processes ICP transactions so we don't need to keep track of the last time we processed transactions.

# Changes

1. Remove field `last_ledger_sync_timestamp_nanos` from `AccountsStore`.
2. When encoding the `AccountsStore` to stable memory, write `0u64` in the slot of `last_ledger_sync_timestamp_nanos`.
3. Ignore the slot of  `last_ledger_sync_timestamp_nanos` when decoding the `AccountsStore` from stable memory.

# Tests

This was was already not used anymore so no tests needed to be changed.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary