### PR TITLE
goback

### DIFF
--- a/frontend/src/routes/(app)/(u)/(list)/accounts/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/accounts/+layout.svelte
@@ -4,10 +4,10 @@
   import IslandWidthMain from "$lib/components/layout/IslandWidthMain.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
-  import { AppPath } from "$lib/constants/routes.constants";
   import { accountsTitleStore } from "$lib/derived/accounts-title.derived";
+  import { accountsPageOrigin } from "$lib/derived/routes.derived";
 
-  const back = (): Promise<void> => goto(AppPath.Tokens);
+  const back = (): Promise<void> => goto($accountsPageOrigin);
 </script>
 
 <LayoutList title={$accountsTitleStore}>


### PR DESCRIPTION
# Motivation

The Accounts page features a custom back button that currently redirects users to the Tokens page. However, this is no longer always accurate, as users can now access this page from the Portfolio page.

Since users can also navigate from the Accounts page to the Wallet page, we cannot rely on a local solution. The Accounts layout will be unmounted, resulting in the loss of this information.

This third PR follows up on #6285 by using the derived store that checks the entry page for the Accounts page, whether it is the Portfolio or the Tokens page.

# Changes

- ...

# Tests

- ...
- Manually tested [here](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/) with additional changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary