### PR TITLE
Use setIcpSwapUsdPrices test util

### DIFF
--- a/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
@@ -1,15 +1,17 @@
 import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
 import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import { dispatchIntersecting } from "$lib/utils/events.utils";
 import en from "$tests/mocks/i18n.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  setIcpPrice,
+  setIcpSwapUsdPrices,
+} from "$tests/utils/icp-swap.test-utils";
 import { Principal } from "@dfinity/principal";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
@@ -44,13 +46,7 @@ describe("WalletPageHeading", () => {
   };
 
   beforeEach(() => {
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-    ]);
+    setIcpPrice(10);
   });
 
   it("should render balance as title and no skeleton", async () => {
@@ -207,18 +203,9 @@ describe("WalletPageHeading", () => {
 
     const ledgerCanisterId = principal(3);
 
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: ledgerCanisterId.toText(),
-        last_price: "2.00",
-      },
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-    ]);
+    setIcpSwapUsdPrices({
+      [ledgerCanisterId.toText()]: 5,
+    });
 
     const balance = TokenAmountV2.fromString({
       amount: "3",

--- a/frontend/src/tests/lib/components/common/HeadingSubtitleWithUsdValue.spec.ts
+++ b/frontend/src/tests/lib/components/common/HeadingSubtitleWithUsdValue.spec.ts
@@ -1,11 +1,13 @@
 import HeadingSubtitleWithUsdValue from "$lib/components/common/HeadingSubtitleWithUsdValue.svelte";
 import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  setIcpPrice,
+  setIcpSwapUsdPrices,
+} from "$tests/utils/icp-swap.test-utils";
 import { Principal } from "@dfinity/principal";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
@@ -28,13 +30,7 @@ describe("HeadingSubtitleWithUsdValue", () => {
   };
 
   beforeEach(() => {
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-    ]);
+    setIcpPrice(10);
   });
 
   it("should render amount in USD", async () => {
@@ -77,18 +73,9 @@ describe("HeadingSubtitleWithUsdValue", () => {
   it("should get token price based on ledger canister ID", async () => {
     const ledgerCanisterId = principal(3);
 
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: ledgerCanisterId.toText(),
-        last_price: "2.00",
-      },
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-    ]);
+    setIcpSwapUsdPrices({
+      [ledgerCanisterId.toText()]: 5,
+    });
 
     const amount = TokenAmountV2.fromString({
       amount: "3",

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -1,9 +1,7 @@
 import NnsNeuronPageHeading from "$lib/components/neuron-detail/NnsNeuronPageHeading.svelte";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -11,7 +9,6 @@ import {
   mockHardwareWalletAccount,
   mockMainAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronPageHeadingPo } from "$tests/page-objects/NnsNeuronPageHeading.page-object";
@@ -20,6 +17,7 @@ import {
   resetAccountsForTesting,
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { NeuronType } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
@@ -35,13 +33,7 @@ describe("NnsNeuronPageHeading", () => {
     resetIdentity();
     resetAccountsForTesting();
 
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-    ]);
+    setIcpPrice(10);
   });
 
   it("should render the neuron's stake", async () => {

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -1,10 +1,8 @@
 import TotalAssetsCard from "$lib/components/portfolio/TotalAssetsCard.svelte";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import en from "$tests/mocks/i18n.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { TotalAssetsCardPo } from "$tests/page-objects/TotalAssetsCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 
 describe("TotalAssetsCard", () => {
@@ -23,16 +21,6 @@ describe("TotalAssetsCard", () => {
       isLoading,
     });
     return TotalAssetsCardPo.under(new JestPageObjectElement(container));
-  };
-
-  const setIcpPrice = (icpPrice: number) => {
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: String(icpPrice),
-      },
-    ]);
   };
 
   it("should display the USD amount as absent", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
@@ -1,5 +1,5 @@
 import SnsNeuronPageHeading from "$lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import {
   SECONDS_IN_DAY,
   SECONDS_IN_EIGHT_YEARS,
@@ -7,10 +7,8 @@ import {
 } from "$lib/constants/constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -19,6 +17,7 @@ import {
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { SnsNeuronPageHeadingPo } from "$tests/page-objects/SnsNeuronPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
@@ -65,18 +64,10 @@ describe("SnsNeuronPageHeading", () => {
     // of the neuron age.
     vi.useFakeTimers();
 
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-      {
-        ...mockIcpSwapTicker,
-        base_id: ledgerCanisterId.toText(),
-        last_price: "100.00",
-      },
-    ]);
+    setIcpSwapUsdPrices({
+      [LEDGER_CANISTER_ID.toText()]: 10,
+      [ledgerCanisterId.toText()]: 0.1,
+    });
   });
 
   it("should render the neuron's stake", async () => {

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -16,6 +16,7 @@ import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
@@ -897,25 +898,10 @@ describe("ProjectsTable", () => {
       certified: true,
     });
 
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-      {
-        ...mockIcpSwapTicker,
-        base_id: ledgerCanisterId5.toText(),
-        last_price: "10.00",
-      },
-      {
-        ...mockIcpSwapTicker,
-        base_id: ledgerCanisterId6.toText(),
-        // This is the price of 1 ICP in tokens. So lower means the token is
-        // worth more.
-        last_price: "5.00",
-      },
-    ]);
+    setIcpSwapUsdPrices({
+      [ledgerCanisterId5.toText()]: 1,
+      [ledgerCanisterId6.toText()]: 2,
+    });
 
     const po = renderComponent();
     const rowPos = await po.getProjectsTableRowPos();

--- a/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
@@ -1,10 +1,8 @@
 import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import en from "$tests/mocks/i18n.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { UsdValueBannerPo } from "$tests/page-objects/UsdValueBanner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 
 describe("UsdValueBanner", () => {
@@ -20,16 +18,6 @@ describe("UsdValueBanner", () => {
       hasUnpricedTokens,
     });
     return UsdValueBannerPo.under(new JestPageObjectElement(container));
-  };
-
-  const setIcpPrice = (icpPrice: number) => {
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: String(icpPrice),
-      },
-    ]);
   };
 
   it("should display the USD amount", async () => {

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
@@ -1,9 +1,8 @@
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import UsdValueHeadlessTest from "$tests/lib/components/ui/UsdValueHeadlessTest.svelte";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { UsdValueHeadlessPo } from "$tests/page-objects/UsdValueHeadless.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 
 describe("UsdValueHeadless", () => {
@@ -23,16 +22,6 @@ describe("UsdValueHeadless", () => {
     });
 
     return UsdValueHeadlessPo.under(new JestPageObjectElement(container));
-  };
-
-  const setIcpPrice = (icpPrice: number) => {
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: String(icpPrice),
-      },
-    ]);
   };
 
   it("should handle undefined usdAmount", async () => {

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -1,9 +1,7 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { icpTokensListUser } from "$lib/derived/icp-tokens-list-user.derived";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import {
   UserTokenAction,
   type UserTokenData,
@@ -15,7 +13,6 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import {
   createIcpUserToken,
   icpTokenBase,
@@ -24,6 +21,7 @@ import {
   resetAccountsForTesting,
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -151,13 +149,7 @@ describe("icp-tokens-list-user.derived", () => {
       const hwAccountBalance = 3;
       const icpPrice = 10;
 
-      icpSwapTickersStore.set([
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: String(icpPrice),
-        },
-      ]);
+      setIcpPrice(icpPrice);
 
       setAccountsForTesting({
         main: {

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -5,11 +5,9 @@ import {
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
 import { authStore } from "$lib/stores/auth.store";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import {
@@ -29,7 +27,6 @@ import {
   mockCkETHToken,
 } from "$tests/mocks/cketh-accounts.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
@@ -45,6 +42,7 @@ import {
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { TokenAmountV2 } from "@dfinity/utils";
@@ -374,22 +372,12 @@ describe("tokens-list-user.derived", () => {
     it("should include USD value if ICP Swap data is loaded", () => {
       const tetrisBalance = 30;
       const tetrisBalanceE8s = BigInt(tetrisBalance * 100_000_000);
-      const icpPrice = 10;
       const tetrisPrice = 0.2;
       const tetrisUsdBalance = tetrisBalance * tetrisPrice;
 
-      icpSwapTickersStore.set([
-        {
-          ...mockIcpSwapTicker,
-          base_id: snsTetris.ledgerCanisterId.toText(),
-          last_price: String(icpPrice / tetrisPrice),
-        },
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: String(icpPrice),
-        },
-      ]);
+      setIcpSwapUsdPrices({
+        [snsTetris.ledgerCanisterId.toText()]: tetrisPrice,
+      });
       icrcAccountsStore.set({
         accounts: {
           accounts: [

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -1,20 +1,18 @@
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { createUserToken } from "$tests/mocks/tokens-page.mock";
 import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { resetAccountsForTesting } from "$tests/utils/accounts.test-utils";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -40,13 +38,7 @@ describe("NnsAccounts", () => {
       return mockAccountDetails;
     });
 
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-    ]);
+    setIcpPrice(10);
   });
 
   describe("when tokens flag is enabled", () => {

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -1,5 +1,4 @@
 import * as api from "$lib/api/governance.api";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import {
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_YEAR,
@@ -7,15 +6,14 @@ import {
 import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronsPo } from "$tests/page-objects/NnsNeurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
@@ -121,13 +119,7 @@ describe("NnsNeurons", () => {
         },
       ]);
 
-      icpSwapTickersStore.set([
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "11.00",
-        },
-      ]);
+      setIcpPrice(11);
 
       const po = await renderComponent();
 
@@ -167,13 +159,7 @@ describe("NnsNeurons", () => {
         },
       ]);
 
-      icpSwapTickersStore.set([
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "11.00",
-        },
-      ]);
+      setIcpPrice(11);
 
       const po = await renderComponent();
 

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -1,12 +1,9 @@
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import Portfolio from "$lib/pages/Portfolio.svelte";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import { mockTableProject } from "$tests/mocks/staking.mock";
 import {
@@ -19,6 +16,7 @@ import {
 } from "$tests/mocks/tokens-page.mock";
 import { PortfolioPagePo } from "$tests/page-objects/PortfolioPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
@@ -232,13 +230,7 @@ describe("Portfolio page", () => {
     beforeEach(() => {
       resetIdentity();
 
-      icpSwapTickersStore.set([
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "10.00",
-        },
-      ]);
+      setIcpPrice(10);
     });
 
     it("should not display the LoginCard when the user is logged in", async () => {

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -1,20 +1,17 @@
 import * as ledgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import TokensPage from "$lib/pages/Tokens.svelte";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
-import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { tokensTableOrderStore } from "$lib/stores/tokens-table.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { UserTokenData } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
-import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import {
   createIcpUserToken,
@@ -23,6 +20,7 @@ import {
 } from "$tests/mocks/tokens-page.mock";
 import { TokensPagePo } from "$tests/page-objects/TokensPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -81,13 +79,7 @@ describe("Tokens page", () => {
     vi.useFakeTimers();
 
     importedTokensStore.set({ importedTokens: [], certified: true });
-    icpSwapTickersStore.set([
-      {
-        ...mockIcpSwapTicker,
-        base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-        last_price: "10.00",
-      },
-    ]);
+    setIcpPrice(10);
   });
 
   it("should render the tokens table", async () => {

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -1,5 +1,7 @@
 import * as icpSwapApi from "$lib/api/icp-swap.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 
 import * as importedTokensApi from "$lib/api/imported-tokens.api";
 import {
@@ -153,7 +155,7 @@ describe("Portfolio route", () => {
   describe("when logged in", () => {
     const icpBalanceE8s = 100n * 100_000_000n; // 100ICP(1ICP==10$) -> $1000
     const ckBTCBalanceE8s = 1n * 100_000_000n; // 1BTC(1BTC==10_000ICP) -> $100_000
-    const ckETHBalanceUlps = 1n * 100_000_000_000_000_000n; // 1ETH(1ETH=100ICP) -> $1000
+    const ckETHBalanceUlps = BigInt(0.1 * 1_000_000_000_000_000_000); // 0.1ETH(1ETH=1000ICP) -> $1000
     const tetrisBalanceE8s = 2n * 100_000_000n; // 2Tetris(1Tetris==1ICP) -> $20
     const importedToken1BalanceE6s = 100n * 1_000_000n; // 100ZTOKEN1(1ZTOKEN1==1ICP) -> $1000
     const ckUSDCBalanceE6s = 1n * 1_000_000n; // 1USDC -> $1
@@ -273,38 +275,14 @@ describe("Portfolio route", () => {
       setAccountsForTesting({
         main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
       });
-      icpSwapTickersStore.set([
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKBTC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "0.0001",
-        },
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKTESTBTC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "0.0001",
-        },
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKETH_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "0.001",
-        },
-        {
-          ...mockIcpSwapTicker,
-          base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
-          last_price: "10.00",
-        },
-        {
-          ...mockIcpSwapTicker,
-          base_id: importedToken1Id.toText(),
-          last_price: "1.00",
-        },
-        {
-          ...mockIcpSwapTicker,
-          base_id: tetrisSNS.ledgerCanisterId.toText(),
-          last_price: "1.00",
-        },
-      ]);
+      setIcpSwapUsdPrices({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: 100_000,
+        [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: 100_000,
+        [CKETH_UNIVERSE_CANISTER_ID.toText()]: 10_000,
+        [LEDGER_CANISTER_ID.toText()]: 10,
+        [importedToken1Id.toText()]: 10,
+        [tetrisSNS.ledgerCanisterId.toText()]: 10,
+      });
 
       const nnsNeuronWithStake = {
         ...mockNeuron,
@@ -333,7 +311,7 @@ describe("Portfolio route", () => {
       // 1BTC -> $100_000
       // 1BTCTest -> $100_000
       // 100ICP -> $1000
-      // 1ETH -> $1000
+      // 0.1ETH -> $1000
       // 1USDC -> $1
       // 100ZTOKEN1 -> $1000
       // 2Tetris -> $20

--- a/frontend/src/tests/utils/icp-swap.test-utils.spec.ts
+++ b/frontend/src/tests/utils/icp-swap.test-utils.spec.ts
@@ -2,7 +2,10 @@ import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
-import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
+import {
+  setIcpPrice,
+  setIcpSwapUsdPrices,
+} from "$tests/utils/icp-swap.test-utils";
 import { get } from "svelte/store";
 
 describe("icp-swap.test-utils.spec.ts", () => {
@@ -47,6 +50,17 @@ describe("icp-swap.test-utils.spec.ts", () => {
 
       expect(get(icpSwapUsdPricesStore)).toEqual({
         [CKBTC_LEDGER_CANISTER_ID.toText()]: 99_000,
+        [LEDGER_CANISTER_ID.toText()]: 123,
+        [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: 1,
+      });
+    });
+  });
+
+  describe("setIcpPrice", () => {
+    it("should set the price of ICP to 123 USD", () => {
+      setIcpPrice(123);
+
+      expect(get(icpSwapUsdPricesStore)).toEqual({
         [LEDGER_CANISTER_ID.toText()]: 123,
         [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: 1,
       });

--- a/frontend/src/tests/utils/icp-swap.test-utils.ts
+++ b/frontend/src/tests/utils/icp-swap.test-utils.ts
@@ -36,3 +36,9 @@ export const setIcpSwapUsdPrices = (prices: Record<string, number>) => {
 
   icpSwapTickersStore.set(tickers);
 };
+
+export const setIcpPrice = (icpPrice: number) => {
+  setIcpSwapUsdPrices({
+    [LEDGER_CANISTER_ID.toText()]: icpPrice,
+  });
+};


### PR DESCRIPTION
# Motivation

Setting the `icpSwapTickersStore` in tests can be confusing because we usually want certain USD prices for certain tokens, but the tickers are such that they specify how many of a token go in 1 ICP.
This means you have to divide in order to get the actual value you should set.

https://github.com/dfinity/nns-dapp/pull/6296 added `setIcpSwapUsdPrices` to make this easier.

This PR uses `setIcpSwapUsdPrices` in all the relevant tests.

# Changes

1. Add one more utility function `setIcpPrice` for convenience when setting just the ICP price.
2. Use `setIcpSwapUsdPrices` or `setIcpPrice` in tests that need to populate `icpSwapTickersStore`.

# Tests

1. Unit test added for `setIcpPrice`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary