### PR TITLE
feat: default test constants with object reference

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -118,19 +118,22 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
 }));
 
 vi.mock("./src/lib/constants/mockable.constants.ts", () => mockedConstants);
-setDefaultTestConstants({
+
+const defaultTestConstants = {
   DEV: false,
   FORCE_CALL_STRATEGY: undefined,
   IS_TEST_ENV: true,
   QR_CODE_RENDERED_DEFAULT_STATE: true,
   ENABLE_QR_CODE_READER: false,
   isForceCallStrategy: function () {
-    return this.FORCE_CALL_STRATEGY === "query";
+    return defaultTestConstants.FORCE_CALL_STRATEGY === "query";
   },
   notForceCallStrategy: function () {
-    return !this.isForceCallStrategy();
+    return !defaultTestConstants.isForceCallStrategy();
   },
-});
+};
+
+setDefaultTestConstants(defaultTestConstants);
 
 failTestsThatLogToConsole();
 


### PR DESCRIPTION
# Motivation

I'm not exactly sure why—maybe due to Svelte v5 using proxies or some changes in Vitest v3—but using `this` for an inner reference when declaring `setDefaultTestConstants` in the test suite does not work in branch #6020.

Few tests are failing when trying to read `FORCE_CALL_STRATEGY`.

```
TypeError: Cannot read properties of undefined (reading 'FORCE_CALL_STRATEGY')
 ❯ isForceCallStrategy vitest.setup.ts:150:17
    148|   ENABLE_QR_CODE_READER: false,
    149|   isForceCallStrategy: function () {
    150|     return this.FORCE_CALL_STRATEGY === "query";
       |                 ^
    151|   },
    152|   notForceCallStrategy: function () {
 ❯ pollAccounts src/lib/services/icp-accounts.services.ts:496:29
 ❯ src/lib/pages/NnsAccounts.svelte:23:17
 ❯ run node_modules/svelte/src/internal/shared/utils.js:51:9
 ❯ node_modules/svelte/src/internal/client/dom/legacy/lifecycle.js:50:67
 ❯ untrack node_modules/svelte/src/internal/client/runtime.js:1133:10
 ❯ $effect node_modules/svelte/src/internal/client/dom/legacy/lifecycle.js:50:48
 ❯ update_reaction node_modules/svelte/src/internal/client/runtime.js:469:56
 ❯ update_effect node_modules/svelte/src/internal/client/runtime.js:622:18

This error originated in "src/tests/lib/pages/NnsAccounts.spec.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
The latest test that might've caused the error is "should not allow sorting". It might mean one of the following:
- The error was thrown, while Vitest was running this test.
- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
```

See for example this CI job: https://github.com/dfinity/nns-dapp/actions/runs/13114592952/job/36585717844?pr=6020

# Changes

- Declare a global object and use it as reference from itself instead of referencing it with `this`.
