### PR TITLE
test(utils): add ckUSDC canister test setup utility

### DIFF
--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -34,7 +34,7 @@ import { PortfolioRoutePo } from "$tests/page-objects/PortfolioRoute.page-object
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
-import { setCkUSDCanisters } from "$tests/utils/ckusd.test-utils";
+import { setCkUSDCCanisters } from "$tests/utils/ckusdc.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { Principal } from "@dfinity/principal";
@@ -84,7 +84,7 @@ describe("Portfolio route", () => {
     );
 
     setCkETHCanisters();
-    setCkUSDCanisters();
+    setCkUSDCCanisters();
   });
 
   it("should load ICP Swap tickers", async () => {

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -7,13 +7,8 @@ import {
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
-import {
-  CKUSDC_INDEX_CANISTER_ID,
-  CKUSDC_LEDGER_CANISTER_ID,
-  CKUSDC_UNIVERSE_CANISTER_ID,
-} from "$lib/constants/ckusdc-canister-ids.constants";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { getAnonymousIdentity } from "$lib/services/auth.services";
-import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -39,6 +34,7 @@ import { PortfolioRoutePo } from "$tests/page-objects/PortfolioRoute.page-object
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
+import { setCkUSDCanisters } from "$tests/utils/ckusd.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { Principal } from "@dfinity/principal";
@@ -88,15 +84,7 @@ describe("Portfolio route", () => {
     );
 
     setCkETHCanisters();
-    // TODO: Copy setCkETHCanisters aproach to set the canisters for CKUSDC
-    defaultIcrcCanistersStore.setCanisters({
-      ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
-      indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
-    });
-    tokensStore.setToken({
-      canisterId: CKUSDC_UNIVERSE_CANISTER_ID,
-      token: mockCkUSDCToken,
-    });
+    setCkUSDCanisters();
   });
 
   it("should load ICP Swap tickers", async () => {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -44,7 +44,7 @@ import type { TokensTableRowPo } from "$tests/page-objects/TokensTableRow.page-o
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
-import { setCkUSDCanisters } from "$tests/utils/ckusd.test-utils";
+import { setCkUSDCCanisters } from "$tests/utils/ckusdc.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { AuthClient } from "@dfinity/auth-client";
@@ -209,7 +209,7 @@ describe("Tokens route", () => {
       setAccountsForTesting({
         main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
       });
-      setCkUSDCanisters();
+      setCkUSDCCanisters();
     });
 
     describe("when logged in", () => {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -11,12 +11,7 @@ import {
   CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
-import {
-  CKUSDC_INDEX_CANISTER_ID,
-  CKUSDC_LEDGER_CANISTER_ID,
-  CKUSDC_UNIVERSE_CANISTER_ID,
-} from "$lib/constants/ckusdc-canister-ids.constants";
-import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import {
@@ -49,6 +44,7 @@ import type { TokensTableRowPo } from "$tests/page-objects/TokensTableRow.page-o
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
+import { setCkUSDCanisters } from "$tests/utils/ckusd.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { AuthClient } from "@dfinity/auth-client";
@@ -213,15 +209,7 @@ describe("Tokens route", () => {
       setAccountsForTesting({
         main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
       });
-
-      defaultIcrcCanistersStore.setCanisters({
-        ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
-        indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
-      });
-      tokensStore.setToken({
-        canisterId: CKUSDC_UNIVERSE_CANISTER_ID,
-        token: mockCkUSDCToken,
-      });
+      setCkUSDCanisters();
     });
 
     describe("when logged in", () => {

--- a/frontend/src/tests/utils/ckusd.test-utils.ts
+++ b/frontend/src/tests/utils/ckusd.test-utils.ts
@@ -1,0 +1,19 @@
+import {
+  CKUSDC_INDEX_CANISTER_ID,
+  CKUSDC_LEDGER_CANISTER_ID,
+  CKUSDC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckusdc-canister-ids.constants";
+import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
+
+export const setCkUSDCanisters = () => {
+  defaultIcrcCanistersStore.setCanisters({
+    ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
+    indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
+  });
+  tokensStore.setToken({
+    canisterId: CKUSDC_UNIVERSE_CANISTER_ID,
+    token: mockCkUSDCToken,
+  });
+};

--- a/frontend/src/tests/utils/ckusdc.test-utils.ts
+++ b/frontend/src/tests/utils/ckusdc.test-utils.ts
@@ -7,7 +7,7 @@ import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.st
 import { tokensStore } from "$lib/stores/tokens.store";
 import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
 
-export const setCkUSDCanisters = () => {
+export const setCkUSDCCanisters = () => {
   defaultIcrcCanistersStore.setCanisters({
     ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
     indexCanisterId: CKUSDC_INDEX_CANISTER_ID,


### PR DESCRIPTION
# Motivation

We want to simplify the setup of the ckUSDC canister, similar to how we do it for [ckETH](https://github.com/dfinity/nns-dapp/blob/7a668d6280e0f0d022484430a95d2ad9e8f139f0/frontend/src/tests/utils/cketh.test-utils.ts#L10)

# Changes

- New test utility function to set up the ckUSDC canister
-  Replaces manual setups with calls to this function

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary)
Not necessary