### PR TITLE
feat(navigation): implement contextual back navigation for Tokens page

### DIFF
--- a/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
@@ -3,12 +3,9 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
-  import { AppPath } from "$lib/constants/routes.constants";
-  import { accountsPathStore } from "$lib/derived/paths.derived";
-  import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
+  import { walletPageOrigin } from "$lib/derived/routes.derived";
 
-  const back = (): Promise<void> =>
-    goto($isNnsUniverseStore ? $accountsPathStore : AppPath.Tokens);
+  const back = (): Promise<void> => goto($walletPageOrigin);
 </script>
 
 <LayoutNavGuard>

--- a/frontend/src/tests/routes/app/wallet/layout.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/layout.spec.ts
@@ -1,6 +1,7 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
+import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import WalletLayout from "$routes/(app)/(u)/(detail)/wallet/+layout.svelte";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
@@ -43,5 +44,23 @@ describe("Wallet layout", () => {
       path: AppPath.Accounts,
       universe: OWN_CANISTER_ID_TEXT,
     });
+  });
+
+  it("back button should navigate to Portfolio page previous page is Portfolio page", async () => {
+    page.mock({
+      routeId: AppPath.Wallet,
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+        account: mockMainAccount.identifier,
+      },
+    });
+    referrerPathStore.pushPath(AppPath.Portfolio);
+
+    const { queryByTestId } = render(WalletLayout);
+
+    expect(get(pageStore).path).toEqual(AppPath.Wallet);
+    await fireEvent.click(queryByTestId("back"));
+
+    expect(get(pageStore).path).toEqual(AppPath.Portfolio);
   });
 });

--- a/frontend/src/tests/routes/app/wallet/layout.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/layout.spec.ts
@@ -46,7 +46,7 @@ describe("Wallet layout", () => {
     });
   });
 
-  it("back button should navigate to Portfolio page previous page is Portfolio page", async () => {
+  it("back button should navigate to Portfolio page if previous page was Portfolio page", async () => {
     page.mock({
       routeId: AppPath.Wallet,
       data: {

--- a/frontend/src/tests/routes/app/wallet/layout.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/layout.spec.ts
@@ -10,40 +10,38 @@ import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Wallet layout", () => {
-  describe("when tokens flag is enabled", () => {
-    it("back button should navigate to tokens page if universe is not NNS", async () => {
-      page.mock({
-        routeId: AppPath.Wallet,
-        data: {
-          universe: rootCanisterIdMock.toText(),
-          account: mockSnsMainAccount.identifier,
-        },
-      });
-      const { queryByTestId } = render(WalletLayout);
-
-      expect(get(pageStore).path).toEqual(AppPath.Wallet);
-      await fireEvent.click(queryByTestId("back"));
-
-      expect(get(pageStore).path).toEqual(AppPath.Tokens);
+  it("back button should navigate to tokens page if universe is not NNS", async () => {
+    page.mock({
+      routeId: AppPath.Wallet,
+      data: {
+        universe: rootCanisterIdMock.toText(),
+        account: mockSnsMainAccount.identifier,
+      },
     });
+    const { queryByTestId } = render(WalletLayout);
 
-    it("back button should navigate to Accounts page if universe is NNS", async () => {
-      page.mock({
-        routeId: AppPath.Wallet,
-        data: {
-          universe: OWN_CANISTER_ID_TEXT,
-          account: mockMainAccount.identifier,
-        },
-      });
-      const { queryByTestId } = render(WalletLayout);
+    expect(get(pageStore).path).toEqual(AppPath.Wallet);
+    await fireEvent.click(queryByTestId("back"));
 
-      expect(get(pageStore).path).toEqual(AppPath.Wallet);
-      await fireEvent.click(queryByTestId("back"));
+    expect(get(pageStore).path).toEqual(AppPath.Tokens);
+  });
 
-      expect(get(pageStore)).toEqual({
-        path: AppPath.Accounts,
+  it("back button should navigate to Accounts page if universe is NNS", async () => {
+    page.mock({
+      routeId: AppPath.Wallet,
+      data: {
         universe: OWN_CANISTER_ID_TEXT,
-      });
+        account: mockMainAccount.identifier,
+      },
+    });
+    const { queryByTestId } = render(WalletLayout);
+
+    expect(get(pageStore).path).toEqual(AppPath.Wallet);
+    await fireEvent.click(queryByTestId("back"));
+
+    expect(get(pageStore)).toEqual({
+      path: AppPath.Accounts,
+      universe: OWN_CANISTER_ID_TEXT,
     });
   });
 });


### PR DESCRIPTION
# Motivation

The tokens page has three potential entry points:  
-  The Accounts page, accessed by clicking any account except the NNS account.  
-  The NNS account page, reached by navigating from the Accounts page to the NNS account and then to the wallet.  
-  A new entry point will be added to allow navigation back from the Portfolio page when the user clicks on a token in the HeldTokensTable.  

This PR follows up on #6321 by redirecting users from the Tokens page based on how they entered.

Note: Tests are easier to read by hiding the whitespaces.

# Changes

- Uses the new store `walletPageOrigin` to decide where to navigate back from Portfolio page.

# Tests

- Added unit test to check that navigation is correct when coming from Portfolio page.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary