### PR TITLE
feat: skip transition in test for transition.utils

### DIFF
--- a/frontend/src/lib/utils/transition.utils.ts
+++ b/frontend/src/lib/utils/transition.utils.ts
@@ -8,6 +8,11 @@ export const heightTransition = (
     duration?: number;
   }
 ) => {
+  // Prevent "TypeError: Cannot set properties of undefined (setting 'onfinish')" in vitest mode
+  if (process.env.NODE_ENV === "test") {
+    return {};
+  }
+
   const height = element.offsetHeight;
   return {
     delay,


### PR DESCRIPTION
# Motivation

Svelte v5 requires the web animation API which is not supported in emulated testing environment. That's why this PR makes `transition.utils` skip animating in test mode.

# Notes

- Similar as Gix-components PR https://github.com/dfinity/gix-components/pull/573
- Relates to the Svelte v5 migration PR #6020

# Changes

- If `process.env.NODE_ENV === "test"` then no animation
