### PR TITLE
test: invalid NnsNeuronCard role link

### DIFF
--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -57,7 +57,7 @@ describe("NnsNeuronCard", () => {
   });
 
   it("renders role and aria-label passed", async () => {
-    const role = "link";
+    const role = "button";
     const ariaLabel = "test label";
     const { container } = render(NnsNeuronCard, {
       props: {


### PR DESCRIPTION
# Motivation

Discussed in https://github.com/dfinity/nns-dapp/pull/6258#discussion_r1932056272, `role=link` used in the test "renders role and aria-label passed" of `NnsNeuronCard` is actually no valid property. The component expect `role: undefined | "button" | "checkbox"`.

# Changes

- Change test role to `button`
