### PR TITLE
Await async expects

### DIFF
--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -186,7 +186,7 @@ describe("neurons api-service", () => {
     });
 
     it("should fail if queryNeuron api fails", async () => {
-      expect(() =>
+      await expect(() =>
         governanceApiService.queryNeuron({ neuronId: 999n, ...params })
       ).rejects.toThrow("No neuron with id 999");
       expect(api.queryNeuron).toHaveBeenCalledTimes(1);
@@ -231,7 +231,7 @@ describe("neurons api-service", () => {
     });
 
     it("should fail if queryNeurons api fails", async () => {
-      expect(() =>
+      await expect(() =>
         governanceApiService.queryNeurons({
           identity: unknownIdentity,
           ...params,
@@ -299,9 +299,9 @@ describe("neurons api-service", () => {
       const params = { identity: identity1, certified: true };
       vi.spyOn(api, "queryNeurons").mockRejectedValueOnce(new Error("500"));
 
-      expect(() => governanceApiService.queryNeurons(params)).rejects.toThrow(
-        "500"
-      );
+      await expect(() =>
+        governanceApiService.queryNeurons(params)
+      ).rejects.toThrow("500");
       expect(await governanceApiService.queryNeurons(params)).toEqual([
         neuron1,
       ]);
@@ -353,7 +353,7 @@ describe("neurons api-service", () => {
         new Error("500")
       );
 
-      expect(() =>
+      await expect(() =>
         governanceApiService.queryKnownNeurons(certifiedParams)
       ).rejects.toThrow("500");
       expect(api.queryKnownNeurons).toHaveBeenCalledTimes(1);
@@ -410,7 +410,7 @@ describe("neurons api-service", () => {
         new Error("500")
       );
 
-      expect(() =>
+      await expect(() =>
         governanceApiService.queryKnownNeurons(certifiedParams)
       ).rejects.toThrow("500");
       expect(
@@ -474,7 +474,7 @@ describe("neurons api-service", () => {
     });
 
     it("should fail if queryLastestRewardEvent api fails", async () => {
-      expect(() =>
+      await expect(() =>
         governanceApiService.queryLastestRewardEvent({
           identity: unknownIdentity,
           ...params,

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -117,7 +117,7 @@ describe("canisters-api", () => {
           name: longName,
         });
 
-      expect(call).rejects.toThrowError(
+      await expect(call).rejects.toThrowError(
         new NameTooLongError("error__canister.name_too_long", {
           $name: longName,
         })
@@ -146,7 +146,7 @@ describe("canisters-api", () => {
           name: longName,
         });
 
-      expect(call).rejects.toThrowError(
+      await expect(call).rejects.toThrowError(
         new NameTooLongError("error__canister.name_too_long", {
           $name: longName,
         })
@@ -333,7 +333,7 @@ describe("canisters-api", () => {
           amount: 300_000_000n,
           fee,
         });
-      expect(call).rejects.toThrow();
+      await expect(call).rejects.toThrow();
       expect(mockCMCCanister.notifyCreateCanister).not.toBeCalled();
       expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
     });
@@ -348,7 +348,7 @@ describe("canisters-api", () => {
           fee,
         });
 
-      expect(call).rejects.toThrowError(
+      await expect(call).rejects.toThrowError(
         new NameTooLongError("error__canister.name_too_long", {
           $name: longName,
         })
@@ -505,7 +505,7 @@ describe("canisters-api", () => {
           canisterId: mockCanisterDetails.id,
           fee,
         });
-      expect(call).rejects.toThrow();
+      await expect(call).rejects.toThrow();
       expect(mockCMCCanister.notifyTopUp).not.toBeCalled();
     });
   });

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -51,14 +51,14 @@ describe("ckbtc-minter api", () => {
       expect(getBTCAddressSpy).toBeCalled();
     });
 
-    it("throws an error if no token", () => {
+    it("throws an error if no token", async () => {
       minterCanisterMock.getBtcAddress.mockImplementation(async () => {
         throw new Error();
       });
 
       const call = () => getBTCAddress(params);
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 
@@ -74,14 +74,14 @@ describe("ckbtc-minter api", () => {
       expect(getBTCAddressSpy).toBeCalled();
     });
 
-    it("bubble errors", () => {
+    it("bubble errors", async () => {
       minterCanisterMock.updateBalance.mockImplementation(async () => {
         throw new Error();
       });
 
       const call = () => updateBalance(params);
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 
@@ -112,7 +112,7 @@ describe("ckbtc-minter api", () => {
       );
     });
 
-    it("bubble errors", () => {
+    it("bubble errors", async () => {
       minterCanisterMock.retrieveBtcWithApproval.mockImplementation(
         async () => {
           throw new Error();
@@ -125,7 +125,7 @@ describe("ckbtc-minter api", () => {
           ...retrieveWithApprovalParams,
         });
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 
@@ -182,14 +182,14 @@ describe("ckbtc-minter api", () => {
       expect(estimateFeeSpy).toBeCalled();
     });
 
-    it("bubble errors", () => {
+    it("bubble errors", async () => {
       minterCanisterMock.estimateWithdrawalFee.mockImplementation(async () => {
         throw new Error();
       });
 
       const call = () => estimateFee(feeParams);
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 
@@ -205,14 +205,14 @@ describe("ckbtc-minter api", () => {
       expect(minterFeeSpy).toBeCalled();
     });
 
-    it("bubble errors", () => {
+    it("bubble errors", async () => {
       minterCanisterMock.getMinterInfo.mockImplementation(async () => {
         throw new Error();
       });
 
       const call = () => minterInfo(params);
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 });

--- a/frontend/src/tests/lib/api/icp-swap.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-swap.api.spec.ts
@@ -23,7 +23,7 @@ describe("icp-swap.api", () => {
         ok: false,
       } as Response);
 
-      expect(queryIcpSwapTickers()).rejects.toThrow(
+      await expect(queryIcpSwapTickers()).rejects.toThrow(
         new Error("Failed to fetch ticker information from ICP Swap")
       );
     });

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -75,13 +75,13 @@ describe("icrc-index api", () => {
       });
     });
 
-    it("throws an error if canister throws", () => {
+    it("throws an error if canister throws", async () => {
       const err = new Error("test");
       indexCanisterMock.getTransactions.mockRejectedValue(err);
 
       const call = () => getTransactions(params);
 
-      expect(call).rejects.toThrowError(err);
+      await expect(call).rejects.toThrowError(err);
     });
   });
 
@@ -111,7 +111,7 @@ describe("icrc-index api", () => {
       });
     });
 
-    it("throws an error if canister throws", () => {
+    it("throws an error if canister throws", async () => {
       const err = new Error("test");
       indexCanisterMock.ledgerId.mockRejectedValue(err);
 
@@ -122,7 +122,7 @@ describe("icrc-index api", () => {
           certified: true,
         });
 
-      expect(call).rejects.toThrowError(err);
+      await expect(call).rejects.toThrowError(err);
     });
   });
 });

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -78,7 +78,7 @@ describe("ICManagementCanister", () => {
       const call = () =>
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
 
-      expect(call).rejects.toThrowError(UserNotTheControllerError);
+      await expect(call).rejects.toThrowError(UserNotTheControllerError);
     });
 
     it('throws Error if "IC0512" is present, but not as "Error Code"', async () => {
@@ -97,7 +97,7 @@ describe("ICManagementCanister", () => {
       const call = () =>
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
 
-      expect(call).rejects.toThrowError(Error);
+      await expect(call).rejects.toThrowError(Error);
     });
 
     it("throws Error", async () => {
@@ -110,7 +110,7 @@ describe("ICManagementCanister", () => {
       const call = () =>
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
 
-      expect(call).rejects.toThrowError(Error);
+      await expect(call).rejects.toThrowError(Error);
     });
   });
 
@@ -164,7 +164,7 @@ describe("ICManagementCanister", () => {
           canisterId: mockCanisterId,
           settings: mockCanisterSettings,
         });
-      expect(call).rejects.toThrowError(UserNotTheControllerError);
+      await expect(call).rejects.toThrowError(UserNotTheControllerError);
     });
 
     it("throws Error", async () => {
@@ -179,7 +179,7 @@ describe("ICManagementCanister", () => {
           canisterId: mockCanisterId,
           settings: mockCanisterSettings,
         });
-      expect(call).rejects.toThrowError(Error);
+      await expect(call).rejects.toThrowError(Error);
     });
   });
 });

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -193,7 +193,7 @@ describe("NNSDapp", () => {
           principal: mockPrincipal,
         });
 
-      expect(call).rejects.toThrow(err);
+      await expect(call).rejects.toThrow(err);
     };
 
     it("should throw register Ledger device error not found", async () =>
@@ -272,7 +272,7 @@ describe("NNSDapp", () => {
           blockIndex: 123n,
         });
 
-      expect(call).rejects.toThrowError(CanisterAlreadyAttachedError);
+      await expect(call).rejects.toThrowError(CanisterAlreadyAttachedError);
     });
 
     it("should throw CanisterNameAlreadyTakenError", async () => {
@@ -289,7 +289,7 @@ describe("NNSDapp", () => {
           blockIndex: 123n,
         });
 
-      expect(call).rejects.toThrowError(CanisterNameAlreadyTakenError);
+      await expect(call).rejects.toThrowError(CanisterNameAlreadyTakenError);
     });
 
     it("should throw CanisterNameTooLongError", async () => {
@@ -306,7 +306,7 @@ describe("NNSDapp", () => {
           blockIndex: 123n,
         });
 
-      expect(call).rejects.toThrowError(CanisterNameTooLongError);
+      await expect(call).rejects.toThrowError(CanisterNameTooLongError);
     });
 
     it("should throw CanisterLimitExceededError", async () => {
@@ -323,7 +323,7 @@ describe("NNSDapp", () => {
           blockIndex: 123n,
         });
 
-      expect(call).rejects.toThrowError(CanisterLimitExceededError);
+      await expect(call).rejects.toThrowError(CanisterLimitExceededError);
     });
   });
 
@@ -357,7 +357,7 @@ describe("NNSDapp", () => {
           canisterId: mockCanister.canister_id,
         });
 
-      expect(call).rejects.toThrowError(CanisterNotFoundError);
+      await expect(call).rejects.toThrowError(CanisterNotFoundError);
     });
 
     it("should throw CanisterNameAlreadyTakenError", async () => {
@@ -373,7 +373,7 @@ describe("NNSDapp", () => {
           canisterId: mockCanister.canister_id,
         });
 
-      expect(call).rejects.toThrowError(CanisterNameAlreadyTakenError);
+      await expect(call).rejects.toThrowError(CanisterNameAlreadyTakenError);
     });
 
     it("should throw CanisterNameTooLongError", async () => {
@@ -389,7 +389,7 @@ describe("NNSDapp", () => {
           canisterId: mockCanister.canister_id,
         });
 
-      expect(call).rejects.toThrowError(CanisterNameTooLongError);
+      await expect(call).rejects.toThrowError(CanisterNameTooLongError);
     });
   });
 
@@ -413,7 +413,7 @@ describe("NNSDapp", () => {
 
       const call = () => nnsDapp.detachCanister(mockCanister.canister_id);
 
-      expect(call).rejects.toThrowError(CanisterNotFoundError);
+      await expect(call).rejects.toThrowError(CanisterNotFoundError);
     });
   });
 
@@ -457,7 +457,7 @@ describe("NNSDapp", () => {
         proposalId: 0n,
       });
 
-    expect(call).rejects.toThrowError(ProposalPayloadNotFoundError);
+    await expect(call).rejects.toThrowError(ProposalPayloadNotFoundError);
   });
 
   it("should throw ProposalPayloadTooLargeError", async () => {
@@ -472,7 +472,7 @@ describe("NNSDapp", () => {
         proposalId: 0n,
       });
 
-    expect(call).rejects.toThrowError(ProposalPayloadTooLargeError);
+    await expect(call).rejects.toThrowError(ProposalPayloadTooLargeError);
   });
 
   it("should throw UnknownProposalPayloadError", async () => {
@@ -487,7 +487,7 @@ describe("NNSDapp", () => {
         proposalId: 0n,
       });
 
-    expect(call).rejects.toThrowError(UnknownProposalPayloadError);
+    await expect(call).rejects.toThrowError(UnknownProposalPayloadError);
   });
 
   describe("NNSDapp.getImportedTokens", () => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -75,7 +75,7 @@ describe("ProjectCommitment", () => {
     });
     const po = renderComponent(summary);
 
-    expect(po.getCurrentTotalCommitment()).resolves.toEqual("500.00 ICP");
+    await expect(po.getCurrentTotalCommitment()).resolves.toEqual("500.00 ICP");
   });
 
   it("should hide success message when current commitment is less then the min participation goal", async () => {

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -243,7 +243,7 @@ describe("LedgerIdentity", () => {
       const identity = await LedgerIdentity.create();
 
       const call = () => identity.transformRequest(mockHttpRequest1);
-      expect(call).rejects.toMatchObject({
+      await expect(call).rejects.toMatchObject({
         message: "error__ledger.app_version_not_supported",
         renderAsHtml: true,
       });
@@ -267,7 +267,7 @@ describe("LedgerIdentity", () => {
       identity.flagUpcomingStakeNeuron();
 
       const call = () => identity.transformRequest(mockHttpRequest1);
-      expect(call).rejects.toMatchObject({
+      await expect(call).rejects.toMatchObject({
         message: "error__ledger.app_version_not_supported",
         renderAsHtml: true,
       });

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -423,7 +423,7 @@ describe("icp-ledger.services", () => {
           identity,
           minVersion,
         });
-      expect(call).rejects.toThrow(LedgerErrorMessage);
+      await expect(call).rejects.toThrow(LedgerErrorMessage);
     });
 
     it("should not throw if ledger version is larger than min version", async () => {

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -720,7 +720,7 @@ describe("icrc-accounts-services", () => {
           ledgerCanisterId,
         });
 
-      expect(call).rejects.toThrow(testError);
+      await expect(call).rejects.toThrow(testError);
       expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
       expect(ledgerApi.queryIcrcToken).toHaveBeenCalledWith({
         identity: mockIdentity,

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -2229,14 +2229,14 @@ describe("neurons-services", () => {
       expect(getAccountIdentityByPrincipal).toBeCalledTimes(1);
     });
 
-    it("should raise NotAuthorizedNeuronError if fullNeuron is not defined", () => {
+    it("should raise NotAuthorizedNeuronError if fullNeuron is not defined", async () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: undefined,
       };
       neuronsStore.setNeurons({ neurons: [neuron], certified: true });
       const call = () => getIdentityOfControllerByNeuronId(neuron.neuronId);
-      expect(call).rejects.toThrow(NotAuthorizedNeuronError);
+      await expect(call).rejects.toThrow(NotAuthorizedNeuronError);
     });
 
     it("should raise NotAuthorizedNeuronError if contoller is not in authStore nor accounts helper", async () => {
@@ -2251,7 +2251,7 @@ describe("neurons-services", () => {
       };
       neuronsStore.setNeurons({ neurons: [neuron], certified: true });
       const call = () => getIdentityOfControllerByNeuronId(neuron.neuronId);
-      expect(call).rejects.toThrow(NotAuthorizedNeuronError);
+      await expect(call).rejects.toThrow(NotAuthorizedNeuronError);
     });
   });
 

--- a/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
+++ b/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
@@ -40,7 +40,7 @@ describe("nns-reward-event-services", () => {
 
     const call = async () => await loadLatestRewardEvent();
 
-    expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
     expect(get(nnsLatestRewardEventStore)).toBeUndefined();
 
     resetIdentity();

--- a/frontend/src/tests/lib/services/utils.services.spec.ts
+++ b/frontend/src/tests/lib/services/utils.services.spec.ts
@@ -33,7 +33,7 @@ describe("api-utils", () => {
             logMessage: "test-log",
           });
 
-        expect(call).rejects.toThrowError();
+        await expect(call).rejects.toThrowError();
       });
 
       it("should use 'query' strategy by default", async () => {

--- a/frontend/src/tests/lib/utils/ledger.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ledger.utils.spec.ts
@@ -18,7 +18,7 @@ describe("ledger-utils", () => {
   describe("decodePublicKey", () => {
     const principalText = new MockLedgerIdentity().getPrincipal().toText();
 
-    it("should throw an error because ledger is closed", () => {
+    it("should throw an error because ledger is closed", async () => {
       const call = () =>
         decodePublicKey({
           principalText,
@@ -26,13 +26,13 @@ describe("ledger-utils", () => {
           returnCode: ExtendedLedgerError.AppNotOpen as unknown as LedgerError,
         } as ResponseAddress);
 
-      expect(call).rejects.toMatchObject({
+      await expect(call).rejects.toMatchObject({
         message: "error__ledger.please_open",
         renderAsHtml: false,
       });
     });
 
-    it("should throw an error because ledger is locked", () => {
+    it("should throw an error because ledger is locked", async () => {
       const call = () =>
         decodePublicKey({
           principalText,
@@ -40,13 +40,13 @@ describe("ledger-utils", () => {
           returnCode: LedgerError.TransactionRejected,
         } as ResponseAddress);
 
-      expect(call).rejects.toMatchObject({
+      await expect(call).rejects.toMatchObject({
         message: "error__ledger.locked",
         renderAsHtml: false,
       });
     });
 
-    it("should throw an error because public key cannot be fetched", () => {
+    it("should throw an error because public key cannot be fetched", async () => {
       const call = () =>
         decodePublicKey({
           principalText,
@@ -55,7 +55,7 @@ describe("ledger-utils", () => {
             ExtendedLedgerError.CannotFetchPublicKey as unknown as LedgerError,
         } as ResponseAddress);
 
-      expect(call).rejects.toMatchObject({
+      await expect(call).rejects.toMatchObject({
         message: "error__ledger.fetch_public_key",
         renderAsHtml: false,
       });
@@ -68,7 +68,7 @@ describe("ledger-utils", () => {
           publicKey: fromHexString(rawPublicKeyHex) as unknown as Buffer,
         } as ResponseAddress);
 
-      expect(call).rejects.toMatchObject({
+      await expect(call).rejects.toMatchObject({
         message: "error__ledger.principal_not_match",
         renderAsHtml: false,
       });
@@ -86,34 +86,34 @@ describe("ledger-utils", () => {
   });
 
   describe("decodeSignature", () => {
-    it("should throw an error if no signature is provided", () => {
+    it("should throw an error if no signature is provided", async () => {
       const call = () =>
         decodeSignature({
           signatureRS: undefined,
           returnCode: LedgerError.UnknownError,
         } as unknown as ResponseSign);
 
-      expect(call).rejects.toThrow(
+      await expect(call).rejects.toThrow(
         new LedgerErrorMessage(
           `A ledger error happened during signature. undefined (code ${LedgerError.UnknownError}).`
         )
       );
     });
 
-    it("should throw an error if transaction is rejected", () => {
+    it("should throw an error if transaction is rejected", async () => {
       const call = () =>
         decodeSignature({
           signatureRS: Uint8Array.from("test", (x) => x.charCodeAt(0)),
           returnCode: LedgerError.TransactionRejected,
         } as unknown as ResponseSign);
 
-      expect(call).rejects.toMatchObject({
+      await expect(call).rejects.toMatchObject({
         message: "error__ledger.user_rejected_transaction",
         renderAsHtml: false,
       });
     });
 
-    it("should throw an error if signature too short", () => {
+    it("should throw an error if signature too short", async () => {
       const test = "test";
 
       const call = () =>
@@ -122,7 +122,7 @@ describe("ledger-utils", () => {
           returnCode: LedgerError.WrongLength,
         } as unknown as ResponseSign);
 
-      expect(call).rejects.toThrow(
+      await expect(call).rejects.toThrow(
         new LedgerErrorMessage(
           `Signature must be 64 bytes long (is ${test.length})`
         )

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -650,7 +650,7 @@ describe("utils", () => {
           });
 
         const pollPromise = callPoll();
-        expect(callPoll).rejects.toThrowError(PollingCancelledError);
+        await expect(callPoll).rejects.toThrowError(PollingCancelledError);
 
         const expectedPollResult = "foo";
         resolvePromise(expectedPollResult);

--- a/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
@@ -54,13 +54,13 @@ describe("icrc-index.worker-api", () => {
     expect(getTransactionsSpy).toBeCalled();
   });
 
-  it("should bubble errors", () => {
+  it("should bubble errors", async () => {
     indexCanisterMock.getTransactions.mockImplementation(async () => {
       throw new Error();
     });
 
     const call = () => getIcrcTransactions(params);
 
-    expect(call).rejects.toThrowError();
+    await expect(call).rejects.toThrowError();
   });
 });

--- a/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
@@ -41,13 +41,13 @@ describe("icrc-ledger.worker-api", () => {
     expect(balanceSpy).toBeCalled();
   });
 
-  it("should bubble errors", () => {
+  it("should bubble errors", async () => {
     ledgerCanisterMock.balance.mockImplementation(() =>
       Promise.reject(new Error())
     );
 
     const call = () => getIcrcBalance(params);
 
-    expect(call).rejects.toThrowError();
+    await expect(call).rejects.toThrowError();
   });
 });

--- a/frontend/src/tests/lib/worker-api/tvl.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/tvl.worker-api.spec.ts
@@ -43,14 +43,14 @@ describe("tvl worker-api", () => {
       expect(getTVLSpy).toBeCalled();
     });
 
-    it("throws an error if no token", () => {
+    it("throws an error if no token", async () => {
       tvlCanisterMock.getTVL.mockImplementation(async () => {
         throw new Error();
       });
 
       const call = () => queryTVL(paramsCanisterId);
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 

--- a/frontend/src/tests/lib/worker-services/icrc-balances.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-balances.worker-services.spec.ts
@@ -62,6 +62,6 @@ describe("balances.worker-services", () => {
 
     const call = () => getIcrcAccountsBalances(params);
 
-    expect(call).rejects.toThrowError();
+    await expect(call).rejects.toThrowError();
   });
 });

--- a/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
@@ -271,6 +271,6 @@ describe("transactions.worker-services", () => {
         data,
       });
 
-    expect(call).rejects.toThrowError();
+    await expect(call).rejects.toThrowError();
   });
 });


### PR DESCRIPTION
# Motivation

In noticed output like this in test logs:
```
Promise returned by `expect(actual).rejects.toThrow()` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
```

# Changes

1. Add `await` in front of `expects` which have to await a promise because they use `.rejects.` or `.resolves.`.

# Tests

Tests no longer complain in the logs.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary