### PR TITLE
refactor(utils): extract csv to file generation utilities

### DIFF
--- a/frontend/src/lib/components/reporting/ReportingNeuronsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingNeuronsButton.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
-  import { IconDown } from "@dfinity/gix-components";
-  import {
-    buildNeuronsDatasets,
-    CsvGenerationError,
-    FileSystemAccessError,
-    generateCsvFileToSave,
-  } from "$lib/utils/reporting.utils";
-  import { toastsError } from "$lib/stores/toasts.store";
-  import { formatDateCompact } from "$lib/utils/date.utils";
-  import type { NeuronInfo } from "@dfinity/nns";
-  import type { Identity } from "@dfinity/agent";
   import { queryNeurons } from "$lib/api/governance.api";
-  import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
   import { getAuthenticatedIdentity } from "$lib/services/auth.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { i18n } from "$lib/stores/i18n";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import { formatDateCompact } from "$lib/utils/date.utils";
+  import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
+  import {
+    CsvGenerationError,
+    FileSystemAccessError,
+  } from "$lib/utils/reporting.save-csv-to-file.utils";
+  import {
+    buildNeuronsDatasets,
+    generateCsvFileToSave,
+  } from "$lib/utils/reporting.utils";
+  import type { Identity } from "@dfinity/agent";
+  import { IconDown } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
 
   let loading = false;
 

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -1,31 +1,33 @@
 <script lang="ts">
+  import { queryNeurons } from "$lib/api/governance.api";
+  import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
+  import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
+  import { getAccountTransactionsConcurrently } from "$lib/services/reporting.services";
+  import { authStore } from "$lib/stores/auth.store";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { IconDown } from "@dfinity/gix-components";
-  import { ICPToken, nonNullish } from "@dfinity/utils";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import type { Account } from "$lib/types/account";
+  import type { ReportingPeriod } from "$lib/types/reporting";
+  import { formatDateCompact } from "$lib/utils/date.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
+  import {
+    CsvGenerationError,
+    FileSystemAccessError,
+  } from "$lib/utils/reporting.save-csv-to-file.utils";
   import {
     buildTransactionsDatasets,
     convertPeriodToNanosecondRange,
-    CsvGenerationError,
-    FileSystemAccessError,
     generateCsvFileToSave,
     type CsvHeader,
     type TransactionsCsvData,
   } from "$lib/utils/reporting.utils";
-  import { toastsError } from "$lib/stores/toasts.store";
-  import { formatDateCompact } from "$lib/utils/date.utils";
-  import { authStore } from "$lib/stores/auth.store";
-  import { getAccountTransactionsConcurrently } from "$lib/services/reporting.services";
   import { SignIdentity, type Identity } from "@dfinity/agent";
-  import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import type { Account } from "$lib/types/account";
-  import type { Readable } from "svelte/store";
+  import { IconDown } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { queryNeurons } from "$lib/api/governance.api";
-  import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
-  import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
-  import { startBusy, stopBusy } from "$lib/stores/busy.store";
-  import type { ReportingPeriod } from "$lib/types/reporting";
+  import { ICPToken, nonNullish } from "@dfinity/utils";
+  import type { Readable } from "svelte/store";
 
   export let period: ReportingPeriod = "all";
 

--- a/frontend/src/lib/utils/reporting.save-csv-to-file.utils.ts
+++ b/frontend/src/lib/utils/reporting.save-csv-to-file.utils.ts
@@ -1,0 +1,109 @@
+export class FileSystemAccessError extends Error {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super(message, options);
+    this.name = "FileSystemAccessError";
+  }
+}
+
+export class CsvGenerationError extends Error {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super(message, options);
+    this.name = "CSVGenerationError";
+  }
+}
+
+// Source: https://web.dev/patterns/files/save-a-file
+const saveFileWithPicker = async ({
+  blob,
+  fileName,
+  description,
+}: {
+  blob: Blob;
+  fileName: string;
+  description: string;
+}) => {
+  try {
+    const handle = await window.showSaveFilePicker({
+      suggestedName: `${fileName}.csv`,
+      types: [
+        {
+          description,
+          accept: { "text/csv": [".csv"] },
+        },
+      ],
+    });
+    const writable = await handle.createWritable();
+    await writable.write(blob);
+    await writable.close();
+  } catch (error) {
+    // User cancelled the save dialog - not an error
+    if (error instanceof Error && error.name === "AbortError") return;
+
+    throw new FileSystemAccessError(
+      "Failed to save file using File System Access API",
+      { cause: error }
+    );
+  }
+};
+
+const saveFileWithAnchor = ({
+  blob,
+  fileName,
+}: {
+  blob: Blob;
+  fileName: string;
+}) => {
+  try {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${fileName}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    throw new FileSystemAccessError(
+      "Failed to save file using fallback method",
+      {
+        cause: error,
+      }
+    );
+  }
+};
+
+export const saveGeneratedCsv = async ({
+  csvContent,
+  fileName,
+  description,
+}: {
+  csvContent: string;
+  fileName: string;
+  description: string;
+}): Promise<void> => {
+  try {
+    const blob = new Blob([csvContent], {
+      type: "text/csv;charset=utf-8;",
+    });
+
+    // TODO: Investigate the random issues with showSaveFilePicker.
+    const isShowSaveFilePickerEnabled = false;
+    if (
+      "showSaveFilePicker" in window &&
+      typeof window.showSaveFilePicker === "function" &&
+      isShowSaveFilePickerEnabled
+    ) {
+      await saveFileWithPicker({ blob, fileName, description });
+    } else {
+      saveFileWithAnchor({ blob, fileName });
+    }
+  } catch (error) {
+    console.error(error);
+    if (error instanceof FileSystemAccessError) {
+      throw error;
+    }
+    throw new CsvGenerationError("Unexpected error saving CSV file", {
+      cause: error,
+    });
+  }
+};

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -18,6 +18,11 @@ import {
   neuronStake,
   neuronStakedMaturity,
 } from "$lib/utils/neuron.utils";
+import {
+  CsvGenerationError,
+  FileSystemAccessError,
+  saveGeneratedCsv,
+} from "$lib/utils/reporting.save-csv-to-file.utils";
 import { formatTokenV2 } from "$lib/utils/token.utils";
 import { transactionName } from "$lib/utils/transactions.utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
@@ -49,7 +54,6 @@ export type CsvHeader<T> = {
  * Forces Excel to treat a value as a string by wrapping it in an Excel formula.
  * Uses the '="value"' format which prevents Excel from automatically converting
  * large numbers into scientific notation or losing precision.
- *
  */
 const wrapAsExcelStringFormula = (value: bigint) => `="${value.toString()}"`;
 
@@ -118,84 +122,11 @@ export const convertToCsv = <T>({
 
   for (const row of data) {
     const values = headers.map((header) => escapeCsvValue(row[header.id]));
+
     csvRows.push([...emptyPrefix, ...values].join(","));
   }
 
   return csvRows.join("\n");
-};
-
-export class FileSystemAccessError extends Error {
-  constructor(message: string, options: ErrorOptions = {}) {
-    super(message, options);
-    this.name = "FileSystemAccessError";
-  }
-}
-
-export class CsvGenerationError extends Error {
-  constructor(message: string, options: ErrorOptions = {}) {
-    super(message, options);
-    this.name = "CSVGenerationError";
-  }
-}
-
-// Source: https://web.dev/patterns/files/save-a-file
-const saveFileWithPicker = async ({
-  blob,
-  fileName,
-  description,
-}: {
-  blob: Blob;
-  fileName: string;
-  description: string;
-}) => {
-  try {
-    const handle = await window.showSaveFilePicker({
-      suggestedName: `${fileName}.csv`,
-      types: [
-        {
-          description,
-          accept: { "text/csv": [".csv"] },
-        },
-      ],
-    });
-    const writable = await handle.createWritable();
-    await writable.write(blob);
-    await writable.close();
-  } catch (error) {
-    // User cancelled the save dialog - not an error
-    if (error instanceof Error && error.name === "AbortError") return;
-
-    throw new FileSystemAccessError(
-      "Failed to save file using File System Access API",
-      { cause: error }
-    );
-  }
-};
-
-const saveFileWithAnchor = ({
-  blob,
-  fileName,
-}: {
-  blob: Blob;
-  fileName: string;
-}) => {
-  try {
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `${fileName}.csv`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  } catch (error) {
-    throw new FileSystemAccessError(
-      "Failed to save file using fallback method",
-      {
-        cause: error,
-      }
-    );
-  }
 };
 
 export const combineDatasetsToCsv = <T>({
@@ -250,22 +181,7 @@ export const generateCsvFileToSave = async <T>({
 }): Promise<void> => {
   try {
     const csvContent = combineDatasetsToCsv({ datasets, headers });
-
-    const blob = new Blob([csvContent], {
-      type: "text/csv;charset=utf-8;",
-    });
-
-    // TODO: Investigate the random issues with showSaveFilePicker.
-    const isShowSaveFilePickerEnabled = false;
-    if (
-      "showSaveFilePicker" in window &&
-      typeof window.showSaveFilePicker === "function" &&
-      isShowSaveFilePickerEnabled
-    ) {
-      await saveFileWithPicker({ blob, fileName, description });
-    } else {
-      saveFileWithAnchor({ blob, fileName });
-    }
+    await saveGeneratedCsv({ csvContent, fileName, description });
   } catch (error) {
     console.error(error);
     if (

--- a/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
@@ -2,6 +2,10 @@ import * as gobernanceApi from "$lib/api/governance.api";
 import ReportingNeuronsButton from "$lib/components/reporting/ReportingNeuronsButton.svelte";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import {
+  CsvGenerationError,
+  FileSystemAccessError,
+} from "$lib/utils/reporting.save-csv-to-file.utils";
 import * as exportToCsvUtils from "$lib/utils/reporting.utils";
 import { generateCsvFileToSave } from "$lib/utils/reporting.utils";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -165,7 +169,7 @@ describe("ReportingNeuronsButton", () => {
 
   it("should show error toast when file system access fails", async () => {
     vi.spyOn(exportToCsvUtils, "generateCsvFileToSave").mockRejectedValueOnce(
-      new exportToCsvUtils.FileSystemAccessError("File system access denied")
+      new FileSystemAccessError("File system access denied")
     );
 
     const po = renderComponent();
@@ -183,7 +187,7 @@ describe("ReportingNeuronsButton", () => {
 
   it("should show error toast when Csv generation fails", async () => {
     vi.spyOn(exportToCsvUtils, "generateCsvFileToSave").mockRejectedValueOnce(
-      new exportToCsvUtils.CsvGenerationError("Csv generation failed")
+      new CsvGenerationError("Csv generation failed")
     );
 
     const po = renderComponent();

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -4,6 +4,10 @@ import ReportingTransactionsButton from "$lib/components/reporting/ReportingTran
 import * as exportDataService from "$lib/services/reporting.services";
 import * as toastsStore from "$lib/stores/toasts.store";
 import type { ReportingPeriod } from "$lib/types/reporting";
+import {
+  CsvGenerationError,
+  FileSystemAccessError,
+} from "$lib/utils/reporting.save-csv-to-file.utils";
 import * as exportToCsv from "$lib/utils/reporting.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -280,7 +284,7 @@ describe("ReportingTransactionsButton", () => {
 
   it("should show error toast when file system access fails", async () => {
     vi.spyOn(exportToCsv, "generateCsvFileToSave").mockRejectedValueOnce(
-      new exportToCsv.FileSystemAccessError("File system access denied")
+      new FileSystemAccessError("File system access denied")
     );
 
     const po = renderComponent();
@@ -298,7 +302,7 @@ describe("ReportingTransactionsButton", () => {
 
   it("should show error toast when Csv generation fails", async () => {
     vi.spyOn(exportToCsv, "generateCsvFileToSave").mockRejectedValueOnce(
-      new exportToCsv.CsvGenerationError("Csv generation failed")
+      new CsvGenerationError("Csv generation failed")
     );
 
     const po = renderComponent();

--- a/frontend/src/tests/lib/utils/reporting.save-csv-to-file.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.save-csv-to-file.utils.spec.ts
@@ -1,0 +1,142 @@
+import {
+  FileSystemAccessError,
+  saveGeneratedCsv,
+} from "$lib/utils/reporting.save-csv-to-file.utils";
+
+describe("reporting utils", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  // TODO: Investigate the random issues with showSaveFilePicker.
+  describe("Modern Browser (File System Access API)", () => {
+    let mockWritable;
+    let mockHandle;
+
+    beforeEach(() => {
+      mockWritable = {
+        write: vi.fn(),
+        close: vi.fn(),
+      };
+
+      mockHandle = {
+        createWritable: vi.fn().mockResolvedValue(mockWritable),
+      };
+
+      vi.stubGlobal(
+        "showSaveFilePicker",
+        vi.fn().mockResolvedValue(mockHandle)
+      );
+    });
+
+    it("should use Legacy Browser Link as feature is disabled", async () => {
+      URL.createObjectURL = vi.fn();
+      URL.revokeObjectURL = vi.fn();
+
+      await saveGeneratedCsv({
+        csvContent: "",
+        fileName: "test",
+        description: "test",
+      });
+
+      expect(window.showSaveFilePicker).toHaveBeenCalledTimes(0);
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+    });
+
+    it.skip("should use File System Access API when available", async () => {
+      await saveGeneratedCsv({
+        csvContent: "",
+        fileName: "test",
+        description: "test",
+      });
+
+      expect(window.showSaveFilePicker).toHaveBeenCalledWith({
+        suggestedName: "test.csv",
+        types: [
+          {
+            description: "Csv file",
+            accept: { "text/csv": [".csv"] },
+          },
+        ],
+      });
+      expect(mockHandle.createWritable).toHaveBeenCalledTimes(1);
+      expect(mockWritable.write).toHaveBeenCalledWith(expect.any(Blob));
+      expect(mockWritable.write).toHaveBeenCalledTimes(1);
+      expect(mockWritable.close).toHaveBeenCalledTimes(1);
+    });
+
+    it.skip("should gracefully handle user cancellation of save dialog", async () => {
+      const abortError = new Error("User cancelled");
+      abortError.name = "AbortError";
+
+      vi.stubGlobal(
+        "showSaveFilePicker",
+        vi.fn().mockRejectedValue(abortError)
+      );
+
+      await expect(
+        saveGeneratedCsv({
+          csvContent: "",
+          fileName: "",
+          description: "",
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it.skip("should throw FileSystemAccessError when modern API fails", async () => {
+      vi.stubGlobal(
+        "showSaveFilePicker",
+        vi.fn().mockRejectedValue(new Error("API Error"))
+      );
+
+      await expect(
+        saveGeneratedCsv({
+          csvContent: "",
+          fileName: "",
+          description: "",
+        })
+      ).rejects.toThrow(FileSystemAccessError);
+    });
+  });
+
+  describe("Legacy Browser (Fallback method)", () => {
+    beforeEach(() => {
+      URL.createObjectURL = vi.fn();
+      URL.revokeObjectURL = vi.fn();
+      window.showSaveFilePicker = undefined;
+    });
+
+    it("should use fallback method when showSaveFilePicker is not available", async () => {
+      const mockLink = document.createElement("a");
+      const clickSpy = vi
+        .spyOn(mockLink, "click")
+        .mockImplementationOnce(() => {});
+      vi.spyOn(document, "createElement").mockReturnValue(mockLink);
+
+      await saveGeneratedCsv({
+        csvContent: "",
+        fileName: "",
+        description: "",
+      });
+
+      expect(URL.createObjectURL).toBeCalledTimes(1);
+      expect(clickSpy).toHaveBeenCalled();
+      expect(URL.revokeObjectURL).toHaveBeenCalled();
+    });
+
+    it("should throw FileSystemAccessError on fallback method failure", async () => {
+      document.body.appendChild = vi.fn().mockReturnValueOnce(() => {
+        throw new Error("DOM Error");
+      });
+
+      await expect(
+        saveGeneratedCsv({
+          csvContent: "",
+          fileName: "test",
+          description: "",
+        })
+      ).rejects.toThrow(FileSystemAccessError);
+    });
+  });
+});

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -1,11 +1,9 @@
 import {
-  FileSystemAccessError,
   buildNeuronsDatasets,
   buildTransactionsDatasets,
   combineDatasetsToCsv,
   convertPeriodToNanosecondRange,
   convertToCsv,
-  generateCsvFileToSave,
   type CsvHeader,
 } from "$lib/utils/reporting.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -213,132 +211,6 @@ describe("reporting utils", () => {
         "Report Date,2024-01-01\nDepartment,Sales\n\n,,Name,Age\n,,John,30\n\n\nReport Date,2024-01-01\nDepartment,Marketing\n\n,,Name,Age\n,,Jane,25";
 
       expect(combineDatasetsToCsv({ datasets, headers })).toBe(expected);
-    });
-  });
-
-  describe("downloadCSV", () => {
-    beforeEach(() => {
-      vi.spyOn(console, "error").mockImplementation(() => {});
-    });
-
-    // TODO: Investigate the random issues with showSaveFilePicker.
-    describe("Modern Browser (File System Access API)", () => {
-      let mockWritable;
-      let mockHandle;
-
-      beforeEach(() => {
-        mockWritable = {
-          write: vi.fn(),
-          close: vi.fn(),
-        };
-
-        mockHandle = {
-          createWritable: vi.fn().mockResolvedValue(mockWritable),
-        };
-
-        vi.stubGlobal(
-          "showSaveFilePicker",
-          vi.fn().mockResolvedValue(mockHandle)
-        );
-      });
-
-      it("should use Legacy Browser Link as feature is disabled", async () => {
-        URL.createObjectURL = vi.fn();
-        URL.revokeObjectURL = vi.fn();
-
-        await generateCsvFileToSave({
-          datasets: [],
-          headers: [],
-          fileName: "test",
-        });
-
-        expect(window.showSaveFilePicker).toHaveBeenCalledTimes(0);
-        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
-        expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
-      });
-
-      it.skip("should use File System Access API when available", async () => {
-        await generateCsvFileToSave({
-          datasets: [],
-          headers: [],
-          fileName: "test",
-        });
-
-        expect(window.showSaveFilePicker).toHaveBeenCalledWith({
-          suggestedName: "test.csv",
-          types: [
-            {
-              description: "Csv file",
-              accept: { "text/csv": [".csv"] },
-            },
-          ],
-        });
-        expect(mockHandle.createWritable).toHaveBeenCalledTimes(1);
-        expect(mockWritable.write).toHaveBeenCalledWith(expect.any(Blob));
-        expect(mockWritable.write).toHaveBeenCalledTimes(1);
-        expect(mockWritable.close).toHaveBeenCalledTimes(1);
-      });
-
-      it.skip("should gracefully handle user cancellation of save dialog", async () => {
-        const abortError = new Error("User cancelled");
-        abortError.name = "AbortError";
-
-        vi.stubGlobal(
-          "showSaveFilePicker",
-          vi.fn().mockRejectedValue(abortError)
-        );
-
-        await expect(
-          generateCsvFileToSave({ datasets: [], headers: [] })
-        ).resolves.not.toThrow();
-      });
-
-      it.skip("should throw FileSystemAccessError when modern API fails", async () => {
-        vi.stubGlobal(
-          "showSaveFilePicker",
-          vi.fn().mockRejectedValue(new Error("API Error"))
-        );
-
-        await expect(
-          generateCsvFileToSave({ datasets: [], headers: [] })
-        ).rejects.toThrow(FileSystemAccessError);
-      });
-    });
-
-    describe("Legacy Browser (Fallback method)", () => {
-      beforeEach(() => {
-        URL.createObjectURL = vi.fn();
-        URL.revokeObjectURL = vi.fn();
-        window.showSaveFilePicker = undefined;
-      });
-
-      it("should use fallback method when showSaveFilePicker is not available", async () => {
-        const mockLink = document.createElement("a");
-        const clickSpy = vi
-          .spyOn(mockLink, "click")
-          .mockImplementationOnce(() => {});
-        vi.spyOn(document, "createElement").mockReturnValue(mockLink);
-
-        await generateCsvFileToSave({
-          datasets: [],
-          headers: [],
-          fileName: "test",
-        });
-
-        expect(URL.createObjectURL).toBeCalledTimes(1);
-        expect(clickSpy).toHaveBeenCalled();
-        expect(URL.revokeObjectURL).toHaveBeenCalled();
-      });
-
-      it("should throw FileSystemAccessError on fallback method failure", async () => {
-        document.body.appendChild = vi.fn().mockReturnValueOnce(() => {
-          throw new Error("DOM Error");
-        });
-
-        await expect(
-          generateCsvFileToSave({ datasets: [], headers: [] })
-        ).rejects.toThrow(FileSystemAccessError);
-      });
     });
   });
 


### PR DESCRIPTION
# Motivation

#6255 introduced a bug in how `neuronId`s are rendered in the CSV file. Unit tests did not catch this issue because they focused on the generated data structure rather than the final string that appears in the CSV.

This first PR separates the reporting utilities into a secondary utility. This change is necessary because of how Vitest handles spies. The `generateCsvFileToSave` function would create a closure on `saveGeneratedCsv`, which would require mocking the entire file. This separation allows for the creation of new tests that can spy on the final value included in the CSV.

A follow-up PR will update the existing tests in `ReportingNeuronsButton` and `ReportingTransactionsButton` to verify the CSV string instead of the data structure.

A third PR will address the bug.

No logical changes are introduced in this PR.

# Changes

- Extract the logic for saving a string to a CSV into its own utility.
- Move the relevant tests to their own specification file.
- While updating the imports for `ReportingNeuronsButton` and `ReportingTransactionsButton`, I also sorted them.

# Tests

- Should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary