### PR TITLE
Remove resetSnsProjects from beforeEach

### DIFF
--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -2,7 +2,7 @@ import * as agent from "$lib/api/agent.api";
 import { clearWrapperCache, wrappers } from "$lib/api/sns-wrapper.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import type { SnsWrapper } from "@dfinity/sns";
 import { mock } from "vitest-mock-extended";
@@ -10,7 +10,6 @@ import { mock } from "vitest-mock-extended";
 describe("sns-wrapper api", () => {
   beforeEach(() => {
     clearWrapperCache();
-    resetSnsProjects();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -17,7 +17,7 @@ import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
@@ -51,7 +51,6 @@ describe("ImportTokenModal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
 
     queryIcrcTokenSpy = vi
       .spyOn(ledgerApi, "queryIcrcToken")

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -13,14 +13,10 @@ import {
   resetAccountsForTesting,
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SelectAccountDropdown", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   describe("no accounts", () => {
     beforeEach(() => {
       resetAccountsForTesting();

--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -9,15 +9,11 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SelectDestinationAddress", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   describe("nns accounts", () => {
     const mockSubAccount2 = {
       ...mockSubAccount,

--- a/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -1,15 +1,11 @@
 import Projects from "$lib/components/launchpad/Projects.svelte";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { ProjectsPo } from "$tests/page-objects/Projects.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("Projects", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   const renderComponent = ({
     testId,
     status,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -19,7 +19,6 @@ import {
 describe("SnsNeuronFollowingCard", () => {
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
   });
 
   describe("user has permissions to manage followees", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
@@ -11,7 +11,7 @@ import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { SnsNeuronPageHeaderPo } from "$tests/page-objects/SnsNeuronPageHeader.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
 import { get } from "svelte/store";
@@ -57,7 +57,6 @@ describe("SnsNeuronPageHeader", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
     setSnsProjects([
       {
         rootCanisterId: rootCanisterId,

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -11,7 +11,6 @@ import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsProposalDecisionStatus } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
@@ -42,7 +41,6 @@ describe("ProposalSystemInfoSection", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
     fakeSnsGovernanceApi.addNervousSystemFunctionWith({
       rootCanisterId,
       ...nervousFunction,

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -17,7 +17,7 @@ import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { nonNullish } from "@dfinity/utils";
@@ -43,7 +43,6 @@ describe("ProjectsTable", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
     resetIdentity();
 
     page.mock({

--- a/frontend/src/tests/lib/components/summary/Summary.spec.ts
+++ b/frontend/src/tests/lib/components/summary/Summary.spec.ts
@@ -7,7 +7,7 @@ import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
 import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
@@ -19,7 +19,6 @@ describe("Summary", () => {
 
   beforeEach(() => {
     page.reset();
-    resetSnsProjects();
   });
 
   describe("no universe", () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -18,12 +18,11 @@ import {
 } from "$tests/mocks/sns-projects.mock";
 import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseDropdown", () => {
   beforeEach(() => {
-    resetSnsProjects();
     resetIdentity();
 
     page.mock({

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -10,7 +10,7 @@ import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { ProposalInfo } from "@dfinity/nns";
 import {
@@ -28,7 +28,6 @@ describe("SelectUniverseNav", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
     resetIdentity();
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -36,13 +36,11 @@ import {
   ckETHUniverseMock,
   nnsUniverseMock,
 } from "$tests/mocks/universe.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("UniverseAccountsBalance", () => {
   beforeEach(() => {
-    resetSnsProjects();
-
     page.mock({
       data: { universe: mockSnsCanisterId.toText() },
     });

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -18,7 +18,7 @@ import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { ProposalInfo } from "@dfinity/nns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
@@ -27,10 +27,6 @@ describe("actionable proposals derived stores", () => {
   const principal0 = principal(0);
   const principal1 = principal(1);
   const principal2 = principal(2);
-
-  beforeEach(() => {
-    resetSnsProjects();
-  });
 
   describe("actionableProposalIndicationVisibleStore", () => {
     it("returns true when the user is signed-in and on proposals page", async () => {

--- a/frontend/src/tests/lib/derived/sns-functions.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-functions.derived.spec.ts
@@ -2,7 +2,6 @@ import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import {
-  resetSnsProjects,
   setProdSnsProjects,
   setSnsProjects,
 } from "$tests/utils/sns.test-utils";
@@ -10,10 +9,6 @@ import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
 describe("sns functions store", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   it("should be set to an empty object", () => {
     const store = get(snsFunctionsStore);
     expect(store).toEqual({});

--- a/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
@@ -2,15 +2,11 @@ import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
 
 describe("nsFunctionsProjectStore", () => {
   const rootCanisterId = rootCanisterIdMock;
-
-  beforeEach(() => {
-    resetSnsProjects();
-  });
 
   it("returns the functions", () => {
     const rootCanisterId = rootCanisterIdMock;

--- a/frontend/src/tests/lib/derived/sns-total-token-supply.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-total-token-supply.derived.spec.ts
@@ -2,17 +2,12 @@ import { snsTotalTokenSupplyStore } from "$lib/derived/sns-total-token-supply.de
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import {
-  resetSnsProjects,
   setProdSnsProjects,
   setSnsProjects,
 } from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
 
 describe("SNS Total Tokens Supply store", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   const totalTokenSupply = 1_000_000_000n;
 
   const totalSupplyData = {

--- a/frontend/src/tests/lib/derived/sns/sns-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-accounts.derived.spec.ts
@@ -1,7 +1,7 @@
 import { snsAccountsStore } from "$lib/derived/sns/sns-accounts.derived";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
@@ -32,8 +32,6 @@ describe("sns-accounts.derived", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
-
     setSnsProjects([
       {
         rootCanisterId: Principal.fromText(batmanRootCanisterIdText),

--- a/frontend/src/tests/lib/derived/sns/sns-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-canisters.derived.spec.ts
@@ -1,5 +1,5 @@
 import { snsLedgerCanisterIdsStore } from "$lib/derived/sns/sns-canisters.derived";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
@@ -14,8 +14,6 @@ describe("sns-canisters.derived", () => {
   const robinLedgerCanisterId = Principal.fromText(robinLedgerCanisterIdText);
 
   beforeEach(() => {
-    resetSnsProjects();
-
     setSnsProjects([
       {
         rootCanisterId: batmanRootCanisterId,

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -5,15 +5,11 @@ import {
   snsProjectsRecordStore,
   snsProjectsStore,
 } from "$lib/derived/sns/sns-projects.derived";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("projects.derived", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   describe("projectsDerived", () => {
     it("should set projects of all statuses", () => {
       setSnsProjects([

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -8,7 +8,7 @@ import {
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -18,7 +18,6 @@ describe("selected-project-new-transaction-data derived store", () => {
 
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-      resetSnsProjects();
     });
 
     it("returns undefined when nns", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -10,7 +10,7 @@ import {
   mockSnsSwapCommitment,
   principal,
 } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
@@ -18,9 +18,6 @@ import { get } from "svelte/store";
 describe("selected sns project derived stores", () => {
   const rootCanisterId = principal(0);
   const rootCanisterIdText = rootCanisterId.toText();
-  beforeEach(() => {
-    resetSnsProjects();
-  });
 
   describe("snsOnlyProjectStore", () => {
     beforeEach(() => {

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -3,7 +3,7 @@ import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-tr
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockToken } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -17,7 +17,6 @@ describe("snsSelectedTransactionFeeStore", () => {
     tokenMetadata: mockToken,
   };
   beforeEach(() => {
-    resetSnsProjects();
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });
 

--- a/frontend/src/tests/lib/derived/sns/sns-token-symbol-selected.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-token-symbol-selected.store.spec.ts
@@ -3,7 +3,7 @@ import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-s
 import { page } from "$mocks/$app/stores";
 import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -18,7 +18,6 @@ describe("currentSnsTokenLabelStore", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
     page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
   });
 

--- a/frontend/src/tests/lib/derived/sns/sns-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-tokens.derived.spec.ts
@@ -4,7 +4,6 @@ import {
 } from "$lib/derived/sns/sns-tokens.derived";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import {
-  resetSnsProjects,
   setProdSnsProjects,
   setSnsProjects,
 } from "$tests/utils/sns.test-utils";
@@ -32,8 +31,6 @@ describe("sns-tokens.derived", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
-
     setSnsProjects([
       {
         rootCanisterId: Principal.fromText(batmanRootCanisterIdText),

--- a/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
@@ -1,15 +1,11 @@
 import { snsTotalSupplyTokenAmountStore } from "$lib/derived/sns/sns-total-supply-token-amount.derived";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("snsTotalSupplyTokenAmountStore", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   it("should return the total supply of tokens for each SNS in TokenAmount", () => {
     const projectsParams = [
       { rootCanisterId: principal(0), lifecycle: SnsSwapLifecycle.Committed },

--- a/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
@@ -11,7 +11,7 @@ import {
   ckTESTBTCTokenBase,
   icpTokenBase,
 } from "$tests/mocks/tokens-page.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -51,10 +51,6 @@ describe("tokens-list-base.derived", () => {
   };
 
   describe("tokensListBaseStore", () => {
-    beforeEach(() => {
-      resetSnsProjects();
-    });
-
     it("should return ICP, ckBTC and ckTESTBTC without any other data loaded", () => {
       expect(get(tokensListBaseStore)).toEqual([
         icpTokenBase,

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -43,7 +43,7 @@ import {
 } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
@@ -215,7 +215,6 @@ describe("tokens-list-user.derived", () => {
     beforeEach(() => {
       resetAccountsForTesting();
       authStore.setForTesting(mockIdentity);
-      resetSnsProjects();
 
       setSnsProjects([snsTetris, snsPacman]);
       setCkETHCanisters();

--- a/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
@@ -26,7 +26,7 @@ import {
   createIcpUserToken,
 } from "$tests/mocks/tokens-page.mock";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
@@ -166,7 +166,6 @@ describe("tokens-list-base.derived", () => {
 
   describe("tokensListVisitorsStore", () => {
     beforeEach(() => {
-      resetSnsProjects();
       setCkETHCanisters();
     });
 

--- a/frontend/src/tests/lib/derived/tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens.derived.spec.ts
@@ -14,7 +14,7 @@ import {
 import { tokensStore } from "$lib/stores/tokens.store";
 import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
@@ -39,8 +39,6 @@ describe("tokens.derived", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
-
     setSnsProjects([
       {
         rootCanisterId: Principal.fromText(batmanRootCanisterIdText),

--- a/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
@@ -16,14 +16,10 @@ import {
 } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
 
 describe("universes-accounts", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   it("should derive Nns accounts", () => {
     setAccountsForTesting({
       main: mockMainAccount,

--- a/frontend/src/tests/lib/derived/universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes.derived.spec.ts
@@ -23,15 +23,11 @@ import {
   ckTESTBTCUniverseMock,
   nnsUniverseMock,
 } from "$tests/mocks/universe.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("universes derived stores", () => {
-  beforeEach(() => {
-    resetSnsProjects();
-  });
-
   describe("ckTESTBTC enabled", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", true);

--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsNeuron, mockSnsNeuronId } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
@@ -45,8 +45,6 @@ describe("DisburseSnsNeuronModal", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
-
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
       testIdentity
     );

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsModal.spec.ts
@@ -5,7 +5,7 @@ import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { FollowSnsNeuronsModalPo } from "$tests/page-objects/FollowSnsNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
 import { nonNullish } from "@dfinity/utils";
 
@@ -32,10 +32,6 @@ describe("FollowSnsNeuronsModal", () => {
 
     return FollowSnsNeuronsModalPo.under(new JestPageObjectElement(container));
   };
-
-  beforeEach(() => {
-    resetSnsProjects();
-  });
 
   it("renders title", async () => {
     const po = renderComponent({});

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsDisburseMaturityModal.spec.ts
@@ -13,7 +13,7 @@ import {
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { DisburseMaturityModalPo } from "$tests/page-objects/DisburseMaturityModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import type { SnsNeuron } from "@dfinity/sns";
 import { nonNullish } from "@dfinity/utils";
@@ -42,8 +42,6 @@ describe("SnsDisburseMaturityModal", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
-
     authStore.setForTesting(mockIdentity);
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.spec.ts
@@ -18,7 +18,7 @@ import {
   AMOUNT_INPUT_SELECTOR,
   enterAmount,
 } from "$tests/utils/neurons-modal.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { ICPToken } from "@dfinity/utils";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
@@ -52,7 +52,6 @@ describe("SnsIncreaseStakeNeuronModal", () => {
   };
 
   beforeEach(() => {
-    resetSnsProjects();
     page.mock({
       routeId: AppPath.Neuron,
       data: { universe: rootCanisterId.toText() },

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
@@ -12,7 +12,7 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
 import { SnsStakeNeuronModalPo } from "$tests/page-objects/SnsStakeNeuronModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { Principal } from "@dfinity/principal";
 import { TokenAmount } from "@dfinity/utils";
@@ -37,7 +37,6 @@ describe("SnsStakeNeuronModal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
 
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -18,7 +18,7 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import type { Principal } from "@dfinity/principal";
@@ -75,7 +75,6 @@ describe("TransactionModal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
 
     setAccountsForTesting({
       main: mockMainAccount,

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -10,7 +10,7 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { ActionableProposalsPo } from "$tests/page-objects/ActionableProposals.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { ProposalInfo } from "@dfinity/nns";
@@ -59,7 +59,6 @@ describe("ActionableProposals", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
 
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -37,7 +37,7 @@ import { ProjectDetailPo } from "$tests/page-objects/ProjectDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -81,7 +81,6 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
   const nowInSeconds = Math.floor(now / 1000);
 
   beforeEach(() => {
-    resetSnsProjects();
     userCountryStore.set(NOT_LOADED);
 
     vi.clearAllTimers();

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -27,7 +27,6 @@ import {
 import { SnsProposalDetailPo } from "$tests/page-objects/SnsProposalDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import {
-  resetSnsProjects,
   setProdSnsProjects,
   setSnsProjects,
 } from "$tests/utils/sns.test-utils";
@@ -72,7 +71,6 @@ describe("SnsProposalDetail", () => {
   beforeEach(() => {
     resetIdentity();
     page.reset();
-    resetSnsProjects();
   });
 
   describe("not logged in", () => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -24,7 +24,7 @@ import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransa
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -74,7 +74,6 @@ describe("SnsWallet", () => {
   beforeEach(() => {
     vi.useRealTimers();
     resetIdentity();
-    resetSnsProjects();
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],
     });

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -20,7 +20,6 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
-import { resetSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
@@ -57,7 +56,6 @@ describe("NeuronDetail", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(0n);
     vi.spyOn(icpLedgerApi, "queryAccountBalance").mockResolvedValue(0n);

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -30,7 +30,7 @@ import {
   resetAccountsForTesting,
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { Principal } from "@dfinity/principal";
 import { fromNullable } from "@dfinity/utils";
@@ -42,7 +42,6 @@ describe("Staking", () => {
   const snsCanisterId = principal(1112);
 
   beforeEach(() => {
-    resetSnsProjects();
     resetIdentity();
     resetAccountsForTesting();
 

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -13,7 +13,7 @@ import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
 import type { Principal } from "@dfinity/principal";
 import {
@@ -123,7 +123,6 @@ describe("actionable-sns-proposals.services", () => {
     let spyConsoleError;
 
     beforeEach(() => {
-      resetSnsProjects();
       resetIdentity();
 
       resetIdentity();

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -28,7 +28,6 @@ describe("app-services", () => {
   beforeEach(() => {
     resetIdentity();
     clearSnsAggregatorCache();
-    // resetSnsProjects();
     vi.spyOn(LedgerCanister, "create").mockImplementation(
       (): LedgerCanister => mockLedgerCanister
     );

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -30,7 +30,7 @@ import { mockIcrcMainAccount } from "$tests/mocks/icrc-accounts.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
@@ -47,7 +47,6 @@ describe("icrc-accounts-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
 
     vi.spyOn(ledgerApi, "queryIcrcToken").mockResolvedValue(mockToken);
     vi.spyOn(ledgerApi, "queryIcrcBalance").mockImplementation(

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -4,7 +4,7 @@ import * as services from "$lib/services/sns-accounts-balance.services";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { tick } from "svelte";
 import { get } from "svelte/store";
@@ -15,7 +15,6 @@ describe("sns-accounts-balance.services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
 
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -12,7 +12,7 @@ import {
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
@@ -22,7 +22,6 @@ import { mock } from "vitest-mock-extended";
 describe("sns-accounts-services", () => {
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -8,7 +8,7 @@ import {
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { snsFinalizationStatusResponseMock } from "$tests/mocks/sns-finalization-status.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -17,7 +17,6 @@ describe("sns-finalization-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
     resetSnsFinalizationStatusStore();
 
     vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   SnsNeuronPermissionType,
   neuronSubaccount,
@@ -62,7 +62,6 @@ describe("sns-neurons-check-balances-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
 
     setSnsProjects([
       {

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -35,7 +35,7 @@ import {
   mockSnsNeuron,
 } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsToken, mockTokenStore } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { NeuronState } from "@dfinity/nns";
@@ -92,7 +92,6 @@ describe("sns-neurons-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetSnsProjects();
     vi.spyOn(console, "error").mockReturnValue(undefined);
   });
 

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -14,7 +14,7 @@ import {
   mockSnsSwapCommitment,
   principal,
 } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -46,7 +46,6 @@ describe("sns-services", () => {
     resetIdentity();
     vi.useFakeTimers();
     vi.clearAllTimers();
-    resetSnsProjects();
   });
 
   describe("getSwapAccount", () => {

--- a/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons-table-order-sorted-neuron-ids-store.spec.ts
@@ -4,7 +4,7 @@ import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -37,7 +37,6 @@ describe("snsNeuronsTableOrderSortedNeuronIdsStore", () => {
   const mockRootCanisterId = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
 
   beforeEach(() => {
-    resetSnsProjects();
     snsNeuronsStore.setNeurons({
       rootCanisterId: mockRootCanisterId,
       neurons: testSnsNeurons,


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
`resetSnsProjects` is a [function](https://github.com/dfinity/nns-dapp/blob/f7f6fbd9f94c7e304c70538f86331e28eba5c061/frontend/src/tests/utils/sns.test-utils.ts#L72-L76) that resets 3 stores and does nothing else.
So there is no need to call this in `beforeEach`.

`resetSnsProjects` is also called in some individual tests. I tried not to remove any of those.

# Changes

1. Remove `resetSnsProjects` in `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary