### PR TITLE
Refactor reading/writing stable memory bytes into Partitions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,7 +18,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 - Proceed with rollout of re-enabling of certification of certain calls from `30%` to `100%`.
 - Change the Page Banner icon in the staking page.
-- Refactors for cleaning up stable storage migration code for accounts.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 - Proceed with rollout of re-enabling of certification of certain calls from `30%` to `100%`.
 - Change the Page Banner icon in the staking page.
+- Refactors for cleaning up stable storage migration code for accounts.
 
 #### Deprecated
 

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -129,7 +129,7 @@ impl State {
     pub fn new_restored(memory: DefaultMemoryImpl) -> Self {
         println!("START state::new_restored: ())");
         let partitions = Partitions::from(memory);
-        let mut state = Self::recover_heap_from_managed_memory(&partitions.get(PartitionType::Heap.memory_id()));
+        let mut state = Self::recover_heap_from_managed_memory(&partitions);
         let accounts_db = AccountsDb::UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap::load(
             partitions.get(PartitionType::Accounts.memory_id()),
         ));

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -120,7 +120,7 @@ impl Partitions {
 
     /// Writes given bytes into the "managed memory", which is the stable memory section to store
     /// data that needs to be persisted across upgrades by serialization/deserialization.
-    pub fn write_bytes_to_managed_memory(&self, bytes: Vec<u8>) {
+    pub fn write_bytes_to_managed_memory(&self, bytes: &[u8]) {
         let len = bytes.len();
         let length_field = u64::try_from(len)
             .unwrap_or_else(|e| {
@@ -130,11 +130,12 @@ impl Partitions {
             })
             .to_be_bytes();
         self.growing_write(PartitionType::Heap.memory_id(), 0, &length_field);
-        self.growing_write(PartitionType::Heap.memory_id(), 8, &bytes);
+        self.growing_write(PartitionType::Heap.memory_id(), 8, bytes);
     }
 
     /// Reads bytes from the "managed memory", which is the stable memory section to store data that
     /// needs to be persisted across upgrades by serialization/deserialization.
+    #[must_use]
     pub fn read_bytes_from_managed_memory(&self) -> Vec<u8> {
         let memory = self.get(PartitionType::Heap.memory_id());
         let len = {

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -118,6 +118,8 @@ impl Partitions {
         memory.write(offset, bytes);
     }
 
+    /// Writes given bytes into the "managed memory", which is the stable memory section to store
+    /// data that needs to be persisted across upgrades by serialization/deserialization.
     pub fn write_bytes_to_managed_memory(&self, bytes: Vec<u8>) {
         let len = bytes.len();
         let length_field = u64::try_from(len)
@@ -131,6 +133,8 @@ impl Partitions {
         self.growing_write(PartitionType::Heap.memory_id(), 8, &bytes);
     }
 
+    /// Reads bytes from the "managed memory", which is the stable memory section to store data that
+    /// needs to be persisted across upgrades by serialization/deserialization.
     pub fn read_bytes_from_managed_memory(&self) -> Vec<u8> {
         let memory = self.get(PartitionType::Heap.memory_id());
         let len = {

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -5,6 +5,7 @@
 //!
 //! This code also stores virtual memory IDs and other memory functions.
 use core::borrow::Borrow;
+use dfn_core::api::trap_with;
 use ic_cdk::api::stable::WASM_PAGE_SIZE_IN_BYTES;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, Memory};
@@ -115,6 +116,32 @@ impl Partitions {
             memory.grow(min_pages - current_pages);
         }
         memory.write(offset, bytes);
+    }
+
+    pub fn write_bytes_to_managed_memory(&self, bytes: Vec<u8>) {
+        let len = bytes.len();
+        let length_field = u64::try_from(len)
+            .unwrap_or_else(|e| {
+                trap_with(&format!(
+                    "The serialized memory takes more than 2**64 bytes.  Amazing: {e:?}"
+                ));
+            })
+            .to_be_bytes();
+        self.growing_write(PartitionType::Heap.memory_id(), 0, &length_field);
+        self.growing_write(PartitionType::Heap.memory_id(), 8, &bytes);
+    }
+
+    pub fn read_bytes_from_managed_memory(&self) -> Vec<u8> {
+        let memory = self.get(PartitionType::Heap.memory_id());
+        let len = {
+            let mut length_field = [0u8; 8];
+            memory.read(0, &mut length_field);
+            usize::try_from(u64::from_be_bytes(length_field))
+                .unwrap_or_else(|err| unreachable!("The stable memory size appears to be larger than usize: {err:?}"))
+        };
+        let mut bytes = vec![0u8; len];
+        memory.read(8, &mut bytes);
+        bytes
     }
 }
 

--- a/rs/backend/src/state/partitions/tests.rs
+++ b/rs/backend/src/state/partitions/tests.rs
@@ -220,3 +220,26 @@ fn debug_should_portray_partitions_accurately() {
         "Partitions {\n  Metadata partition: 5 pages\n  Heap partition: 0 pages\n  Accounts partition: 2 pages\n}\n"
     );
 }
+
+#[test]
+fn write_to_and_read_from_managed_memory_should_work() {
+    let partitions = Partitions::from(DefaultMemoryImpl::default());
+
+    // Reading a previously written buffer should return the same bytes.
+    let toy_bytes = b"foo_bar".to_vec();
+    partitions.write_bytes_to_managed_memory(&toy_bytes);
+    let read_bytes = partitions.read_bytes_from_managed_memory();
+    assert_eq!(read_bytes, toy_bytes, "Managed memory read did not return the expected bytes.");
+
+    // Reading a previously written buffer should return the same bytes, when the buffer is smaller.
+    let toy_bytes = b"foo".to_vec();
+    partitions.write_bytes_to_managed_memory(&toy_bytes);
+    let read_bytes = partitions.read_bytes_from_managed_memory();
+    assert_eq!(read_bytes, toy_bytes, "Managed memory read did not return the expected bytes.");
+
+    // Reading a previously written buffer should return the same bytes, when the buffer is larger.
+    let toy_bytes = b"foo_bar".to_vec();
+    partitions.write_bytes_to_managed_memory(&toy_bytes);
+    let read_bytes = partitions.read_bytes_from_managed_memory();
+    assert_eq!(read_bytes, toy_bytes, "Managed memory read did not return the expected bytes.");
+}

--- a/rs/backend/src/state/partitions/tests.rs
+++ b/rs/backend/src/state/partitions/tests.rs
@@ -229,17 +229,26 @@ fn write_to_and_read_from_managed_memory_should_work() {
     let toy_bytes = b"foo_bar".to_vec();
     partitions.write_bytes_to_managed_memory(&toy_bytes);
     let read_bytes = partitions.read_bytes_from_managed_memory();
-    assert_eq!(read_bytes, toy_bytes, "Managed memory read did not return the expected bytes.");
+    assert_eq!(
+        read_bytes, toy_bytes,
+        "Managed memory read did not return the expected bytes."
+    );
 
     // Reading a previously written buffer should return the same bytes, when the buffer is smaller.
     let toy_bytes = b"foo".to_vec();
     partitions.write_bytes_to_managed_memory(&toy_bytes);
     let read_bytes = partitions.read_bytes_from_managed_memory();
-    assert_eq!(read_bytes, toy_bytes, "Managed memory read did not return the expected bytes.");
+    assert_eq!(
+        read_bytes, toy_bytes,
+        "Managed memory read did not return the expected bytes."
+    );
 
     // Reading a previously written buffer should return the same bytes, when the buffer is larger.
     let toy_bytes = b"foo_bar".to_vec();
     partitions.write_bytes_to_managed_memory(&toy_bytes);
     let read_bytes = partitions.read_bytes_from_managed_memory();
-    assert_eq!(read_bytes, toy_bytes, "Managed memory read did not return the expected bytes.");
+    assert_eq!(
+        read_bytes, toy_bytes,
+        "Managed memory read did not return the expected bytes."
+    );
 }

--- a/rs/backend/src/state/with_accounts_in_stable_memory.rs
+++ b/rs/backend/src/state/with_accounts_in_stable_memory.rs
@@ -10,7 +10,7 @@ impl State {
         let candid_bytes = self.encode();
         match &self.partitions_maybe {
             PartitionsMaybe::Partitions(partitions) => {
-                partitions.write_bytes_to_managed_memory(candid_bytes);
+                partitions.write_bytes_to_managed_memory(&candid_bytes);
             }
             PartitionsMaybe::None(_) => {
                 println!("END state::save_heap: ()");

--- a/rs/backend/src/state/with_accounts_in_stable_memory.rs
+++ b/rs/backend/src/state/with_accounts_in_stable_memory.rs
@@ -1,29 +1,16 @@
 //! State from/to a stable memory partition in the `SchemaLabel::AccountsInStableMemory` format.
-use super::State;
-use crate::state::partitions::{PartitionType, PartitionsMaybe};
-use crate::state::StableState;
+use crate::state::{partitions::PartitionsMaybe, Partitions, StableState, State};
 use dfn_core::api::trap_with;
 use ic_cdk::println;
-use ic_stable_structures::memory_manager::VirtualMemory;
-use ic_stable_structures::{DefaultMemoryImpl, Memory};
 
 impl State {
     /// Save heap to raw or virtual memory.
     pub fn save_heap_to_managed_memory(&self) {
         println!("START state::save_heap: ()");
-        let bytes = self.encode();
+        let candid_bytes = self.encode();
         match &self.partitions_maybe {
             PartitionsMaybe::Partitions(partitions) => {
-                let len = bytes.len();
-                let length_field = u64::try_from(len)
-                    .unwrap_or_else(|e| {
-                        trap_with(&format!(
-                            "The serialized memory takes more than 2**64 bytes.  Amazing: {e:?}"
-                        ));
-                    })
-                    .to_be_bytes();
-                partitions.growing_write(PartitionType::Heap.memory_id(), 0, &length_field);
-                partitions.growing_write(PartitionType::Heap.memory_id(), 8, &bytes);
+                partitions.write_bytes_to_managed_memory(candid_bytes);
             }
             PartitionsMaybe::None(_) => {
                 println!("END state::save_heap: ()");
@@ -33,18 +20,8 @@ impl State {
     }
     /// Create the state from stable memory in the `SchemaLabel::Map` format.
     #[must_use]
-    pub fn recover_heap_from_managed_memory(memory: &VirtualMemory<DefaultMemoryImpl>) -> Self {
-        let candid_len = {
-            let mut length_field = [0u8; 8];
-            memory.read(0, &mut length_field);
-            usize::try_from(u64::from_be_bytes(length_field))
-                .unwrap_or_else(|err| unreachable!("The stable memory size appears to be larger than usize: {err:?}"))
-        };
-        let candid_bytes = {
-            let mut candid_bytes = vec![0u8; candid_len];
-            memory.read(8, &mut candid_bytes);
-            candid_bytes
-        };
+    pub fn recover_heap_from_managed_memory(partitions: &Partitions) -> Self {
+        let candid_bytes = partitions.read_bytes_from_managed_memory();
         State::decode(candid_bytes).unwrap_or_else(|e| {
             trap_with(&format!("Decoding stable memory failed. Error: {e:?}"));
         })


### PR DESCRIPTION
# Motivation

2 reasons for this refactoring:

1. The backup/restore of `State` is currently a bit convoluted - it creates an AccountsStore with `AccountsDbAsMap` and replace it with `AccountsDbAsUnboundedStableBTreeMap` afterwards. This will be changed in a future PR. However, the functionalities of reading/writing bytes from/to managed memory are clear and useful, so they are moved to separate functions.
2. `PartitionsMaybe` will be removed, and the `Partitions` will be moved out of `State` in the next PR. When that happens, it makes less sense to have the logic to read/write managed memory in `State`, but rather `Partitions`. `State` will mostly care about how itself can be encoded/decoded


# Changes

Extract reading/writing bytes logic from `save_heap_to_managed_memory`/`recover_heap_from_managed_memory` to `Partition` methods

# Tests

Added tests for newly extracted methods

# Todos

- [x] Add entry to changelog (if necessary).

# Related PRs

[Next](https://github.com/dfinity/nns-dapp/pull/6298)