### PR TITLE
Persist Partitions into a thread_local variable and remove PartitionsMaybe

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -249,6 +249,16 @@ pub struct RegisterHardwareWalletRequest {
     principal: PrincipalId,
 }
 
+#[cfg(test)]
+impl RegisterHardwareWalletRequest {
+    pub fn test_data() -> Self {
+        RegisterHardwareWalletRequest {
+            name: "test".to_string(),
+            principal: PrincipalId::new_user_test_id(0),
+        }
+    }
+}
+
 #[derive(CandidType)]
 pub enum RegisterHardwareWalletResponse {
     Ok,

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -110,8 +110,8 @@ pub fn with_partitions<R>(f: impl FnOnce(&Partitions) -> R) -> R {
     PARTITIONS.with_borrow(|p| f(p))
 }
 
-/// Resets the stable memory partitions. This is only used in tests where the partitions are not
-/// treated as global's, and usually it's only needed for `proptest!`.
+/// Resets the stable memory partitions. This is only used in tests where the `Partitions` is not
+/// treated as a global variable, and usually it's only needed for `proptest!`.
 #[cfg(test)]
 pub fn reset_partitions() {
     PARTITIONS.replace(Partitions::from(DefaultMemoryImpl::default()));

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -107,16 +107,17 @@ pub fn with_state_mut<R>(f: impl FnOnce(&mut State) -> R) -> R {
 
 /// An accessor for the partitions.
 pub fn with_partitions<R>(f: impl FnOnce(&Partitions) -> R) -> R {
-    PARTITIONS.with_borrow(|p| f(&p))
+    PARTITIONS.with_borrow(|p| f(p))
 }
 
 /// Resets the stable memory partitions. This is only used in tests where the partitions are not
-/// treated as globals, and usually it's only needed for `proptest!`.
+/// treated as global's, and usually it's only needed for `proptest!`.
 #[cfg(test)]
 pub fn reset_partitions() {
     PARTITIONS.replace(Partitions::from(DefaultMemoryImpl::default()));
 }
 
+#[allow(clippy::new_without_default)]
 impl State {
     /// Creates new state. Should be called in `init`.
     #[must_use]

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -3,7 +3,7 @@ pub mod partitions;
 pub mod tests;
 mod with_accounts_in_stable_memory;
 
-use self::partitions::{PartitionType, Partitions, PartitionsMaybe};
+use self::partitions::{PartitionType, Partitions};
 use crate::accounts_store::schema::accounts_in_unbounded_stable_btree_map::AccountsDbAsUnboundedStableBTreeMap;
 use crate::accounts_store::schema::proxy::AccountsDb;
 use crate::accounts_store::AccountsStore;
@@ -25,7 +25,6 @@ pub struct State {
     pub assets: Assets,
     pub asset_hashes: AssetHashes,
     pub performance: PerformanceCounts,
-    pub partitions_maybe: PartitionsMaybe,
     pub tvl_state: TvlState,
 }
 
@@ -50,7 +49,6 @@ impl core::fmt::Debug for State {
             assets: _,
             asset_hashes: _,
             performance: _,
-            partitions_maybe,
             tvl_state,
         } = self;
         writeln!(f, "State {{")?;
@@ -58,7 +56,6 @@ impl core::fmt::Debug for State {
         writeln!(f, "  assets: <html etc> (elided)")?;
         writeln!(f, "  asset_hashes: <hashes of the assets> (elided)")?;
         writeln!(f, "  performance: <stats for the metrics endpoint> (elided)")?;
-        writeln!(f, "  partitions_maybe: {partitions_maybe:?}")?;
         writeln!(f, "  tvl_state: {tvl_state:?}")?;
         writeln!(f, "}}")
     }
@@ -71,16 +68,17 @@ pub trait StableState: Sized {
 
 thread_local! {
     static STATE: RefCell<Option<State>> = const { RefCell::new(None) };
+    static PARTITIONS: RefCell<Partitions> = RefCell::new(Partitions::from(DefaultMemoryImpl::default()));
 }
 
 /// Initializes the state when the canister is initialized.
 pub fn init_state() {
-    STATE.with_borrow_mut(|s| *s = Some(State::new(DefaultMemoryImpl::default())));
+    STATE.set(Some(State::new()));
 }
 
 /// Initializes the state when the canister is upgraded.
 pub fn restore_state() {
-    STATE.with_borrow_mut(|s| *s = Some(State::new_restored(DefaultMemoryImpl::default())));
+    STATE.set(Some(State::new_restored()));
 }
 
 /// Saves the state to stable memory.
@@ -107,37 +105,52 @@ pub fn with_state_mut<R>(f: impl FnOnce(&mut State) -> R) -> R {
     STATE.with_borrow_mut(|s| f(s.as_mut().expect("State not initialized")))
 }
 
+/// An accessor for the partitions.
+pub fn with_partitions<R>(f: impl FnOnce(&Partitions) -> R) -> R {
+    PARTITIONS.with_borrow(|p| f(&p))
+}
+
+/// Resets the stable memory partitions. This is only used in tests where the partitions are not
+/// treated as globals, and usually it's only needed for `proptest!`.
+#[cfg(test)]
+pub fn reset_partitions() {
+    PARTITIONS.replace(Partitions::from(DefaultMemoryImpl::default()));
+}
+
 impl State {
-    /// Creates new state with the specified schema.
+    /// Creates new state. Should be called in `init`.
     #[must_use]
-    pub fn new(memory: DefaultMemoryImpl) -> Self {
-        let partitions = Partitions::from(memory);
+    pub fn new() -> Self {
+        let accounts_partition = with_partitions(|p| p.get(PartitionType::Accounts.memory_id()));
         let accounts_store = AccountsStore::from(AccountsDb::UnboundedStableBTreeMap(
-            AccountsDbAsUnboundedStableBTreeMap::new(partitions.get(PartitionType::Accounts.memory_id())),
+            AccountsDbAsUnboundedStableBTreeMap::new(accounts_partition),
         ));
         State {
             accounts_store,
             assets: Assets::default(),
             asset_hashes: AssetHashes::default(),
             performance: PerformanceCounts::default(),
-            partitions_maybe: PartitionsMaybe::Partitions(partitions),
             tvl_state: TvlState::default(),
         }
     }
 
+    /// Recovers the state from stable memory. Should be called in `post_upgrade`.
     #[must_use]
-    pub fn new_restored(memory: DefaultMemoryImpl) -> Self {
+    pub fn new_restored() -> Self {
         println!("START state::new_restored: ())");
-        let partitions = Partitions::from(memory);
-        let mut state = Self::recover_heap_from_managed_memory(&partitions);
-        let accounts_db = AccountsDb::UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap::load(
-            partitions.get(PartitionType::Accounts.memory_id()),
-        ));
+        let accounts_partition = with_partitions(|p| p.get(PartitionType::Accounts.memory_id()));
+        let mut state = Self::recover_heap_from_managed_memory();
+        let accounts_db =
+            AccountsDb::UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap::load(accounts_partition));
         // Replace the default accountsdb created by `serde` with the one from stable memory.
         let _deserialized_accounts_db = state.accounts_store.replace_accounts_db(accounts_db);
-        state.partitions_maybe = PartitionsMaybe::Partitions(partitions);
         println!("END   state::new_restored: ()");
         state
+    }
+
+    /// Saves the state to stable memory. Should be called in `pre_upgrade`.
+    pub fn save(&self) {
+        self.save_heap_to_managed_memory();
     }
 }
 
@@ -165,16 +178,7 @@ impl StableState for State {
             assets,
             asset_hashes,
             performance,
-            partitions_maybe: PartitionsMaybe::None(DefaultMemoryImpl::default()),
             tvl_state,
         })
-    }
-}
-
-// Methods called on pre_upgrade and post_upgrade.
-impl State {
-    /// Saves any unsaved state to stable memory.
-    pub fn save(&self) {
-        self.save_heap_to_managed_memory();
     }
 }

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -35,37 +35,6 @@ impl core::fmt::Debug for Partitions {
     }
 }
 
-#[derive(strum_macros::Display)]
-pub enum PartitionsMaybe {
-    /// Memory that has a memory manager.
-    Partitions(Partitions),
-    /// Memory that does not have any kind of memory manager.
-    None(DefaultMemoryImpl),
-}
-
-impl Default for PartitionsMaybe {
-    fn default() -> Self {
-        PartitionsMaybe::None(DefaultMemoryImpl::default())
-    }
-}
-
-impl core::fmt::Debug for PartitionsMaybe {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PartitionsMaybe::Partitions(partitions) => {
-                write!(f, "MemoryWithPartitionType::MemoryManager({partitions:?})")
-            }
-            PartitionsMaybe::None(memory) => {
-                write!(
-                    f,
-                    "MemoryWithPartitionType::None( Memory with {} pages )",
-                    memory.size()
-                )
-            }
-        }
-    }
-}
-
 /// The virtual memory IDs for the partitions.
 ///
 /// IMPORTANT: There must be a 1-1 mapping between enum entries and virtual memories (aka partitions of the stable memory).

--- a/rs/backend/src/state/tests.rs
+++ b/rs/backend/src/state/tests.rs
@@ -1,18 +1,12 @@
 use crate::{
-    accounts_store::{
-        schema::{map::AccountsDbAsMap, proxy::AccountsDb, AccountsDbTrait},
-        RegisterHardwareWalletRequest,
-    },
+    accounts_store::RegisterHardwareWalletRequest,
     assets::{insert_asset_into_state, Asset},
-    perf::PerformanceCount,
-    state::{reset_partitions, AssetHashes, Assets, PerformanceCounts, StableState, State},
+    state::{reset_partitions, PerformanceCounts, State},
     tvl::state::TvlState,
 };
 use ic_base_types::PrincipalId;
-use ic_stable_structures::{DefaultMemoryImpl, VectorMemory};
 use pretty_assertions::assert_eq;
 use proptest::proptest;
-use std::rc::Rc;
 
 pub(crate) fn populate_test_state(num_accounts: u64, state: &mut State) {
     for account_index in 0..num_accounts {
@@ -41,20 +35,20 @@ fn state_can_be_saved_and_recovered_from_stable_memory(num_accounts: u64) {
     state.save();
 
     // Restore the state (should be called in `post_upgrade`).
-    let new_state = State::new_restored();
+    let restored_state = State::new_restored();
 
     // Now we examine the restored state against the original state:
 
     // The content in the AccountsStore are either in stable structures, or serialized/deserialized during upgrades.
-    assert_eq!(new_state.accounts_store, state.accounts_store);
+    assert_eq!(restored_state.accounts_store, state.accounts_store);
     // The assets and tvl state are serialized/deserialized during upgrades.
-    assert_eq!(new_state.assets, state.assets);
-    assert_eq!(new_state.tvl_state, state.tvl_state);
+    assert_eq!(restored_state.assets, state.assets);
+    assert_eq!(restored_state.tvl_state, state.tvl_state);
     // The asset hashes are recomputed from assets during upgrades.
-    assert_eq!(new_state.asset_hashes, state.asset_hashes);
+    assert_eq!(restored_state.asset_hashes, state.asset_hashes);
     // The performance counts are not persisted through upgrades, so they are reset after upgrades.
     assert_ne!(state.performance, PerformanceCounts::default());
-    assert_eq!(new_state.performance, PerformanceCounts::default());
+    assert_eq!(restored_state.performance, PerformanceCounts::default());
 }
 
 proptest! {

--- a/rs/backend/src/state/with_accounts_in_stable_memory.rs
+++ b/rs/backend/src/state/with_accounts_in_stable_memory.rs
@@ -13,7 +13,7 @@ impl State {
     /// Create the state from stable memory in the `SchemaLabel::Map` format.
     #[must_use]
     pub fn recover_heap_from_managed_memory() -> Self {
-        let bytes = with_partitions(|p| p.read_bytes_from_managed_memory());
+        let bytes = with_partitions(Partitions::read_bytes_from_managed_memory);
         State::decode(bytes).unwrap_or_else(|e| {
             trap_with(&format!("Decoding stable memory failed. Error: {e:?}"));
         })

--- a/rs/backend/src/state/with_accounts_in_stable_memory.rs
+++ b/rs/backend/src/state/with_accounts_in_stable_memory.rs
@@ -1,5 +1,5 @@
 //! State from/to a stable memory partition in the `SchemaLabel::AccountsInStableMemory` format.
-use crate::state::{partitions::PartitionsMaybe, Partitions, StableState, State};
+use crate::state::{with_partitions, Partitions, StableState, State};
 use dfn_core::api::trap_with;
 use ic_cdk::println;
 
@@ -7,22 +7,14 @@ impl State {
     /// Save heap to raw or virtual memory.
     pub fn save_heap_to_managed_memory(&self) {
         println!("START state::save_heap: ()");
-        let candid_bytes = self.encode();
-        match &self.partitions_maybe {
-            PartitionsMaybe::Partitions(partitions) => {
-                partitions.write_bytes_to_managed_memory(&candid_bytes);
-            }
-            PartitionsMaybe::None(_) => {
-                println!("END state::save_heap: ()");
-                trap_with("No memory manager found.  Cannot save heap.");
-            }
-        }
+        let bytes = self.encode();
+        with_partitions(|p| p.write_bytes_to_managed_memory(&bytes));
     }
     /// Create the state from stable memory in the `SchemaLabel::Map` format.
     #[must_use]
-    pub fn recover_heap_from_managed_memory(partitions: &Partitions) -> Self {
-        let candid_bytes = partitions.read_bytes_from_managed_memory();
-        State::decode(candid_bytes).unwrap_or_else(|e| {
+    pub fn recover_heap_from_managed_memory() -> Self {
+        let bytes = with_partitions(|p| p.read_bytes_from_managed_memory());
+        State::decode(bytes).unwrap_or_else(|e| {
             trap_with(&format!("Decoding stable memory failed. Error: {e:?}"));
         })
     }

--- a/rs/backend/src/stats/tests.rs
+++ b/rs/backend/src/stats/tests.rs
@@ -1,13 +1,20 @@
 /// Tests that the stats data collection is as expected
 use super::get_stats;
-use crate::state::tests::setup_test_state;
+use crate::state::{tests::populate_test_state, State};
 
 /// Verifies that the stats match the state.
 #[test]
 fn populated_state_should_have_populated_stats() {
-    let state = setup_test_state();
+    let mut state = State::new();
+    populate_test_state(2, &mut state);
+
     let stats = get_stats(&state);
-    crate::accounts_store::tests::assert_initial_test_store_stats_are_correct(&stats);
+
+    // Each account has a sub-account and a hardware wallet account.
+    assert_eq!(stats.accounts_count, 2);
+    assert_eq!(stats.sub_accounts_count, 2);
+    assert_eq!(stats.hardware_wallet_accounts_count, 2);
+
     assert!(
         !stats.performance_counts.is_empty(),
         "Stats should include performance counts"


### PR DESCRIPTION
# Motivation

`Partitions` is already "global", in the sense that even in unit tests ([ic_stable_structures::VectorMemory](https://github.com/dfinity/stable-structures/blob/69ed47f9b5001af67d650c714cd56ec3ee0ef2bb/src/lib.rs#L38)) is an `Rc<RefCell<Vec<u8>>>`, and operations to various memory partitions read/write from/to the bytes owned by the `Rc`. Therefore, it makes sense for `Partitions` to be a `thread_local!` variable. On the other hand, `PartitionsMaybe` is only useful when there can be 2 cases (raw/managed memory), which is no longer the case after the migration.

# Changes

1. Define `PARTITIONS` `thread_local` variable and add accessors
2. Remove everything related to `PartitionsMaybe` and simplify dead code

# Tests

N/A since it's mostly trivial refactoring. Tests under `rs/backend/src/state/tests.rs` should cover the code changed in this PR.

# Related PRs

[Previous](https://github.com/dfinity/nns-dapp/pull/6297) | [Next](https://github.com/dfinity/nns-dapp/pull/6301)