### PR TITLE
Use vi.stubGlobal for requestAnimationFrame

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -195,8 +195,8 @@ vi.mock("$app/stores", () => ({
 }));
 
 // Issue: https://github.com/testing-library/svelte-testing-library/issues/206
-Object.defineProperty(global, "requestAnimationFrame", {
-  value: (fn) => {
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", (fn) => {
     return window.setTimeout(() => fn(Date.now()), 0);
-  },
+  });
 });


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/3483 we stubbed `requestAnimationFrame` to work around https://github.com/testing-library/svelte-testing-library/issues/206

In https://github.com/dfinity/nns-dapp/pull/4695 we changed from `vi.stubGlobal` to `Object.defineProperty` because `vi.unstubAllGlobals` was undoing the workaround.

With Vitest 3, using `Object.defineProperty` to redefine `requestAnimationFrame` causes
```
TypeError: Cannot assign to read only property 'requestAnimationFrame' of object '#<Object>'
```

Instead we should go back to `vi.stubGlobal` but use it in `beforeEach` after `vi.unstubAllGlobals` so it's re-stubbed each time.

# Changes

1. Use `vi.stubGlobal` for `requestAnimationFrame` instead of `Object.defineProperty` and wrap it in `beforeEach`.

# Tests

1. Existing tests still pass.
2. Tested in another branch with `vitest` updated to 3.0.5.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary