### PR TITLE
No missing rewards tags for not votable neurons

### DIFF
--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -552,9 +552,12 @@ const getNeuronTagsUnrelatedToController = ({
     tags.push({ text: i18n.neurons.community_fund });
   }
 
-  // Skip the "missing rewards" tag when voting power economics not available
+  // Skip the "missing rewards" tags when
+  // 1. neuron has not enough dissolve delay to vote
+  // 2. no voting power economics available
   if (
     nonNullish(startReducingVotingPowerAfterSeconds) &&
+    hasEnoughDissolveDelayToVote(neuron) &&
     get(ENABLE_PERIODIC_FOLLOWING_CONFIRMATION)
   ) {
     if (

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -1,5 +1,8 @@
 import NnsNeuronPageHeading from "$lib/components/neuron-detail/NnsNeuronPageHeading.svelte";
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import {
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_YEAR,
+} from "$lib/constants/constants";
 import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";
@@ -167,6 +170,7 @@ describe("NnsNeuronPageHeading", () => {
     });
     const po = renderComponent({
       ...mockNeuron,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR),
       fullNeuron: {
         ...mockNeuron.fullNeuron,
         votingPowerRefreshedTimestampSeconds: BigInt(

--- a/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsLosingRewardsNeuronCard.spec.ts
@@ -1,5 +1,8 @@
 import NnsLosingRewardsNeuronCard from "$lib/components/neurons/NnsLosingRewardsNeuronCard.svelte";
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import {
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_YEAR,
+} from "$lib/constants/constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
@@ -18,6 +21,7 @@ describe("NnsLosingRewardsNeuronCard", () => {
   const neuron: NeuronInfo = {
     ...mockNeuron,
     neuronId,
+    dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR),
     fullNeuron: {
       ...mockFullNeuron,
       controller: mockIdentity.getPrincipal().toText(),

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -1,5 +1,8 @@
 import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import {
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_YEAR,
+} from "$lib/constants/constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { formatTokenE8s } from "$lib/utils/token.utils";
@@ -205,6 +208,7 @@ describe("NnsNeuronCard", () => {
       props: {
         neuron: {
           ...mockNeuron,
+          dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR),
           fullNeuron: {
             ...mockNeuron.fullNeuron,
             votingPowerRefreshedTimestampSeconds: BigInt(

--- a/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.spec.ts
@@ -1,4 +1,7 @@
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import {
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_YEAR,
+} from "$lib/constants/constants";
 import ChangeBulkNeuronVisibilityForm from "$lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";
@@ -36,6 +39,7 @@ describe("ChangeBulkNeuronVisibilityForm", () => {
     ({
       neuronId: id,
       visibility,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR),
       fullNeuron: {
         ...mockFullNeuron,
         id,

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -183,6 +183,7 @@ describe("NnsNeurons", () => {
       vi.spyOn(api, "queryNeurons").mockResolvedValue([
         {
           ...mockNeuron,
+          dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR),
           fullNeuron: {
             ...mockFullNeuron,
             votingPowerRefreshedTimestampSeconds: BigInt(

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1843,24 +1843,20 @@ describe("neuron-utils", () => {
           true
         );
 
-        const tenDaysToConfirmSeconds =
-          nowSeconds -
-          SECONDS_IN_HALF_YEAR +
-          SECONDS_IN_DAY * 10 +
-          10 * 60 * 60;
+        const oneDayToConfirmSeconds =
+          nowSeconds - SECONDS_IN_HALF_YEAR + SECONDS_IN_DAY;
         expect(
           getNeuronTags({
             neuron: {
               ...mockNeuron,
               dissolveDelaySeconds: enoughDissolveDelayToVote - 1n,
               votingPowerRefreshedTimestampSeconds: BigInt(
-                tenDaysToConfirmSeconds
+                oneDayToConfirmSeconds
               ),
               fullNeuron: {
                 ...mockNeuron.fullNeuron,
-                dissolveDelaySeconds: enoughDissolveDelayToVote,
                 votingPowerRefreshedTimestampSeconds: BigInt(
-                  tenDaysToConfirmSeconds
+                  oneDayToConfirmSeconds
                 ),
               },
             } as NeuronInfo,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -113,6 +113,7 @@ import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("neuron-utils", () => {
+  const enoughDissolveDelayToVote = BigInt(SECONDS_IN_HALF_YEAR);
   const nowSeconds = nowInSeconds();
   beforeEach(() => {
     vi.useFakeTimers().setSystemTime(nowSeconds * 1000);
@@ -1740,6 +1741,7 @@ describe("neuron-utils", () => {
     describe("Periodic confirmation tags", () => {
       const losingRewardNeuron: NeuronInfo = {
         ...mockNeuron,
+        dissolveDelaySeconds: enoughDissolveDelayToVote,
         fullNeuron: {
           ...mockNeuron.fullNeuron,
           votingPowerRefreshedTimestampSeconds: BigInt(
@@ -1753,6 +1755,7 @@ describe("neuron-utils", () => {
         daysBeforeMissingRewardsSoon * SECONDS_IN_DAY;
       const losingRewardSoonNeuron: NeuronInfo = {
         ...mockNeuron,
+        dissolveDelaySeconds: enoughDissolveDelayToVote,
         fullNeuron: {
           ...mockNeuron.fullNeuron,
           votingPowerRefreshedTimestampSeconds: BigInt(
@@ -1777,11 +1780,13 @@ describe("neuron-utils", () => {
             getNeuronTags({
               neuron: {
                 ...mockNeuron,
+                dissolveDelaySeconds: enoughDissolveDelayToVote,
                 votingPowerRefreshedTimestampSeconds: BigInt(
                   nowSeconds - SECONDS_IN_HALF_YEAR + secondsToConfirm
                 ),
                 fullNeuron: {
                   ...mockNeuron.fullNeuron,
+                  dissolveDelaySeconds: enoughDissolveDelayToVote,
                   votingPowerRefreshedTimestampSeconds: BigInt(
                     nowSeconds - SECONDS_IN_HALF_YEAR + secondsToConfirm
                   ),
@@ -1832,6 +1837,41 @@ describe("neuron-utils", () => {
         );
       });
 
+      it("returns no 'XX days to confirm' tag when dissolve delay too low", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+
+        const tenDaysToConfirmSeconds =
+          nowSeconds -
+          SECONDS_IN_HALF_YEAR +
+          SECONDS_IN_DAY * 10 +
+          10 * 60 * 60;
+        expect(
+          getNeuronTags({
+            neuron: {
+              ...mockNeuron,
+              dissolveDelaySeconds: enoughDissolveDelayToVote - 1n,
+              votingPowerRefreshedTimestampSeconds: BigInt(
+                tenDaysToConfirmSeconds
+              ),
+              fullNeuron: {
+                ...mockNeuron.fullNeuron,
+                dissolveDelaySeconds: enoughDissolveDelayToVote,
+                votingPowerRefreshedTimestampSeconds: BigInt(
+                  tenDaysToConfirmSeconds
+                ),
+              },
+            } as NeuronInfo,
+            identity: mockIdentity,
+            accounts: accountsWithHW,
+            i18n: en,
+            startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+          })
+        ).toEqual([]);
+      });
+
       it("returns 'Missing rewards' tag", () => {
         overrideFeatureFlagsStore.setFlag(
           "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
@@ -1847,6 +1887,26 @@ describe("neuron-utils", () => {
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
           })
         ).toEqual([missingRewardsTag]);
+      });
+
+      it("returns no 'Missing rewards' tag when dissolve delay too low", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+
+        expect(
+          getNeuronTags({
+            neuron: {
+              ...losingRewardNeuron,
+              dissolveDelaySeconds: enoughDissolveDelayToVote - 1n,
+            },
+            identity: mockIdentity,
+            accounts: accountsWithHW,
+            i18n: en,
+            startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+          })
+        ).toEqual([]);
       });
 
       it("returns no 'Missing rewards' tag when no voting power economics", () => {
@@ -1898,6 +1958,26 @@ describe("neuron-utils", () => {
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
           })
         ).toEqual([missingRewardsSoonTag]);
+      });
+
+      it("returns no 'Missing rewards soon' tag when dissolve delay too low", () => {
+        overrideFeatureFlagsStore.setFlag(
+          "ENABLE_PERIODIC_FOLLOWING_CONFIRMATION",
+          true
+        );
+
+        expect(
+          getNeuronTags({
+            neuron: {
+              ...losingRewardSoonNeuron,
+              dissolveDelaySeconds: enoughDissolveDelayToVote - 1n,
+            },
+            identity: mockIdentity,
+            accounts: accountsWithHW,
+            i18n: en,
+            startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+          })
+        ).toEqual([]);
       });
 
       it("returns no 'Missing rewards soon' tag w/o voting power economics", () => {


### PR DESCRIPTION
# Motivation

In today's implementation, you can have neurons that are unlocked but have been inactive for so long that the "confirm following" warning appears. This is undesired, so the followee confirmation warning shouldn't be shown if the neuron cannot vote.

This PR ensures that the "missing rewards" tags are not shown for neurons that do not have enough dissolve delay to vote.

# Changes

- Update tag generation logic.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.