### PR TITLE
Import by url cancel fix

### DIFF
--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -68,8 +68,6 @@
         substitutions: { $canisterId: canisterIdText },
       });
       close();
-      // Navigate to clear all query parameters.
-      goto(AppPath.Tokens);
     }
   };
   let isLedgerCanisterIdProcessed = false;
@@ -170,6 +168,7 @@
         level: "warn",
         labelKey: "error__imported_tokens.is_duplication",
       });
+      dispatch("nnsClose");
       goto(
         buildWalletUrl({
           universe: ledgerCanisterId.toText(),
@@ -242,7 +241,11 @@
     }
   };
 
-  const close = () => dispatch("nnsClose");
+  const close = () => {
+    dispatch("nnsClose");
+    // Navigate on close to clear all query parameters.
+    goto(AppPath.Tokens);
+  };
 </script>
 
 <WizardModal
@@ -250,11 +253,7 @@
   {steps}
   bind:currentStep
   bind:this={modal}
-  on:nnsClose={() => {
-    close();
-    // Navigate on close to clear all query parameters.
-    goto(AppPath.Tokens);
-  }}
+  on:nnsClose={close}
 >
   <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
 
@@ -262,7 +261,7 @@
     <ImportTokenForm
       bind:ledgerCanisterId
       bind:indexCanisterId
-      on:nnsClose
+      on:nnsClose={close}
       on:nnsSubmit={onSubmit}
     />
   {/if}

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -535,7 +535,7 @@ describe("ImportTokenModal", () => {
       });
     });
 
-    it("closes on cancel click", async () => {
+    it("removes the URL parameters on cancel click", async () => {
       vi.spyOn(console, "error").mockReturnValue();
       queryIcrcTokenSpy = vi
         .spyOn(ledgerApi, "queryIcrcToken")

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -535,6 +535,49 @@ describe("ImportTokenModal", () => {
       });
     });
 
+    it("closes on cancel click", async () => {
+      vi.spyOn(console, "error").mockReturnValue();
+      queryIcrcTokenSpy = vi
+        .spyOn(ledgerApi, "queryIcrcToken")
+        .mockRejectedValue(new Error());
+
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [],
+      });
+      vi.spyOn(importedTokensApi, "setImportedTokens").mockResolvedValue();
+
+      importedTokensStore.set({
+        importedTokens: [],
+        certified: true,
+      });
+
+      const po = renderComponent();
+      const formPo = po.getImportTokenFormPo();
+      const reviewPo = po.getImportTokenReviewPo();
+
+      await runResolvedPromises();
+
+      expect(await formPo.isPresent()).toEqual(true);
+      expect(await reviewPo.isPresent()).toEqual(false);
+
+      expect(get(pageStore)).toMatchObject({
+        path: AppPath.Tokens,
+        universe: OWN_CANISTER_ID_TEXT,
+        importTokenLedgerId: ledgerCanisterId.toText(),
+        importTokenIndexId: indexCanisterId.toText(),
+      });
+
+      await formPo.getCancelButtonPo().click();
+      await runResolvedPromises();
+
+      expect(get(pageStore)).toMatchObject({
+        path: AppPath.Tokens,
+        universe: OWN_CANISTER_ID_TEXT,
+        importTokenLedgerId: undefined,
+        importTokenIndexId: undefined,
+      });
+    });
+
     it("does not auto validate when feature flag disabled", async () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_IMPORT_TOKEN_BY_URL", false);
       vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({


### PR DESCRIPTION
# Motivation

When imported token validation fails (for reasons other than an invalid ID format or token duplication), clicking the Cancel button does not close the modal, which is undesirable. This happens because the Cancel button only updates showImportTokenModal but does not remove import-ledger-id from the URL, causing the modal to remain open ([the logic to open the modal](https://github.com/dfinity/nns-dapp/blob/1e511c6d974104c2fa1746cc4ec107bcb01c29a0/frontend/src/lib/pages/Tokens.svelte#L158))

# Changes

- Remove query params from URL on cancel.
- Drive-by changes: Ensure consistent behavior by dispatching dispatch("nnsClose") before navigating to the already imported token.

# Tests

- Added and verified that it fails w/o this fix.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.