### PR TITLE
fix(styles): improve text wrapping in proposal card titles

### DIFF
--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -118,6 +118,7 @@
   h3 {
     padding: var(--padding-2x) 0 var(--padding-0_5x);
     margin-bottom: var(--padding-2x);
+    overflow-wrap: break-word;
   }
 
   p {


### PR DESCRIPTION
# Motivation

The proposal cards have titles that are usually predefined based on the type of proposal. These titles contain spaces, so when their length exceeds the width of the card, the text automatically breaks into lines. However, sometimes these titles are custom, and their format may lack spaces but include underlines.

Before: 

<img width="1375" alt="Screenshot 2025-02-11 at 08 29 20" src="https://github.com/user-attachments/assets/ac3b1318-3db7-4ba7-8f8c-371a193bf4a8" />

After:

<img width="1449" alt="Screenshot 2025-02-11 at 08 29 37" src="https://github.com/user-attachments/assets/da3345d0-5f57-4280-b5e5-176c7eccff14" />


Relates to [NNS1-3615](https://dfinity.atlassian.net/browse/NNS1-3615)

# Changes

- Adds CSS property to the titles to break down text based on natural boundaries using `break-word`.

# Tests

- Manually tested by modifying the translations file locally with a custom breaking title.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3615]: https://dfinity.atlassian.net/browse/NNS1-3615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ