### PR TITLE
chore: remove webcrypto mock for test

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,4 +1,3 @@
-import { Crypto as SubtleCrypto } from "@peculiar/webcrypto";
 import "@testing-library/jest-dom";
 import { configure } from "@testing-library/svelte";
 import "fake-indexeddb/auto";
@@ -66,12 +65,6 @@ beforeEach(() => {
   for (const cleanup of cleanupFunctions) {
     cleanup();
   }
-});
-
-// Mock SubtleCrypto to test @dfinity/auth-client
-const crypto = new SubtleCrypto();
-Object.defineProperty(global, "crypto", {
-  value: crypto,
 });
 
 global.TextEncoder = TextEncoder;


### PR DESCRIPTION
# Motivation

Mocking SubtleCrypto to test @dfinity/auth-client isn't required anymore because the test are running for the web with jsdom.

# Changes

- Remove mock in `vitest.setup`
