### PR TITLE
NNS1-3548: Custom sorting for projects table

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,6 +15,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 - Import tokens by URL.
+- Custom sorting of staking nervous systems table.
 
 #### Changed
 

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -13,9 +13,13 @@
   import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
+  import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { ProjectsTableColumn, TableProject } from "$lib/types/staking";
   import {
+    compareByNeuronCount,
+    compareByProjectTitle,
+    compareByStake,
     getTableProjects,
     getTotalStakeInUsd,
     sortTableProjects,
@@ -30,10 +34,12 @@
 
   const columns: ProjectsTableColumn[] = [
     {
+      id: "title",
       title: $i18n.staking.nervous_systems,
       cellComponent: ProjectTitleCell,
       alignment: "left",
       templateColumns: ["minmax(min-content, max-content)"],
+      comparator: compareByProjectTitle,
     },
     {
       title: "",
@@ -41,10 +47,12 @@
       templateColumns: ["1fr"],
     },
     {
+      id: "stake",
       title: $i18n.neuron_detail.stake,
       cellComponent: ProjectStakeCell,
       alignment: "right",
       templateColumns: ["max-content"],
+      comparator: compareByStake,
     },
     {
       title: "",
@@ -63,10 +71,12 @@
       templateColumns: ["1fr"],
     },
     {
+      id: "neurons",
       title: $i18n.neurons.title,
       cellComponent: ProjectNeuronsCell,
       alignment: "right",
       templateColumns: ["max-content"],
+      comparator: compareByNeuronCount,
     },
     {
       title: "",
@@ -128,6 +138,7 @@
     tableData={sortedTableProjects}
     {columns}
     on:nnsAction={handleAction}
+    bind:order={$projectsTableOrderStore}
   ></ResponsiveTable>
 </div>
 


### PR DESCRIPTION
# Motivation

We want to allow the user to change the order in the projects table by clicking on the table headers, similar to the neurons table.
When clicking the "Nervous Systems" header, the projects should be ordered alphabetically by name.
When clicking the "Neurons" header, the projects should be ordered number of neurons.
When clicking the "Stake" header, the projects should be ordered by:
1. USD value of the stake
2. Projects without exchange rate but positive number of neurons before projects with zero neurons.
3. Within projects with the same (probably 0) USD stake, ICP should be sorted before others.

# Changes

1. Change the columns spec to support custom sorting.
2. Connect the `projectsTableOrderStore` to the `ResponsiveTable` to persist the order between navigations.

# Tests

1. Existing unit tests updated based on the different default ordering.
2. Unit tests added.
3. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/tokens/

# Todos

- [x] Add entry to changelog (if necessary).
