### PR TITLE
fix(reporting): correct neuronId formatting in CSV output

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,7 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Fix the back button on the accounts page when navigating from the portfolio page.
-* Reporting: Fix neuron id formatting in CSV output.
+* Reporting: Correct the formatting of neuron ids in the csv output.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Fix the back button on the accounts page when navigating from the portfolio page.
+* Reporting: Fix neuron id formatting in CSV output.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,7 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Fix the back button on the accounts page when navigating from the portfolio page.
-* Reporting: Correct the formatting of neuron ids in the csv output.
+* Reporting: Correct the formatting of neuron ids in the CSV output.
 
 #### Security
 

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -62,6 +62,11 @@ const escapeCsvValue = (value: unknown): string => {
 
   let stringValue = String(value);
 
+  const patternForExcelFormulaString = /^="\d+"$/;
+  if (patternForExcelFormulaString.test(stringValue)) {
+    return stringValue;
+  }
+
   const patternForSpecialCharacters = /[",\r\n=@|]/;
   if (!patternForSpecialCharacters.test(stringValue)) {
     return stringValue;

--- a/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
@@ -185,7 +185,7 @@ describe("ReportingNeuronsButton", () => {
       'Export Date Time,"Oct 14, 2023 12:00 AM"',
       "",
       ",,Neuron ID,Project Name,Symbol,Neuron Account ID,Controller Principal ID,Stake,Available Maturity,Staked Maturity,Dissolve Delay,Dissolve Date,Creation Date,State",
-      ',,"\'=""1""",Internet Computer,ICP,d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32,1,30.00,0.0000001,0,"3 hours, 5 minutes",N/A,"Jan 1, 1970",Locked',
+      ',,="1",Internet Computer,ICP,d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32,1,30.00,0.0000001,0,"3 hours, 5 minutes",N/A,"Jan 1, 1970",Locked',
     ].join("\n");
 
     expect(spySaveGeneratedCsv).toBeCalledWith(

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -121,7 +121,7 @@ describe("ReportingTransactionsButton", () => {
     expect(spySaveGeneratedCsv).toHaveBeenCalledTimes(1);
   });
 
-  it("should transform transaction data correctly", async () => {
+  it("should transform transaction data correctly to csv", async () => {
     const po = renderComponent();
 
     expect(spySaveGeneratedCsv).toBeCalledTimes(0);
@@ -150,7 +150,7 @@ describe("ReportingTransactionsButton", () => {
     expect(spySaveGeneratedCsv).toBeCalledTimes(1);
   });
 
-  it("should transform transaction data correctly to csv", async () => {
+  it("should transform transaction data correctly", async () => {
     const spyGenerateCsvFileToSave = vi
       .spyOn(exportToCsv, "generateCsvFileToSave")
       .mockResolvedValue();


### PR DESCRIPTION
# Motivation

#6255 introduced a bug in how neuron IDs are rendered in the CSV file. Unit tests did not catch this issue because they focused on the generated data structure rather than the final string that appears in the CSV.

#6308 and #6310 improved the tests, and this final PR fixes the issue.

Note: Values can be copied by navigating the sheet and using `cmd+c` in all clients. When double-clicking a cell, I have encountered different behaviors:  
* Excel removes the equation and quotes.  
* Sheets and Numbers do not.

Some tests conducted in the development environment:  
* [Excel](https://onedrive.live.com/personal/c1392d169c907bfd/_layouts/15/doc.aspx?resid=C1392D169C907BFD!s68841b824cb747639537909bf40260bc&cid=c1392d169c907bfd&login_hint=habibfernandez%40gmail.com&ct=1738597106959&wdOrigin=OFFICECOM-WEB.START.UPLOAD&wdPreviousSessionSrc=HarmonyWeb&wdPreviousSession=9bdbf03d-2a2c-4453-a1aa-9d8703895c48)  
* [Sheets](https://docs.google.com/spreadsheets/d/1hmLl8LPPMnFJgltMjb5NLfy1dLEjKVgNMg4dGkwd_A0/edit?gid=377735422#gid=377735422)  
* Numbers
<img width="1750" alt="Screenshot 2025-02-03 at 16 41 38" src="https://github.com/user-attachments/assets/7801bf45-6fde-4e10-8a7f-baea57324c2f" />

# Changes

- Skip processing string formulas with numbers in `escapeCsvValue` because these values are `bigint`s converted for compatibility with Excel.

# Tests

- Updated tests
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [x] Add entry to changelog (if necessary).