### PR TITLE
Script to release beta on orbit

### DIFF
--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -80,7 +80,7 @@ check_dfx_orbit_identity() {
     {
       echo
       echo "Your identity '$DFX_IDENTITY' needs to be registered with the orbit station."
-      echo "Ask someone on the team to add your principal '$MY_PRINCIPAL' to the 'Team member' group."
+      echo "Ask someone on the NNS team to add your principal '$MY_PRINCIPAL' to the 'Team member' group."
     } >&2
     exit 1
   fi
@@ -101,7 +101,7 @@ require_asset_permission() {
     {
       echo "You need permission to $permission_description."
       echo "Request permission with:"
-      echo "dfx-orbit --identity \"$DFX_IDENTITY\" --station \"$STATION\" request asset permission $ASSET_CANISTER_ID $lowercase_permission --target \"$MY_PRINCIPAL\""
+      echo "dfx-orbit --identity \"$DFX_IDENTITY\" --station \"$STATION\" request --title \"Add $permission permission for $USER\" asset permission $ASSET_CANISTER_ID $lowercase_permission --target \"$MY_PRINCIPAL\""
     } >&2
     exit 1
   fi

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Releases a new wasm to beta.nns.ic0.app.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="orbit"
+clap.define short=s long=station desc="The orbit station to use" variable=STATION default="nns-team"
+clap.define long=skip-checks desc="Skip the checks that dfx-orbit is set up correctly" variable=SKIP_CHECKS nargs=0
+clap.define short=c long=commit desc="The commit to download the wasm for" variable=COMMIT default="main"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+NNS_TEAM_STATION_ID="fv4dp-biaaa-aaaal-amrua-cai"
+NNS_DAPP_BETA_CANISTER_ID="$(dfx canister id nns-dapp --network beta)"
+ASSET_CANISTER_ID="qoju7-6iaaa-aaaal-amsga-cai"
+
+check_dfx_orbit_installed() {
+  if ! command -v dfx-orbit >/dev/null; then
+    {
+      echo "You need dfx-orbit. Install it with:"
+      echo "cargo install -f --git https://github.com/dfinity/orbit.git --bin dfx-orbit"
+    } >&2
+    exit 1
+  fi
+}
+
+check_dfx_orbit_station() {
+  if ! dfx-orbit station use "$STATION"; then
+    {
+      echo "You need to have the '$STATION' station set up. Set it up with:"
+      echo "dfx-orbit station add --station-id $NNS_TEAM_STATION_ID --network beta \"$STATION\""
+    } >&2
+    exit 1
+  fi
+}
+
+IDENTITY_JSON_FILE="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.json"
+
+maybe_identity_password() {
+  if [[ -e "$IDENTITY_JSON_FILE" ]]; then
+    echo "If asked for a password, enter the password of your dfx identity '$DFX_IDENTITY'."
+  fi
+}
+
+check_dfx_orbit_identity() {
+  if ! dfx identity list 2>/dev/null | grep "$DFX_IDENTITY" >/dev/null; then
+    {
+      echo "You need to have the identity $DFX_IDENTITY set up. Set it up with:"
+      echo "dfx identity new --storage-mode password-protected orbit"
+      echo
+      echo "NOTE: dfx-orbit does not support Keyring protected identities, which is the default for dfx."
+    } >&2
+    exit 1
+  fi
+
+  if [[ -e "$IDENTITY_JSON_FILE" ]] && [[ "$(jq '.keyring_identity_suffix // null' "$IDENTITY_JSON_FILE")" != "null" ]]; then
+    {
+      echo "dfx-orbit does not support Keyring protected identities."
+      echo "Use a different identity than '$DFX_IDENTITY'."
+    } >&2
+    exit 1
+  fi
+
+  maybe_identity_password
+  MY_PRINCIPAL="$(dfx identity get-principal --identity "$DFX_IDENTITY")"
+
+  maybe_identity_password
+  if ! dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" me; then
+    {
+      echo
+      echo "Your identity '$DFX_IDENTITY' needs to be registered with the orbit station."
+      echo "Ask someone on the team to add your principal '$MY_PRINCIPAL' to the 'Team member' group."
+    } >&2
+    exit 1
+  fi
+}
+
+has_asset_permission() {
+  principal="$1"
+  permission="$2"
+  dfx canister call qoju7-6iaaa-aaaal-amsga-cai list_permitted "(record { permission = variant { $permission } })" --identity anonymous --network mainnet | idl2json | jq -r '.[]' | grep -q "$principal"
+}
+
+require_asset_permission() {
+  permission="$1"
+  permission_description="$2"
+  lowercase_permission="$(echo "$permission" | tr '[:upper:]' '[:lower:]')"
+
+  if ! has_asset_permission "$MY_PRINCIPAL" "$permission"; then
+    {
+      echo "You need permission to $permission_description."
+      echo "Request permission with:"
+      echo "dfx-orbit --identity \"$DFX_IDENTITY\" --station \"$STATION\" request asset permission $ASSET_CANISTER_ID $lowercase_permission --target \"$MY_PRINCIPAL\""
+    } >&2
+    exit 1
+  fi
+}
+
+check_asset_permissions() {
+  require_asset_permission Commit "commit assets to the asset canister"
+  require_asset_permission Prepare "upload wasm chunks to the asset canister"
+}
+
+check_dfx_orbit_setup() {
+  if [[ "${SKIP_CHECKS:-}" == "true" ]]; then
+    return
+  fi
+
+  check_dfx_orbit_installed
+  check_dfx_orbit_station
+  check_dfx_orbit_identity
+  check_asset_permissions
+
+  echo "All checks passed. If you want to skip these checks in the future, use the --skip-checks flag."
+}
+
+check_dfx_orbit_setup
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+WASM_DIR="$TOP_DIR/release/ci"
+WASM_PATH="$WASM_DIR/nns-dapp.wasm.gz"
+COMMIT="$(git rev-parse "$COMMIT")"
+
+cd "$TOP_DIR"
+
+DFX_NETWORK=beta ./config.sh
+
+echo
+echo "Downloading wasm from CI..."
+"$SOURCE_DIR/nns-dapp/download-ci-wasm" --commit "$COMMIT" --dir "$WASM_DIR"
+
+TITLE="Install NNS dapp at commit $COMMIT"
+SUMMARY="$TITLE"
+
+dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" request --title "$TITLE" --summary "$SUMMARY" canister install --mode upgrade --wasm "$WASM_PATH" "$NNS_DAPP_BETA_CANISTER_ID" --argument "$(cat nns-dapp-arg-beta.did)" --asset-canister "$ASSET_CANISTER_ID"

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -144,3 +144,6 @@ TITLE="Install NNS dapp at commit $COMMIT"
 SUMMARY="$TITLE"
 
 dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" request --title "$TITLE" --summary "$SUMMARY" canister install --mode upgrade --wasm "$WASM_PATH" "$NNS_DAPP_BETA_CANISTER_ID" --argument "$(cat nns-dapp-arg-beta.did)" --asset-canister "$ASSET_CANISTER_ID"
+
+echo
+echo "Instation was requested. A team member now needs to approve the request."

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -90,7 +90,7 @@ check_dfx_orbit_identity() {
 has_asset_permission() {
   principal="$1"
   permission="$2"
-  dfx canister call qoju7-6iaaa-aaaal-amsga-cai list_permitted "(record { permission = variant { $permission } })" --identity anonymous --network mainnet | idl2json | jq -r '.[]' | grep -q "$principal"
+  dfx canister call $ASSET_CANISTER_ID list_permitted "(record { permission = variant { $permission } })" --identity anonymous --network mainnet | idl2json | jq -r '.[]' | grep -q "$principal"
 }
 
 require_asset_permission() {

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -147,4 +147,4 @@ SUMMARY="$TITLE"
 dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" request --title "$TITLE" --summary "$SUMMARY" canister install --mode "$INSTALL_MODE" --wasm "$WASM_PATH" "$NNS_DAPP_BETA_CANISTER_ID" --argument "$(cat nns-dapp-arg-beta.did)" --asset-canister "$ASSET_CANISTER_ID"
 
 echo
-echo "Instation was requested. A team member now needs to approve the request."
+echo "Installation was requested. A team member now needs to approve the request."

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -18,6 +18,7 @@ clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_ID
 clap.define short=s long=station desc="The orbit station to use" variable=STATION default="nns-team"
 clap.define long=skip-checks desc="Skip the checks that dfx-orbit is set up correctly" variable=SKIP_CHECKS nargs=0
 clap.define short=c long=commit desc="The commit to download the wasm for" variable=COMMIT default="main"
+clap.define long=install-mode desc="Install mode" variable=INSTALL_MODE default="upgrade"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -143,7 +144,7 @@ echo "Downloading wasm from CI..."
 TITLE="Install NNS dapp at commit $COMMIT"
 SUMMARY="$TITLE"
 
-dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" request --title "$TITLE" --summary "$SUMMARY" canister install --mode upgrade --wasm "$WASM_PATH" "$NNS_DAPP_BETA_CANISTER_ID" --argument "$(cat nns-dapp-arg-beta.did)" --asset-canister "$ASSET_CANISTER_ID"
+dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" request --title "$TITLE" --summary "$SUMMARY" canister install --mode "$INSTALL_MODE" --wasm "$WASM_PATH" "$NNS_DAPP_BETA_CANISTER_ID" --argument "$(cat nns-dapp-arg-beta.did)" --asset-canister "$ASSET_CANISTER_ID"
 
 echo
 echo "Instation was requested. A team member now needs to approve the request."

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -90,7 +90,7 @@ check_dfx_orbit_identity() {
 has_asset_permission() {
   principal="$1"
   permission="$2"
-  dfx canister call $ASSET_CANISTER_ID list_permitted "(record { permission = variant { $permission } })" --identity anonymous --network mainnet | idl2json | jq -r '.[]' | grep -q "$principal"
+  dfx canister call "$ASSET_CANISTER_ID" list_permitted "(record { permission = variant { $permission } })" --identity anonymous --network mainnet | idl2json | jq -r '.[]' | grep -q "$principal"
 }
 
 require_asset_permission() {


### PR DESCRIPTION
# Motivation

We want to control to Beta NNS dapp canister with orbit for better security.

NOTE: beta.nns.ic0.app does not yet point to the canister managed by this script.

# Changes

1. Add a script which guides a team member through setting up their orbit environment and requesting the installation of nns-dapp on the orbit controlled canister.

# Tests

1. Tested manually together with @yhabib 

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary