### PR TITLE
Use fake timers in proposals.utils.spec.ts

### DIFF
--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -87,6 +87,10 @@ const toTestNnsVotingNode =
     nnsNeuronToVotingNeuron({ neuron, proposal });
 
 describe("proposals-utils", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
   it("should find no last proposal id", () =>
     expect(lastProposalId([])).toBeUndefined());
 


### PR DESCRIPTION
# Motivation

I noticed [flakiness](https://github.com/dfinity/nns-dapp/actions/runs/13242022571/job/36959348708) in `frontend/src/tests/lib/utils/proposals.utils.spec.ts` which seemed to result from the test especting `nowInSeconds` to always return the same value during the test.

# Changes

1. Call `vi.useFakeTimers()` in `beforeEach` in `frontend/src/tests/lib/utils/proposals.utils.spec.ts`.

# Tests

1. I changed `Date.now` to always increase by 1 second on every call to see if any other tests had similar problems but this was the only test that failed.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary