### PR TITLE
Remove AccountWrapper

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -71,13 +71,6 @@ pub struct AccountsDbStats {
     pub hardware_wallet_accounts_count: u64,
 }
 
-/// An abstraction over sub-accounts and hardware wallets.
-#[derive(CandidType, Deserialize, Debug, Eq, PartialEq)]
-enum AccountWrapper {
-    SubAccount(AccountIdentifier, u8),      // Account Identifier + Sub Account Identifier
-    HardwareWallet(Vec<AccountIdentifier>), // Vec of Account Identifiers since a hardware wallet could theoretically be shared between multiple accounts
-}
-
 /// A user's account.
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct Account {
@@ -678,9 +671,7 @@ impl StableState for AccountsStore {
             empty_accounts,
             // hardware_wallets_and_sub_accounts is unused but we need to encode
             // it for backwards compatibility.
-            // TODO: Change AccountWrapper to candid::Empty after we've
-            // deployed to mainnet.
-            HashMap::<AccountIdentifier, AccountWrapper>::new(),
+            HashMap::<AccountIdentifier, candid::Empty>::new(),
             // Pending transactions are unused but we need to encode them for
             // backwards compatibility.
             HashMap::<(AccountIdentifier, AccountIdentifier), candid::Empty>::new(),
@@ -727,11 +718,7 @@ impl StableState for AccountsStore {
             accounts_db_stats_maybe,
         ): (
             candid::Reserved,
-            // TODO: Change to candid:Reserved and remove AccountWrapper after
-            // we've deployed to mainnet. If we do it now, decoding will break
-            // because of the skip quota. The decoder will think there is an
-            // attack with a lot of unnecessary data in a request.
-            HashMap<AccountIdentifier, AccountWrapper>,
+            candid::Reserved,
             candid::Reserved,
             candid::Reserved,
             candid::Reserved,


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/6239 removed the `hardware_wallets_and_sub_accounts` field from `AccountsStore`.
This field was also encoding to and decoded from stable memory.
In order not to violate the skipping quote when decoding `AccountsStore`, we had to continue decoding it as `HashMap<AccountIdentifier, AccountWrapper>` until we could encode an empty structure by deploying a release.

Now that we've had a release we can decode to `candid::Reserved`, encode to `HashMap::<AccountIdentifier, candid::Empty>` and remove the `AccountWrapper` type.

# Changes

1. Remove `AccountWrapper`.
2. Encode the `hardware_wallets_and_sub_accounts` slot as `HashMap::<AccountIdentifier, candid::Empty>`.
3. Decode the `hardware_wallets_and_sub_accounts` slot as `candid::Reserved`.

# Tests

1. Downgrade-upgrade test passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary