### PR TITLE
Annotate create_toy_accounts_impl with candid_method

### DIFF
--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -242,5 +242,6 @@ service: (opt Config) -> {
     step_migration: (nat32) -> ();
 
     // Methods available in the test build only:
+    create_toy_accounts: (nat) -> (nat64) query;
     get_toy_account: (nat64) -> (GetAccountResponse) query;
 }

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -242,6 +242,6 @@ service: (opt Config) -> {
     step_migration: (nat32) -> ();
 
     // Methods available in the test build only:
-    create_toy_accounts: (nat) -> (nat64) query;
+    create_toy_accounts: (nat) -> (nat64);
     get_toy_account: (nat64) -> (GetAccountResponse) query;
 }

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -385,18 +385,22 @@ fn add_stable_asset_impl(asset_bytes: Vec<u8>) {
 #[cfg(any(test, feature = "toy_data_gen"))]
 #[export_name = "canister_update create_toy_accounts"]
 pub fn create_toy_accounts() {
-    over(candid_one, |num_accounts: u128| {
-        let caller = ic_cdk::caller();
-        if !ic_cdk::api::is_controller(&caller) {
-            dfn_core::api::trap_with("Only the controller may generate toy accounts");
-        }
-        with_state_mut(|s| {
-            s.accounts_store
-                .create_toy_accounts(u64::try_from(num_accounts).unwrap_or_else(|_| {
-                    unreachable!("The number of accounts is well below the number of atoms in the universe")
-                }))
-        })
-    });
+    over(candid_one, create_toy_accounts_impl);
+}
+
+#[cfg(any(test, feature = "toy_data_gen"))]
+#[candid_method(query, rename = "create_toy_accounts")]
+fn create_toy_accounts_impl(num_accounts: u128) -> u64 {
+    let caller = ic_cdk::caller();
+    if !ic_cdk::api::is_controller(&caller) {
+        dfn_core::api::trap_with("Only the controller may generate toy accounts");
+    }
+    with_state_mut(|s| {
+        s.accounts_store
+            .create_toy_accounts(u64::try_from(num_accounts).unwrap_or_else(|_| {
+                unreachable!("The number of accounts is well below the number of atoms in the universe")
+            }))
+    })
 }
 
 /// Gets any toy account by toy account index.

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -389,7 +389,7 @@ pub fn create_toy_accounts() {
 }
 
 #[cfg(any(test, feature = "toy_data_gen"))]
-#[candid_method(query, rename = "create_toy_accounts")]
+#[candid_method(update, rename = "create_toy_accounts")]
 fn create_toy_accounts_impl(num_accounts: u128) -> u64 {
     let caller = ic_cdk::caller();
     if !ic_cdk::api::is_controller(&caller) {


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/5283 added a test to make sure `nns-dapp.did` matches the public interface in `main.rs` by adding a `candid_method` annotation to each canister method.
If necessary the method would be split in to a separate `_impl` function to put the annotation on.

But that PR forgot `create_toy_accounts`.

# Changes

1. Split `create_toy_accounts_impl` from `create_toy_accounts`.
2. Add `candid_method` annotation.
3. Add `create_toy_accounts` to `nns-dapp.did`.

# Tests

`test_implemented_interface_matches_declared_interface_exactly` passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary