### PR TITLE
refactor(navigation): enhance referrer path tracking with list

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -57,7 +57,7 @@
 
 <TestIdWrapper testId="nns-proposal-component">
   {#if $store?.proposal?.id !== undefined && nonNullish(proposalIds)}
-    {#if $referrerPathStore !== AppPath.Launchpad}
+    {#if $referrerPathStore.at(-1) !== AppPath.Launchpad}
       <ProposalNavigation
         title={proposalType}
         currentProposalId={{

--- a/frontend/src/lib/pages/Canisters.svelte
+++ b/frontend/src/lib/pages/Canisters.svelte
@@ -38,7 +38,7 @@
   onMount(async () => {
     const reload = reloadRouteData({
       expectedPreviousPath: AppPath.Canister,
-      effectivePreviousPath: $referrerPathStore,
+      effectivePreviousPath: $referrerPathStore.at(-1),
       currentData: $canistersStore.canisters,
     });
 

--- a/frontend/src/lib/pages/NnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/NnsProposalDetail.svelte
@@ -60,7 +60,7 @@
     }
 
     return goto(
-      $referrerPathStore === AppPath.Launchpad
+      $referrerPathStore.at(-1) === AppPath.Launchpad
         ? AppPath.Launchpad
         : AppPath.Proposals
     );

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -79,7 +79,7 @@
   onMount(async () => {
     const reload = reloadRouteData({
       expectedPreviousPath: AppPath.Proposal,
-      effectivePreviousPath: $referrerPathStore,
+      effectivePreviousPath: $referrerPathStore.at(-1),
       currentData: $sortedProposals.proposals,
     });
 

--- a/frontend/src/lib/stores/routes.store.ts
+++ b/frontend/src/lib/stores/routes.store.ts
@@ -1,4 +1,15 @@
 import type { AppPath } from "$lib/constants/routes.constants";
 import { writable } from "svelte/store";
 
-export const referrerPathStore = writable<AppPath | undefined>(undefined);
+const MAX_SIZE_REFERRER_PATHS = 10;
+const initReferrerPathStore = () => {
+  const { update, subscribe } = writable<AppPath[]>([]);
+
+  return {
+    pushPath: (path: AppPath) =>
+      update((paths) => [...paths, path].slice(-MAX_SIZE_REFERRER_PATHS)),
+    subscribe,
+  };
+};
+
+export const referrerPathStore = initReferrerPathStore();

--- a/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
@@ -5,7 +5,6 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { ENABLE_EXPORT_NEURONS_REPORT } from "$lib/stores/feature-flags.store";
   import { referrerPathStore } from "$lib/stores/routes.store";
-  import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
 
   onMount(async () => {
@@ -13,7 +12,7 @@
   });
 
   const back = async () => {
-    if (nonNullish($referrerPathStore)) {
+    if ($referrerPathStore.length > 0) {
       // Referrer might be a detail page which needs query parameters therefore we use the browser API to go back there
       history.back();
       return;

--- a/frontend/src/routes/(app)/(nns)/settings/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/settings/+layout.svelte
@@ -4,10 +4,9 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { referrerPathStore } from "$lib/stores/routes.store";
-  import { nonNullish } from "@dfinity/utils";
 
   const back = async () => {
-    if (nonNullish($referrerPathStore)) {
+    if ($referrerPathStore.length > 0) {
       // Referrer might be a detail page which needs query parameters therefore we use the browser API to go back there
       history.back();
       return;

--- a/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
@@ -8,16 +8,15 @@
   import { referrerPathStore } from "$lib/stores/routes.store";
 
   const back = async (): Promise<void> => {
+    const lastReferrer = $referrerPathStore.at(-1);
     // This is a hack to jump back to the specific project page (because of the query params)
-    if ($referrerPathStore === AppPath.Project) {
+    if (lastReferrer === AppPath.Project) {
       history.back();
       return;
     }
 
     goto(
-      $referrerPathStore === AppPath.Launchpad
-        ? $referrerPathStore
-        : $proposalsPathStore
+      lastReferrer === AppPath.Launchpad ? lastReferrer : $proposalsPathStore
     );
   };
 </script>

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -14,6 +14,7 @@
   import { referrerPathForNav } from "$lib/utils/page.utils";
   import { voteRegistrationActive } from "$lib/utils/proposals.utils";
   import { BusyScreen, Toasts } from "@dfinity/gix-components";
+  import { isNullish } from "@dfinity/utils";
   import type { AfterNavigate } from "@sveltejs/kit";
   import { onMount } from "svelte";
 
@@ -26,10 +27,13 @@
   );
 
   // Use the top level layout to set the `referrerPath` because anything under `{#if isNullish($navigating)}` will miss the `afterNavigate` events
-  afterNavigate((nav: AfterNavigate) =>
+  afterNavigate((nav: AfterNavigate) => {
     // TODO: e2e to test this
-    referrerPathStore.set(referrerPathForNav(nav))
-  );
+    const path = referrerPathForNav(nav);
+    if (isNullish(path)) return;
+
+    referrerPathStore.pushPath(path);
+  });
 
   // To improve the UX while the app is loading on mainnet we display a spinner which is attached statically in the index.html files.
   // Once the authentication has been initialized we know most JavaScript resources has been loaded and therefore we can hide the spinner, the loading information.

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -36,7 +36,6 @@ describe("Proposal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    referrerPathStore.set(undefined);
   });
 
   const renderProposalModern = (id = 1000n) =>
@@ -136,7 +135,7 @@ describe("Proposal", () => {
     vi.spyOn(filteredProposals, "subscribe").mockImplementation(
       createMockProposalsStoreSubscribe(generateMockProposals(10))
     );
-    referrerPathStore.set(AppPath.Launchpad);
+    referrerPathStore.pushPath(AppPath.Launchpad);
 
     const { container } = renderProposalModern(5n);
     const po = ProposalNavigationPo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/lib/stores/routes.store.spec.ts
+++ b/frontend/src/tests/lib/stores/routes.store.spec.ts
@@ -1,0 +1,35 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { referrerPathStore } from "$lib/stores/routes.store";
+import { get } from "svelte/store";
+
+describe("routes.store", () => {
+  describe("referrerPathStore", () => {
+    it("should have an initial value", () => {
+      expect(get(referrerPathStore)).toEqual([]);
+    });
+
+    it("should push a new path", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+
+      expect(get(referrerPathStore).length).toEqual(1);
+      expect(get(referrerPathStore)).toEqual([AppPath.Portfolio]);
+    });
+
+    it("should remove old paths when reaching limit of 10 entries", () => {
+      referrerPathStore.pushPath(AppPath.Accounts);
+      for (let i = 0; i < 9; i++) {
+        referrerPathStore.pushPath(AppPath.Portfolio);
+      }
+
+      expect(get(referrerPathStore).length).toEqual(10);
+      expect(get(referrerPathStore).at(0)).toEqual(AppPath.Accounts);
+      expect(get(referrerPathStore).at(1)).toEqual(AppPath.Portfolio);
+
+      referrerPathStore.pushPath(AppPath.Tokens);
+
+      expect(get(referrerPathStore).length).toEqual(10);
+      expect(get(referrerPathStore).at(0)).toEqual(AppPath.Portfolio);
+      expect(get(referrerPathStore).at(-1)).toEqual(AppPath.Tokens);
+    });
+  });
+});

--- a/frontend/src/tests/routes/app/reporting/layout.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/layout.spec.ts
@@ -46,8 +46,6 @@ describe("Layout", () => {
   });
 
   it("should go back to the accounts page as fallback", async () => {
-    referrerPathStore.set(undefined);
-
     const { queryByTestId } = renderReporting();
 
     const { path } = get(pageStore);
@@ -64,7 +62,7 @@ describe("Layout", () => {
   });
 
   it("should go back to referrer", async () => {
-    referrerPathStore.set(AppPath.Wallet);
+    referrerPathStore.pushPath(AppPath.Wallet);
 
     const spy = vi.spyOn(history, "back");
 

--- a/frontend/src/tests/routes/app/settings/layout.spec.ts
+++ b/frontend/src/tests/routes/app/settings/layout.spec.ts
@@ -28,8 +28,6 @@ describe("Layout", () => {
   };
 
   it("should go back to the accounts page as fallback", async () => {
-    referrerPathStore.set(undefined);
-
     renderSettingsAndBack();
 
     await waitFor(() => {
@@ -39,8 +37,7 @@ describe("Layout", () => {
   });
 
   it("should go back to referrer", async () => {
-    referrerPathStore.set(AppPath.Wallet);
-
+    referrerPathStore.pushPath(AppPath.Wallet);
     const spy = vi.spyOn(history, "back");
 
     renderSettingsAndBack();


### PR DESCRIPTION
# Motivation

The Accounts page features a custom back button that currently redirects users to the Tokens page. This is no longer always accurate, as users can now access this page from the Portfolio page.

Since users can also navigate from the Accounts page to the Wallet page, we cannot rely on a local solution. The Accounts layout will be unmounted, resulting in the loss of this information.

This first PR modifies the existing solution used by the Proposal page to redirect back to either the Proposals or Launchpad by tracking the referrer. To gain more insight than just the last jump, the current single value has been changed to a list of referrers.

A follow-up PR will use this updated store in the Accounts layout to track how users enter the page and determine where to navigate when they click the custom back button.

Note: We do not want to rely on the browser's history stack. If a user directly enters the Accounts page, we want to navigate them back to the Tokens page as we currently do.

# Changes

- Updates the `referrerPathStore` to maintain a list of referrers.

# Tests

- Updates unit tests affected by the change.  
-  Adds new unit tests for the updated store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary