### PR TITLE
feat(neurons): add script to create neurons

### DIFF
--- a/scripts/create_neurons
+++ b/scripts/create_neurons
@@ -25,7 +25,7 @@ source "$(clap.build)"
 GOVERNANCE_CANISTER_ID=$(dfx canister --network local id nns-governance)
 
 # Create neurons
-for (( i=1; i<=NUM_NEURONS; i++ )); do
+for ((i = 1; i <= NUM_NEURONS; i++)); do
   # Generate random memo using /dev/urandom
   MEMO=$(od -vAn -N8 -tu8 </dev/urandom | tr -d ' ')
 

--- a/scripts/create_neurons
+++ b/scripts/create_neurons
@@ -4,8 +4,10 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 print_help() {
-    cat <<-EOF
-	Creates multiple neurons with random memos.
+  cat <<-EOF
+
+	Create and controll new neurons
+
 	EOF
 }
 
@@ -14,7 +16,7 @@ source "$SOURCE_DIR/clap.bash"
 
 # Define options
 clap.define short=n long=number desc="Number of neurons to create" variable=NUM_NEURONS default="10"
-clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER default=$(dfx identity get-principal)
+clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER default="$(dfx identity get-principal)"
 
 # Source the output file
 source "$(clap.build)"
@@ -23,27 +25,26 @@ source "$(clap.build)"
 GOVERNANCE_CANISTER_ID=$(dfx canister --network local id nns-governance)
 
 # Create neurons
-for (( i=1; i<=$NUM_NEURONS; i++ ))
-do
-    # Generate random memo using /dev/urandom
-    MEMO=$(od -vAn -N8 -tu8 < /dev/urandom | tr -d ' ')
+for (( i=1; i<=NUM_NEURONS; i++ )); do
+  # Generate random memo using /dev/urandom
+  MEMO=$(od -vAn -N8 -tu8 </dev/urandom | tr -d ' ')
 
-    echo "Creating neuron $i of $NUM_NEURONS with memo: $MEMO"
+  echo "Creating neuron $i of $NUM_NEURONS with memo: $MEMO"
 
-    # Generate subaccount
-    SUBACCOUNT="$(scripts/convert-id --input text --output hex --as_neuron_subaccount $CONTROLLER $MEMO)"
+  # Generate subaccount
+  SUBACCOUNT="$(scripts/convert-id --input text --output hex --as_neuron_subaccount "$CONTROLLER" "$MEMO")"
 
-    # Generate account identifier
-    ACCOUNT_IDENTIFIER=$(scripts/convert-id --input text --output account_identifier --subaccount_format hex $GOVERNANCE_CANISTER_ID $SUBACCOUNT)
+  # Generate account identifier
+  ACCOUNT_IDENTIFIER=$(scripts/convert-id --input text --output account_identifier --subaccount_format hex "$GOVERNANCE_CANISTER_ID" "$SUBACCOUNT")
 
-    # Transfer funds
-    dfx ledger --network local transfer $ACCOUNT_IDENTIFIER --amount 1 --memo $MEMO
+  # Transfer funds
+  dfx ledger --network local transfer "$ACCOUNT_IDENTIFIER" --amount 1 --memo "$MEMO"
 
-    # Claim the neuron
-    dfx canister --network local call nns-governance claim_or_refresh_neuron_from_account "(record { controller = opt principal \"${CONTROLLER}\"; memo = ${MEMO} : nat64 })"
+  # Claim the neuron
+  dfx canister --network local call nns-governance claim_or_refresh_neuron_from_account "(record { controller = opt principal \"${CONTROLLER}\"; memo = ${MEMO} : nat64 })"
 
-    echo "Neuron $i created successfully"
-    echo "----------------------------"
+  echo "Neuron $i created successfully"
+  echo "----------------------------"
 done
 
 echo "All $NUM_NEURONS neurons created successfully"

--- a/scripts/create_neurons
+++ b/scripts/create_neurons
@@ -17,6 +17,7 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=n long=number desc="Number of neurons to create" variable=NUM_NEURONS default="10"
 clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER default="$(dfx identity get-principal)"
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 
 # Source the output file
 source "$(clap.build)"
@@ -38,10 +39,10 @@ for ((i = 1; i <= NUM_NEURONS; i++)); do
   ACCOUNT_IDENTIFIER=$(scripts/convert-id --input text --output account_identifier --subaccount_format hex "$GOVERNANCE_CANISTER_ID" "$SUBACCOUNT")
 
   # Transfer funds
-  dfx ledger --network local transfer "$ACCOUNT_IDENTIFIER" --amount 1 --memo "$MEMO"
+  dfx ledger --network "$DFX_NETWORK" transfer "$ACCOUNT_IDENTIFIER" --amount 1 --memo "$MEMO"
 
   # Claim the neuron
-  dfx canister --network local call nns-governance claim_or_refresh_neuron_from_account "(record { controller = opt principal \"${CONTROLLER}\"; memo = ${MEMO} : nat64 })"
+  dfx canister --network "$DFX_NETWORK" call nns-governance claim_or_refresh_neuron_from_account "(record { controller = opt principal \"${CONTROLLER}\"; memo = ${MEMO} : nat64 })"
 
   echo "Neuron $i created successfully"
   echo "----------------------------"

--- a/scripts/create_neurons
+++ b/scripts/create_neurons
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+    cat <<-EOF
+	Creates multiple neurons with random memos.
+	EOF
+}
+
+# Source the clap.bash file
+source "$SOURCE_DIR/clap.bash"
+
+# Define options
+clap.define short=n long=number desc="Number of neurons to create" variable=NUM_NEURONS default="10"
+clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER default=$(dfx identity get-principal)
+
+# Source the output file
+source "$(clap.build)"
+
+# Get governance canister ID
+GOVERNANCE_CANISTER_ID=$(dfx canister --network local id nns-governance)
+
+# Create neurons
+for (( i=1; i<=$NUM_NEURONS; i++ ))
+do
+    # Generate random memo using /dev/urandom
+    MEMO=$(od -vAn -N8 -tu8 < /dev/urandom | tr -d ' ')
+
+    echo "Creating neuron $i of $NUM_NEURONS with memo: $MEMO"
+
+    # Generate subaccount
+    SUBACCOUNT="$(scripts/convert-id --input text --output hex --as_neuron_subaccount $CONTROLLER $MEMO)"
+
+    # Generate account identifier
+    ACCOUNT_IDENTIFIER=$(scripts/convert-id --input text --output account_identifier --subaccount_format hex $GOVERNANCE_CANISTER_ID $SUBACCOUNT)
+
+    # Transfer funds
+    dfx ledger --network local transfer $ACCOUNT_IDENTIFIER --amount 1 --memo $MEMO
+
+    # Claim the neuron
+    dfx canister --network local call nns-governance claim_or_refresh_neuron_from_account "(record { controller = opt principal \"${CONTROLLER}\"; memo = ${MEMO} : nat64 })"
+
+    echo "Neuron $i created successfully"
+    echo "----------------------------"
+done
+
+echo "All $NUM_NEURONS neurons created successfully"

--- a/scripts/create_neurons
+++ b/scripts/create_neurons
@@ -16,7 +16,7 @@ source "$SOURCE_DIR/clap.bash"
 
 # Define options
 clap.define short=c long=count desc="Number of neurons to create" variable=NUM_NEURONS default="10"
-clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER
+clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER default="$(dfx identity get-principal)"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 
 # Source the output file
@@ -24,10 +24,6 @@ source "$(clap.build)"
 
 # Get governance canister ID
 GOVERNANCE_CANISTER_ID=$(dfx canister --network "$DFX_NETWORK" id nns-governance)
-
-if [[ -z "${CONTROLLER:-}" ]]; then
-  CONTROLLER=$(dfx identity --network "$DFX_NETWORK" get-principal)
-fi
 
 # Create neurons
 for ((i = 1; i <= NUM_NEURONS; i++)); do

--- a/scripts/create_neurons
+++ b/scripts/create_neurons
@@ -15,15 +15,19 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 
 # Define options
-clap.define short=n long=number desc="Number of neurons to create" variable=NUM_NEURONS default="10"
-clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER default="$(dfx identity get-principal)"
+clap.define short=c long=count desc="Number of neurons to create" variable=NUM_NEURONS default="10"
+clap.define short=p long=principal desc="Principal ID (defaults to current dfx identity)" variable=CONTROLLER
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 
 # Source the output file
 source "$(clap.build)"
 
 # Get governance canister ID
-GOVERNANCE_CANISTER_ID=$(dfx canister --network local id nns-governance)
+GOVERNANCE_CANISTER_ID=$(dfx canister --network "$DFX_NETWORK" id nns-governance)
+
+if [[ -z "${CONTROLLER:-}" ]]; then
+  CONTROLLER=$(dfx identity --network "$DFX_NETWORK" get-principal)
+fi
 
 # Create neurons
 for ((i = 1; i <= NUM_NEURONS; i++)); do


### PR DESCRIPTION
# Motivation

To test the pagination for `list_neurons`, introduced in https://github.com/dfinity/ic-js/pull/833, an account must have more than 500 neurons. Ideally, this account should be an Internet Identity to evaluate its behavior in the UI and when generating a report.

The script will create the specified number of neurons, which will be controlled by the provided `principalId`.

Here’s an example of how to create 100 neurons for a given principal:
```
scripts/create_neurons -c 100 -p <principalId>
```

# Changes

- Added new script.

# Tests

- Tested locally

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary