### PR TITLE
Add setIcpSwapUsdPrices test util

### DIFF
--- a/frontend/src/tests/utils/icp-swap.test-utils.spec.ts
+++ b/frontend/src/tests/utils/icp-swap.test-utils.spec.ts
@@ -1,0 +1,55 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
+import { get } from "svelte/store";
+
+describe("icp-swap.test-utils.spec.ts", () => {
+  describe("setIcpSwapUsdPrices", () => {
+    it("should set the price of ICP to 10 USD by default", () => {
+      setIcpSwapUsdPrices({});
+
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [LEDGER_CANISTER_ID.toText()]: 10,
+        [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: 1,
+      });
+    });
+
+    it("should set the price of ICP to 123 USD", () => {
+      setIcpSwapUsdPrices({
+        [LEDGER_CANISTER_ID.toText()]: 123,
+      });
+
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [LEDGER_CANISTER_ID.toText()]: 123,
+        [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: 1,
+      });
+    });
+
+    it("should set the price of ckBTC to 99_000 USD", () => {
+      setIcpSwapUsdPrices({
+        [CKBTC_LEDGER_CANISTER_ID.toText()]: 99_000,
+      });
+
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [CKBTC_LEDGER_CANISTER_ID.toText()]: 99_000,
+        [LEDGER_CANISTER_ID.toText()]: 10,
+        [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: 1,
+      });
+    });
+
+    it("should set the price of ckBTC to 99_000 USD and ICP to 123 USD", () => {
+      setIcpSwapUsdPrices({
+        [CKBTC_LEDGER_CANISTER_ID.toText()]: 99_000,
+        [LEDGER_CANISTER_ID.toText()]: 123,
+      });
+
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [CKBTC_LEDGER_CANISTER_ID.toText()]: 99_000,
+        [LEDGER_CANISTER_ID.toText()]: 123,
+        [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: 1,
+      });
+    });
+  });
+});

--- a/frontend/src/tests/utils/icp-swap.test-utils.ts
+++ b/frontend/src/tests/utils/icp-swap.test-utils.ts
@@ -1,0 +1,38 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+
+// Sets the contents of the icpSwapTickersStore such that the result is the
+// given map from ledger canister IDs to their USD prices.
+// The price of ckUSDC is always set to 1 USD.
+// Unless specified otherwise, the price of ICP is set to 10 USD.
+export const setIcpSwapUsdPrices = (prices: Record<string, number>) => {
+  const defaultIcpPrice = 10;
+  const tickers = [];
+  const entries = Object.entries(prices);
+  let icpPrice =
+    entries.find(
+      ([ledgerCanisterId]) => ledgerCanisterId === LEDGER_CANISTER_ID.toText()
+    )?.[1] ?? defaultIcpPrice;
+
+  tickers.push({
+    ...mockIcpSwapTicker,
+    base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+    last_price: icpPrice,
+  });
+
+  for (const [ledgerCanisterId, price] of entries) {
+    if (ledgerCanisterId === LEDGER_CANISTER_ID.toText()) {
+      icpPrice = price;
+      continue;
+    }
+    tickers.push({
+      ...mockIcpSwapTicker,
+      base_id: ledgerCanisterId,
+      last_price: icpPrice / price,
+    });
+  }
+
+  icpSwapTickersStore.set(tickers);
+};


### PR DESCRIPTION
# Motivation

Setting the `icpSwapTickersStore` in tests can be confusing because we usually want certain USD prices for certain tokens, but the tickers are such that they specify how many of a token go in 1 ICP.
This means you have to divide in order to get the actual value you should set.

# Changes

1. Add a test util function where you can specify the USD values you want for each token and it will set the tickers store such that the derived `icpSwapUsdPricesStore` has the given USD prices.

# Tests

1. Unit tests added.
2. Tried to use it in an existing test but will update existing tests in a separate PR.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary