### PR TITLE
Remove resetAccountsForTesting from beforeEach

### DIFF
--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -9,19 +9,12 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SelectAccountDropdown", () => {
   describe("no accounts", () => {
-    beforeEach(() => {
-      resetAccountsForTesting();
-    });
-
     const props = { rootCanisterId: OWN_CANISTER_ID };
     it("should render spinner", () => {
       const { getByTestId } = render(SelectAccountDropdown, { props });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -9,10 +9,7 @@ import {
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsAvailableMaturityItemActionPo } from "$tests/page-objects/NnsAvailableMaturityItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
@@ -32,7 +29,6 @@ describe("NnsAvailableMaturityItemAction", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetAccountsForTesting();
   });
 
   it("should render available maturity", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -16,10 +16,7 @@ import { createMockNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { NnsNeuronAdvancedSectionPo } from "$tests/page-objects/NnsNeuronAdvancedSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
@@ -47,7 +44,6 @@ describe("NnsNeuronAdvancedSection", () => {
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
     resetIdentity();
-    resetAccountsForTesting();
   });
 
   it("should render neuron data", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -9,10 +9,7 @@ import {
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
@@ -39,7 +36,6 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
   };
 
   beforeEach(() => {
-    resetAccountsForTesting();
     resetIdentity();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -16,10 +16,7 @@ import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronPageHeadingPo } from "$tests/page-objects/NnsNeuronPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { NeuronType } from "@dfinity/nns";
@@ -34,7 +31,6 @@ describe("NnsNeuronPageHeading", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetAccountsForTesting();
 
     setIcpPrice(10);
   });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -16,10 +16,7 @@ import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import type { Neuron } from "@dfinity/nns";
 import { NeuronState, NeuronType } from "@dfinity/nns";
@@ -30,8 +27,6 @@ describe("NnsNeuronCard", () => {
   beforeEach(() => {
     vi.useFakeTimers().setSystemTime(nowInSeconds * 1000);
     resetIdentity();
-
-    resetAccountsForTesting();
   });
 
   it("renders a Card", () => {

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactions.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactions.spec.ts
@@ -10,10 +10,7 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { ReportingTransactionsPo } from "$tests/page-objects/ReportingTransactions.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/api/icp-ledger.api");
@@ -33,7 +30,6 @@ describe("ReportingTransactions", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetAccountsForTesting();
 
     vi.spyOn(exportToCsv, "generateCsvFileToSave").mockImplementation(() =>
       Promise.resolve()

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -41,7 +41,6 @@ describe("ReportingTransactionsButton", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetAccountsForTesting();
 
     spySaveGeneratedCsv = vi
       .spyOn(reportingSaveCsvToFile, "saveGeneratedCsv")
@@ -212,8 +211,6 @@ describe("ReportingTransactionsButton", () => {
   });
 
   it("should fetch transactions for accounts and neurons", async () => {
-    resetAccountsForTesting();
-
     setAccountsForTesting({
       main: mockMainAccount,
     });
@@ -286,7 +283,6 @@ describe("ReportingTransactionsButton", () => {
     const beginningOfYearInNanoseconds =
       BigInt(beginningOfYear.getTime()) * NANOS_IN_MS;
 
-    resetAccountsForTesting();
     setAccountsForTesting({
       main: mockMainAccount,
     });

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -20,10 +20,7 @@ import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
 import { SelectUniverseCardPo } from "$tests/page-objects/SelectUniverseCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
@@ -41,7 +38,6 @@ describe("SelectUniverseCard", () => {
   };
 
   beforeEach(() => {
-    resetAccountsForTesting();
     resetIdentity();
   });
 

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -17,10 +17,7 @@ import {
   createIcpUserToken,
   icpTokenBase,
 } from "$tests/mocks/tokens-page.mock";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
@@ -104,10 +101,6 @@ describe("icp-tokens-list-user.derived", () => {
   };
 
   describe("icpTokensListVisitors", () => {
-    beforeEach(() => {
-      resetAccountsForTesting();
-    });
-
     it("should return empty if no accounts", () => {
       expect(get(icpTokensListUser)).toEqual([loadingUserTokenData]);
     });

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -37,10 +37,7 @@ import {
   createIcpUserToken,
   icpTokenBase,
 } from "$tests/mocks/tokens-page.mock";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
@@ -213,7 +210,6 @@ describe("tokens-list-user.derived", () => {
 
   describe("tokensListUserStore", () => {
     beforeEach(() => {
-      resetAccountsForTesting();
       authStore.setForTesting(mockIdentity);
 
       setSnsProjects([snsTetris, snsPacman]);

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -8,18 +8,11 @@ import {
 import { renderModal } from "$tests/mocks/modal.mock";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import type { Principal } from "@dfinity/principal";
 
 describe("ReceiveModal", () => {
   const reloadSpy = vi.fn();
-
-  beforeEach(() => {
-    resetAccountsForTesting();
-  });
 
   const qrCodeLabel = "test QR code";
   const logo = "logo";

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -19,10 +19,7 @@ import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { DisburseNnsNeuronModalPo } from "$tests/page-objects/DisburseNnsNeuronModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -124,10 +121,6 @@ describe("DisburseNnsNeuronModal", () => {
   });
 
   describe("when accounts store is empty", () => {
-    beforeEach(() => {
-      resetAccountsForTesting();
-    });
-
     it("should fetch accounts and render account selector", async () => {
       const mainBalanceE8s = 10_000_000n;
       let resolveQueryAccount;
@@ -166,7 +159,6 @@ describe("DisburseNnsNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
-      resetAccountsForTesting();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -10,10 +10,7 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { waitFor } from "@testing-library/svelte";
 
@@ -35,10 +32,6 @@ describe("IncreaseNeuronStakeModal", () => {
   });
 
   describe("when accounts store is empty", () => {
-    beforeEach(() => {
-      resetAccountsForTesting();
-    });
-
     it("should fetch accounts and render account selector", async () => {
       const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -14,10 +14,7 @@ import {
 import { renderModal } from "$tests/mocks/modal.mock";
 import { MergeNeuronsModalPo } from "$tests/page-objects/MergeNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
@@ -45,7 +42,6 @@ describe("MergeNeuronsModal", () => {
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
       testIdentity
     );
-    resetAccountsForTesting();
   });
 
   const selectAndTestTwoNeurons = async ({ po, neurons }) => {

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -28,10 +28,7 @@ import { renderModal } from "$tests/mocks/modal.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsStakeNeuronModalPo } from "$tests/page-objects/NnsStakeNeuronModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -520,7 +517,6 @@ describe("NnsStakeNeuronModal", () => {
 
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
-      resetAccountsForTesting();
       const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
@@ -563,7 +559,6 @@ describe("NnsStakeNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
-      resetAccountsForTesting();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
@@ -31,10 +31,7 @@ import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { ParticipateSwapModalPo } from "$tests/page-objects/ParticipateSwapModal.page-object";
 import type { TransactionReviewPo } from "$tests/page-objects/TransactionReview.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -53,7 +50,6 @@ describe("ParticipateSwapModal", () => {
   beforeEach(() => {
     cancelPollAccounts();
     resetIdentity();
-    resetAccountsForTesting();
     snsTicketsStore.setNoTicket(rootCanisterIdMock);
 
     vi.spyOn(snsServices, "getSwapAccount").mockResolvedValue(
@@ -275,7 +271,6 @@ describe("ParticipateSwapModal", () => {
     let resolveQueryAccounts;
 
     beforeEach(() => {
-      resetAccountsForTesting();
       queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -345,7 +340,6 @@ describe("ParticipateSwapModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: MockInstance;
     beforeEach(() => {
-      resetAccountsForTesting();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -11,7 +11,6 @@ import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { createUserToken } from "$tests/mocks/tokens-page.mock";
 import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import {
   advanceTime,
@@ -32,7 +31,6 @@ describe("NnsAccounts", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetAccountsForTesting();
     // TODO: Move the pollAccounts to Accounts route when universe selected is NNS instead of the child.
     vi.spyOn(nnsDappApi, "queryAccount").mockImplementation(async () => {
       return mockAccountDetails;

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -47,10 +47,7 @@ import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.p
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import {
@@ -87,7 +84,6 @@ describe("NnsWallet", () => {
 
   beforeEach(() => {
     cancelPollAccounts();
-    resetAccountsForTesting();
     resetIdentity();
 
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -25,10 +25,7 @@ import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
@@ -64,7 +61,6 @@ describe("Accounts", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetAccountsForTesting();
 
     subaccountBalance = subaccountBalanceDefault;
     mainAccountBalance = mainAccountBalanceDefault;

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -26,10 +26,7 @@ import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import { StakingPo } from "$tests/page-objects/Staking.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { Principal } from "@dfinity/principal";
@@ -43,7 +40,6 @@ describe("Staking", () => {
 
   beforeEach(() => {
     resetIdentity();
-    resetAccountsForTesting();
 
     page.mock({
       routeId: AppPath.Staking,

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -49,10 +49,7 @@ import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import {
   advanceTime,
@@ -80,7 +77,6 @@ describe("icp-accounts.services", () => {
 
   beforeEach(() => {
     vi.spyOn(console, "error").mockReturnValue();
-    resetAccountsForTesting();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity
@@ -932,7 +928,6 @@ describe("icp-accounts.services", () => {
     };
 
     beforeEach(() => {
-      resetAccountsForTesting();
       cancelPollAccounts();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -36,10 +36,7 @@ import { MockLedgerIdentity } from "$tests/mocks/ledger.identity.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockTransactionWithId } from "$tests/mocks/transaction.mock";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { Identity } from "@dfinity/agent";
 import { AnonymousIdentity } from "@dfinity/agent";
@@ -155,7 +152,6 @@ describe("neurons-services", () => {
 
   beforeEach(() => {
     spyConsoleError = vi.spyOn(console, "error");
-    resetAccountsForTesting();
     resetAccountIdentity();
 
     vi.spyOn(icpAccountsServices, "loadBalance").mockReturnValue(undefined);

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -39,10 +39,7 @@ import {
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
-import {
-  resetAccountsForTesting,
-  setAccountsForTesting,
-} from "$tests/utils/accounts.test-utils";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
@@ -132,8 +129,6 @@ describe("sns-api", () => {
     cancelPollGetOpenTicket();
 
     vi.useFakeTimers();
-
-    resetAccountsForTesting();
 
     vi.spyOn(agentApi, "createAgent").mockImplementation(async () =>
       mock<Agent>()

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -8,7 +8,6 @@ import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { AccountsPlusPagePo } from "$tests/page-objects/AccountsPlusPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/api/icp-ledger.api");
@@ -22,7 +21,6 @@ describe("Accounts page", () => {
   };
 
   beforeEach(() => {
-    resetAccountsForTesting();
     vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue(mockAccountDetails);
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(314000000n);
   });


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/5724 every Svelte store (created with `writable`) gets reset automatically before each test.
`resetAccountsForTesting` is a [function](https://github.com/dfinity/nns-dapp/blob/7c6bc968bf90465bc7f75ef9fd4731b1a81597fd/frontend/src/tests/utils/accounts.test-utils.ts#L114) that resets 2 stores and does nothing else.
So there is no need to call this in `beforeEach`.

# Changes

1. Remove `resetAccountsForTesting` in `beforeEach` of individual tests.
2. Remove `resetAccountsForTesting` inside tests where it's immediately followed by `setAccountsForTesting`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary