### PR TITLE
Fix URL parameter double validation

### DIFF
--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -72,21 +72,27 @@
       goto(AppPath.Tokens);
     }
   };
+  let isLedgerCanisterIdProcessed = false;
   $: {
     if (
       $ENABLE_IMPORT_TOKEN_BY_URL &&
+      !isLedgerCanisterIdProcessed &&
       isNullish(ledgerCanisterId) &&
       nonNullish($pageStore.importTokenLedgerId)
     ) {
+      isLedgerCanisterIdProcessed = true;
       ledgerCanisterId = getCanisterIdFromText($pageStore.importTokenLedgerId);
     }
   }
+  let isIndexCanisterIdProcessed = false;
   $: {
     if (
       $ENABLE_IMPORT_TOKEN_BY_URL &&
+      !isIndexCanisterIdProcessed &&
       isNullish(indexCanisterId) &&
       nonNullish($pageStore.importTokenIndexId)
     ) {
+      isIndexCanisterIdProcessed = true;
       indexCanisterId = getCanisterIdFromText($pageStore.importTokenIndexId);
     }
   }

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -653,14 +653,15 @@ describe("ImportTokenModal", () => {
     });
 
     it("catches invalid canister ID formats from URL", async () => {
-      page.mock({
+      const pageData = {
         routeId: AppPath.Tokens,
         data: {
           universe: OWN_CANISTER_ID_TEXT,
           importTokenLedgerId: "INVALID_CANISTER_ID",
           importTokenIndexId: indexCanisterId.toText(),
         },
-      });
+      };
+      page.mock(pageData);
 
       const consoleErrorSpy = vi.spyOn(console, "error").mockReturnValue();
       vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
@@ -677,6 +678,10 @@ describe("ImportTokenModal", () => {
       const formPo = po.getImportTokenFormPo();
       const reviewPo = po.getImportTokenReviewPo();
 
+      await runResolvedPromises();
+
+      // Imitate the second page emission
+      page.mock(pageData);
       await runResolvedPromises();
 
       // Should stay on the form


### PR DESCRIPTION
# Motivation

The importTokenLedgerId comes from $pageStore (derived from app/stores/page), which dispatches an update twice on page load (presumably due to the Svelte hydration mechanism). This results in reading the canister ID from the URL twice, and if the ID format is incorrect, the error warning appears twice as well.

To prevent this, we introduce a flags to check the URL params only once. I also considered adding two derived stores (one per parameter), but flags offer a leaner solution.

# Changes

- Use local flags to avoid multiple validation calls.

# Tests

- The test was changed and verified that it fails w/o the fix.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.