### PR TITLE
Reset timers and localStorage before all tests

### DIFF
--- a/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
@@ -20,7 +20,6 @@ describe("sns-aggregator api-service", () => {
 
   beforeEach(() => {
     clearSnsAggregatorCache();
-    vi.useRealTimers();
     resolveFn = undefined;
     rejectFn = undefined;
     vi.spyOn(aggregatorApi, "querySnsProjects").mockImplementation(

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -50,8 +50,6 @@ describe("canisters-api", () => {
   const fee = 10_000n;
 
   beforeEach(() => {
-    vi.clearAllTimers();
-
     // Prevent HttpAgent.create(), which is called by createAgent, from making a
     // real network request via agent.syncTime().
     vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);

--- a/frontend/src/tests/lib/api/icp-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-index.api.spec.ts
@@ -12,7 +12,6 @@ import { mock } from "vitest-mock-extended";
 
 describe("icp-index.api", () => {
   beforeEach(() => {
-    vi.clearAllTimers();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -14,8 +14,6 @@ import { mock } from "vitest-mock-extended";
 
 describe("icp-ledger.api", () => {
   beforeEach(() => {
-    vi.clearAllTimers();
-
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCUpdateBalanceButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCUpdateBalanceButton.spec.ts
@@ -20,7 +20,6 @@ describe("CkBTCUpdateBalanceButton", () => {
   beforeEach(() => {
     resetIdentity();
     vi.useFakeTimers().setSystemTime(now);
-    vi.clearAllTimers();
     vi.spyOn(api, "updateBalance").mockRejectedValue(
       new MinterNoNewUtxosError({
         required_confirmations: 12,

--- a/frontend/src/tests/lib/components/accounts/LedgerNeuronHotkeyWarning.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/LedgerNeuronHotkeyWarning.spec.ts
@@ -12,10 +12,6 @@ describe("LedgerNeuronHotkeyWarning", () => {
     );
   };
 
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
   it("should be shown when localStorageKey not set", async () => {
     const po = await renderComponent();
     expect(localStorage.getItem(localStorageKey)).toBeNull();

--- a/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingNeuronsButton.spec.ts
@@ -27,7 +27,6 @@ describe("ReportingNeuronsButton", () => {
   let spySaveGeneratedCsv;
 
   beforeEach(() => {
-    vi.clearAllTimers();
     resetIdentity();
 
     vi.spyOn(toastsStore, "toastsError");

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactions.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactions.spec.ts
@@ -32,7 +32,6 @@ describe("ReportingTransactions", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllTimers();
     resetIdentity();
     resetAccountsForTesting();
 

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -40,7 +40,6 @@ describe("ReportingTransactionsButton", () => {
   let spySaveGeneratedCsv;
 
   beforeEach(() => {
-    vi.clearAllTimers();
     resetIdentity();
     resetAccountsForTesting();
 

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
@@ -23,7 +23,6 @@ describe("SnsProposalCard", () => {
   const now = 1698139468000;
   const nowInSeconds = Math.ceil(now / 1000);
   beforeEach(() => {
-    vi.clearAllTimers();
     vi.useFakeTimers().setSystemTime(now);
   });
 

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -167,7 +167,6 @@ describe("DisburseNnsNeuronModal", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
       resetAccountsForTesting();
-      vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -564,7 +564,6 @@ describe("NnsStakeNeuronModal", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
       resetAccountsForTesting();
-      vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.spec.ts
@@ -62,7 +62,6 @@ describe("IncreaseSnsDissolveDelayModal", () => {
       testIdentity
     );
 
-    vi.clearAllTimers();
     vi.useFakeTimers().setSystemTime(now);
 
     setSnsProjects([

--- a/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
@@ -346,7 +346,6 @@ describe("ParticipateSwapModal", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
       resetAccountsForTesting();
-      vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -111,8 +111,6 @@ describe("CkBTCWallet", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllTimers();
-    vi.useRealTimers();
     resetIdentity();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -113,8 +113,6 @@ describe("IcrcWallet", () => {
 
   beforeEach(() => {
     balancesObserverCallback = undefined;
-    vi.clearAllTimers();
-    vi.useRealTimers();
     resetIdentity();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -174,7 +174,6 @@ describe("NnsAccounts", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
-      vi.clearAllTimers();
       cancelPollAccounts();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -86,7 +86,6 @@ describe("NnsWallet", () => {
   const accountTransactions = [mockTransactionWithId];
 
   beforeEach(() => {
-    vi.clearAllTimers();
     cancelPollAccounts();
     resetAccountsForTesting();
     resetIdentity();

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -83,7 +83,6 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
   beforeEach(() => {
     userCountryStore.set(NOT_LOADED);
 
-    vi.clearAllTimers();
     vi.useFakeTimers().setSystemTime(now);
 
     vi.spyOn(ledgerApi, "sendICP").mockResolvedValue(undefined);

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -72,7 +72,6 @@ describe("SnsWallet", () => {
   };
 
   beforeEach(() => {
-    vi.useRealTimers();
     resetIdentity();
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -59,7 +59,6 @@ describe("ckbtc-convert-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.clearAllTimers();
 
     vi.spyOn(CkBTCMinterCanister, "create").mockImplementation(
       () => minterCanisterMock

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -933,7 +933,6 @@ describe("icp-accounts.services", () => {
 
     beforeEach(() => {
       resetAccountsForTesting();
-      vi.clearAllTimers();
       cancelPollAccounts();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -190,7 +190,6 @@ describe("sns-api", () => {
   describe("loadOpenTicket", () => {
     describe("when polling is enabled", () => {
       beforeEach(() => {
-        vi.clearAllTimers();
         const now = Date.now();
         vi.useFakeTimers().setSystemTime(now);
       });
@@ -455,7 +454,6 @@ describe("sns-api", () => {
 
     describe("when disabling polling", () => {
       beforeEach(() => {
-        vi.clearAllTimers();
         const now = Date.now();
         vi.useFakeTimers().setSystemTime(now);
       });
@@ -541,7 +539,6 @@ describe("sns-api", () => {
 
   describe("loadNewSaleTicket ", () => {
     beforeEach(() => {
-      vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
     });
@@ -1018,7 +1015,6 @@ describe("sns-api", () => {
 
   describe("participateInSnsSale", () => {
     beforeEach(() => {
-      vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
     });

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -45,7 +45,6 @@ describe("sns-services", () => {
   beforeEach(() => {
     resetIdentity();
     vi.useFakeTimers();
-    vi.clearAllTimers();
   });
 
   describe("getSwapAccount", () => {

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -3,10 +3,6 @@ import { writableStored } from "$lib/stores/writable-stored";
 import { get } from "svelte/store";
 
 describe("writableStored", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
   it("writes to local storage when state changes", () => {
     const store = writableStored({
       key: StoreLocalStorageKey.ProposalFilters,

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -50,10 +50,6 @@ describe("project-utils", () => {
     restrictedCountries: [],
   });
 
-  beforeEach(() => {
-    vi.useRealTimers();
-  });
-
   describe("filter", () => {
     it("should filter by status", () => {
       expect(

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -433,7 +433,6 @@ describe("reporting utils", () => {
     const NANOS_IN_MS = BigInt(1_000_000);
 
     beforeEach(() => {
-      vi.clearAllTimers();
       vi.useFakeTimers();
       vi.setSystemTime(mockDate);
     });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -31,7 +31,6 @@ import { get } from "svelte/store";
 describe("utils", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.clearAllTimers();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 

--- a/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
+++ b/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
@@ -14,7 +14,6 @@ describe("timer.worker-utils", () => {
   beforeEach(() => {
     silentConsoleErrors();
 
-    vi.clearAllTimers();
     vi.useFakeTimers().setSystemTime(now);
 
     spyPostMessage = vi.fn();

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -80,7 +80,10 @@ beforeEach(async () => {
   // writableStored write to localStorage, and resetting them also causes them
   // to write to localStorage.
   if (vi.isFakeTimers()) {
-    await vi.runAllTimersAsync();
+    // See https://testing-library.com/docs/using-fake-timers/
+    // "It's important to also call runOnlyPendingTimers before switching to
+    // real timers."
+    await vi.runOnlyPendingTimers();
   }
   vi.clearAllTimers();
   vi.useRealTimers();

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -74,6 +74,14 @@ beforeEach(() => {
   for (const cleanup of cleanupFunctions) {
     cleanup();
   }
+
+  // Do these cleanups after cleanup functions, in case a cleanup function does
+  // something that needs to be cleaned up. In particular, stores created with
+  // writableStored write to localStorage, and resetting them also causes them
+  // to write to localStorage.
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  localStorage.clear();
 });
 
 // Mock SubtleCrypto to test @dfinity/auth-client

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -21,7 +21,10 @@ import {
   setDefaultTestConstants,
 } from "./src/tests/utils/mockable-constants.test-utils";
 
-beforeEach(() => {
+beforeEach(async () => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+
   // Restore all mocks original behvior before each test.
   //
   // NOTE: This restores mocks created with vi.spyOn() to their production
@@ -79,14 +82,6 @@ beforeEach(async () => {
   // something that needs to be cleaned up. In particular, stores created with
   // writableStored write to localStorage, and resetting them also causes them
   // to write to localStorage.
-  if (vi.isFakeTimers()) {
-    // See https://testing-library.com/docs/using-fake-timers/
-    // "It's important to also call runOnlyPendingTimers before switching to
-    // real timers."
-    await vi.runOnlyPendingTimers();
-  }
-  vi.clearAllTimers();
-  vi.useRealTimers();
   localStorage.clear();
 });
 

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -70,7 +70,7 @@ vi.mock("$lib/utils/test-support.utils", async () => {
   };
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   for (const cleanup of cleanupFunctions) {
     cleanup();
   }
@@ -79,6 +79,9 @@ beforeEach(() => {
   // something that needs to be cleaned up. In particular, stores created with
   // writableStored write to localStorage, and resetting them also causes them
   // to write to localStorage.
+  if (vi.isFakeTimers()) {
+    await vi.runAllTimersAsync();
+  }
   vi.clearAllTimers();
   vi.useRealTimers();
   localStorage.clear();

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -21,7 +21,7 @@ import {
   setDefaultTestConstants,
 } from "./src/tests/utils/mockable-constants.test-utils";
 
-beforeEach(async () => {
+beforeEach(() => {
   vi.clearAllTimers();
   vi.useRealTimers();
 
@@ -73,7 +73,7 @@ vi.mock("$lib/utils/test-support.utils", async () => {
   };
 });
 
-beforeEach(async () => {
+beforeEach(() => {
   for (const cleanup of cleanupFunctions) {
     cleanup();
   }


### PR DESCRIPTION
# Motivation

All tests should start with a clean slate. But it can be tricky to remember to clean up everything in the `beforeEach` of each test file.

# Changes

1. Call `vi.clearAllTimers()`, `vi.useRealTimers()` and `localStorage.clear()` in `beforeEach` of `frontend/vitest.setup.ts`.
2. Remove these calls from `beforeEach` of individual tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary