### PR TITLE
build: prepare sveltekit sync to prevent breaking change

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && tsc --noEmit && vite build && npm run build:post-process",
     "preview": "vite preview",
+    "prepare": "svelte-kit sync",
     "check": "svelte-kit sync && svelte-check --fail-on-warnings --tsconfig ./tsconfig.json && npm run lint",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check './**/*.{ts,js,mjs,json,scss,svelte,html}' && eslint --max-warnings 0 .",


### PR DESCRIPTION
# Motivation

Same as in Gix-cmp or OISY (PR [#4354](https://github.com/dfinity/oisy-wallet/pull/4354)), this PR sets up a `prepare` step in `package.json` to sync SvelteKit. By doing so, the `.svelte-kit/ts-config.json` file is generated.

The NNS dapp does not strictly require this setup yet, but it will be necessary when upgrading to Svelte v5. See the failing tests job [here](https://github.com/dfinity/nns-dapp/actions/runs/13107110902/job/36563668448?pr=6020).

This "minor change" was announced in this [CHANGELOG](https://github.com/sveltejs/kit/blob/main/packages/kit/CHANGELOG.md#2160).

