### PR TITLE
Prepare for PocketIC snapshots

### DIFF
--- a/scripts/deploy-devenv
+++ b/scripts/deploy-devenv
@@ -30,7 +30,7 @@ else
   exit 1
 fi
 
-if ! pgrep -x replica; then
+if ! pgrep -q -x replica && ! pgrep -q -x pocket-ic; then
   echo "A local replica must be running to deploy to." >&2
   exit 1
 fi

--- a/scripts/deploy-devenv
+++ b/scripts/deploy-devenv
@@ -30,7 +30,7 @@ else
   exit 1
 fi
 
-if ! pgrep -q -x replica && ! pgrep -q -x pocket-ic; then
+if ! pgrep -x replica && ! pgrep -x pocket-ic; then
   echo "A local replica must be running to deploy to." >&2
   exit 1
 fi

--- a/scripts/dfx-snapshot-install
+++ b/scripts/dfx-snapshot-install
@@ -215,7 +215,7 @@ install_state() {
 
 output_restore_backup_script() {
   cat <<-EOF
-	if pgrep -q -x replica || pgrep -q -x pocket-ic; then
+	if pgrep -x replica || pgrep -x pocket-ic; then
 	  echo "A replica is still running. State should be restored automatically when the replica is stopped." >&2
 	  exit 1
 	fi

--- a/scripts/dfx-snapshot-install
+++ b/scripts/dfx-snapshot-install
@@ -215,7 +215,7 @@ install_state() {
 
 output_restore_backup_script() {
   cat <<-EOF
-	if pgrep -x replica; then
+	if pgrep -q -x replica || pgrep -q -x pocket-ic; then
 	  echo "A replica is still running. State should be restored automatically when the replica is stopped." >&2
 	  exit 1
 	fi

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -33,7 +33,7 @@ source "$(clap.build)"
 # shellcheck disable=SC2009
 SCRIPT_COUNT="$(ps -A -o command | grep -c "^bash .*$(basename "$0")")"
 
-if pgrep -q -x replica || pgrep -q -x pocket-ic || [ "$SCRIPT_COUNT" -gt 2 ]; then
+if pgrep -x replica || pgrep -x pocket-ic || [ "$SCRIPT_COUNT" -gt 2 ]; then
   echo "ERROR: There is already a replica running. Please stop it first."
   exit 1
 fi

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -33,7 +33,7 @@ source "$(clap.build)"
 # shellcheck disable=SC2009
 SCRIPT_COUNT="$(ps -A -o command | grep -c "^bash .*$(basename "$0")")"
 
-if pgrep -x replica || [ "$SCRIPT_COUNT" -gt 2 ]; then
+if pgrep -q -x replica || pgrep -q -x pocket-ic || [ "$SCRIPT_COUNT" -gt 2 ]; then
   echo "ERROR: There is already a replica running. Please stop it first."
   exit 1
 fi

--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -331,7 +331,7 @@ sha256() {
 }
 
 get_dfx_identity() {
-  if pgrep -x replica; then
+  if pgrep -q -x replica || pgrep -q -x pocket-ic; then
     (
       echo
       echo "A replica is running."

--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -331,7 +331,7 @@ sha256() {
 }
 
 get_dfx_identity() {
-  if pgrep -q -x replica || pgrep -q -x pocket-ic; then
+  if pgrep -x replica || pgrep -x pocket-ic; then
     (
       echo
       echo "A replica is running."

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -17,7 +17,7 @@ clap.define short=i long=identity desc="Identity to use to create proposals" var
 source "$(clap.build)"
 
 # Check if a replica is running:
-if ! pgrep -q -x replica && ! pgrep -q -x pocket-ic; then
+if ! pgrep -x replica && ! pgrep -x pocket-ic; then
   echo "A replica must be running to submit proposals to." >&2
   exit 1
 fi

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -17,7 +17,7 @@ clap.define short=i long=identity desc="Identity to use to create proposals" var
 source "$(clap.build)"
 
 # Check if a replica is running:
-if ! pgrep -x replica; then
+if ! pgrep -q -x replica && ! pgrep -q -x pocket-ic; then
   echo "A replica must be running to submit proposals to." >&2
   exit 1
 fi
@@ -33,7 +33,7 @@ fi
 PEM="${IDENTITY_PATH}/identity.pem"
 NNS_URL="http://localhost:$(
   cd ~
-  dfx info replica-port
+  dfx info webserver-port
 )"
 NEURON_ID="$(cat "${IDENTITY_PATH}/neurons/local")"
 SUMMARY="Testing proposal payloads"

--- a/scripts/nns-dapp/upgrade-downgrade-test
+++ b/scripts/nns-dapp/upgrade-downgrade-test
@@ -35,7 +35,7 @@ if ! [ -f "$ARGS_FILE" ]; then
 fi
 
 # Check if a replica is running:
-if pgrep -q -x replica || pgrep -q -x pocket-ic; then
+if pgrep -x replica || pgrep -x pocket-ic; then
   echo "A replica is already running. Shut it down first." >&2
   exit 1
 fi

--- a/scripts/nns-dapp/upgrade-downgrade-test
+++ b/scripts/nns-dapp/upgrade-downgrade-test
@@ -35,7 +35,7 @@ if ! [ -f "$ARGS_FILE" ]; then
 fi
 
 # Check if a replica is running:
-if pgrep -x replica; then
+if pgrep -q -x replica || pgrep -q -x pocket-ic; then
   echo "A replica is already running. Shut it down first." >&2
   exit 1
 fi


### PR DESCRIPTION
# Motivation

We want to start using PocketIC to create snsdemo snapshots.
When running a PocketIC snapshot, there is no `replica` process running.
We use `pgrep replica` in several places to check if a replica is running.

For now I'm not checking the scripts output so it still calls it a "replica" when `dfx start` is running, regardless of whether it's PocketIC or not.

# Changes

1. Where we check `pgrep replica`, also check `pgrep pocket-ic`.
2. In `scripts/nns-dapp/test-proposal-payload` use `dfx info webserver-port` instead of `dfx info replica-port`, which is required when running PocketIC and also works fine without it.

# Tests

1. Manually ran `scripts/nns-dapp/test-proposal-payload` with and without PocketIC snapshot.
2. Relying on CI for the others.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary