### PR TITLE
Run all timers after each test

### DIFF
--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -423,6 +423,7 @@ describe("utils", () => {
       it("should show 'high load' message after ~1 minute", async () => {
         let calls = 0;
         const failuresBeforeHighLoadMessage = 3;
+        let caughtError;
         const _ = poll({
           fn: async () => {
             calls += 1;
@@ -433,6 +434,8 @@ describe("utils", () => {
           millisecondsToWait: 20 * 1000,
           useExponentialBackoff: false,
           failuresBeforeHighLoadMessage,
+        }).catch((err) => {
+          caughtError = err;
         });
         expect(calls).toEqual(1);
         await advanceTime();
@@ -441,6 +444,10 @@ describe("utils", () => {
         await advanceTime();
         expect(calls).toBeGreaterThanOrEqual(failuresBeforeHighLoadMessage);
         expect(get(toastsStore)).toMatchObject(highLoadToast);
+
+        expect(caughtError).toBeUndefined();
+        await vi.runAllTimersAsync();
+        expect(caughtError).toBeInstanceOf(PollingLimitExceededError);
       });
 
       it("should hide 'high load' message after success", async () => {
@@ -493,6 +500,7 @@ describe("utils", () => {
       });
 
       it("should show 'high load' message only once", async () => {
+        let caughtError;
         const _ = poll({
           fn: async () => {
             throw new Error();
@@ -502,6 +510,8 @@ describe("utils", () => {
           millisecondsToWait: 20 * 1000,
           useExponentialBackoff: false,
           failuresBeforeHighLoadMessage: 3,
+        }).catch((err) => {
+          caughtError = err;
         });
         expect(get(toastsStore)).toEqual([]);
         await advanceTime();
@@ -513,6 +523,10 @@ describe("utils", () => {
         await advanceTime();
         // Still only 1 toast.
         expect(get(toastsStore)).toMatchObject(highLoadToast);
+
+        expect(caughtError).toBeUndefined();
+        await vi.runAllTimersAsync();
+        expect(caughtError).toBeInstanceOf(PollingLimitExceededError);
       });
 
       it("should stop polling when cancelled during wait", async () => {

--- a/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
+++ b/frontend/src/tests/lib/worker-utils/timer.worker-utils.spec.ts
@@ -69,6 +69,8 @@ describe("timer.worker-utils", () => {
       });
 
       expect(job).toHaveBeenCalledTimes(1);
+
+      worker.stop();
     });
 
     it("should not call job if already started", async () => {
@@ -93,6 +95,8 @@ describe("timer.worker-utils", () => {
       });
 
       expect(anotherJob).not.toHaveBeenCalled();
+
+      worker.stop();
     });
 
     it("should call job after interval", async () => {
@@ -117,6 +121,8 @@ describe("timer.worker-utils", () => {
       await advanceTime(5000);
 
       expect(job).toHaveBeenCalledTimes(3);
+
+      worker.stop();
     });
 
     it("should call job with identity and data", async () => {
@@ -132,6 +138,8 @@ describe("timer.worker-utils", () => {
       });
 
       expect(job).toBeCalledWith({ identity: mockIdentity, data });
+
+      worker.stop();
     });
 
     it("should call job after interval with same parameter", async () => {
@@ -162,6 +170,8 @@ describe("timer.worker-utils", () => {
       await advanceTime(5000);
 
       expect(job).toBeCalledWith({ identity: mockIdentity, data });
+
+      worker.stop();
     });
 
     it("should stop timer", async () => {
@@ -183,6 +193,8 @@ describe("timer.worker-utils", () => {
       await advanceTime(5000);
 
       expect(job).toHaveBeenCalledTimes(1);
+
+      worker.stop();
     });
 
     it("should stop timer on job error", async () => {
@@ -213,6 +225,8 @@ describe("timer.worker-utils", () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((worker as any).timer).toBeUndefined();
+
+      worker.stop();
     });
 
     it("should call postMessage when status changes", async () => {
@@ -239,6 +253,8 @@ describe("timer.worker-utils", () => {
           state: "idle",
         },
       });
+
+      worker.stop();
     });
 
     it("should allow call to postMessage when timer is not idle", async () => {
@@ -276,6 +292,8 @@ describe("timer.worker-utils", () => {
       });
 
       expect(spyPostMessage).toHaveBeenCalledWith(testMsg);
+
+      worker.stop();
     });
 
     it("should not allow call to postMessage when timer is already idle", async () => {
@@ -324,6 +342,8 @@ describe("timer.worker-utils", () => {
       });
 
       expect(spyPostMessage).not.toHaveBeenCalledWith(testMsg);
+
+      worker.stop();
     });
   });
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -36,6 +36,14 @@ beforeEach(() => {
   vi.stubGlobal("CustomEvent", CustomEventForTesting);
 });
 
+afterEach(async () => {
+  // Do this in afterEach such that if any timers cause any errors or logs,
+  // these are associated with the test that caused them.
+  if (vi.isFakeTimers()) {
+    await vi.runAllTimersAsync();
+  }
+});
+
 const cleanupFunctions = vi.hoisted(() => {
   return [];
 });


### PR DESCRIPTION
# Motivation

We should run all timers after each test:
1. to make sure timers from one test don't interfere with timers from another test, and
2. to make sure no errors happen in timers after a test has already passed.

# Changes

1. Call `vi.runAllTimersAsync()` in `afterEach` in `frontend/vitest.setup.ts`.
2. Catch the error from `poll` in `utils.spec.ts` after the polling limit is exceeded, to make sure the error doesn't happen as "unhandled error" in `afterEach`.
3. Stop workers in `timer.worker-utils.spec.ts` to avoid an infinite loop in `afterEach`.

# Tests

1. Affected tests updated.
2. All remaining tests continue to pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary