### PR TITLE
Remove the script to send conversion rate proposals since it's no longer needed

### DIFF
--- a/frontend/static/assets/libs/dummy-proposals.utils.js
+++ b/frontend/static/assets/libs/dummy-proposals.utils.js
@@ -234,12 +234,6 @@ const addOrRemoveDataCentersPayload = new Uint8Array([
   44, 84, 111, 107, 121, 111, 7, 69, 113, 117, 105, 110, 105, 120, 0,
 ]);
 
-const exchageRatePayload = new Uint8Array([
-  68, 73, 68, 76, 1, 108, 3, 144, 203, 139, 170, 1, 113, 223, 245, 129, 160, 8, 120,
-  214, 213, 218, 198, 15, 120, 1, 0, 3, 105, 109, 102, 16, 39, 0, 0, 0, 0, 0, 0, 229,
-  10, 27, 96, 0, 0, 0, 0
-]);
-
 const makeMotionDummyProposalRequest = ({ title, url, summary, neuronId }) => ({
   neuronId,
   title,
@@ -491,16 +485,6 @@ export const makeDummyProposals = async ({
             "Initialize datacenter records. For more info about this proposal, read the forum announcement: https://forum.dfinity.org/t/improvements-to-node-provider-remuneration/10553",
           nnsFunction: 21,
           payload: addOrRemoveDataCentersPayload,
-        }),
-        log: "Execute NNS Function Proposal...",
-      }, {
-        request: makeExecuteNnsFunctionDummyProposalRequest({
-          neuronId,
-          title: "Exchange Rate Proposal Tests",
-          url: "",
-          summary: "Test proposal for exchange rate.",
-          nnsFunction: 10,
-          payload: exchageRatePayload,
         }),
         log: "Execute NNS Function Proposal...",
       },

--- a/scripts/propose-to/propose-xdr-icp-conversion-rate
+++ b/scripts/propose-to/propose-xdr-icp-conversion-rate
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-set ic-admin --nns-url "$NNS_URL" propose-xdr-icp-conversion-rate --test-neuron-proposer --summary-file ./README.md --xdr-permyriad-per-icp 123456789


### PR DESCRIPTION
# Motivation

Since CMC has a default xdr/icp conversion rate at initialization, and we stopped using such conversion rate proposals in the mainnet a long time ago, it no longer makes sense to send such proposals in testing.

# Changes

* Remove `scripts/propose-to/propose-xdr-icp-conversion-rate`
* Remove exchange rate proposal from `frontend/static/assets/libs/dummy-proposals.utils.js`

# Tests

Tested on a local replica for making dummy proposals. Dummy proposals are still created, just without the conversion rate proposals:
![image](https://github.com/user-attachments/assets/ef72aa88-93d3-4029-8783-c8888648c1ce)

