### PR TITLE
chore: fix tsconfig for vitest.setup

### DIFF
--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -32,6 +32,7 @@
     ".svelte-kit/ambient.d.ts",
     "./vite.config.ts",
     "./vitest.config.ts",
+    "./vitest.setup.ts",
     "./src/**/*.js",
     "./src/**/*.ts",
     "./src/**/*.svelte"


### PR DESCRIPTION
# Motivation

IDE does not validate `vitest.setup.ts`

> TS2304: Cannot find name beforeEach

# Changes

- Add `vitest.setup.ts` to `tsconfig.spec`

# Screenshot

<img width="1470" alt="Capture d’écran 2025-02-03 à 10 22 03" src="https://github.com/user-attachments/assets/b54ce292-4cda-4953-8681-74f27938959a" />
