### PR TITLE
Move FORCE_CALL_STRATEGY helpers to utils

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import VotingCard from "$lib/components/proposal-detail/VotingCard/VotingCard.svelte";
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-  import { isForceCallStrategy } from "$lib/constants/mockable.constants";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
+  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { registerNnsVotes } from "$lib/services/nns-vote-registration.services";
   import { neuronsStore } from "$lib/stores/neurons.store";
-  import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import {
     voteRegistrationStore,
     type VoteRegistrationStoreEntry,
@@ -15,6 +14,7 @@
     SELECTED_PROPOSAL_CONTEXT_KEY,
     type SelectedProposalContext,
   } from "$lib/types/selected-proposal.context";
+  import { isForceCallStrategy } from "$lib/utils/call.utils";
   import {
     filterIneligibleNnsNeurons,
     votedNeuronDetails,

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -33,11 +33,6 @@ const initForceCallStrategy = (): undefined | "query" => {
 
 export const FORCE_CALL_STRATEGY: "query" | undefined = initForceCallStrategy();
 
-export const isForceCallStrategy = (): boolean =>
-  FORCE_CALL_STRATEGY === "query";
-
-export const notForceCallStrategy = (): boolean => !isForceCallStrategy();
-
 export const IS_TEST_ENV = process.env.NODE_ENV === "test";
 
 // When the QR code is rendered (draw), it triggers an event that is replicated to a property to get to know if the QR code has been or not rendered.

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import ConfirmFollowingBanner from "$lib/components/neuron-detail/ConfirmFollowingBanner.svelte";
   import NeuronFollowingCard from "$lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte";
   import NeuronVotingHistoryCard from "$lib/components/neuron-detail/NeuronVotingHistoryCard.svelte";
   import NnsNeuronAdvancedSection from "$lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte";
@@ -16,8 +17,8 @@
   import SkeletonHeader from "$lib/components/ui/SkeletonHeader.svelte";
   import SkeletonHeading from "$lib/components/ui/SkeletonHeading.svelte";
   import { IS_TESTNET } from "$lib/constants/environment.constants";
-  import { isForceCallStrategy } from "$lib/constants/mockable.constants";
   import { AppPath } from "$lib/constants/routes.constants";
+  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
   import { pageStore } from "$lib/derived/page.derived";
   import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
   import {
@@ -25,6 +26,7 @@
     refreshNeuronIfNeeded,
   } from "$lib/services/neurons.services";
   import { loadLatestRewardEvent } from "$lib/services/nns-reward-event.services";
+  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { toastsError } from "$lib/stores/toasts.store";
@@ -34,6 +36,7 @@
     NnsNeuronStore,
   } from "$lib/types/nns-neuron-detail.context";
   import { NNS_NEURON_CONTEXT_KEY } from "$lib/types/nns-neuron-detail.context";
+  import { isForceCallStrategy } from "$lib/utils/call.utils";
   import {
     getNeuronById,
     isSpawning,
@@ -45,9 +48,6 @@
   import { nonNullish } from "@dfinity/utils";
   import { onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
-  import ConfirmFollowingBanner from "$lib/components/neuron-detail/ConfirmFollowingBanner.svelte";
-  import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
-  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuronIdText: string | undefined | null;
 

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -14,10 +14,7 @@ import {
   SYNC_ACCOUNTS_RETRY_MAX_ATTEMPTS,
   SYNC_ACCOUNTS_RETRY_SECONDS,
 } from "$lib/constants/accounts.constants";
-import {
-  FORCE_CALL_STRATEGY,
-  isForceCallStrategy,
-} from "$lib/constants/mockable.constants";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
@@ -45,6 +42,7 @@ import {
   invalidIcrcAddress,
   toIcpAccountIdentifier,
 } from "$lib/utils/accounts.utils";
+import { isForceCallStrategy } from "$lib/utils/call.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import {
   cancelPoll,

--- a/frontend/src/lib/utils/call.utils.ts
+++ b/frontend/src/lib/utils/call.utils.ts
@@ -1,0 +1,6 @@
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+
+export const isForceCallStrategy = (): boolean =>
+  FORCE_CALL_STRATEGY === "query";
+
+export const notForceCallStrategy = (): boolean => !isForceCallStrategy();

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -1,9 +1,9 @@
-import { notForceCallStrategy } from "$lib/constants/mockable.constants";
 import type { CkBTCInfoStoreUniverseData } from "$lib/stores/ckbtc-info.store";
 import { i18n } from "$lib/stores/i18n";
 import type { Account } from "$lib/types/account";
 import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
 import { assertEnoughAccountFunds } from "$lib/utils/accounts.utils";
+import { notForceCallStrategy } from "$lib/utils/call.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import { isNullish } from "@dfinity/utils";

--- a/frontend/src/tests/utils/mockable-constants.test-utils.ts
+++ b/frontend/src/tests/utils/mockable-constants.test-utils.ts
@@ -16,8 +16,6 @@ export const mockedConstants: MockableConstants = {
   IS_TEST_ENV: undefined,
   QR_CODE_RENDERED_DEFAULT_STATE: undefined,
   ENABLE_QR_CODE_READER: undefined,
-  isForceCallStrategy: undefined,
-  notForceCallStrategy: undefined,
 };
 
 const resetMockedConstants = () => {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -124,12 +124,6 @@ setDefaultTestConstants({
   IS_TEST_ENV: true,
   QR_CODE_RENDERED_DEFAULT_STATE: true,
   ENABLE_QR_CODE_READER: false,
-  isForceCallStrategy: function () {
-    return this.FORCE_CALL_STRATEGY === "query";
-  },
-  notForceCallStrategy: function () {
-    return !this.isForceCallStrategy();
-  },
 });
 
 failTestsThatLogToConsole();


### PR DESCRIPTION
# Motivation

We have 2 helpers `isForceCallStrategy` and `notForceCallStrategy` which are defined in `"$lib/constants/mockable.constants"`.
This is causing problems with the migration to Svelte v5.
But also, since they are not constants, they don't belong in `constants`.

# Changes

1. Move the helper functions to `"$lib/utils/call.utils"`.
2. Remove them from mockable constants test setup.

# Tests

1. Existing tests should pass.
2. I haven't tested it with Svelte v5 but it's a good change in itself even if it doesn't help with v5.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary