### PR TITLE
Stop reseting remaining stores in beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -52,7 +52,6 @@ describe("ImportTokenModal", () => {
   beforeEach(() => {
     resetIdentity();
     resetSnsProjects();
-    busyStore.resetForTesting();
 
     queryIcrcTokenSpy = vi
       .spyOn(ledgerApi, "queryIcrcToken")

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -63,6 +63,8 @@ describe("MenuItems", () => {
   };
 
   beforeEach(() => {
+    // NOTE: menuStore.resetForTesting() sets the menuStore to EXPANDED, while
+    // the store is initialized to undefined. So it's not actually resetting.
     menuStore.resetForTesting();
     layoutMenuOpen.set(false);
     vi.useFakeTimers();

--- a/frontend/src/tests/lib/components/header/AccountSyncIndicator.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountSyncIndicator.spec.ts
@@ -11,10 +11,6 @@ import {
 import type { SvelteComponent } from "svelte";
 
 describe("AccountSyncIndicator", () => {
-  beforeEach(() => {
-    syncStore.reset();
-  });
-
   describe("not signed in", () => {
     beforeEach(() => {
       setNoIdentity();

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -16,8 +16,6 @@ describe("Followee", () => {
   };
 
   beforeEach(() => {
-    knownNeuronsStore.reset();
-
     vi.spyOn(console, "error").mockReturnValue();
     copySpy = vi.fn();
     Object.assign(navigator, {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -44,7 +44,6 @@ describe("NnsNeuronAdvancedSection", () => {
   };
 
   beforeEach(() => {
-    nnsLatestRewardEventStore.reset();
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
     resetIdentity();

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
@@ -63,7 +63,6 @@ describe("NnsNeuronPageHeader", () => {
   };
 
   beforeEach(() => {
-    neuronsTableOrderStore.reset();
     neuronsStore.setNeurons({ neurons: testNeurons, certified: true });
   });
 

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -81,10 +81,6 @@ describe("NeuronsTable", () => {
     return NeuronsTablePo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    neuronsTableOrderStore.reset();
-  });
-
   it("should render desktop headers", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
     expect(await po.getDesktopColumnHeaders()).toEqual([

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
@@ -58,7 +58,6 @@ describe("SnsNeuronPageHeader", () => {
 
   beforeEach(() => {
     resetSnsProjects();
-    neuronsTableOrderStore.reset();
     setSnsProjects([
       {
         rootCanisterId: rootCanisterId,

--- a/frontend/src/tests/lib/components/tokens/TokensTable/HideZeroBalancesToggle.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable/HideZeroBalancesToggle.spec.ts
@@ -7,10 +7,6 @@ import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("HideZeroBalancesToggle", () => {
-  beforeEach(() => {
-    hideZeroBalancesStore.resetForTesting();
-  });
-
   const renderComponent = () => {
     const { container } = render(HideZeroBalancesToggle);
     return HideZeroBalancesTogglePo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -30,7 +30,6 @@ describe("actionable proposals derived stores", () => {
 
   beforeEach(() => {
     resetSnsProjects();
-    failedActionableSnsesStore.resetForTesting();
   });
 
   describe("actionableProposalIndicationVisibleStore", () => {

--- a/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
@@ -59,11 +59,6 @@ describe("icpAccountsStore", () => {
     });
   };
 
-  beforeEach(() => {
-    icpAccountDetailsStore.resetForTesting();
-    icpAccountBalancesStore.resetForTesting();
-  });
-
   it("should be initialized to empty", () => {
     expect(get(icpAccountsStore)).toEqual({
       main: undefined,

--- a/frontend/src/tests/lib/derived/sync.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sync.derived.spec.ts
@@ -3,8 +3,6 @@ import { syncStore } from "$lib/stores/sync.store";
 import { get } from "svelte/store";
 
 describe("sync.derived", () => {
-  beforeEach(() => syncStore.reset());
-
   it("should be idle per default", () => {
     const store = get(syncOverallStatusStore);
     expect(store).toEqual("idle");

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -116,7 +116,6 @@ describe("IcrcWallet", () => {
     vi.clearAllTimers();
     vi.useRealTimers();
     resetIdentity();
-    busyStore.resetForTesting();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -89,7 +89,6 @@ describe("NnsWallet", () => {
     vi.clearAllTimers();
     cancelPollAccounts();
     resetAccountsForTesting();
-    icpTransactionsStore.reset();
     resetIdentity();
 
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -5,7 +5,6 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import TokensPage from "$lib/pages/Tokens.svelte";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { tokensTableOrderStore } from "$lib/stores/tokens-table.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
@@ -75,7 +74,6 @@ describe("Tokens page", () => {
   };
 
   beforeEach(() => {
-    hideZeroBalancesStore.resetForTesting();
     vi.useFakeTimers();
 
     importedTokensStore.set({ importedTokens: [], certified: true });

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -84,7 +84,6 @@ describe("Staking", () => {
         rootCanisterId: snsCanisterId,
       },
     ]);
-    snsNeuronsStore.reset();
 
     const po = renderComponent();
     expect(await po.getPageBannerPo().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -84,6 +84,7 @@ describe("Staking", () => {
         rootCanisterId: snsCanisterId,
       },
     ]);
+    snsNeuronsStore.reset();
 
     const po = renderComponent();
     expect(await po.getPageBannerPo().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -32,10 +32,6 @@ import type { MockInstance } from "@vitest/spy";
 import { get } from "svelte/store";
 
 describe("actionable-sns-proposals.services", () => {
-  beforeEach(() => {
-    failedActionableSnsesStore.resetForTesting();
-  });
-
   describe("loadActionableProposalsForSns", () => {
     const allPermissions = Int32Array.from(enumValues(SnsNeuronPermissionType));
     const subaccount = neuronSubaccount({

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -21,7 +21,6 @@ describe("icp-transactions services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    icpTransactionsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 

--- a/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
@@ -23,7 +23,6 @@ describe("icrc-transactions services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    icrcTransactionsStore.reset();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -43,7 +43,6 @@ describe("imported-tokens-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    busyStore.resetForTesting();
     vi.spyOn(console, "error").mockReturnValue();
     vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);
   });

--- a/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
+++ b/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
@@ -16,7 +16,6 @@ describe("nns-reward-event-services", () => {
   let spyQueryLatestRewardEvent: MockInstance;
 
   beforeEach(() => {
-    nnsLatestRewardEventStore.reset();
     spyQueryLatestRewardEvent = vi
       .spyOn(api, "queryLastestRewardEvent")
       .mockResolvedValue(mockRewardEvent);

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1066,7 +1066,6 @@ describe("sns-neurons-services", () => {
         mockTokenStore
       );
 
-      tokensStore.reset();
       setSnsProjects([
         {
           rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
@@ -65,10 +65,6 @@ describe("actionableSnsProposalsStore", () => {
 });
 
 describe("failedActionableSnsesStore", () => {
-  beforeEach(() => {
-    failedActionableSnsesStore.resetForTesting();
-  });
-
   it("should store root canister ids", () => {
     expect(get(failedActionableSnsesStore)).toEqual([]);
     failedActionableSnsesStore.add("1");

--- a/frontend/src/tests/lib/stores/hide-zero-balances.store.spec.ts
+++ b/frontend/src/tests/lib/stores/hide-zero-balances.store.spec.ts
@@ -3,10 +3,6 @@ import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
 import { get } from "svelte/store";
 
 describe("hideZeroBalancesStore", () => {
-  beforeEach(() => {
-    hideZeroBalancesStore.resetForTesting();
-  });
-
   it("should be initialized with the default value", () => {
     expect(get(hideZeroBalancesStore)).toBe("show");
   });

--- a/frontend/src/tests/lib/stores/icp-account-balances.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-account-balances.store.spec.ts
@@ -17,10 +17,6 @@ describe("icpAccountBalancesStore", () => {
     });
   };
 
-  beforeEach(() => {
-    icpAccountBalancesStore.resetForTesting();
-  });
-
   it("should be initialized to empty", () => {
     expect(get(icpAccountBalancesStore)).toEqual({});
   });

--- a/frontend/src/tests/lib/stores/icp-account-details.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-account-details.store.spec.ts
@@ -32,10 +32,6 @@ describe("icpAccountDetailsStore", () => {
     certified: true,
   };
 
-  beforeEach(() => {
-    icpAccountDetailsStore.resetForTesting();
-  });
-
   it("should be initialized to undefined", () => {
     expect(get(icpAccountDetailsStore)).toBeUndefined();
   });

--- a/frontend/src/tests/lib/stores/neurons-table-order-sorted-neuron-ids-store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons-table-order-sorted-neuron-ids-store.spec.ts
@@ -62,7 +62,6 @@ describe("neuronsTableOrderSortedNeuronIdsStore", () => {
   ];
 
   beforeEach(() => {
-    neuronsTableOrderStore.reset();
     resetIdentity();
     setAccountsForTesting({ main: mockMainAccount });
   });

--- a/frontend/src/tests/lib/stores/nns-reward-event.store.spec.ts
+++ b/frontend/src/tests/lib/stores/nns-reward-event.store.spec.ts
@@ -3,10 +3,6 @@ import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { get } from "svelte/store";
 
 describe("nnsLatestRewardEventStore", () => {
-  beforeEach(() => {
-    nnsLatestRewardEventStore.reset();
-  });
-
   it("should set reward event", () => {
     const initialReward = get(nnsLatestRewardEventStore);
     expect(initialReward).toBeUndefined();

--- a/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
@@ -37,7 +37,6 @@ describe("snsNeuronsTableOrderSortedNeuronIdsStore", () => {
   const mockRootCanisterId = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
 
   beforeEach(() => {
-    neuronsTableOrderStore.reset();
     resetSnsProjects();
     snsNeuronsStore.setNeurons({
       rootCanisterId: mockRootCanisterId,

--- a/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
@@ -10,7 +10,6 @@ import { get } from "svelte/store";
 
 describe("SNS Transactions store", () => {
   describe("snsTransactionsStore", () => {
-    beforeEach(() => icrcTransactionsStore.reset());
     it("should set transactions for a project and account when it doesn't exist", () => {
       icrcTransactionsStore.addTransactions({
         canisterId: mockPrincipal,

--- a/frontend/src/tests/lib/stores/sync.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sync.store.spec.ts
@@ -2,8 +2,6 @@ import { syncStore } from "$lib/stores/sync.store";
 import { get } from "svelte/store";
 
 describe("sync.store", () => {
-  beforeEach(() => syncStore.reset());
-
   const data = {
     balances: "idle",
     transactions: "idle",


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
So to clean up the tests, we can stop explicitly resetting stores in individual tests.
There have been many PRs to clean up specific stores.
This PR stops resetting the remaining stores in `beforeEach`.

Stores are also reset in individual tests. I tried hard not to remove any of those.

There was one store reset that I couldn't remove because `menuStore.resetForTesting()` does not actually reset the store.
It [sets it to Menu.EXPANDED](https://github.com/dfinity/gix-components/blob/a896ded1ae60925edd04deab41cb8d3218e339c2/src/lib/stores/menu.store.ts#L28), while the store is initialized in tests [as undefined](https://github.com/dfinity/gix-components/blob/a896ded1ae60925edd04deab41cb8d3218e339c2/src/lib/utils/menu.utils.ts#L11).

# Changes

1. Remove resetting of stores in `beforeEach` of individual tests.
2. Add a comment about `menuStore.resetForTesting()`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary