### PR TITLE
chore: fix importOriginal in vitest.setup

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -42,7 +42,8 @@ const cleanupFunctions = vi.hoisted(() => {
 
 // Reset every store before each test.
 vi.mock("svelte/store", async (importOriginal) => {
-  const svelteStoreModule = await importOriginal();
+  const svelteStoreModule =
+    await importOriginal<typeof import("svelte/store")>();
   return {
     ...svelteStoreModule,
     writable: <T>(initialValue, ...otherArgs) => {


### PR DESCRIPTION
# Motivation

IDE and [CI](https://github.com/dfinity/nns-dapp/actions/runs/13110241729/job/36572373003?pr=6322) throws following errors when validating `tsconfig.spec`

> Error: vitest.setup.ts(47,5): error TS2698: Spread types may only be created from object types.
> Error: vitest.setup.ts(49,39): error TS2339: Property 'writable' does not exist on type 'unknown'.

# Changes

- Infer types for `importOriginal`

# Screenshot

<img width="1536" alt="Capture d’écran 2025-02-03 à 10 24 19" src="https://github.com/user-attachments/assets/db9f202c-9ad2-4f19-9264-5e5e5f02d3ea" />

