### PR TITLE
NNS1-3548: Allow disabling table sorting on mobile

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -27,6 +27,7 @@
   export let gridRowsPerTableRow = 1;
   export let getRowStyle: (rowData: RowDataType) => string | undefined = (_) =>
     undefined;
+  export let disableMobileSorting = false;
 
   let nonLastColumns: ResponsiveTableColumn<RowDataType>[];
   let lastColumn: ResponsiveTableColumn<RowDataType> | undefined;
@@ -132,7 +133,7 @@
             role="columnheader"
             style="--column-span: {lastColumn.templateColumns.length}"
             class="desktop-align-{lastColumn.alignment} header-icon"
-            >{#if isSortingEnabled}<button
+            >{#if isSortingEnabled && !disableMobileSorting}<button
                 data-tid="open-sort-modal"
                 class="mobile-only icon-only"
                 on:click={openSortModal}><IconSort /></button

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -90,6 +90,7 @@ describe("ResponsiveTable", () => {
     order?: ResponsiveTableOrder;
     gridRowsPerTableRow?: number;
     getRowStyle?: (rowData: ResponsiveTableRowData) => string;
+    disableMobileSorting?: boolean;
   }
 
   const renderComponent = ({
@@ -341,6 +342,22 @@ describe("ResponsiveTable", () => {
     await sortModal.waitForClosed();
     await po.openSortModal();
     expect(await sortModal.getOptionWithArrow()).toBe("Age");
+  });
+
+  it("should disable mobile sorting", async () => {
+    const po = renderComponent({
+      columns,
+      tableData,
+      order: [{ columnId: "name" }],
+      disableMobileSorting: true,
+    });
+    expect(await po.getOpenSortModalButtonPo().isPresent()).toBe(false);
+
+    // Desktop sorting should still work.
+    expect(await po.getColumnHeaderWithArrow()).toBe("Name");
+
+    await po.clickColumnHeader("Age");
+    expect(await po.getColumnHeaderWithArrow()).toBe("Age");
   });
 
   it("should not have a sorting button if no columns are sortable", async () => {


### PR DESCRIPTION
# Motivation

We want to allow sorting the tokens table.
On desktop, sorting the table is done by clicking on the table column header.
But on mobile, there is an icon in the top-right to open a sorting modal.
However, the tokens table already has an icon in the top right.
Until we have a better solution for that, we've decided to just not allow sorting the tokens table on mobile so that we can already allow sorting the tokens table on desktop.

This PR adds a prop to the `ResponsiveTable` component to control whether the sorting icon should be displayed on mobile.

# Changes

1. Add `disableMobileSorting` prop to `ResponsiveTable` to hide the sorting icon button.

# Tests

1. Unit test added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet