### PR TITLE
feat(portfolio): add authenticated neurons navigation from top projects

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Custom sorting of staking nervous systems table.
 * Custom sorting of tokens table.
-* Navigation to a token's wallet from the top token positions on the portfolio page
+* Navigation to a token's wallet from the top token positions on the portfolio page.
+* Navigation to a project's neurons from the top projects on the portfolio page.
 
 #### Changed
 

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -70,7 +70,14 @@
 
       <div class="list" role="rowgroup">
         {#each topStakedTokens as stakedToken (stakedToken.domKey)}
-          <div class="row" data-tid="staked-tokens-card-row" role="row">
+          <svelte:element
+            this={$authSignedInStore ? "a" : "div"}
+            href={$authSignedInStore ? stakedToken.rowHref : undefined}
+            class="row"
+            class:link={$authSignedInStore}
+            data-tid="staked-tokens-card-row"
+            role="row"
+          >
             <div class="info" role="cell">
               <div>
                 <Logo
@@ -115,7 +122,7 @@
                 : PRICE_NOT_AVAILABLE_PLACEHOLDER}
               {stakedToken.stake.token.symbol}
             </div>
-          </div>
+          </svelte:element>
         {/each}
         {#if showInfoRow}
           <div class="info-row desktop-only" role="note" data-tid="info-row">
@@ -166,6 +173,14 @@
         flex-direction: column;
         background-color: var(--card-background);
         flex-grow: 1;
+
+        .link {
+          text-decoration: none;
+          cursor: pointer;
+          &:hover {
+            background-color: var(--table-row-background-hover);
+          }
+        }
 
         .row {
           display: grid;

--- a/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
@@ -112,6 +112,19 @@ describe("StakedTokensCard", () => {
 
       expect(await po.getInfoRow().isPresent()).toBe(false);
     });
+
+    it("should render rows as DIV tag", async () => {
+      const po = renderComponent({
+        topStakedTokens: mockStakedTokens,
+        usdAmount: 0,
+      });
+
+      const allTags = await po.getRowsTags();
+      const allHrefs = await po.getRowsHref();
+
+      expect(allTags.every((tag) => tag === "DIV")).toBe(true);
+      expect(allHrefs).toEqual([null, null, null, null]);
+    });
   });
 
   describe("when signed in", () => {
@@ -294,6 +307,23 @@ describe("StakedTokensCard", () => {
       expect(stakesInNativeCurrency).toEqual(["0.01 ICP"]);
 
       expect(await po.getInfoRow().isPresent()).toBe(true);
+    });
+
+    it("should render rows as an A tag", async () => {
+      const po = renderComponent({
+        topStakedTokens: mockStakedTokens,
+      });
+
+      const allTags = await po.getRowsTags();
+      const allHrefs = await po.getRowsHref();
+
+      expect(allTags.every((tag) => tag === "A")).toBe(true);
+      expect(allHrefs).toEqual([
+        mockStakedTokens[0].rowHref,
+        mockStakedTokens[1].rowHref,
+        mockStakedTokens[2].rowHref,
+        mockStakedTokens[3].rowHref,
+      ]);
     });
   });
 });

--- a/frontend/src/tests/page-objects/StakedTokensCard.page-object.ts
+++ b/frontend/src/tests/page-objects/StakedTokensCard.page-object.ts
@@ -13,6 +13,14 @@ class StakedTokensCardRowPo extends BasePageObject {
     return rows.map((el) => new StakedTokensCardRowPo(el));
   }
 
+  getRowTag(): Promise<string> {
+    return this.root.getTagName();
+  }
+
+  getRowHref(): Promise<string> {
+    return this.root.getAttribute("href");
+  }
+
   getStakedTokenTitle(): Promise<string> {
     return this.getText("title");
   }
@@ -73,5 +81,15 @@ export class StakedTokensCardPo extends BasePageObject {
     return Promise.all(
       rows.map((row) => row.getStakedTokenStakeInNativeCurrency())
     );
+  }
+
+  async getRowsTags(): Promise<string[]> {
+    const rows = await this.getRows();
+    return Promise.all(rows.map((row) => row.getRowTag()));
+  }
+
+  async getRowsHref(): Promise<string[]> {
+    const rows = await this.getRows();
+    return Promise.all(rows.map((row) => row.getRowHref()));
   }
 }


### PR DESCRIPTION
# Motivation

We want signed-in users to navigate to their wallets from their top positions on the Portfolio page.

This follows up on #6335. It adds navigation to the rows of the staked tokens table. Similar to the held tokens card, navigation will only be available to signed-in users.

https://github.com/user-attachments/assets/1e7e52e3-f24b-439d-9fb3-f171001c4ed6

# Changes

- Make `StakedTokensCard` rows clickable if user is signed-in.

# Tests

- Added unit tests to verify that the correct tag is rendered: a `div` when not signed in and an `a` when signed in, with the appropriate href value passed.
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/portfolio/)

# Todos

- [x] Add entry to changelog (if necessary).
