### PR TITLE
fix(styles): add missing TotalAssetsCard style

### DIFF
--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -103,9 +103,10 @@
               font-size: 2.5rem; // 40px
             }
           }
-          .secondary-amount {
-            color: var(--text-description);
-          }
+        }
+
+        .secondary-amount {
+          color: var(--text-description);
         }
       }
     }


### PR DESCRIPTION
# Motivation

The `secondary-amount` class was not applied in the `TotalAssetsCard` component because it was incorrectly placed. The linter did not detect this issue, but the new version did, as noted in #6318.

Before:
<img width="916" alt="Screenshot 2025-02-03 at 13 21 21" src="https://github.com/user-attachments/assets/fd447d56-feef-441d-ad2b-7a31f56d1636" />

After: 
<img width="888" alt="Screenshot 2025-02-03 at 13 21 51" src="https://github.com/user-attachments/assets/4a4fd459-e29a-44de-a06b-b62317835049" />

# Changes

- Change style

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary