### PR TITLE
Rename secondsToRoundedDuration

### DIFF
--- a/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmFollowingBanner.svelte
@@ -4,7 +4,7 @@
   import Banner from "$lib/components/ui/Banner.svelte";
   import BannerIcon from "$lib/components/ui/BannerIcon.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { secondsToRoundedDuration } from "$lib/utils/date.utils";
   import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
   import { nonNullish } from "@dfinity/utils";
 
@@ -17,7 +17,7 @@
     testId="confirm-following-banner-component"
     {title}
     text={replacePlaceholders($i18n.missing_rewards.description, {
-      $period: secondsToDissolveDelayDuration(
+      $period: secondsToRoundedDuration(
         $startReducingVotingPowerAfterSecondsStore
       ),
     })}

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -3,7 +3,7 @@
   import FollowNeuronsButton from "$lib/components/neuron-detail/actions/FollowNeuronsButton.svelte";
   import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { secondsToRoundedDuration } from "$lib/utils/date.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
     isNeuronFollowingReset,
@@ -100,7 +100,7 @@
   <CommonItemAction
     testId="nns-neuron-reward-status-action-component"
     tooltipText={replacePlaceholders($i18n.missing_rewards.description, {
-      $period: secondsToDissolveDelayDuration(
+      $period: secondsToRoundedDuration(
         $startReducingVotingPowerAfterSecondsStore
       ),
     })}

--- a/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
+++ b/frontend/src/lib/components/neurons/LosingRewardsBanner.svelte
@@ -11,7 +11,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { nonNullish, secondsToDuration } from "@dfinity/utils";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { secondsToRoundedDuration } from "$lib/utils/date.utils";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import LosingRewardNeuronsModal from "$lib/modals/neurons/LosingRewardNeuronsModal.svelte";
   import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
@@ -53,8 +53,7 @@
           $startReducingVotingPowerAfterSecondsStore,
       })}
       text={replacePlaceholders($i18n.missing_rewards.description, {
-        // TODO(mstr): Rename to secondsToRoundedDuration
-        $period: secondsToDissolveDelayDuration(
+        $period: secondsToRoundedDuration(
           $startReducingVotingPowerAfterSecondsStore
         ),
       })}

--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -2,7 +2,7 @@
   import VotingCardNeuronList from "$lib/components/proposal-detail/VotingCard/VotingCardNeuronList.svelte";
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
   import { i18n } from "$lib/stores/i18n";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { secondsToRoundedDuration } from "$lib/utils/date.utils";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type {
@@ -21,9 +21,7 @@
   $: reasonShort = replacePlaceholders(
     $i18n.proposal_detail__ineligible.reason_short,
     {
-      $minDissolveDelay: secondsToDissolveDelayDuration(
-        minSnsDissolveDelaySeconds
-      ),
+      $minDissolveDelay: secondsToRoundedDuration(minSnsDissolveDelaySeconds),
     }
   );
   const reasonText = ({ reason }: IneligibleNeuronData) =>
@@ -42,9 +40,7 @@
 {#if visible}
   <p class="description" data-tid="ineligible-neurons-description">
     {replacePlaceholders($i18n.proposal_detail__ineligible.text, {
-      $minDissolveDelay: secondsToDissolveDelayDuration(
-        minSnsDissolveDelaySeconds
-      ),
+      $minDissolveDelay: secondsToRoundedDuration(minSnsDissolveDelaySeconds),
     })}
   </p>
   <VotingCardNeuronList>

--- a/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
@@ -3,7 +3,7 @@
   import Hash from "$lib/components/ui/Hash.svelte";
   import { snsParametersStore } from "$lib/derived/sns-parameters.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { secondsToRoundedDuration } from "$lib/utils/date.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
     getSnsLockedTimeInSeconds,
@@ -69,7 +69,7 @@
   $: minDissolveDelayDescription = isNullish(snsParameters)
     ? ""
     : replacePlaceholders($i18n.sns_neurons.min_dissolve_delay_description, {
-        $duration: `${secondsToDissolveDelayDuration(
+        $duration: `${secondsToRoundedDuration(
           BigInt(minSnsDissolveDelaySeconds)
         )}`,
       });

--- a/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/LosingRewardNeuronsModal.svelte
@@ -2,7 +2,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { Modal } from "@dfinity/gix-components";
   import { createEventDispatcher, onMount } from "svelte";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { secondsToRoundedDuration } from "$lib/utils/date.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
@@ -56,7 +56,7 @@
     {#if nonNullish($startReducingVotingPowerAfterSecondsStore)}
       <p class="description" data-tid="losing-rewards-description">
         {replacePlaceholders($i18n.missing_rewards.description, {
-          $period: secondsToDissolveDelayDuration(
+          $period: secondsToRoundedDuration(
             BigInt($startReducingVotingPowerAfterSecondsStore)
           ),
         })}

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -60,7 +60,7 @@ export const daysToDuration = (days: number): string => {
  *
  * @param seconds
  */
-export const secondsToDissolveDelayDuration = (seconds: bigint): string => {
+export const secondsToRoundedDuration = (seconds: bigint): string => {
   const i18nObj = get(i18n);
   const years = seconds / BigInt(SECONDS_IN_YEAR);
   const months = (seconds % BigInt(SECONDS_IN_YEAR)) / BigInt(SECONDS_IN_MONTH);

--- a/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
@@ -1,6 +1,6 @@
 import IneligibleNeuronsCard from "$lib/components/proposal-detail/IneligibleNeuronsCard.svelte";
 import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
-import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+import { secondsToRoundedDuration } from "$lib/utils/date.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import type { IneligibleNeuronData } from "$lib/utils/neuron.utils";
 import en from "$tests/mocks/i18n.mock";
@@ -70,7 +70,7 @@ describe("IneligibleNeuronsCard", () => {
     expect(
       getByText(
         replacePlaceholders(en.proposal_detail__ineligible.reason_short, {
-          $minDissolveDelay: secondsToDissolveDelayDuration(
+          $minDissolveDelay: secondsToRoundedDuration(
             BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE)
           ),
         }),
@@ -134,7 +134,7 @@ describe("IneligibleNeuronsCard", () => {
     expect(
       getByText(
         replacePlaceholders(en.proposal_detail__ineligible.reason_short, {
-          $minDissolveDelay: secondsToDissolveDelayDuration(
+          $minDissolveDelay: secondsToRoundedDuration(
             BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE)
           ),
         }),

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -7,7 +7,7 @@ import {
   nanoSecondsToDateTime,
   secondsToDate,
   secondsToDateTime,
-  secondsToDissolveDelayDuration,
+  secondsToRoundedDuration,
   secondsToTime,
 } from "$lib/utils/date.utils";
 import en from "$tests/mocks/i18n.mock";
@@ -73,53 +73,49 @@ describe("daysToDuration", () => {
   });
 });
 
-describe("secondsToDissolveDelayDuration", () => {
+describe("secondsToRoundedDuration", () => {
   it("should display a day", () => {
-    expect(secondsToDissolveDelayDuration(BigInt(SECONDS_IN_DAY))).toContain(
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_DAY))).toContain(
       en.time.day
     );
-    expect(secondsToDissolveDelayDuration(BigInt(SECONDS_IN_DAY))).toContain(
-      "1"
-    );
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_DAY))).toContain("1");
   });
 
   it("should display 1 month", () => {
-    expect(secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH))).toContain(
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH))).toContain(
       en.time.month
     );
-    expect(secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH))).toContain(
-      "1"
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH))).toContain("1");
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH))).not.toContain(
+      en.time.month_plural
     );
-    expect(
-      secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH))
-    ).not.toContain(en.time.month_plural);
   });
 
   it("should display 2 months", () => {
-    expect(
-      secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH * 2))
-    ).toContain(en.time.month_plural);
-    expect(
-      secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH * 2))
-    ).toContain("2");
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH * 2))).toContain(
+      en.time.month_plural
+    );
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH * 2))).toContain(
+      "2"
+    );
   });
 
   it("should display 1 year", () => {
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH * 12))).toContain(
+      en.time.year
+    );
+    expect(secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH * 12))).toContain(
+      "1"
+    );
     expect(
-      secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH * 12))
-    ).toContain(en.time.year);
-    expect(
-      secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH * 12))
-    ).toContain("1");
-    expect(
-      secondsToDissolveDelayDuration(BigInt(SECONDS_IN_MONTH * 12))
+      secondsToRoundedDuration(BigInt(SECONDS_IN_MONTH * 12))
     ).not.toContain(en.time.year_plural);
   });
 
   it("should display 2 years, 9 months, 11 days", () => {
-    expect(secondsToDissolveDelayDuration(87_654_321n)).toContain("2");
-    expect(secondsToDissolveDelayDuration(87_654_321n)).toContain("9");
-    expect(secondsToDissolveDelayDuration(87_654_321n)).toContain("11");
+    expect(secondsToRoundedDuration(87_654_321n)).toContain("2");
+    expect(secondsToRoundedDuration(87_654_321n)).toContain("9");
+    expect(secondsToRoundedDuration(87_654_321n)).toContain("11");
   });
 });
 


### PR DESCRIPTION
# Motivation

Refactoring: renamed secondsToDissolveDelayDuration to secondsToRoundedDuration, as it is used not only for the dissolve delay but also in confirm following.

# Changes

- renamed secondsToDissolveDelayDuration to secondsToRoundedDuration. 

# Tests

- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.