### PR TITLE
Improve canisters e2e test

### DIFF
--- a/frontend/src/tests/e2e/canisters.spec.ts
+++ b/frontend/src/tests/e2e/canisters.spec.ts
@@ -60,7 +60,7 @@ test("Test canisters", async ({ page, context }) => {
   step("Rename canister");
   const canisterCards = await canistersPo.getCanisterCardPos();
   expect(canisterCards).toHaveLength(2);
-  const [myCanisterCard, linkedCanisterCard] = canisterCards;
+  let [myCanisterCard, linkedCanisterCard] = canisterCards;
   expect(await myCanisterCard.getCanisterName()).toBe(canisterName);
   expect(await linkedCanisterCard.getCanisterName()).toBe(linkedCanisterName);
   await myCanisterCard.click();
@@ -85,6 +85,8 @@ test("Test canisters", async ({ page, context }) => {
 
   step("Verify name");
   await appPo.goBack();
+  await canistersPo.waitForContentLoaded();
+  [myCanisterCard, linkedCanisterCard] = await canistersPo.getCanisterCardPos();
   expect(await myCanisterCard.getCanisterName()).toBe(newCanisterName);
 
   step("Open linked canister");

--- a/frontend/src/tests/page-objects/Canisters.page-object.ts
+++ b/frontend/src/tests/page-objects/Canisters.page-object.ts
@@ -2,6 +2,7 @@ import { CanisterCardPo } from "$tests/page-objects/CanisterCard.page-object";
 import { CreateCanisterModalPo } from "$tests/page-objects/CreateCanisterModal.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import { LinkCanisterModalPo } from "$tests/page-objects/LinkCanisterModal.page-object";
+import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -10,6 +11,11 @@ export class CanistersPo extends BasePageObject {
 
   static under(element: PageObjectElement): CanistersPo {
     return new CanistersPo(element.byTestId(CanistersPo.TID));
+  }
+
+  getSkeletonCardPo(): SkeletonCardPo {
+    // There are multiple but we only need one.
+    return SkeletonCardPo.under(this.root);
   }
 
   getCanisterCardPos(): Promise<CanisterCardPo[]> {
@@ -65,5 +71,10 @@ export class CanistersPo extends BasePageObject {
     await modal.waitFor();
     await modal.linkCanister({ canisterId, name });
     await modal.waitForClosed();
+  }
+
+  async waitForContentLoaded(): Promise<void> {
+    await this.waitFor();
+    await this.getSkeletonCardPo().waitForAbsent();
   }
 }


### PR DESCRIPTION
# Motivation

We've observed [flakiness](https://github.com/dfinity/nns-dapp/actions/runs/13017255077/job/36309718238?pr=6276) in the canisters end-to-end test.
I was not able to reproduce this, but while looking into the test I noticed something which seemed brittle.
On line 63, the test gets canister card page objects, and then reuses those objects on 88 and below, even though the test navigates to a different page (and back) on the lines in between.
And when it arrives, on line 88, those cards are not even on the page (it's showing skeleton cards).
The test relies on the fact that getting the name of the card in `expect(await myCanisterCard.getCanisterName()).toBe(newCanisterName);` causes the test to wait for the name to exist in the DOM.
This seems very brittle and it would be better to explicitly wait for the page content the be loaded and not reuse the page objects from before.

# Changes

1. Wait for content to be loaded after navigating back to the canisters page.
2. Get new page objects for the canister cards after navigating back to the canisters page.

# Tests

1. I wasn't able to reproduce the flakiness but the tests still pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary