### PR TITLE
fix(styles): correct number and text overlap in Safari

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -51,9 +51,8 @@
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   div {
-    display: inline-grid;
-    grid-template-columns: repeat(2, auto);
-    grid-gap: var(--padding-0_5x);
+    display: inline-flex;
+    gap: var(--padding-0_5x);
     align-items: baseline;
 
     span:first-of-type {


### PR DESCRIPTION
# Motivation

There is a visual bug in Safari that affects the display of numbers and text within an `inline-grid` and a `baseline`. This bug causes the numbers to overlap the text.

Before:

https://github.com/user-attachments/assets/b32535cd-bdcf-426f-974b-6ca1c7e34759

After:

https://github.com/user-attachments/assets/49b69220-155c-40af-baea-4793fc95f0c5

Fixes [NNS1-3606](https://dfinity.atlassian.net/browse/NNS1-3606)

# Changes

- Change display from `inline-grid` to `inline-flex` as it breaks in Safari.

# Tests

- Manually tested in Safari using [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/accounts/?u=qsgjb-riaaa-aaaaa-aaaga-cai)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary


[NNS1-3606]: https://dfinity.atlassian.net/browse/NNS1-3606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ