### PR TITLE
Split config.json from dfx.json

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -56,7 +56,7 @@ runs:
         set -euxo pipefail
         if command -v didc
         then echo "Skipping didc installation, as didc is already installed"
-        else dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
+        else dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_RELEASE config.json)"
         fi
     - name: Create local arguments
       shell: bash

--- a/.github/actions/checkout_snsdemo/action.yaml
+++ b/.github/actions/checkout_snsdemo/action.yaml
@@ -1,10 +1,10 @@
 name: 'Clone the snsdemo repository'
 description: |
-  Ensures that the snsdemo repository is checked out at the commit specified in `dfx.json`.
+  Ensures that the snsdemo repository is checked out at the commit specified in `config.json`.
 
   * If the snsdemo repository is already present: Checks that the repo is checked
     out at the expected commit.  If not, this fails with an error message.
-  * Otherwise: Clones the snsdemo repository at the commit specified in `dfx.json`
+  * Otherwise: Clones the snsdemo repository at the commit specified in `config.json`
 inputs:
   token:
     description: "Github access token used to clone"
@@ -33,7 +33,7 @@ runs:
       id: snsdemo_ref
       shell: bash
       run: |
-        SNSDEMO_RELEASE="$(jq -r .defaults.build.config.SNSDEMO_RELEASE dfx.json)"
+        SNSDEMO_RELEASE="$(jq -r .defaults.build.config.SNSDEMO_RELEASE config.json)"
         echo "ref=$SNSDEMO_RELEASE" >> "$GITHUB_OUTPUT"
     - name: Check that the existing repo has the expected commit.
       if: ${{ steps.have_snsdemo.outputs.have_snsdemo == 'true' }}

--- a/.github/actions/install_binstall/action.yaml
+++ b/.github/actions/install_binstall/action.yaml
@@ -1,12 +1,12 @@
 name: 'Installs binstall'
 description: |
-  Installs `cargo binstall` at the version specified in dfx.json
+  Installs `cargo binstall` at the version specified in config.json
 runs:
   using: "composite"
   steps:
     - name: Install binstall
       shell: bash
       run: |
-        BINSTALL_VERSION="$(jq -r .defaults.build.config.BINSTALL_VERSION dfx.json)"
+        BINSTALL_VERSION="$(jq -r .defaults.build.config.BINSTALL_VERSION config.json)"
         curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
         ./cargo-binstall -y --force "cargo-binstall@$BINSTALL_VERSION"

--- a/.github/actions/install_ic_wasm/action.yaml
+++ b/.github/actions/install_ic_wasm/action.yaml
@@ -1,6 +1,6 @@
 name: 'Installs ic-wasm'
 description: |
-  Installs `cargo ic-wasm` at the version specified in dfx.json
+  Installs `cargo ic-wasm` at the version specified in config.json
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       id: ic-wasm-version
       shell: bash
       run: |
-        echo "IC_WASM_VERSION=$(jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json)" >> "$GITHUB_OUTPUT"
+        echo "IC_WASM_VERSION=$(jq -r '.defaults.build.config.IC_WASM_VERSION' config.json)" >> "$GITHUB_OUTPUT"
         echo "IC_WASM_PATH=/home/runner/.cargo/bin/ic-wasm" >> "$GITHUB_OUTPUT"
     - name: Cache ic-wasm
       id: cache-ic-wasm

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -4,11 +4,11 @@ description: |
   Optionally installs nns-dapp and sns_aggregator.
 inputs:
   snsdemo_ref:
-    description: "The git ref at which to use the snsdemo scripts.  Defaults to the release tag in dfx.json"
+    description: "The git ref at which to use the snsdemo scripts.  Defaults to the release tag in config.json"
     required: false
     default: ""
   snapshot_url:
-    description: "The URL of the snapshot to download and install.  Defaults to the URL of the release tag in dfx.json."
+    description: "The URL of the snapshot to download and install.  Defaults to the URL of the release tag in config.json."
     required: false
     default: ""
   nns_dapp_wasm:
@@ -41,7 +41,7 @@ runs:
       shell: bash
       run: |
         SNSDEMO_REF="${{ inputs.snsdemo_ref }}"
-        test -n "$SNSDEMO_REF" || SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_RELEASE dfx.json)"
+        test -n "$SNSDEMO_REF" || SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_RELEASE config.json)"
         echo "ref=$SNSDEMO_REF" >> "$GITHUB_OUTPUT"
     - name: Determine snsdemo snapshot URL
       id: snsdemo_snapshot
@@ -67,7 +67,7 @@ runs:
     - name: Install SNS script dependencies
       shell: bash
       run: |
-        cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
+        cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION config.json)"
     - name: Get test environment
       shell: bash
       run: |
@@ -76,10 +76,7 @@ runs:
         # uses to determine the version will be replaced by the snapshot.
         export DFX_VERSION="$(dfx --version | sed 's/dfx //')"
         scripts/dfx-snapshot-install --snapshot state.tar.xz
-        # Change to $HOME to avoid using nns-dapp dfx.json.
-        pushd "$HOME"
         dfx start --background &> '${{ inputs.logfile }}'
-        popd
         dfx identity use snsdemo8
     - name: Wait before installing canisters
       if: ${{ inputs.nns_dapp_wasm }} || ${{ inputs.sns_aggregator_wasm }}

--- a/.github/actions/vitest/action.yml
+++ b/.github/actions/vitest/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: actions/checkout@v4
     - name: Get node version
       shell: bash
-      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}

--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -3,8 +3,8 @@
 
 Cargo.lock
 Cargo.toml
+config.json
 declarations/*/*/*.did
-dfx.json
 frontend/package-lock.json
 frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json
 rs/proposals/src/canisters/*/api.rs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Install tools
         run: |
           sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
-          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
+          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION config.json)" && idl2json --version
       - name: Run uprade-downgrade test
         run: ./scripts/nns-dapp/upgrade-downgrade-test --wasm out/nns-dapp_test.wasm.gz --args out/nns-dapp-arg-local.did --github_step_summary "$GITHUB_STEP_SUMMARY"
   test-upgrade-stable:
@@ -140,7 +140,7 @@ jobs:
       - name: Install tools
         run: |
           sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
-          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
+          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION config.json)" && idl2json --version
       - name: Start dfx
         run: dfx start --clean --background &>test-upgrade-stable-dfx.log
       - name: Downgrade nns-dapp to prod and upgrade back again

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get cargo sort version
-        run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
+        run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' config.json >> $GITHUB_ENV
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -112,7 +112,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -143,16 +143,16 @@ jobs:
         run: command -v didc
       - name: Run the ic_commit code generator for proposals
         run: |
-          ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_PROPOSALS dfx.json)"
+          ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_PROPOSALS config.json)"
           ./scripts/proposals/did2rs
       - name: Run the ic_commit code generator for sns_aggregator
         run: |
-          ./scripts/update_ic_commit --crate sns_aggregator --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
+          ./scripts/update_ic_commit --crate sns_aggregator --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR config.json)"
           ./scripts/sns/aggregator/mk_nns_patch.sh
       - name: Verify that there are no code changes
         run: |
           if git diff | grep . ; then
-                  echo "ERROR: The code is not consistent with the IC_COMMIT in dfx.json"
+                  echo "ERROR: The code is not consistent with the IC_COMMIT in config.json"
                   echo "Note:  didc version: $(didc --version)"
                   exit 1
           fi
@@ -189,7 +189,7 @@ jobs:
         uses: ./.github/actions/install_binstall
       - name: Install tools
         run: |
-          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
+          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION config.json)"
       - name: Check mainnet config
         run: bash -x config.test
   migration-test-utils-work:
@@ -200,7 +200,7 @@ jobs:
       - name: Install cargo binstall
         uses: ./.github/actions/install_binstall
       - name: Install idl2json
-        run: cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
+        run: cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION config.json)" && idl2json --version
       - name: Test migration utilities
         run: |
           set +x
@@ -217,7 +217,7 @@ jobs:
       - name: Install cargo binstall
         uses: ./.github/actions/install_binstall
       - name: Install idl2json
-        run: cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
+        run: cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION config.json)" && idl2json --version
       - name: Install sponge
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Install dfx
@@ -233,7 +233,7 @@ jobs:
       - name: Install sponge
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Find newer IC release, if any
         id: update
         run: |
-          current_release="$(jq -r .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
+          current_release="$(jq -r .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR config.json)"
           echo "Current IC release: $current_release"
           latest_release=$(curl -sSL https://api.github.com/repos/dfinity/ic/releases/latest | jq .tag_name -r)
           echo "Latest IC release:  $latest_release"
@@ -66,7 +66,7 @@ jobs:
           reviewers: mstrasinskis, dskloetd, anchpop, aterga, yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
-            dfx.json
+            config.json
             declarations/*/*.did
             rs/sns_aggregator/src/types/*
           branch: bot-aggregator-update
@@ -80,7 +80,7 @@ jobs:
             Even with no changes, just updating the reference is good practice.
 
             # Changes
-            * Update the version of `IC_COMMIT_FOR_SNS_AGGREGATOR` specified in `dfx.json`.
+            * Update the version of `IC_COMMIT_FOR_SNS_AGGREGATOR` specified in `config.json`.
             * Updated the `sns_aggregator` candid files to the versions in that commit.
             * Updated the Rust code derived from `.did` files in the aggregator.
 

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pwd
           find .github/actions
-          current_didc_release=$(jq -r '.defaults.build.config.DIDC_RELEASE' dfx.json)
+          current_didc_release=$(jq -r '.defaults.build.config.DIDC_RELEASE' config.json)
           echo "current didc release '$current_didc_release'"
 
           latest_didc_release=$(curl -sSL https://api.github.com/repos/dfinity/candid/releases/latest | jq .tag_name -r)
@@ -33,21 +33,21 @@ jobs:
           then
             echo didc needs an update
             sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
-            DIDC_RELEASE="$latest_didc_release" jq '.defaults.build.config.DIDC_RELEASE=(env.DIDC_RELEASE)' dfx.json  | sponge dfx.json
+            DIDC_RELEASE="$latest_didc_release" jq '.defaults.build.config.DIDC_RELEASE=(env.DIDC_RELEASE)' config.json  | sponge config.json
             scripts/install-didc
-            DIDC_VERSION="$(didc --version)" jq '.defaults.build.config.DIDC_VERSION=(env.DIDC_VERSION)' dfx.json  | sponge dfx.json
+            DIDC_VERSION="$(didc --version)" jq '.defaults.build.config.DIDC_VERSION=(env.DIDC_VERSION)' config.json  | sponge config.json
             echo "updated=1" >> "$GITHUB_OUTPUT"
             echo "version=$latest_didc_release" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi
 
-          jq '.defaults.build.config.DIDC_RELEASE' dfx.json
+          jq '.defaults.build.config.DIDC_RELEASE' config.json
           echo "Git status:"
           git status
           echo "Changes:"
           git diff
-        # If `dfx.json` was updated, create a PR.
+        # If `config.json` was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v7
@@ -56,7 +56,7 @@ jobs:
           base: main
           reviewers: mstrasinskis, dskloetd, yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
-          add-paths: dfx.json
+          add-paths: config.json
           commit-message: Update didc release
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
@@ -71,7 +71,7 @@ jobs:
 
             # Changes
             ## Changes made by a bot triggered by ${{ github.actor }}
-            - Update the version of `didc` specified in `dfx.json`.
+            - Update the version of `didc` specified in `config.json`.
 
             ## Changes made by a human (delete if inapplicable)
 

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Find newer IC release, if any
         id: update
         run: |
-          current_release="$(jq -r .defaults.build.config.IC_COMMIT_FOR_PROPOSALS dfx.json)"
+          current_release="$(jq -r .defaults.build.config.IC_COMMIT_FOR_PROPOSALS config.json)"
           echo "Current IC release: $current_release"
           latest_release=$(curl -sSL https://api.github.com/repos/dfinity/ic/releases/latest | jq .tag_name -r)
           echo "Latest IC release:  $latest_release"
@@ -73,12 +73,12 @@ jobs:
           reviewers: mstrasinskis, dskloetd, yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
-            dfx.json
+            config.json
             declarations/*/*.did
             rs/proposals/src/canisters/*/api.rs
           delete-branch: true
           title: 'bot: Update proposals candid bindings'
-          # Note: It is _likely_ but not guaranteed that the .did files match the `IC_COMMIT` in `dfx.json`.  The files in the PR have a header that give this information reliably.
+          # Note: It is _likely_ but not guaranteed that the .did files match the `IC_COMMIT` in `config.json`.  The files in the PR have a header that give this information reliably.
           #       We do _not_ put a commit in the PR title as it could be misleading.
           body: |
             # Motivation
@@ -86,7 +86,7 @@ jobs:
             Even with no changes, just updating the reference is good practice.
 
             # Changes
-            * Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
+            * Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `config.json`.
             * Updated the `proposals` candid files to the versions in that commit.
             * Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
 

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Update to match the snsdemo repo
         id: update
         run: |
-          current_release="$(jq -r .defaults.build.config.SNSDEMO_RELEASE dfx.json)"
+          current_release="$(jq -r .defaults.build.config.SNSDEMO_RELEASE config.json)"
           echo "Current snsdemo release: $current_release"
           latest_release=$(curl -sSL https://api.github.com/repos/dfinity/snsdemo/releases/latest | jq .tag_name -r)
           echo "Latest snsdemo release:  $latest_release"
@@ -50,7 +50,7 @@ jobs:
           set -x
           echo snsdemo needs an update
           # Install `didc`
-          snsdemo/bin/dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
+          snsdemo/bin/dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_RELEASE config.json)"
           # Install sponge
           sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
           # Update
@@ -72,7 +72,9 @@ jobs:
           branch-suffix: timestamp
           reviewers: mstrasinskis, dskloetd, yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
-          add-paths: dfx.json
+          add-paths: |
+            config.json
+            dfx.json
           delete-branch: true
           title: 'bot: Update snsdemo to ${{ steps.update.outputs.release }}'
           body: |
@@ -80,7 +82,7 @@ jobs:
             We would like to keep the testing environment, provided by snsdemo, up to date.
 
             # Changes
-            * Updated `snsdemo` version in `dfx.json`.
+            * Updated `snsdemo` version in `config.json`.
             * Ensured that the `dfx` version in `dfx.json` matches `snsdemo`.
 
             # Tests

--- a/HACKING.md
+++ b/HACKING.md
@@ -21,7 +21,7 @@ This document list a couple of useful information to develop the NNS-dapp fronte
 
 NNS-dapp frontend uses an `.env` file to read various environment information and variables.
 
-The repo itself does **not** contain any such file because the source of truth we are using is `dfx.json`.
+The repo itself does **not** contain any such file because the source of truth we are using is `dfx.json` and `config.json`.
 That is why we are providing a `./config.sh` script that generate the above environment file automatically.
 
 ## Local
@@ -212,7 +212,7 @@ Likewise, as the configuration is not yet automated, there are no `.env` variabl
 
 Because the e2e tests are using the `local` environment to perform, we cannot enable `ENABLE_CKTESTBTC` per default.
 
-Therefore, this flag should also be manually set to `true` in [`dfx.json`](./dfx.json) and the `.env` should be generated.
+Therefore, this flag should also be manually set to `true` in [`config.json`](./config.json) and the `.env` should be generated.
 
 Use `scripts/nns-dapp/test-config --update` to update `arg.did` and `env` files under `nns-dapp/test-config-assets`
 

--- a/build-config.sh
+++ b/build-config.sh
@@ -2,5 +2,5 @@
 # Prints build configuration as KEY=VALUE lines, suitable for bash and github actions.
 set -euo pipefail
 cd "$(dirname "$(realpath "$0")")"
-jq -r '.defaults.build.config | to_entries | .[] | .key+"="+(.value|tostring)' dfx.json
+jq -r '.defaults.build.config | to_entries | .[] | .key+"="+(.value|tostring)' config.json
 jq -r '"DFX_VERSION="+.dfx' dfx.json

--- a/config.json
+++ b/config.json
@@ -1,0 +1,117 @@
+{
+  "networks": {
+    "mainnet": {
+      "config": {
+        "FETCH_ROOT_KEY": false,
+        "API_HOST": "https://icp-api.io",
+        "STATIC_HOST": "https://icp0.io",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "app": {
+      "config": {
+        "FETCH_ROOT_KEY": false,
+        "API_HOST": "https://icp-api.io",
+        "STATIC_HOST": "https://icp0.io",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "beta": {
+      "config": {
+        "FETCH_ROOT_KEY": false,
+        "API_HOST": "https://icp-api.io",
+        "STATIC_HOST": "https://icp0.io",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "devenv_llorenc": {
+      "config": {
+        "HOST": "https://llorenc-ingress.devenv.dfinity.network",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "devenv_dskloet": {
+      "config": {
+        "HOST": "https://dskloet-ingress.devenv.dfinity.network",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "devenv_mstr": {
+      "config": {
+        "HOST": "https://mstr-ingress.devenv.dfinity.network",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "devenv_cosku": {
+      "config": {
+        "HOST": "https://cosku-ingress.devenv.dfinity.network",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "devenv_yhabib": {
+      "config": {
+        "HOST": "https://yhabib-ingress.devenv.dfinity.network",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    },
+    "local": {
+      "config": {
+        "HOST": "http://localhost:8080",
+        "OWN_CANISTER_ID": "qsgjb-riaaa-aaaaa-aaaga-cai",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false
+        }
+      }
+    }
+  },
+  "defaults": {
+    "network": {
+      "config": {
+        "FETCH_ROOT_KEY": true,
+        "FEATURE_FLAGS": {
+          "ENABLE_CKTESTBTC": false,
+          "DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING": false,
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION": true,
+          "ENABLE_EXPORT_NEURONS_REPORT": true,
+          "ENABLE_USD_VALUES": true,
+          "ENABLE_USD_VALUES_FOR_NEURONS": true,
+          "ENABLE_PORTFOLIO_PAGE": true,
+          "ENABLE_IMPORT_TOKEN_BY_URL": true
+        }
+      }
+    },
+    "build": {
+      "config": {
+        "NODE_VERSION": "18.14.2",
+        "IC_WASM_VERSION": "0.6.0",
+        "IDL2JSON_VERSION": "0.8.8",
+        "OPTIMIZER_VERSION": "0.3.6",
+        "BINSTALL_VERSION": "1.3.0",
+        "DIDC_RELEASE": "2024-05-14",
+        "DIDC_VERSION": "didc 0.4.0",
+        "POCKETIC_VERSION": "3.0.1",
+        "CARGO_SORT_VERSION": "1.0.9",
+        "SNSDEMO_RELEASE": "release-2025-01-29",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2025-01-30_03-03-hashes-in-blocks",
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2025-01-30_03-03-hashes-in-blocks"
+      },
+      "packtool": ""
+    }
+  }
+}

--- a/config.sh
+++ b/config.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # - In javascript, load config.json, located in the repo root directory and created by running this script.
 #
 # To define a constant:
-# - Add it to dfx.json
+# - Add it to config.json
 #   - either under defaults.networks.config.SOMEVAR=SOMEVAL
 #   - or under networks.SOME_NETWORK.config.SOMEVAR=SOMEVAL
 # - Verify that the constant appears in config.json if you run this script.
@@ -171,9 +171,9 @@ local_deployment_data="$(
 
 : "Put all configuration in JSON."
 : "In case of conflict:"
-: "- The dfx.json networks section has the highest priority,"
+: "- The config.json networks section has the highest priority,"
 : "- next, look at the environment,"
-: "- last is the defaults section in dfx.json"
+: "- last is the defaults section in config.json"
 : ""
 : "After assembling the configuration:"
 : "- replace OWN_CANISTER_ID"
@@ -184,7 +184,7 @@ json=$(HOST=$(dfx-canister-url --network "$DFX_NETWORK" --type api) jq -s --sort
   .DFX_NETWORK = env.DFX_NETWORK |
   . as $config |
   .HOST=env.HOST
-    ' dfx.json <(network_config) <(echo "$local_deployment_data"))
+    ' config.json <(network_config) <(echo "$local_deployment_data"))
 
 dfxNetwork=$(echo "$json" | jq -r ".DFX_NETWORK")
 cmcCanisterId=$(echo "$json" | jq -r ".CYCLES_MINTING_CANISTER_ID")

--- a/dfx.json
+++ b/dfx.json
@@ -300,154 +300,57 @@
   },
   "networks": {
     "mainnet": {
-      "config": {
-        "FETCH_ROOT_KEY": false,
-        "API_HOST": "https://icp-api.io",
-        "STATIC_HOST": "https://icp0.io",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://icp0.io"
       ],
       "type": "persistent"
     },
     "app": {
-      "config": {
-        "FETCH_ROOT_KEY": false,
-        "API_HOST": "https://icp-api.io",
-        "STATIC_HOST": "https://icp0.io",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://icp0.io"
       ],
       "type": "persistent"
     },
     "beta": {
-      "config": {
-        "FETCH_ROOT_KEY": false,
-        "API_HOST": "https://icp-api.io",
-        "STATIC_HOST": "https://icp0.io",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://icp0.io"
       ],
       "type": "persistent"
     },
     "devenv_llorenc": {
-      "config": {
-        "HOST": "https://llorenc-ingress.devenv.dfinity.network",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://llorenc-ingress.devenv.dfinity.network"
       ],
       "type": "persistent"
     },
     "devenv_dskloet": {
-      "config": {
-        "HOST": "https://dskloet-ingress.devenv.dfinity.network",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://dskloet-ingress.devenv.dfinity.network"
       ],
       "type": "persistent"
     },
     "devenv_mstr": {
-      "config": {
-        "HOST": "https://mstr-ingress.devenv.dfinity.network",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://mstr-ingress.devenv.dfinity.network"
       ],
       "type": "persistent"
     },
     "devenv_cosku": {
-      "config": {
-        "HOST": "https://cosku-ingress.devenv.dfinity.network",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://cosku-ingress.devenv.dfinity.network"
       ],
       "type": "persistent"
     },
     "devenv_yhabib": {
-      "config": {
-        "HOST": "https://yhabib-ingress.devenv.dfinity.network",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
       "providers": [
         "https://yhabib-ingress.devenv.dfinity.network"
       ],
       "type": "persistent"
-    },
-    "local": {
-      "config": {
-        "HOST": "http://localhost:8080",
-        "OWN_CANISTER_ID": "qsgjb-riaaa-aaaaa-aaaga-cai",
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false
-        }
-      },
-      "bind": "127.0.0.1:8080",
-      "type": "ephemeral"
     }
   },
   "defaults": {
     "replica": {
       "subnet_type": "system"
-    },
-    "network": {
-      "config": {
-        "FETCH_ROOT_KEY": true,
-        "FEATURE_FLAGS": {
-          "ENABLE_CKTESTBTC": false,
-          "DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING": false,
-          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION": true,
-          "ENABLE_EXPORT_NEURONS_REPORT": true,
-          "ENABLE_USD_VALUES": true,
-          "ENABLE_USD_VALUES_FOR_NEURONS": true,
-          "ENABLE_PORTFOLIO_PAGE": true,
-          "ENABLE_IMPORT_TOKEN_BY_URL": true
-        }
-      }
-    },
-    "build": {
-      "config": {
-        "NODE_VERSION": "18.14.2",
-        "IC_WASM_VERSION": "0.6.0",
-        "IDL2JSON_VERSION": "0.8.8",
-        "OPTIMIZER_VERSION": "0.3.6",
-        "BINSTALL_VERSION": "1.3.0",
-        "DIDC_RELEASE": "2024-05-14",
-        "DIDC_VERSION": "didc 0.4.0",
-        "POCKETIC_VERSION": "3.0.1",
-        "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2025-01-29",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2025-01-30_03-03-hashes-in-blocks",
-        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2025-01-30_03-03-hashes-in-blocks"
-      },
-      "packtool": ""
     }
   },
   "version": 1

--- a/scripts/dfx-nns-deploy-custom
+++ b/scripts/dfx-nns-deploy-custom
@@ -31,7 +31,7 @@ nns)
 sns)
   : "Deploy nns-dapp with NNS and SNS canisters"
   : "Note: This is done with a script from the snsdemo repository."
-  dfx-sns-demo --ic_commit "$(jq -r '.defaults.build.config.IC_COMMIT' "${SOURCE_DIR}/../dfx.json")"
+  dfx-sns-demo --ic_commit "$(jq -r '.defaults.build.config.IC_COMMIT' "${SOURCE_DIR}/../config.json")"
   ;;
 *)
   {

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -56,8 +56,6 @@ fi
 
 "$SOURCE_DIR/dfx-snapshot-install" --backup-dir "$BACKUP_DIR" --snapshot "$SNAPSHOT_ARCHIVE" "$CLEAN_ARG"
 
-# Change to $HOME to avoid using nns-dapp dfx.json.
-cd "$HOME"
 echo "*********************************************************************"
 echo "*                                                                   *"
 echo "*  If the state was generated on a different type of machine, then  *"

--- a/scripts/ensure-required-didc-version
+++ b/scripts/ensure-required-didc-version
@@ -4,7 +4,7 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 ACTUAL_VERSION="$(didc --version)"
-EXPECTED_VERSION="$(jq -r '.defaults.build.config.DIDC_VERSION' "$SOURCE_DIR/../dfx.json")"
+EXPECTED_VERSION="$(jq -r '.defaults.build.config.DIDC_VERSION' "$SOURCE_DIR/../config.json")"
 
 if [[ "${ACTUAL_VERSION:-}" != "${EXPECTED_VERSION:-}" ]]; then
   echo "Expected didc version '$EXPECTED_VERSION', but found '$ACTUAL_VERSION'"

--- a/scripts/fmt-json
+++ b/scripts/fmt-json
@@ -4,3 +4,6 @@ cd "$(dirname "$(realpath "$0")")/.."
 
 # shellcheck disable=SC2094 # The file is completely read before it is written so this is correct and safe.
 cat <<<"$(jq . dfx.json)" >dfx.json
+
+# shellcheck disable=SC2094 # The file is completely read before it is written so this is correct and safe.
+cat <<<"$(jq . config.json)" config.json

--- a/scripts/install-didc
+++ b/scripts/install-didc
@@ -11,7 +11,7 @@ clap.define short=r long=release desc="The didc release to install" variable=REL
 source "$(clap.build)"
 
 if [[ "${RELEASE:-}" == "pinned" ]]; then
-  RELEASE="$(jq -r '.defaults.build.config.DIDC_RELEASE' "$SOURCE_DIR/../dfx.json")"
+  RELEASE="$(jq -r '.defaults.build.config.DIDC_RELEASE' "$SOURCE_DIR/../config.json")"
 fi
 
 echo "Installing didc release $RELEASE"

--- a/scripts/network-config.test
+++ b/scripts/network-config.test
@@ -10,14 +10,6 @@ sample_global_config() {
   cat <<-EOF
 	{
 	  "local": {
-	    "config": {
-	      "FETCH_ROOT_KEY": true,
-	      "HOST": "http://localhost:8080",
-	      "FEATURE_FLAGS": {
-		"ENABLE_SNS": true,
-		"ENABLE_SNS_2": true
-	      }
-	    },
 	    "bind": "127.0.0.1:8080",
 	    "type": "ephemeral",
 	    "replica": {
@@ -25,10 +17,6 @@ sample_global_config() {
 	    }
 	  },
 	  "fubar": {
-	    "config": {
-	      "FETCH_ROOT_KEY": true,
-	      "HOST": "https://fubar.testnet.dfinity.network"
-	    },
 	    "providers": [
 	      "http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"
 	    ],
@@ -60,14 +48,6 @@ sample_local_config() {
 	  },
 	  "networks": {
 	    "mainnet": {
-	      "config": {
-		"FETCH_ROOT_KEY": false,
-		"API_HOST": "https://icp-api.io",
-		"STATIC_HOST": "https://icp0.io",
-		"FEATURE_FLAGS": {
-		  "ENABLE_CKTESTBTC": false
-		}
-	      },
 	      "providers": [
 		"https://icp-api.io/"
 	      ],

--- a/scripts/setup
+++ b/scripts/setup
@@ -169,7 +169,7 @@ install_rust() {
 
 install_binstall() {
   local BINSTALL_VERSION
-  BINSTALL_VERSION="$(jq -r .defaults.build.config.BINSTALL_VERSION dfx.json)"
+  BINSTALL_VERSION="$(jq -r .defaults.build.config.BINSTALL_VERSION config.json)"
   curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
   ./cargo-binstall -y --force "cargo-binstall@$BINSTALL_VERSION"
 }
@@ -223,22 +223,22 @@ install_cmake_linux() {
 }
 
 check_ic_wasm() {
-  EXPECTED_IC_WASM_VERSION="$(jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json)"
+  EXPECTED_IC_WASM_VERSION="$(jq -r '.defaults.build.config.IC_WASM_VERSION' config.json)"
   INSTALLED_IC_WASM_VERSION="$(ic-wasm --version | awk '{print $2}')"
   [[ "${INSTALLED_IC_WASM_VERSION:-}" == "$EXPECTED_IC_WASM_VERSION" ]]
 }
 install_ic_wasm() {
-  IC_WASM_VERSION="$(jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json)"
+  IC_WASM_VERSION="$(jq -r '.defaults.build.config.IC_WASM_VERSION' config.json)"
   cargo binstall --force --no-confirm "ic-wasm@${IC_WASM_VERSION}"
 }
 
 check_cargo_sort() {
-  EXPECTED_CARGO_SORT_VERSION="$(jq -r '.defaults.build.config.CARGO_SORT_VERSION' dfx.json)"
+  EXPECTED_CARGO_SORT_VERSION="$(jq -r '.defaults.build.config.CARGO_SORT_VERSION' config.json)"
   INSTALLED_CARGO_SORT_VERSION="$(cargo sort --version | awk '{print $2}')"
   [[ "${INSTALLED_CARGO_SORT_VERSION:-}" == "$EXPECTED_CARGO_SORT_VERSION" ]]
 }
 install_cargo_sort() {
-  CARGO_SORT_VERSION="$(jq -r '.defaults.build.config.CARGO_SORT_VERSION' dfx.json)"
+  CARGO_SORT_VERSION="$(jq -r '.defaults.build.config.CARGO_SORT_VERSION' config.json)"
   cargo binstall --force --no-confirm "cargo-sort@${CARGO_SORT_VERSION}"
 }
 
@@ -258,13 +258,13 @@ install_idl2json() {
 
 install_didc_linux() {
   local version
-  version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
+  version="$(jq -r .defaults.build.config.DIDC_RELEASE config.json)"
   # TODO: Use binstall
   curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
 }
 install_didc_darwin() {
   local version
-  version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
+  version="$(jq -r .defaults.build.config.DIDC_RELEASE config.json)"
   tempfile="$(mktemp ,didc-XXXXXXXX)"
   curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-macos" >"$tempfile"
   install -m 755 "$tempfile" "$USER_BIN/didc"

--- a/scripts/update-snsdemo
+++ b/scripts/update-snsdemo
@@ -54,7 +54,7 @@ done
 cd "$SOURCE_DIR/.."
 
 # Update the snsdemo commit in dfx.json
-jq --arg c "$SNSDEMO_RELEASE" '.defaults.build.config.SNSDEMO_RELEASE |= $c' dfx.json | sponge dfx.json
+jq --arg c "$SNSDEMO_RELEASE" '.defaults.build.config.SNSDEMO_RELEASE |= $c' config.json | sponge config.json
 
 # Update dfx to match snsdemo
 v="$DFX_VERSION" jq '.dfx |= env.v' dfx.json | sponge dfx.json

--- a/scripts/update_ic_commit
+++ b/scripts/update_ic_commit
@@ -29,15 +29,15 @@ fi
   exit 1
 } >&2
 
-: "Bump IC_COMMIT in dfx.json"
+: "Bump IC_COMMIT in config.json"
 bump_ic_commit() {
   export IC_COMMIT_CONFIG_FIELD="$1"
-  NEW_CONFIG="$(DFX_IC_COMMIT="$DFX_IC_COMMIT" jq '.defaults.build.config[env.IC_COMMIT_CONFIG_FIELD] = (env.DFX_IC_COMMIT)' "$SOURCE_DIR/../dfx.json")"
+  NEW_CONFIG="$(DFX_IC_COMMIT="$DFX_IC_COMMIT" jq '.defaults.build.config[env.IC_COMMIT_CONFIG_FIELD] = (env.DFX_IC_COMMIT)' "$SOURCE_DIR/../config.json")"
   [[ "$NEW_CONFIG" != "" ]] || {
-    echo "ERROR: Failed to set ${IC_COMMIT_CONFIG_FIELD}  in dfx.json.  Please verify that dfx.json is valid JSON."
+    echo "ERROR: Failed to set ${IC_COMMIT_CONFIG_FIELD}  in config.json.  Please verify that config.json is valid JSON."
     exit 1
   } >&2
-  printf "%s\n" "$NEW_CONFIG" >"$SOURCE_DIR/../dfx.json"
+  printf "%s\n" "$NEW_CONFIG" >"$SOURCE_DIR/../config.json"
 }
 
 : "Get the latest did files"


### PR DESCRIPTION
# Motivation

For years we've had problems with not being able to run certain `dfx` commands from the nns-dapp repo directory because `dfx` is confused by the `.networks.local` entry in our `dfx.json` which will isolate a `dfx` instance running in that directory from one running from another directory.

This is, for example, why we `cd $HOME` [here](https://github.com/dfinity/nns-dapp/blob/acb99323c33d849b969c1e181ad6a6c4b987545a/scripts/dfx-snapshot-start#L59-L60).

This is extra confusing because it's not enforced strictly so only some commands fail require this.

For historical reasons we have a lot of configuration in our `dfx.json` which is not read by `dfx` itself and only by our scripts.

By moving this configuration to a separate file, we can finally remove the `.networks.local` entry and run all `dfx` commands from the same directory.

# Changes

1. Split `config.json` from `dfx.json`.
2. Update scripts to read config from `config.json` instead of `dfx.json`.
3. Stop `cd`ing to another directory before invoking `dfx`.

# Tests

1. Manually ran `dfx-snapshot-start` and verified that it works without `cd`'ing away.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary