### PR TITLE
Fix build-config.sh

### DIFF
--- a/build-config.sh
+++ b/build-config.sh
@@ -2,5 +2,5 @@
 # Prints build configuration as KEY=VALUE lines, suitable for bash and github actions.
 set -euo pipefail
 cd "$(dirname "$(realpath "$0")")"
-jq -r '.defaults.build.config | to_entries | .[] | .key+"="+(.value|tostring)' dfx.json
+jq -r '.defaults.build.config | to_entries | .[] | .key+"="+(.value|@sh)' dfx.json
 jq -r '"DFX_VERSION="+.dfx' dfx.json


### PR DESCRIPTION
# Motivation

`build-config.sh` is a script used in `scripts/setup` to set config variables defined in `dfx.json` as bash variables.
https://github.com/dfinity/nns-dapp/pull/5628 added `"DIDC_VERSION": "didc 0.4.0",` to `dfx.json`.
Because this has a space, it breaks when trying to run this line from the output of `build-config.sh`, which breaks `scripts/setup`:
```
DIDC_VERSION=didc 0.4.0
```

# Changes

1. Use `@sh` instead of `tostring` to create a quoted shell string.

# Tests

1. Was able to run `scripts/setup` again.
2. Also tried adding `"`, `\` and `'` in the variables and they are all quoted correctly.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary