### PR TITLE
Stop resetting some proposals related stores in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -53,7 +53,6 @@ describe("Proposal", () => {
     });
 
   beforeEach(() => {
-    actionableProposalsSegmentStore.resetForTesting();
     vi.spyOn(proposalsApi, "queryProposalPayload").mockResolvedValue({});
     actionableProposalsSegmentStore.set("all");
   });

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
@@ -2,7 +2,6 @@ import * as agent from "$lib/api/agent.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import NnsProposalProposerPayloadEntry from "$lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte";
 import { jsonRepresentationStore } from "$lib/stores/json-representation.store";
-import { proposalPayloadsStore } from "$lib/stores/proposals.store";
 import {
   mockProposalInfo,
   proposalActionMotion,
@@ -22,7 +21,6 @@ describe("NnsProposalProposerPayloadEntry", () => {
   const payload = { b: "c" };
 
   beforeEach(() => {
-    proposalPayloadsStore.reset();
     vi.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -37,8 +37,6 @@ describe("NnsProposalsFilters", () => {
   };
 
   beforeEach(() => {
-    actionableProposalsSegmentStore.resetForTesting();
-    proposalsFiltersStore.reset();
     resetIdentity();
   });
 
@@ -109,10 +107,6 @@ describe("NnsProposalsFilters", () => {
       await runResolvedPromises();
       return NnsProposalFiltersPo.under(new JestPageObjectElement(container));
     };
-
-    beforeEach(() => {
-      proposalsFiltersStore.reset();
-    });
 
     describe("when signed out", () => {
       beforeEach(() => {

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -1,6 +1,4 @@
 import SnsProposalsFilters from "$lib/components/sns-proposals/SnsProposalsFilters.svelte";
-import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
-import { proposalsFiltersStore } from "$lib/stores/proposals.store";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { SnsProposalFiltersPo } from "$tests/page-objects/SnsProposalFilters.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -16,8 +14,6 @@ describe("SnsProposalsFilters", () => {
 
   beforeEach(() => {
     resetIdentity();
-    proposalsFiltersStore.reset();
-    actionableProposalsSegmentStore.resetForTesting();
   });
 
   it("should render filter buttons", async () => {
@@ -49,10 +45,6 @@ describe("SnsProposalsFilters", () => {
   });
 
   describe("actionable proposals", () => {
-    beforeEach(() => {
-      proposalsFiltersStore.reset();
-    });
-
     it("should render actionable proposals segment", async () => {
       const po = await renderComponent();
 

--- a/frontend/src/tests/lib/derived/proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/proposals.derived.spec.ts
@@ -3,10 +3,7 @@ import {
   sortedProposals,
 } from "$lib/derived/proposals.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
-import {
-  proposalsFiltersStore,
-  proposalsStore,
-} from "$lib/stores/proposals.store";
+import { proposalsStore } from "$lib/stores/proposals.store";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import type { ProposalInfo } from "@dfinity/nns";
 import { get } from "svelte/store";
@@ -53,11 +50,6 @@ describe("proposals-derived", () => {
   });
 
   describe("filteredActionableProposals", () => {
-    beforeEach(() => {
-      proposalsStore.resetForTesting();
-      proposalsFiltersStore.reset();
-    });
-
     it("should append isActionable", () => {
       proposalsStore.setProposalsForTesting({
         proposals: [...mockProposals],

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -7,10 +7,7 @@ import NnsProposals from "$lib/pages/NnsProposals.svelte";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
-import {
-  proposalsFiltersStore,
-  proposalsStore,
-} from "$lib/stores/proposals.store";
+import { proposalsFiltersStore } from "$lib/stores/proposals.store";
 import {
   mockIdentity,
   resetIdentity,
@@ -47,10 +44,6 @@ describe("NnsProposals", () => {
   };
 
   beforeEach(() => {
-    proposalsStore.resetForTesting();
-    proposalsFiltersStore.reset();
-    actionableProposalsSegmentStore.resetForTesting();
-
     resetIdentity();
     vi.spyOn(proposalsApi, "queryProposals").mockResolvedValue(mockProposals);
     // Loading proposals is debounced but we don't want to wait for the delay in

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -73,7 +73,6 @@ describe("SnsProposalDetail", () => {
     resetIdentity();
     page.reset();
     resetSnsProjects();
-    actionableProposalsSegmentStore.resetForTesting();
   });
 
   describe("not logged in", () => {

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -61,7 +61,6 @@ describe("SnsProposals", () => {
         ],
       },
     ]);
-    actionableProposalsSegmentStore.resetForTesting();
   });
 
   describe("logged in user", () => {

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -24,7 +24,6 @@ import { get } from "svelte/store";
 describe("proposals-services", () => {
   beforeEach(() => {
     proposalsStore.setProposalsForTesting({ proposals: [], certified: true });
-    proposalPayloadsStore.reset();
     vi.spyOn(console, "error").mockRestore();
   });
 

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -74,7 +74,6 @@ describe("vote-registration-services", () => {
 
   beforeEach(() => {
     // Cleanup:
-    proposalsStore.resetForTesting();
     resetIdentity();
 
     // Setup:

--- a/frontend/src/tests/lib/stores/actionable-proposals-segment.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-proposals-segment.store.spec.ts
@@ -2,10 +2,6 @@ import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposal
 import { get } from "svelte/store";
 
 describe("actionable proposals segment store", () => {
-  beforeEach(() => {
-    actionableProposalsSegmentStore.resetForTesting();
-  });
-
   it('should have "actionable" by default ', () => {
     expect(get(actionableProposalsSegmentStore).selected).toEqual("actionable");
   });

--- a/frontend/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/proposals.store.spec.ts
@@ -9,11 +9,6 @@ import { ProposalStatus, Topic } from "@dfinity/nns";
 import { get } from "svelte/store";
 
 describe("proposals-store", () => {
-  beforeEach(() => {
-    proposalsStore.resetForTesting();
-    proposalsFiltersStore.reset();
-  });
-
   describe("proposals", () => {
     it("should set proposals", () => {
       const mutationStore = proposalsStore.getSingleMutationProposalsStore();


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
To keep PRs reviewable, we should remove the resetting of a few stores at a time.

This PR does so for `actionableProposalsSegmentStore`, `proposalsStore`, `proposalsFiltersStore` and `proposalPayloadsStore`.

# Changes

1. Remove resetting of `actionableProposalsSegmentStore`, `proposalsStore`, `proposalsFiltersStore` and `proposalPayloadsStore` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary