### PR TITLE
chore: bump ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.5-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.5-next-2025-01-16.tgz",
-      "integrity": "sha512-1PVyvFlc8Zlp7IEr8xQxqMtbmBRvE6m/CJ8CnhnsE+Ux+fngBONiq/fXTj5saogdYuqRjn7xOqlIlYYBVKMTuA==",
+      "version": "3.1.6-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.6-next-2025-01-29.tgz",
+      "integrity": "sha512-2WteWvGJSiU8K6cVeM2MRBlzeqc8QCdVWA14YF5F1DQh8QWqtkM7RpcQFfehhatij0DJ9CRIo56sdoHxUMsbvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "4.1.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.1.0-next-2025-01-16.tgz",
-      "integrity": "sha512-bYG1NHXOJciTQY96ntlurtx02qJEFULfSte5icPNanmddxqGdK6wn5i0Uy6hXrvtGjA8Y5VV+kYqay7mEgbHng==",
+      "version": "4.1.1-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.1.1-next-2025-01-29.tgz",
+      "integrity": "sha512-bPZ9tIWFTnjPX6O85Dn7dIeYNKq4GqEyKghlyCi5UscCrjB+FMtADJ/PsLTowIUucfLtXjGwinuv1DZzra+RWg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "6.0.2-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.2-next-2025-01-16.tgz",
-      "integrity": "sha512-zRBxR1Z83n/LGM/GPFV0i25NxZJJ9rw7DctCkbhHyLIM+fJNJED0co8TKlDDe7Z1htHDmFiL8VyZJLmnH9Ev0g==",
+      "version": "6.0.3-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.3-next-2025-01-29.tgz",
+      "integrity": "sha512-KoNCXWyQ/AMF2ma2PK3NvdvjXQFyzXDzCqjAh2rZ/m4DsCKmZwSCjuSyd6IJWBVp18+y4SIBxp26bNqX18GeKg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.6.5-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.5-next-2025-01-16.tgz",
-      "integrity": "sha512-lZsaLTtUYLQSESd01a4+8MOOoy3xpGCaUU2CKNoUbzoNtMTMfvpDx1MPvcKq2C96KfLclSuj4n5k4M4CIluwGQ==",
+      "version": "2.6.7-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.7-next-2025-01-29.tgz",
+      "integrity": "sha512-imAogSOi38NQXL/LCrgF81U+M5Q6y4d2w5U5qDh+9D/p/xBTCXiLX+YoVpa/d7KfJ8btECTU7fJnZNSLM3QWsA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.7.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.7.0-next-2025-01-16.tgz",
-      "integrity": "sha512-QK9YxhDYn+vMAl9l+SVGosaNRXDqo9pBz7UIGDN777BGrXfZzbrJhYVAwNjzh7kIBpTBNymBL5+9Q0KcVK9BPQ==",
+      "version": "2.7.2-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.7.2-next-2025-01-29.tgz",
+      "integrity": "sha512-ACsl3Vial3VfO/NWuMt+vZkHLFrO6JlE9PTGef6aw1rAHiF27oQ72ymNW2Jqzdwlm+T4gBPJ34so5/4cl9HyWw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "8.1.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.1.0-next-2025-01-16.tgz",
-      "integrity": "sha512-r3GvhlzbhQMcr1V4uDCrG/YoA0e/nmkbIkozu4P7SzD4ysbAQoeHyBb+a/sfHf3a3vloYnLCNqj6uksggdRD4Q==",
+      "version": "8.2.1-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.2.1-next-2025-01-29.tgz",
+      "integrity": "sha512-ZaDdDR/umyhmCZJ/qfleE6+hFpPV8wB3+Q6DfmIRqzjvkbDR3yJjzFLkv1UNCYxOHjn2vxLrqGlAvECQuN5Ccw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -419,9 +419,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.2.6-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.6-next-2025-01-16.tgz",
-      "integrity": "sha512-LDMocf74H0gxHbNaLRbPcK9XnhKnkeXLHabRups/zbMT1uwlm3IFFStc8JZ465tQt46vkid88Y+Z/IOz+JHbSQ==",
+      "version": "3.2.8-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.8-next-2025-01-29.tgz",
+      "integrity": "sha512-l7MizqkhfOUocGSg80WfP3fDvowPtBKXwECAjq5PaQKkjuW1awbaY7zSDNrYj44xN0Ez60eQS3sog7KF14IZCA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.8.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.8.0-next-2025-01-16.tgz",
-      "integrity": "sha512-KulyFn+R65f4BlI8ueDBOFkxR0poOqQGeU0pKyocMDyIaIl/zExzllpoMcK51sgcozj5Vr43JjZHzyej2EIhZQ==",
+      "version": "2.9.0-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.9.0-next-2025-01-29.tgz",
+      "integrity": "sha512-IbzpVFcoOZjsiE/Ls5518i7rNEgDCOGu5dEmQWskKzoJBB9PozTykES1RpLrhgae8+MmYC0i/Pbbu78RKFChcA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -6688,9 +6688,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "3.1.5-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.5-next-2025-01-16.tgz",
-      "integrity": "sha512-1PVyvFlc8Zlp7IEr8xQxqMtbmBRvE6m/CJ8CnhnsE+Ux+fngBONiq/fXTj5saogdYuqRjn7xOqlIlYYBVKMTuA==",
+      "version": "3.1.6-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.6-next-2025-01-29.tgz",
+      "integrity": "sha512-2WteWvGJSiU8K6cVeM2MRBlzeqc8QCdVWA14YF5F1DQh8QWqtkM7RpcQFfehhatij0DJ9CRIo56sdoHxUMsbvA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -6698,9 +6698,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "4.1.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.1.0-next-2025-01-16.tgz",
-      "integrity": "sha512-bYG1NHXOJciTQY96ntlurtx02qJEFULfSte5icPNanmddxqGdK6wn5i0Uy6hXrvtGjA8Y5VV+kYqay7mEgbHng==",
+      "version": "4.1.1-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.1.1-next-2025-01-29.tgz",
+      "integrity": "sha512-bPZ9tIWFTnjPX6O85Dn7dIeYNKq4GqEyKghlyCi5UscCrjB+FMtADJ/PsLTowIUucfLtXjGwinuv1DZzra+RWg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -6715,9 +6715,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "6.0.2-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.2-next-2025-01-16.tgz",
-      "integrity": "sha512-zRBxR1Z83n/LGM/GPFV0i25NxZJJ9rw7DctCkbhHyLIM+fJNJED0co8TKlDDe7Z1htHDmFiL8VyZJLmnH9Ev0g==",
+      "version": "6.0.3-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.3-next-2025-01-29.tgz",
+      "integrity": "sha512-KoNCXWyQ/AMF2ma2PK3NvdvjXQFyzXDzCqjAh2rZ/m4DsCKmZwSCjuSyd6IJWBVp18+y4SIBxp26bNqX18GeKg==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -6731,21 +6731,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.6.5-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.5-next-2025-01-16.tgz",
-      "integrity": "sha512-lZsaLTtUYLQSESd01a4+8MOOoy3xpGCaUU2CKNoUbzoNtMTMfvpDx1MPvcKq2C96KfLclSuj4n5k4M4CIluwGQ==",
+      "version": "2.6.7-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.7-next-2025-01-29.tgz",
+      "integrity": "sha512-imAogSOi38NQXL/LCrgF81U+M5Q6y4d2w5U5qDh+9D/p/xBTCXiLX+YoVpa/d7KfJ8btECTU7fJnZNSLM3QWsA==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.7.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.7.0-next-2025-01-16.tgz",
-      "integrity": "sha512-QK9YxhDYn+vMAl9l+SVGosaNRXDqo9pBz7UIGDN777BGrXfZzbrJhYVAwNjzh7kIBpTBNymBL5+9Q0KcVK9BPQ==",
+      "version": "2.7.2-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.7.2-next-2025-01-29.tgz",
+      "integrity": "sha512-ACsl3Vial3VfO/NWuMt+vZkHLFrO6JlE9PTGef6aw1rAHiF27oQ72ymNW2Jqzdwlm+T4gBPJ34so5/4cl9HyWw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "8.1.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.1.0-next-2025-01-16.tgz",
-      "integrity": "sha512-r3GvhlzbhQMcr1V4uDCrG/YoA0e/nmkbIkozu4P7SzD4ysbAQoeHyBb+a/sfHf3a3vloYnLCNqj6uksggdRD4Q==",
+      "version": "8.2.1-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.2.1-next-2025-01-29.tgz",
+      "integrity": "sha512-ZaDdDR/umyhmCZJ/qfleE6+hFpPV8wB3+Q6DfmIRqzjvkbDR3yJjzFLkv1UNCYxOHjn2vxLrqGlAvECQuN5Ccw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -6760,17 +6760,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.2.6-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.6-next-2025-01-16.tgz",
-      "integrity": "sha512-LDMocf74H0gxHbNaLRbPcK9XnhKnkeXLHabRups/zbMT1uwlm3IFFStc8JZ465tQt46vkid88Y+Z/IOz+JHbSQ==",
+      "version": "3.2.8-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.2.8-next-2025-01-29.tgz",
+      "integrity": "sha512-l7MizqkhfOUocGSg80WfP3fDvowPtBKXwECAjq5PaQKkjuW1awbaY7zSDNrYj44xN0Ez60eQS3sog7KF14IZCA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.8.0-next-2025-01-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.8.0-next-2025-01-16.tgz",
-      "integrity": "sha512-KulyFn+R65f4BlI8ueDBOFkxR0poOqQGeU0pKyocMDyIaIl/zExzllpoMcK51sgcozj5Vr43JjZHzyej2EIhZQ==",
+      "version": "2.9.0-next-2025-01-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.9.0-next-2025-01-29.tgz",
+      "integrity": "sha512-IbzpVFcoOZjsiE/Ls5518i7rNEgDCOGu5dEmQWskKzoJBB9PozTykES1RpLrhgae8+MmYC0i/Pbbu78RKFChcA==",
       "requires": {}
     },
     "@esbuild/aix-ppc64": {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -166,6 +166,7 @@ export const convertNervousSystemParameters = ({
   maturity_modulation_disabled,
   max_number_of_principals_per_neuron,
 }: CachedNervousSystemParametersDto): SnsNervousSystemParameters => ({
+  automatically_advance_target_version: [],
   default_followees: convertDefaultFollowees(default_followees),
   max_dissolve_delay_seconds: numberToNullableBigInt(
     max_dissolve_delay_seconds

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -755,6 +755,7 @@ describe("sns aggregator converters utils", () => {
             ],
           },
         ],
+        automatically_advance_target_version: [],
         max_dissolve_delay_seconds: [252460800n],
         max_dissolve_delay_bonus_percentage: [100n],
         max_followees_per_function: [15n],
@@ -774,11 +775,7 @@ describe("sns aggregator converters utils", () => {
         transaction_fee_e8s: [100000n],
         max_number_of_proposals_with_ballots: [700n],
         max_age_bonus_percentage: [25n],
-        neuron_grantable_permissions: [
-          {
-            permissions: [0, 1, 2, 3, 4],
-          },
-        ],
+        neuron_grantable_permissions: [{ permissions: [0, 1, 2, 3, 4] }],
         voting_rewards_parameters: [
           {
             final_reward_rate_basis_points: [75n],
@@ -821,6 +818,7 @@ describe("sns aggregator converters utils", () => {
       };
 
       const expectedSnsNervousSystemParameters: SnsNervousSystemParameters = {
+        automatically_advance_target_version: [],
         default_followees: [],
         max_dissolve_delay_seconds: [],
         max_dissolve_delay_bonus_percentage: [],


### PR DESCRIPTION
# Motivation

We want to pull in the latest changes to make the get the the ICP to XDR conversion rate certified.
Related ic-js pr: https://github.com/dfinity/ic-js/pull/830

# Changes

- Run `npm run upgrade:next`
- Add new fields to the mock - the reason why the CI action upgrade is failing.

# Tests

- Should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary