### PR TITLE
NNS1-3548: Add projectsTableOrderStore

### DIFF
--- a/frontend/src/lib/stores/projects-table.store.ts
+++ b/frontend/src/lib/stores/projects-table.store.ts
@@ -1,0 +1,24 @@
+import type { ProjectsTableOrder } from "$lib/types/staking";
+import { writable } from "svelte/store";
+
+const initialProjectsTableOrder: ProjectsTableOrder = [
+  {
+    columnId: "stake",
+  },
+  {
+    columnId: "title",
+  },
+];
+
+const initProjectsTableOrderStore = () => {
+  const { subscribe, set } = writable<ProjectsTableOrder>(
+    initialProjectsTableOrder
+  );
+
+  return {
+    subscribe,
+    set,
+  };
+};
+
+export const projectsTableOrderStore = initProjectsTableOrderStore();

--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -1,4 +1,7 @@
-import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+import type {
+  ResponsiveTableColumn,
+  ResponsiveTableOrder,
+} from "$lib/types/responsive-table";
 import type { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import type { TokenAmountV2 } from "@dfinity/utils";
 
@@ -17,4 +20,11 @@ export type TableProject = {
   isStakeLoading?: boolean;
 };
 
-export type ProjectsTableColumn = ResponsiveTableColumn<TableProject>;
+export type ProjectsTableColumnId = "title" | "stake" | "neurons";
+
+export type ProjectsTableColumn = ResponsiveTableColumn<
+  TableProject,
+  ProjectsTableColumnId
+>;
+
+export type ProjectsTableOrder = ResponsiveTableOrder<ProjectsTableColumnId>;

--- a/frontend/src/tests/lib/stores/projects-table.store.spec.ts
+++ b/frontend/src/tests/lib/stores/projects-table.store.spec.ts
@@ -1,0 +1,31 @@
+import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
+import { get } from "svelte/store";
+
+describe("projects-table.store", () => {
+  describe("projectsTableOrderStore", () => {
+    it("should have an initial value", () => {
+      expect(get(projectsTableOrderStore)).toEqual([
+        {
+          columnId: "stake",
+        },
+        {
+          columnId: "title",
+        },
+      ]);
+    });
+
+    it("should set", () => {
+      projectsTableOrderStore.set([
+        {
+          columnId: "title",
+        },
+      ]);
+
+      expect(get(projectsTableOrderStore)).toEqual([
+        {
+          columnId: "title",
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to allow the user to change the order in the projects table by clicking on the table headers, similar to the neurons table.
To remember the order between navigations (not between sessions) we will use a store, similar to the [neuronsTableOrderStore](https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/stores/neurons-table.store.ts).

# Changes

1. Add `projectsTableOrderStore`.
2. Add `ProjectsTableOrder` type.

# Tests

1. Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary