### PR TITLE
chore: remove Unused CSS selector

### DIFF
--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -103,9 +103,6 @@
               font-size: 2.5rem; // 40px
             }
           }
-          .secondary-amount {
-            color: var(--text-description);
-          }
         }
       }
     }


### PR DESCRIPTION
# Motivation

Lint seems more restrictive in latest version / Svelte v5. An unsued CSS style has been detected [here](https://github.com/dfinity/nns-dapp/actions/runs/13107472757/job/36564605264?pr=6020).

# Changes

- Remove unused css
