### PR TITLE
fix(security): enable certified calls for ICP/XDR conversion rate

### DIFF
--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -61,7 +61,7 @@ export const getIcpToCyclesExchangeRate = async (
   logWithTimestamp("Getting ICP to Cycles ratio call...");
   const { cmc } = await canisters(identity);
 
-  const response = await cmc.getIcpToCyclesConversionRate();
+  const response = await cmc.getIcpToCyclesConversionRate({ certified: true });
 
   logWithTimestamp("Getting ICP to Cycles ratio complete.");
 

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -219,7 +219,9 @@ describe("canisters-api", () => {
       mockCMCCanister.getIcpToCyclesConversionRate.mockResolvedValue(10_000n);
 
       const response = await getIcpToCyclesExchangeRate(mockIdentity);
-      expect(mockCMCCanister.getIcpToCyclesConversionRate).toBeCalled();
+      expect(mockCMCCanister.getIcpToCyclesConversionRate).toHaveBeenCalledWith(
+        { certified: true }
+      );
       expect(response).toEqual(10_000n);
     });
   });

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -219,9 +219,9 @@ describe("canisters-api", () => {
       mockCMCCanister.getIcpToCyclesConversionRate.mockResolvedValue(10_000n);
 
       const response = await getIcpToCyclesExchangeRate(mockIdentity);
-      expect(mockCMCCanister.getIcpToCyclesConversionRate).toHaveBeenCalledWith(
-        { certified: true }
-      );
+      expect(mockCMCCanister.getIcpToCyclesConversionRate).toBeCalledWith({
+        certified: true,
+      });
       expect(response).toEqual(10_000n);
     });
   });


### PR DESCRIPTION
# Motivation

It has been flagged as a security concern not to use a certified query when reading the ICP to XDR conversion rate.

This is a follow up of https://github.com/dfinity/ic-js/pull/830 to make the call as a certified one.

[SECFIND-421](https://dfinity.atlassian.net/browse/SECFIND-421)

# Changes

- Pass the `certified` flag to `getIcpToCyclesConversionRate` to make it an update call

# Tests

- Updated unit test to check that the flag is provided

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[SECFIND-421]: https://dfinity.atlassian.net/browse/SECFIND-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ