### PR TITLE
feat(portfolio): add authenticated wallet navigation from top token positions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Custom sorting of staking nervous systems table.
 * Custom sorting of tokens table.
+* Navigation to a token's wallet from the top token positions on the portfolio page
 
 #### Changed
 

--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -66,7 +66,14 @@
 
       <div class="list" role="rowgroup">
         {#each topHeldTokens as heldToken (heldToken.domKey)}
-          <div class="row" data-tid="held-token-card-row" role="row">
+          <svelte:element
+            this={$authSignedInStore ? "a" : "div"}
+            href={$authSignedInStore ? heldToken.rowHref : undefined}
+            class="row"
+            class:link={$authSignedInStore}
+            data-tid="held-token-card-row"
+            role="row"
+          >
             <div class="info" role="cell">
               <div>
                 <Logo
@@ -102,7 +109,7 @@
             >
               ${formatNumber(heldToken?.balanceInUsd ?? 0)}
             </div>
-          </div>
+          </svelte:element>
         {/each}
         {#if showInfoRow}
           <div class="info-row desktop-only" role="note" data-tid="info-row">
@@ -154,6 +161,15 @@
         flex-direction: column;
         background-color: var(--card-background);
         flex-grow: 1;
+
+        .link {
+          text-decoration: none;
+          cursor: pointer;
+
+          &:hover {
+            background-color: var(--table-row-background-hover);
+          }
+        }
 
         .row {
           display: grid;

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -81,8 +81,10 @@ describe("HeldTokensCard", () => {
       });
 
       const allTags = await po.getRowsTags();
+      const allHrefs = await po.getRowsHref();
 
       expect(allTags.every((tag) => tag === "DIV")).toBe(true);
+      expect(allHrefs).toEqual([null, null, null]);
     });
   });
 
@@ -226,8 +228,14 @@ describe("HeldTokensCard", () => {
       });
 
       const allTags = await po.getRowsTags();
+      const allHrefs = await po.getRowsHref();
 
       expect(allTags.every((tag) => tag === "A")).toBe(true);
+      expect(allHrefs).toEqual([
+        mockTokens[0].rowHref,
+        mockTokens[1].rowHref,
+        mockTokens[2].rowHref,
+      ]);
     });
   });
 });

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -73,6 +73,17 @@ describe("HeldTokensCard", () => {
       expect(balances.length).toBe(3);
       expect(balances).toEqual(["$0.00", "$0.00", "$0.00"]);
     });
+
+    it("should render rows as DIV tag", async () => {
+      const po = renderComponent({
+        topHeldTokens: mockTokens,
+        usdAmount: 0,
+      });
+
+      const allTags = await po.getRowsTags();
+
+      expect(allTags.every((tag) => tag === "DIV")).toBe(true);
+    });
   });
 
   describe("when signed in", () => {
@@ -207,6 +218,16 @@ describe("HeldTokensCard", () => {
       expect(nativeBalances).toEqual(["21.60 ICP", "21.60 ckBTC"]);
 
       expect(await po.getInfoRow().isPresent()).toBe(true);
+    });
+
+    it("should render rows as an A tag", async () => {
+      const po = renderComponent({
+        topHeldTokens: mockTokens,
+      });
+
+      const allTags = await po.getRowsTags();
+
+      expect(allTags.every((tag) => tag === "A")).toBe(true);
     });
   });
 });

--- a/frontend/src/tests/page-objects/HeldTokensCard.page-object.ts
+++ b/frontend/src/tests/page-objects/HeldTokensCard.page-object.ts
@@ -11,6 +11,10 @@ class HeldTokensCardRowPo extends BasePageObject {
     return rows.map((el) => new HeldTokensCardRowPo(el));
   }
 
+  getRowTag(): Promise<string> {
+    return this.root.getTagName();
+  }
+
   getHeldTokenTitle(): Promise<string> {
     return this.getText("title");
   }
@@ -60,5 +64,10 @@ export class HeldTokensCardPo extends BasePageObject {
     return Promise.all(
       rows.map((row) => row.getHeldTokenBalanceInNativeCurrency())
     );
+  }
+
+  async getRowsTags(): Promise<string[]> {
+    const rows = await this.getRows();
+    return Promise.all(rows.map((row) => row.getRowTag()));
   }
 }

--- a/frontend/src/tests/page-objects/HeldTokensCard.page-object.ts
+++ b/frontend/src/tests/page-objects/HeldTokensCard.page-object.ts
@@ -15,6 +15,10 @@ class HeldTokensCardRowPo extends BasePageObject {
     return this.root.getTagName();
   }
 
+  getRowHref(): Promise<string> {
+    return this.root.getAttribute("href");
+  }
+
   getHeldTokenTitle(): Promise<string> {
     return this.getText("title");
   }
@@ -69,5 +73,10 @@ export class HeldTokensCardPo extends BasePageObject {
   async getRowsTags(): Promise<string[]> {
     const rows = await this.getRows();
     return Promise.all(rows.map((row) => row.getRowTag()));
+  }
+
+  async getRowsHref(): Promise<string[]> {
+    const rows = await this.getRows();
+    return Promise.all(rows.map((row) => row.getRowHref()));
   }
 }


### PR DESCRIPTION
# Motivation

We want signed-in users to be able to navigate to their wallets from their top positions on the Portfolio page.

Note that the Tokens page also allows users to access the wallet even if they are not logged in. We want to avoid this behavior on the Portfolio page to maintain consistency with the Staked Tokens card (nextPr), as we do not allow this on the Staking page.

https://github.com/user-attachments/assets/fd25259d-64b7-4540-ba00-7731d25fa68a

A follow-up PR will add the behavior to the staked tokens card.

# Changes

- Make `HeldTokensCard` rows clickable if user is signed-in.

# Tests

- Added unit tests to verify that the correct tag is rendered: a `div` when not signed in and an `a` when signed in.
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/portfolio/)

# Todos

- [ ] Add entry to changelog (if necessary).
