### PR TITLE
Run dfx start from $HOME

### DIFF
--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -56,6 +56,10 @@ fi
 
 "$SOURCE_DIR/dfx-snapshot-install" --backup-dir "$BACKUP_DIR" --snapshot "$SNAPSHOT_ARCHIVE" "$CLEAN_ARG"
 
+# Change to $HOME to allow using a different version of dfx than required by
+# dfx.json, in case the snapshot was created with a different version.
+cd "$HOME"
+
 echo "*********************************************************************"
 echo "*                                                                   *"
 echo "*  If the state was generated on a different type of machine, then  *"


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/6346 removed `cd $HOME` from `scripts/dfx-snapshot-start` because it was no longer required.
It's true that it's not required, but running `dfx start` from the repo directory, limits you to using the `dfx` version specified in `dfx.json`.
This prevents you from running snapshots created with a different version.
But it's convenient to be able to run snapshots even if the dfx version doesn't match.

# Changes

1. Add `cd $HOME` back to `dfx-snapshot-start` with a comment explaining the new reason.

# Tests

Tested manually

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary