### PR TITLE
feat(navigation): implement Neuron's page entry point tracking 

### DIFF
--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -41,3 +41,18 @@ export const walletPageOrigin = derived(
     return AppPath.Tokens;
   }
 );
+
+/**
+ * Derives the origin page (Portfolio or Tokens) to return from Neurons.
+ * Looks at last entry to handle navigation flows:
+ * Portfolio -> Neurons -> (back) -> Portfolio
+ * Tokens -> Neurons -> (back) -> Tokens
+ *
+ * Returns AppPath.Tokens as default if no matching page is found.
+ */
+export const neuronsPageOrigin = derived(referrerPathStore, (paths) => {
+  const lastPath = paths.at(-1);
+  if (lastPath === AppPath.Portfolio) return lastPath;
+
+  return AppPath.Staking;
+});

--- a/frontend/src/tests/lib/derived/routes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/routes.derived.spec.ts
@@ -2,6 +2,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath, UNIVERSE_PARAM } from "$lib/constants/routes.constants";
 import {
   accountsPageOrigin,
+  neuronsPageOrigin,
   walletPageOrigin,
 } from "$lib/derived/routes.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
@@ -72,6 +73,27 @@ describe("routes.derived", () => {
       referrerPathStore.pushPath(AppPath.Wallet);
 
       expect(get(walletPageOrigin)).toBe(AppPath.Tokens);
+    });
+  });
+
+  describe("neuronsPageOrigin.derived", () => {
+    it("should return Portfolio when it was the last page visited", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+
+      expect(get(neuronsPageOrigin)).toBe(AppPath.Portfolio);
+    });
+
+    it("should return to Staking page when it was the last page visited", () => {
+      referrerPathStore.pushPath(AppPath.Staking);
+
+      expect(get(neuronsPageOrigin)).toBe(AppPath.Staking);
+    });
+
+    it("should return to Staking page as defaultf", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+      referrerPathStore.pushPath(AppPath.Settings);
+
+      expect(get(neuronsPageOrigin)).toBe(AppPath.Staking);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Following a similar approach to #6321, the neurons page will include multiple return pages based on how it was accessed.

Currently, there is only one entry point: the Staking page, which is accessed by clicking on any `ProjectsTable` row.

A new entry point will be added in #6342, so we need to know the origin to determine where to navigate back.

A follow-up PR will update the Neuron's layout to utilize this store.

# Changes

- A new derived store has been created to determine the return destination from the Neuron's page.

# Tests

- Unit tests have been implemented for this new derived store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary