### PR TITLE
feat(navigation): add derived store for last tokens/portfolio visit

### DIFF
--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -4,7 +4,7 @@ import { derived, type Readable } from "svelte/store";
 
 /**
  * Derives the origin page (Portfolio or Tokens) to return to from Accounts.
- * Looks at last two entries to handle navigation flows:
+ * Looks at last three entries to handle navigation flows:
  * Portfolio/Tokens -> Accounts -> Wallet -> (back) -> Accounts -> (back) -> Origin
  *
  * Returns AppPath.Tokens as default if no matching page is found.

--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -3,7 +3,7 @@ import { referrerPathStore } from "$lib/stores/routes.store";
 import { derived, type Readable } from "svelte/store";
 
 /**
- * Derives the origin page (Portfolio or Tokens) to return to from Accounts.
+ * Derives the origin page (Portfolio or Tokens) to return from Accounts.
  * Looks at last three entries to handle navigation flows:
  * Portfolio/Tokens -> Accounts -> Wallet -> (back) -> Accounts -> (back) -> Origin
  *

--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -1,0 +1,13 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { referrerPathStore } from "$lib/stores/routes.store";
+import { derived, type Readable } from "svelte/store";
+
+export const accountsPageOrigin: Readable<AppPath> = derived(
+  referrerPathStore,
+  ($paths) => {
+    const lastPath = [...$paths]
+      .reverse()
+      .find((path) => path === AppPath.Portfolio || path === AppPath.Tokens);
+    return lastPath ?? AppPath.Tokens;
+  }
+);

--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -2,11 +2,19 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { derived, type Readable } from "svelte/store";
 
+/**
+ * Derives the origin page (Portfolio or Tokens) to return to from Accounts.
+ * Looks at last two entries to handle navigation flows:
+ * Portfolio/Tokens -> Accounts -> Wallet -> (back) -> Accounts -> (back) -> Origin
+ *
+ * Returns AppPath.Tokens as default if no matching page is found.
+ */
 export const accountsPageOrigin: Readable<AppPath> = derived(
   referrerPathStore,
   ($paths) => {
     const lastPath = [...$paths]
       .reverse()
+      .slice(0, 3)
       .find((path) => path === AppPath.Portfolio || path === AppPath.Tokens);
     return lastPath ?? AppPath.Tokens;
   }

--- a/frontend/src/tests/lib/derived/routes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/routes.derived.spec.ts
@@ -8,6 +8,13 @@ describe("accountsPageOrigin.derived", () => {
     expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
   });
 
+  it("should return Tokens as default when no main pages were visited", () => {
+    referrerPathStore.pushPath(AppPath.Staking);
+    referrerPathStore.pushPath(AppPath.Settings);
+
+    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+  });
+
   it("should return Portfolio when it was the last main page visited", () => {
     referrerPathStore.pushPath(AppPath.Tokens);
     referrerPathStore.pushPath(AppPath.Portfolio);
@@ -16,25 +23,18 @@ describe("accountsPageOrigin.derived", () => {
   });
 
   it("should return Tokens when it was the last main page visited", () => {
-    referrerPathStore.pushPath(AppPath.Tokens);
     referrerPathStore.pushPath(AppPath.Portfolio);
     referrerPathStore.pushPath(AppPath.Tokens);
 
     expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
   });
 
-  it("should return Tokens as default when no main pages were visited", () => {
-    referrerPathStore.pushPath(AppPath.Staking);
-    referrerPathStore.pushPath(AppPath.Settings);
-
-    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
-  });
-
-  it("should return Portfolio when it was last main page among other pages", () => {
-    referrerPathStore.pushPath(AppPath.Tokens);
+  it("should return Tokens when pages visited are more than the 3 slots", () => {
     referrerPathStore.pushPath(AppPath.Portfolio);
     referrerPathStore.pushPath(AppPath.Settings);
+    referrerPathStore.pushPath(AppPath.Launchpad);
+    referrerPathStore.pushPath(AppPath.Wallet);
 
-    expect(get(accountsPageOrigin)).toBe(AppPath.Portfolio);
+    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
   });
 });

--- a/frontend/src/tests/lib/derived/routes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/routes.derived.spec.ts
@@ -1,0 +1,40 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { accountsPageOrigin } from "$lib/derived/routes.derived";
+import { referrerPathStore } from "$lib/stores/routes.store";
+import { get } from "svelte/store";
+
+describe("accountsPageOrigin.derived", () => {
+  it("should return Tokens page as default when history is empty", () => {
+    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+  });
+
+  it("should return Portfolio when it was the last main page visited", () => {
+    referrerPathStore.pushPath(AppPath.Tokens);
+    referrerPathStore.pushPath(AppPath.Portfolio);
+
+    expect(get(accountsPageOrigin)).toBe(AppPath.Portfolio);
+  });
+
+  it("should return Tokens when it was the last main page visited", () => {
+    referrerPathStore.pushPath(AppPath.Tokens);
+    referrerPathStore.pushPath(AppPath.Portfolio);
+    referrerPathStore.pushPath(AppPath.Tokens);
+
+    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+  });
+
+  it("should return Tokens as default when no main pages were visited", () => {
+    referrerPathStore.pushPath(AppPath.Staking);
+    referrerPathStore.pushPath(AppPath.Settings);
+
+    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+  });
+
+  it("should return Portfolio when it was last main page among other pages", () => {
+    referrerPathStore.pushPath(AppPath.Tokens);
+    referrerPathStore.pushPath(AppPath.Portfolio);
+    referrerPathStore.pushPath(AppPath.Settings);
+
+    expect(get(accountsPageOrigin)).toBe(AppPath.Portfolio);
+  });
+});


### PR DESCRIPTION
# Motivation

The Accounts page features a custom back button that currently redirects users to the Tokens page. However, this is no longer always accurate, as users can now access this page from the Portfolio page.

Since users can also navigate from the Accounts page to the Wallet page, we cannot rely on a local solution. The Accounts layout will be unmounted, resulting in the loss of this information.

This second PR follows up on #6274 by creating a derived store that checks the entry page for the Accounts page, whether it is the Portfolio or the Tokens page.

A third PR will utilize this derived store in the Accounts layout to determine the appropriate redirect.

# Changes

- New derived store to calculate the last visited page: Tokens or Portfolio, defaulting to Tokens if neither was selected.

# Tests

- Added unit tests for the derived store.
- Manually tested [here](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/) with additional changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary