### PR TITLE
test: mock ResizeObserver

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -80,6 +80,20 @@ global.TextEncoder = TextEncoder;
   global as { IntersectionObserver: typeof IntersectionObserver }
 ).IntersectionObserver = IntersectionObserverPassive;
 
+// We mock ResizeObserver because neither JSDOM nor Happy DOM supports it.
+// Interesting related thread: https://github.com/testing-library/svelte-testing-library/issues/284
+global.ResizeObserver = class ResizeObserver {
+  observe() {
+    // do nothing
+  }
+  unobserve() {
+    // do nothing
+  }
+  disconnect() {
+    // do nothing
+  }
+};
+
 // Environment Variables Setup
 vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
   getEnvVars: () => ({


### PR DESCRIPTION
# Motivation

We have to disable the transition for testing purposes, as Svelte v5 introduces breaking changes in how it handles transitions. It now uses the Web Animations API, which is not available in JSDOM or Happy-DOM.

While testing this new setup against `main`, we discovered that disabling animations causes Svelte to use the `ResizeObserver`, which is also an API not currently available in JSDOM or Happy-DOM (see this [CI job](https://github.com/dfinity/nns-dapp/actions/runs/13131513035/job/36637485021)).

That is why we are mocking this API.

Worth noting, we would need to mock it anyway to integrate Svelte v5.

# References

- https://github.com/dfinity/gix-components/pull/573
- https://github.com/dfinity/gix-components/pull/573

# Changes

<!-- List the changes that have been developed -->

# Tests

After mocking the `ResizeObserver`, the CI passed for the branch (see PR #6336) that was use to assert this new feature.