### PR TITLE
Store and log debug info on invalid signature

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Custom sorting of tokens table.
 * Navigation to a token's wallet from the top token positions on the portfolio page.
 * Navigation to a project's neurons from the top projects on the portfolio page.
+* Store debug info to help diagnose "invalid signature" issues.
 
 #### Changed
 

--- a/frontend/src/lib/api/agent.api.ts
+++ b/frontend/src/lib/api/agent.api.ts
@@ -162,7 +162,11 @@ const storeInvalidSignatureDebugInfo = (logEntry: AgentLog) => {
 };
 
 const logRecordedInvalidSignatureDebugInfo = () => {
-  if (INVALID_SIGNATURE_DEBUG_INFO_KEY in localStorage) {
+  if (
+    typeof window !== "undefined" &&
+    window.localStorage &&
+    INVALID_SIGNATURE_DEBUG_INFO_KEY in localStorage
+  ) {
     console.warn(
       "Found invalid signature debug info:",
       localStorage.getItem(INVALID_SIGNATURE_DEBUG_INFO_KEY)

--- a/frontend/src/lib/api/agent.api.ts
+++ b/frontend/src/lib/api/agent.api.ts
@@ -11,7 +11,12 @@ import type {
   ReadStateResponse,
   SubmitResponse,
 } from "@dfinity/agent";
-import { AgentCallError, IdentityInvalidError } from "@dfinity/agent";
+import {
+  AgentCallError,
+  AgentQueryError,
+  AgentReadStateError,
+  IdentityInvalidError,
+} from "@dfinity/agent";
 import type { JsonObject } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
 import {
@@ -134,7 +139,11 @@ const storeInvalidSignatureDebugInfo = (logEntry: AgentLog) => {
   if (
     logEntry.level != "error" ||
     !logEntry.message.includes("Invalid signature") ||
-    !(logEntry.error instanceof AgentCallError)
+    !(
+      logEntry.error instanceof AgentCallError ||
+      logEntry.error instanceof AgentQueryError ||
+      logEntry.error instanceof AgentReadStateError
+    )
   ) {
     return;
   }

--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -1,6 +1,5 @@
 import * as agentApi from "$lib/api/agent.api";
 import { mockCreateAgent } from "$tests/mocks/agent.mock";
-import { advanceTime } from "$tests/utils/timers.test-utils";
 import type {
   Agent,
   AgentLog,
@@ -591,8 +590,6 @@ describe("agent-api", () => {
       expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(
         expectedDebugInfo
       );
-
-      advanceTime(300000);
 
       const newRequestId = requestId + "new";
       const newSenderPubkey = senderPubkey + "new";

--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -1,14 +1,19 @@
 import * as agentApi from "$lib/api/agent.api";
+import { advanceTime } from "$tests/utils/timers.test-utils";
 import type {
   Agent,
+  AgentLog,
   ApiQueryResponse,
   CallOptions,
   HttpAgent,
   Identity,
+  ObservableLog,
+  ObserveFunction,
   QueryFields,
   ReadStateOptions,
   SubmitResponse,
 } from "@dfinity/agent";
+import { AgentCallError } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import * as utils from "@dfinity/utils";
 import type { Mocked } from "vitest";
@@ -29,6 +34,15 @@ const createAgent = (identity: Identity) =>
     host,
   });
 
+const createMockAgent = () => {
+  const mockAgent = mock<HttpAgent>({
+    log: mock<ObservableLog>({
+      subscribe: vi.fn(),
+    }),
+  });
+  return mockAgent;
+};
+
 describe("agent-api", () => {
   let utilsCreateAgentSpy;
 
@@ -37,7 +51,7 @@ describe("agent-api", () => {
 
     utilsCreateAgentSpy = vi
       .spyOn(utils, "createAgent")
-      .mockResolvedValue(mock<HttpAgent>());
+      .mockImplementation(async () => createMockAgent());
   });
 
   it("createAgent should create an agent", async () => {
@@ -62,12 +76,12 @@ describe("agent-api", () => {
 
     expect(utilsCreateAgentSpy).not.toBeCalled();
 
-    const mockAgent1 = mock<HttpAgent>();
+    const mockAgent1 = createMockAgent();
     utilsCreateAgentSpy.mockResolvedValue(mockAgent1);
     const agent1 = await createAgent(testIdentity1);
     expect(utilsCreateAgentSpy).toBeCalledTimes(1);
 
-    const mockAgent2 = mock<HttpAgent>();
+    const mockAgent2 = createMockAgent();
     utilsCreateAgentSpy.mockResolvedValue(mockAgent2);
     const agent2 = await createAgent(testIdentity2);
     expect(utilsCreateAgentSpy).toBeCalledTimes(2);
@@ -93,7 +107,7 @@ describe("agent-api", () => {
     let agent: Agent;
 
     beforeEach(async () => {
-      mockAgent = mock<HttpAgent>();
+      mockAgent = createMockAgent();
       utilsCreateAgentSpy.mockResolvedValue(mockAgent);
 
       agent = await createAgent(testIdentity);
@@ -226,7 +240,7 @@ describe("agent-api", () => {
     let agent: Agent;
 
     beforeEach(async () => {
-      mockAgent = mock<HttpAgent>();
+      mockAgent = createMockAgent();
       utilsCreateAgentSpy.mockResolvedValue(mockAgent);
 
       agent = await createAgent(testIdentity);
@@ -315,7 +329,7 @@ describe("agent-api", () => {
     // different objects.
     const testIdentity2 = createIdentity(testPrincipal1);
 
-    const mockAgent = mock<HttpAgent>();
+    const mockAgent = createMockAgent();
 
     beforeEach(async () => {
       utilsCreateAgentSpy.mockResolvedValue(mockAgent);
@@ -432,6 +446,196 @@ describe("agent-api", () => {
 
       expect(mockAgent.query).toBeCalledTimes(2);
       expect(mockAgent.query).toBeCalledWith(...params, testIdentity2);
+    });
+  });
+
+  describe("with agent log", () => {
+    let mockAgent: Mocked<HttpAgent>;
+    let logSubscriber: ObserveFunction<AgentLog> | undefined;
+
+    const invalidSignatureMessage =
+      "Error while making call: Server returned an error:\n Code: 400 (Bad Request)\n  Body: Invalid signature: Invalid basic signature: EcdsaP256 signature could not be verified: public key 04219a05346288ccd0a293a341790087152e8cf332219b6f66a69ebac3383a78e2aa8c14a7a944190ca1a0040e353f18056e9ec7fcb128860f4318c207d589c429, signature 9b9facce1f719d6dc177243df0a196f04c794b2d46b9b01c7723f3f58bf348addb3af491331af8785e25b1c2cd93afd4db627da3ec4183c566dec5fca0713341, error: verification failed\n";
+    const response = {
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      headers: [
+        ["content-length", "396"] as [string, string],
+        ["content-type", "text/plain; charset=utf-8"] as [string, string],
+      ],
+    };
+    const requestId =
+      "436fdf3d349c375f1018f8fa6612bed1988cc000ccdb26e5c0f292a75994cea1";
+    const senderPubkey =
+      "303c300c060a2b0601040183b8430102032c000a000000000000000b01013c658db985648bbc2f58bc796f82cc94e8695f790fa7f676788b37513116d68a";
+    const senderSig =
+      "9b9facce1f719d6dc177243df0a196f04c794b2d46b9b01c7723f3f58bf348addb3af491331af8785e25b1c2cd93afd4db627da3ec4183c566dec5fca0713341";
+    const ingressExpiry = "1738765560000000000";
+
+    const invalidSignatureError = new AgentCallError(
+      invalidSignatureMessage,
+      response,
+      requestId,
+      senderPubkey,
+      senderSig,
+      ingressExpiry
+    );
+    const invalidSignatureLogEntry: AgentLog = {
+      message: invalidSignatureMessage,
+      level: "error",
+      error: invalidSignatureError,
+    };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.spyOn(console, "warn").mockReturnValue();
+
+      logSubscriber = undefined;
+
+      mockAgent = createMockAgent();
+      vi.mocked(mockAgent.log.subscribe).mockImplementation((func) => {
+        logSubscriber = func;
+      });
+
+      utilsCreateAgentSpy.mockResolvedValue(mockAgent);
+    });
+
+    it("subscribes to invalid signature errors", async () => {
+      expect(logSubscriber).toBe(undefined);
+      expect(mockAgent.log.subscribe).toBeCalledTimes(0);
+
+      await createAgent(createIdentity(testPrincipal1));
+
+      expect(mockAgent.log.subscribe).toBeCalledTimes(1);
+      expect(logSubscriber).not.toBe(undefined);
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(null);
+      expect(console.warn).toBeCalledTimes(0);
+
+      logSubscriber(invalidSignatureLogEntry);
+
+      const expectedDebugInfo = JSON.stringify({
+        requestId,
+        senderPubkey,
+        senderSig,
+        ingressExpiry,
+        debugInfoRecordedTimestamp: new Date().toISOString(),
+      });
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(
+        expectedDebugInfo
+      );
+
+      expect(console.warn).toBeCalledWith(
+        "Found invalid signature debug info:",
+        expectedDebugInfo
+      );
+      expect(console.warn).toBeCalledTimes(1);
+    });
+
+    it("ignores other errors", async () => {
+      expect(logSubscriber).toBe(undefined);
+      expect(mockAgent.log.subscribe).toBeCalledTimes(0);
+
+      await createAgent(createIdentity(testPrincipal1));
+
+      expect(mockAgent.log.subscribe).toBeCalledTimes(1);
+      expect(logSubscriber).not.toBe(undefined);
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(null);
+      expect(console.warn).toBeCalledTimes(0);
+
+      logSubscriber({
+        ...invalidSignatureLogEntry,
+        message: "Some other error",
+      });
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(null);
+      expect(console.warn).toBeCalledTimes(0);
+    });
+
+    it("ignores non-error entries", async () => {
+      expect(logSubscriber).toBe(undefined);
+      expect(mockAgent.log.subscribe).toBeCalledTimes(0);
+
+      await createAgent(createIdentity(testPrincipal1));
+
+      expect(mockAgent.log.subscribe).toBeCalledTimes(1);
+      expect(logSubscriber).not.toBe(undefined);
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(null);
+      expect(console.warn).toBeCalledTimes(0);
+
+      logSubscriber({
+        ...invalidSignatureLogEntry,
+        level: "info",
+      });
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(null);
+      expect(console.warn).toBeCalledTimes(0);
+    });
+
+    it("keeps only the last invalid signature debug info", async () => {
+      expect(logSubscriber).toBe(undefined);
+      expect(mockAgent.log.subscribe).toBeCalledTimes(0);
+
+      await createAgent(createIdentity(testPrincipal1));
+
+      expect(mockAgent.log.subscribe).toBeCalledTimes(1);
+      expect(logSubscriber).not.toBe(undefined);
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(null);
+      expect(console.warn).toBeCalledTimes(0);
+
+      logSubscriber(invalidSignatureLogEntry);
+
+      const expectedDebugInfo = JSON.stringify({
+        requestId,
+        senderPubkey,
+        senderSig,
+        ingressExpiry,
+        debugInfoRecordedTimestamp: new Date().toISOString(),
+      });
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(
+        expectedDebugInfo
+      );
+
+      advanceTime(300000);
+
+      const newRequestId = requestId + "new";
+      const newSenderPubkey = senderPubkey + "new";
+      const newSenderSig = senderSig + "new";
+      const newIngressExpiry = ingressExpiry + "new";
+
+      const newInvalidSignatureError = new AgentCallError(
+        invalidSignatureMessage,
+        response,
+        newRequestId,
+        newSenderPubkey,
+        newSenderSig,
+        newIngressExpiry
+      );
+
+      const newInvalidSignatureLogEntry: AgentLog = {
+        message: invalidSignatureMessage,
+        level: "error",
+        error: newInvalidSignatureError,
+      };
+
+      logSubscriber(newInvalidSignatureLogEntry);
+
+      const newExpectedDebugInfo = JSON.stringify({
+        requestId: newRequestId,
+        senderPubkey: newSenderPubkey,
+        senderSig: newSenderSig,
+        ingressExpiry: newIngressExpiry,
+        debugInfoRecordedTimestamp: new Date().toISOString(),
+      });
+
+      expect(localStorage.getItem("invalidSignatureDebugInfo")).toBe(
+        newExpectedDebugInfo
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -21,6 +21,7 @@ import {
 import { CYCLES_MINTING_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
+import { mockCreateAgent } from "$tests/mocks/agent.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCanisterDetails,
@@ -52,7 +53,7 @@ describe("canisters-api", () => {
   beforeEach(() => {
     // Prevent HttpAgent.create(), which is called by createAgent, from making a
     // real network request via agent.syncTime().
-    vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);
+    vi.spyOn(dfinityUtils, "createAgent").mockImplementation(mockCreateAgent);
 
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const now = Date.now();

--- a/frontend/src/tests/lib/api/imported-tokens.api.spec.ts
+++ b/frontend/src/tests/lib/api/imported-tokens.api.spec.ts
@@ -3,6 +3,7 @@ import {
   setImportedTokens,
 } from "$lib/api/imported-tokens.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
+import { mockCreateAgent } from "$tests/mocks/agent.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockImportedToken } from "$tests/mocks/icrc-accounts.mock";
 import * as dfinityUtils from "@dfinity/utils";
@@ -17,7 +18,7 @@ describe("imported-tokens-api", () => {
     );
     // Prevent HttpAgent.create(), which is called by createAgent, from making a
     // real network request via agent.syncTime().
-    vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);
+    vi.spyOn(dfinityUtils, "createAgent").mockImplementation(mockCreateAgent);
   });
 
   describe("getImportedTokens", () => {

--- a/frontend/src/tests/mocks/agent.mock.ts
+++ b/frontend/src/tests/mocks/agent.mock.ts
@@ -1,0 +1,9 @@
+import type { HttpAgent, ObservableLog } from "@dfinity/agent";
+import { mock } from "vitest-mock-extended";
+
+export const mockCreateAgent = async () =>
+  mock<HttpAgent>({
+    log: mock<ObservableLog>({
+      subscribe: vi.fn(),
+    }),
+  });


### PR DESCRIPTION
# Motivation

People have been getting "invalid signature" errors but the team has had difficulty debugging what's happening.
To help debug, we will store some debug information which can help debug the issue the next time someone reports the issue.

# Changes

1. Listen for errors which contain `"Invalid signature"`.
2. When we see such an error, store data relevant for debugging (but not the message body, for privacy) in localStorage.
3. Log the debug info from localStorage on page load for easy discovery.

# Tests

1. Unit tests added.
2. Tested manually in https://github.com/dfinity/nns-dapp/pull/6381 which has extra code to deliberately create an invalid signature.
3. Fixed existing unit tests which returned `undefined` for `createAgent` as the returned agent is now expected to have a `log` field.

# Todos

- [x] Add entry to changelog (if necessary).
