### PR TITLE
Stop mocking canistersStore

### DIFF
--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -3,7 +3,7 @@ import { listCanisters } from "$lib/services/canisters.services";
 import { authStore } from "$lib/stores/auth.store";
 import { canistersStore } from "$lib/stores/canisters.store";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
-import { mockCanistersStoreSubscribe } from "$tests/mocks/canisters.mock";
+import { mockCanisters } from "$tests/mocks/canisters.mock";
 import en from "$tests/mocks/i18n.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
 import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
@@ -39,9 +39,10 @@ describe("Canisters", () => {
     authStoreMock = vi.spyOn(authStore, "subscribe");
     resetIdentity();
 
-    vi.spyOn(canistersStore, "subscribe").mockImplementation(
-      mockCanistersStoreSubscribe
-    );
+    canistersStore.setCanisters({
+      canisters: mockCanisters,
+      certified: true,
+    });
   });
 
   it("should render ic", () => {

--- a/frontend/src/tests/mocks/canisters.mock.ts
+++ b/frontend/src/tests/mocks/canisters.mock.ts
@@ -7,11 +7,10 @@ import {
   CKBTC_INDEX_CANISTER_ID,
   CKBTC_MINTER_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import type { CanistersStore } from "$lib/stores/canisters.store";
 import type { SelectCanisterDetailsStore } from "$lib/types/canister-detail.context";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { Principal } from "@dfinity/principal";
-import { writable, type Subscriber } from "svelte/store";
+import { writable } from "svelte/store";
 
 export const mockCanisterId = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
 export const mockCanister: CanisterInfo = {
@@ -49,14 +48,6 @@ export const mockCanisterDetails: CanisterDetails = {
     computeAllocation: 2_000n,
   },
   idleCyclesBurnedPerDay: 3_000n,
-};
-
-export const mockCanistersStoreSubscribe = (
-  run: Subscriber<CanistersStore>
-): (() => void) => {
-  run({ canisters: mockCanisters, certified: true });
-
-  return () => undefined;
 };
 
 export const mockCanisterDetailsStore = writable<SelectCanisterDetailsStore>({


### PR DESCRIPTION
# Motivation

There is no reason to mock stores. We should use the real stores in tests.

# Changes

1. Use real `canistersStore` in `Canisters.spec.ts`.
2. Remove `mockCanistersStoreSubscribe`.

# Tests

Test-only change. Tests still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary