### PR TITLE
Increase account limit from 300k to 330k

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -27,7 +27,7 @@ use schema::{
 
 // This limit is for DoS protection but should be increased if we get close to
 // the limit.
-const ACCOUNT_LIMIT: u64 = 300_000;
+const ACCOUNT_LIMIT: u64 = 330_000;
 
 const MAX_SUB_ACCOUNT_ID: u8 = u8::MAX - 1;
 


### PR DESCRIPTION
# Motivation

We received an alert that the number of accounts in the NNS dapp has passed 280'000 and is getting close to the limit of 300'000.
Based on the dashboard, it looks like the number of accounts is growing with about 100 per day.
So if we increase both the limit and the alerting limit by 30k, it should last as another 9 months or so.

# Changes

1. Increase the hard account limit from `300_000` to `330_000`.

# Tests

No tested.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary