### PR TITLE
Support sorting in TokensTable

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -4,23 +4,49 @@
   import TokenTitleCell from "$lib/components/tokens/TokensTable/TokenTitleCell.svelte";
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import type { TokensTableColumn, UserToken } from "$lib/types/tokens-page";
+  import type { TokensTableOrder } from "$lib/types/tokens-page";
+  import {
+    compareTokensAlphabetically,
+    compareTokensByBalance,
+  } from "$lib/utils/tokens-table.utils";
+  import { nonNullish } from "@dfinity/utils";
 
   export let userTokensData: Array<UserToken>;
   export let firstColumnHeader: string;
+  export let order: TokensTableOrder = [];
 
-  const columns: TokensTableColumn[] = [
+  let enableSorting: boolean;
+  $: enableSorting = order.length > 0;
+
+  let importedTokenIds: Set<string> = new Set();
+  $: importedTokenIds = new Set(
+    ($importedTokensStore.importedTokens ?? []).map(({ ledgerCanisterId }) =>
+      ledgerCanisterId.toText()
+    )
+  );
+
+  let columns: TokensTableColumn[];
+
+  $: columns = [
     {
+      id: "title",
       title: firstColumnHeader,
       cellComponent: TokenTitleCell,
       alignment: "left",
       templateColumns: ["1fr"],
+      comparator: enableSorting ? compareTokensAlphabetically : undefined,
     },
     {
+      id: "balance",
       title: $i18n.tokens.balance_header,
       cellComponent: TokenBalanceCell,
       alignment: "right",
       templateColumns: ["max-content"],
+      comparator: enableSorting
+        ? compareTokensByBalance({ importedTokenIds })
+        : undefined,
     },
     {
       title: "",
@@ -35,6 +61,7 @@
   testId="tokens-table-component"
   tableData={userTokensData}
   {columns}
+  bind:order
   on:nnsAction
 >
   <slot name="last-row" slot="last-row" />

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -11,7 +11,6 @@
     compareTokensAlphabetically,
     compareTokensByBalance,
   } from "$lib/utils/tokens-table.utils";
-  import { nonNullish } from "@dfinity/utils";
 
   export let userTokensData: Array<UserToken>;
   export let firstColumnHeader: string;

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -41,7 +41,7 @@ describe("TokensTable", () => {
     orderStore?: Writable<TokensTableOrder>;
     order?: TokensTableOrder;
   }) => {
-    const { container } = render(TokensTable, {
+    const { container, component } = render(TokensTable, {
       props: {
         userTokensData,
         firstColumnHeader,

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -17,14 +17,14 @@ import {
   createUserToken,
   createUserTokenLoading,
 } from "$tests/mocks/tokens-page.mock";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { createActionEvent } from "$tests/utils/actions.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { waitFor } from "@testing-library/svelte";
 import { get, writable, type Writable } from "svelte/store";
-import { render } from "$tests/utils/svelte.test-utils";
 import type { Mock } from "vitest";
 
 describe("TokensTable", () => {

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -3,10 +3,8 @@ import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-import type { TokensTableOrder } from "$lib/types/tokens-page";
-import { writable, type Writable } from "svelte/store";
-//import { tokensTableOrderStore } from "$lib/stores/tokens-table.store";
 import { ActionType } from "$lib/types/actions";
+import type { TokensTableOrder } from "$lib/types/tokens-page";
 import {
   UserTokenAction,
   type UserTokenData,
@@ -25,7 +23,7 @@ import { createActionEvent } from "$tests/utils/actions.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
-import { get } from "svelte/store";
+import { get, writable, type Writable } from "svelte/store";
 import type { Mock } from "vitest";
 
 describe("TokensTable", () => {


### PR DESCRIPTION
# Motivation

We want to allow people to sort the tokens table based on name or balance.
The tokens table is used on the tokens page but also on the ICP accounts page.
On the accounts page we don't want to enable sorting.

This PR supports sorting in the tokens table be specifying the `order` prop on the `TokensTable` component.
We should not specify this prop on the accounts page.
On the tokens page we would use the `$tokensTableOrderStore` as the `order prop to persist the order between navigation.

BUT! We can not enable this on the tokens page yet either because the sort button on mobile interferes with the settings button for "hide zero balances".

So this PR only supports the functionality in the component but does not yet enable it on the page.

# Changes

1. Support sorting based on either balance or title in the `TokensTable` component, if the `order` prop is specified to indicate the order that should be used.

# Tests

1. Unit tests added.
2. Tested manually after passing `$tokensTableOrderStore` as the `order` prop.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet