### PR TITLE
feat(navigation): implement wallet page entry point tracking

### DIFF
--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -1,4 +1,6 @@
 import { AppPath } from "$lib/constants/routes.constants";
+import { accountsPathStore } from "$lib/derived/paths.derived";
+import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { derived, type Readable } from "svelte/store";
 
@@ -17,5 +19,25 @@ export const accountsPageOrigin: Readable<AppPath> = derived(
       .slice(0, 3)
       .find((path) => path === AppPath.Portfolio || path === AppPath.Tokens);
     return lastPath ?? AppPath.Tokens;
+  }
+);
+
+/**
+ * Derives the origin page (Portfolio, Tokens or Accounts) to return from Wallets.
+ * Looks at last entry to handle navigation flows:
+ * Portfolio -> Wallet -> (back) -> Portfolio
+ * Accounts -> Wallet -> (back) -> Accounts
+ * Tokens -> Wallet -> (back) -> Tokens
+ *
+ * Returns AppPath.Tokens as default if no matching page is found.
+ */
+export const walletPageOrigin = derived(
+  [referrerPathStore, isNnsUniverseStore, accountsPathStore],
+  ([paths, isNnsUniverse, accountsPath]) => {
+    const lastPath = paths.at(-1);
+
+    if (lastPath === AppPath.Portfolio) return lastPath;
+    if (isNnsUniverse) return accountsPath;
+    return AppPath.Tokens;
   }
 );

--- a/frontend/src/tests/lib/derived/routes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/routes.derived.spec.ts
@@ -1,40 +1,77 @@
-import { AppPath } from "$lib/constants/routes.constants";
-import { accountsPageOrigin } from "$lib/derived/routes.derived";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath, UNIVERSE_PARAM } from "$lib/constants/routes.constants";
+import {
+  accountsPageOrigin,
+  walletPageOrigin,
+} from "$lib/derived/routes.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
+import { page } from "$mocks/$app/stores";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { get } from "svelte/store";
 
-describe("accountsPageOrigin.derived", () => {
-  it("should return Tokens page as default when history is empty", () => {
-    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+describe("routes.derived", () => {
+  describe("accountsPageOrigin.derived", () => {
+    it("should return Tokens page as default when history is empty", () => {
+      expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+    });
+
+    it("should return Tokens as default when no main pages were visited", () => {
+      referrerPathStore.pushPath(AppPath.Staking);
+      referrerPathStore.pushPath(AppPath.Settings);
+
+      expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+    });
+
+    it("should return Portfolio when it was the last main page visited", () => {
+      referrerPathStore.pushPath(AppPath.Tokens);
+      referrerPathStore.pushPath(AppPath.Portfolio);
+
+      expect(get(accountsPageOrigin)).toBe(AppPath.Portfolio);
+    });
+
+    it("should return Tokens when it was the last main page visited", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+      referrerPathStore.pushPath(AppPath.Tokens);
+
+      expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+    });
+
+    it("should return Tokens when pages visited are more than the 3 slots", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+      referrerPathStore.pushPath(AppPath.Settings);
+      referrerPathStore.pushPath(AppPath.Launchpad);
+      referrerPathStore.pushPath(AppPath.Wallet);
+
+      expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+    });
   });
 
-  it("should return Tokens as default when no main pages were visited", () => {
-    referrerPathStore.pushPath(AppPath.Staking);
-    referrerPathStore.pushPath(AppPath.Settings);
+  describe("walletPageOrigin.derived", () => {
+    it("should return Portfolio when it was the last main page visited", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
 
-    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
-  });
+      expect(get(walletPageOrigin)).toBe(AppPath.Portfolio);
+    });
 
-  it("should return Portfolio when it was the last main page visited", () => {
-    referrerPathStore.pushPath(AppPath.Tokens);
-    referrerPathStore.pushPath(AppPath.Portfolio);
+    it("should return ICP account when last page is not Portfolio and in NNS universe", () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      referrerPathStore.pushPath(AppPath.Wallet);
 
-    expect(get(accountsPageOrigin)).toBe(AppPath.Portfolio);
-  });
+      // TODO(yhabib): Extract icp account path to test-variable and use through codebase
+      expect(get(walletPageOrigin)).toBe(
+        `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
+      );
+    });
 
-  it("should return Tokens when it was the last main page visited", () => {
-    referrerPathStore.pushPath(AppPath.Portfolio);
-    referrerPathStore.pushPath(AppPath.Tokens);
+    it("should return Tokens when not in NNS universe and last page was not Portfolio", () => {
+      page.mock({
+        data: {
+          universe: rootCanisterIdMock.toText(),
+        },
+      });
+      referrerPathStore.pushPath(AppPath.Wallet);
 
-    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
-  });
-
-  it("should return Tokens when pages visited are more than the 3 slots", () => {
-    referrerPathStore.pushPath(AppPath.Portfolio);
-    referrerPathStore.pushPath(AppPath.Settings);
-    referrerPathStore.pushPath(AppPath.Launchpad);
-    referrerPathStore.pushPath(AppPath.Wallet);
-
-    expect(get(accountsPageOrigin)).toBe(AppPath.Tokens);
+      expect(get(walletPageOrigin)).toBe(AppPath.Tokens);
+    });
   });
 });


### PR DESCRIPTION
# Motivation

Following a similar approach to #6285, the Wallets page will feature multiple return pages based on how it was accessed. 

Currently, there are two entry points:
* The Accounts page, when clicking any account except the NNS account.
* The NNS account page, when navigating from the Accounts page to the NNS account and then to the wallet.

A new entry point will be added to allow navigation back from the Portfolio page when the user clicks on a token in the `HeldTokensTable`.

A follow-up PR will update the Wallet's layout to make use of this store.

Note: It is easier to review by hiding the whitespaces
<img width="277" alt="Screenshot 2025-02-03 at 14 31 08" src="https://github.com/user-attachments/assets/9c28443e-f013-4afa-8684-dcadc2125340" />

# Changes

-  A new derived store has been created to determine the return destination from the Wallet page.

# Tests

-  Unit tests have been implemented for this new derived store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary