### PR TITLE
Add scripts/find-transaction-from-timestamp

### DIFF
--- a/scripts/find-transaction-from-timestamp
+++ b/scripts/find-transaction-from-timestamp
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Finds the first transaction at or after a given timestamp in a ledger canister.
+	If the transaction needs to come from an archive canister, the script will get
+	it from the archive canister.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=l long=ledger_canister_id desc="The canister ID of the ledger canister" variable=LEDGER_CANISTER_ID default=""
+clap.define short=t long=timestamp desc="The timestamp in seconds" variable=TIMESTAMP default=""
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+if [[ -z "$LEDGER_CANISTER_ID" ]]; then
+  echo "Ledger canister ID is required" >&2
+  exit 1
+fi
+
+if [[ -z "$TIMESTAMP" ]]; then
+  echo "Timestamp is required" >&2
+  exit 1
+fi
+
+get_transaction() {
+  index="$1"
+  "$SOURCE_DIR/get-transaction" --ledger_canister_id "$LEDGER_CANISTER_ID" --index "$index" --network "$DFX_NETWORK"
+}
+
+start_index=0
+end_index="$(dfx canister call "$LEDGER_CANISTER_ID" --query --network "$DFX_NETWORK" get_transactions '(record { start = 0 : nat; length = 0 : nat })' | idl2json | jq -r .log_length | sed -e 's/_//g')"
+
+echo "Binary searching for timestamp $TIMESTAMP" >&2
+
+while [[ $start_index -lt $end_index ]]; do
+  echo "Searching in range [$start_index, $end_index) of length" \
+    "$((end_index - start_index))." \
+    "$(echo "l($((end_index - start_index))) / l(2) + 1" | bc -l | xargs printf "%1.0f\n")" \
+    "steps remaining." >&2
+  mid_index=$((start_index + (end_index - start_index) / 2))
+  mid_timestamp_ns="$(get_transaction "$mid_index" | jq -r .timestamp)"
+  mid_timestamp="$(("$mid_timestamp_ns" / 1000000000))"
+  if [[ "$mid_timestamp" -ge "$TIMESTAMP" ]]; then
+    end_index="$mid_index"
+  else
+    start_index="$((mid_index + 1))"
+  fi
+done
+echo -n "Found index: " >&2
+echo "$start_index"

--- a/scripts/get-transaction
+++ b/scripts/get-transaction
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Gets a transaction from a ledger canister given its index.
+	If the transaction needs to come from an archive canister, the script will get
+	it from the archive canister.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=l long=ledger_canister_id desc="The canister ID of the ledger canister" variable=LEDGER_CANISTER_ID default=""
+clap.define short=i long=index desc="The transaction index" variable=TRANSACTION_INDEX default=""
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+if [[ -z "$LEDGER_CANISTER_ID" ]]; then
+  echo "Ledger canister ID is required" >&2
+  exit 1
+fi
+
+if [[ -z "$TRANSACTION_INDEX" ]]; then
+  echo "Transaction index is required" >&2
+  exit 1
+fi
+
+get_transaction() {
+  canister_id="$1"
+  dfx canister call "$canister_id" --network "$DFX_NETWORK" get_transactions --query "(record { start = $TRANSACTION_INDEX : nat; length = 1 : nat })" | idl2json --bytes-as hex
+}
+
+JSON_RESPONSE="$(get_transaction "$LEDGER_CANISTER_ID")"
+
+ARCHIVED_TRANSACTIONS="$(jq -r '.archived_transactions' <<<"$JSON_RESPONSE")"
+
+if [[ -n "$ARCHIVED_TRANSACTIONS" ]]; then
+  ARCHIVE_CANISTER_ID="$(jq -r '.[0].callback.principal' <<<"$ARCHIVED_TRANSACTIONS")"
+  JSON_RESPONSE="$(get_transaction "$ARCHIVE_CANISTER_ID")"
+fi
+
+jq -r '.transactions[0]' <<<"$JSON_RESPONSE"


### PR DESCRIPTION
# Motivation

I created these scripts when debugging an issue.
Perhaps they'll be useful again in the future.

# Changes

1. Add `scripts/get-transaction` which lets you get a transaction, taking care of getting it from an archive canister if necessary.
2. Add `scripts/find-transaction-from-timestamp` which binary searches transactions for a specific timestamp and outputs the transaction index.

# Tests

Tested manually:
```
$ scripts/find-transaction-from-timestamp --network mainnet --ledger_canister_id oj6if-riaaa-aaaaq-aaeha-cai --timestamp 1738364400
Binary searching for timestamp 1738364400
Searching in range [0, 56367) of length 56367. 17 steps remaining.
Searching in range [28184, 56367) of length 28183. 16 steps remaining.
Searching in range [42276, 56367) of length 14091. 15 steps remaining.
Searching in range [42276, 49321) of length 7045. 14 steps remaining.
Searching in range [45799, 49321) of length 3522. 13 steps remaining.
Searching in range [45799, 47560) of length 1761. 12 steps remaining.
Searching in range [46680, 47560) of length 880. 11 steps remaining.
Searching in range [47121, 47560) of length 439. 10 steps remaining.
Searching in range [47121, 47340) of length 219. 9 steps remaining.
Searching in range [47231, 47340) of length 109. 8 steps remaining.
Searching in range [47286, 47340) of length 54. 7 steps remaining.
Searching in range [47314, 47340) of length 26. 6 steps remaining.
Searching in range [47314, 47327) of length 13. 5 steps remaining.
Searching in range [47321, 47327) of length 6. 4 steps remaining.
Searching in range [47321, 47324) of length 3. 3 steps remaining.
Searching in range [47323, 47324) of length 1. 1 steps remaining.
Found index: 47324

scripts/get-transaction --network mainnet --ledger_canister_id oj6if-riaaa-aaaaq-aaeha-cai -i 47324
{
  "approve": null,
  "burn": null,
  "kind": "transfer",
  "mint": null,
  "timestamp": "1738364454077498613",
  "transfer": [
    {
      "amount": "98_420_721_060",
      "created_at_time": null,
      "fee": [
        "500_000_000"
      ],
      "from": {
        "owner": "2ipq2-uqaaa-aaaar-qailq-cai",
        "subaccount": null
      },
      "memo": null,
      "spender": null,
      "to": {
        "owner": "yw25v-ob2wi-lssuy-yocex-hp63m-hwsrr-zc3rr-s4yb5-kdgwz-hrwwl-xqe",
        "subaccount": null
      }
    }
  ]
}
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary