### PR TITLE
Remove get_exceptional_transactions

### DIFF
--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -5,7 +5,6 @@ canister_pre_upgrade
 canister_query __long_message_noop
 canister_query get_account
 canister_query get_canisters
-canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_imported_tokens
 canister_query get_stats

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -5,7 +5,6 @@ canister_pre_upgrade
 canister_query __long_message_noop
 canister_query get_account
 canister_query get_canisters
-canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_imported_tokens
 canister_query get_stats

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -233,7 +233,6 @@ service: (opt Config) -> {
     get_proposal_payload: (nat64) -> (GetProposalPayloadResponse);
     get_stats: () -> (Stats) query;
     get_histogram: () -> (Histogram) query;
-    get_exceptional_transactions: () -> (opt vec nat64) query;
     get_tvl : () -> (TvlResponse) query;
 
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -420,21 +420,6 @@ fn get_toy_account_impl(toy_account_index: u64) -> GetAccountResponse {
     })
 }
 
-#[export_name = "canister_query get_exceptional_transactions"]
-pub fn get_exceptional_transactions() {
-    over(candid, |()| get_exceptional_transactions_impl());
-}
-
-#[candid_method(query, rename = "get_exceptional_transactions")]
-fn get_exceptional_transactions_impl() -> Option<Vec<u64>> {
-    with_state(|s| {
-        s.performance
-            .exceptional_transactions
-            .as_ref()
-            .map(|transactions| transactions.iter().copied().collect::<Vec<u64>>())
-    })
-}
-
 #[export_name = "canister_query get_tvl"]
 pub fn get_tvl() {
     over(candid, |()| get_tvl_impl());

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -36,7 +36,6 @@ impl PerformanceCount {
 #[derive(CandidType, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct PerformanceCounts {
     pub instruction_counts: VecDeque<PerformanceCount>,
-    pub exceptional_transactions: Option<VecDeque<u64>>,
     // TODO[NNS1-2913]: Delete this once the stable memory migration is complete.  This is used purely to get
     // an idea of how long, in wall clock time, migration is likely to take.
     pub periodic_tasks_count: Option<u32>,
@@ -51,7 +50,6 @@ impl PerformanceCounts {
         self.instruction_counts.push_back(count);
     }
 
-    /// Note: The `exceptional_transactions_count` saturates at `u32::MAX`, in the very unlikely event that we reach that limit.
     pub fn get_stats(&self, stats: &mut Stats) {
         stats.performance_counts = self.instruction_counts.iter().cloned().collect();
     }


### PR DESCRIPTION
# Motivation

When nns-dapp processed transactions, it also stored a list of recent transactions that it wasn't able to parse.
nns-dapp no longer processes transactions so we also no longer need this list of "exceptional" transactions.

# Changes

1. Remove code related to exceptional transaction, as it is no longer used.

# Tests

Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary