### PR TITLE
Fix error expectations

### DIFF
--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "$lib/api/canisters.api";
 import { ICManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
-import { NameTooLongError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
+import { CanisterNameTooLongError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import {
   CREATE_CANISTER_MEMO,
   TOP_UP_CANISTER_MEMO,
@@ -119,7 +119,7 @@ describe("canisters-api", () => {
         });
 
       await expect(call).rejects.toThrowError(
-        new NameTooLongError("error__canister.name_too_long", {
+        new CanisterNameTooLongError("error__canister.name_too_long", {
           $name: longName,
         })
       );
@@ -148,7 +148,7 @@ describe("canisters-api", () => {
         });
 
       await expect(call).rejects.toThrowError(
-        new NameTooLongError("error__canister.name_too_long", {
+        new CanisterNameTooLongError("error__canister.name_too_long", {
           $name: longName,
         })
       );
@@ -350,7 +350,7 @@ describe("canisters-api", () => {
         });
 
       await expect(call).rejects.toThrowError(
-        new NameTooLongError("error__canister.name_too_long", {
+        new CanisterNameTooLongError("error__canister.name_too_long", {
           $name: longName,
         })
       );

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -600,7 +600,7 @@ describe("NNSDapp", () => {
 
       await expect(call).rejects.toThrowError(
         new TooManyImportedTokensError("error__imported_tokens.too_many", {
-          limit: "10",
+          $limit: "10",
         })
       );
     });

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -37,6 +37,7 @@ import { toastsStore } from "@dfinity/gix-components";
 import { Vote } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import {
+  SnsGovernanceError,
   SnsNeuronPermissionType,
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
@@ -219,7 +220,7 @@ describe("SnsProposalDetail", () => {
       });
       expect(console.error).toBeCalledWith(
         expect.objectContaining({
-          error: new Error("No proposal for given proposalId 2"),
+          error: new SnsGovernanceError("No proposal for given proposalId 2"),
         })
       );
       expect(console.error).toBeCalledTimes(1);
@@ -448,13 +449,13 @@ describe("SnsProposalDetail", () => {
       expect(console.error).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          error: new Error("No proposal for given proposalId 19"),
+          error: new SnsGovernanceError("No proposal for given proposalId 19"),
         })
       );
       expect(console.error).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
-          error: new Error("No proposal for given proposalId 19"),
+          error: new SnsGovernanceError("No proposal for given proposalId 19"),
         })
       );
       expect(console.error).toBeCalledTimes(2);
@@ -506,13 +507,13 @@ describe("SnsProposalDetail", () => {
       expect(console.error).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          error: new Error("No proposal for given proposalId 30"),
+          error: new SnsGovernanceError("No proposal for given proposalId 30"),
         })
       );
       expect(console.error).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
-          error: new Error("No proposal for given proposalId 30"),
+          error: new SnsGovernanceError("No proposal for given proposalId 30"),
         })
       );
       expect(console.error).toBeCalledTimes(2);

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -11,7 +11,7 @@ import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import * as busyStore from "$lib/stores/busy.store";
 import { ckbtcPendingUtxosStore } from "$lib/stores/ckbtc-pending-utxos.store";
 import { ckbtcRetrieveBtcStatusesStore } from "$lib/stores/ckbtc-retrieve-btc-statuses.store";
-import { ApiErrorKey } from "$lib/types/api.errors";
+import { CkBTCErrorKey } from "$lib/types/ckbtc.errors";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -113,7 +113,7 @@ describe("ckbtc-minter-services", () => {
 
       const spyReload = vi.fn();
 
-      const err = new ApiErrorKey(en.error__ckbtc.already_process);
+      const err = new CkBTCErrorKey(en.error__ckbtc.already_process);
 
       const result = await services.updateBalance({
         ...params,
@@ -157,7 +157,7 @@ describe("ckbtc-minter-services", () => {
 
       expect(result).toEqual({
         success: false,
-        err: new MinterGenericError(error),
+        err: new CkBTCErrorKey(error),
       });
     });
 
@@ -168,7 +168,7 @@ describe("ckbtc-minter-services", () => {
         throw new MinterTemporaryUnavailableError(error);
       });
 
-      const err = new ApiErrorKey(
+      const err = new CkBTCErrorKey(
         `${en.error__ckbtc.temporary_unavailable} (${error})`
       );
 
@@ -182,7 +182,7 @@ describe("ckbtc-minter-services", () => {
         throw new MinterAlreadyProcessingError();
       });
 
-      const err = new ApiErrorKey(en.error__ckbtc.already_process);
+      const err = new CkBTCErrorKey(en.error__ckbtc.already_process);
 
       const result = await services.updateBalance(params);
 
@@ -318,7 +318,7 @@ describe("ckbtc-minter-services", () => {
 
       expect(result).toEqual({
         success: false,
-        err: new MinterGenericError(error),
+        err: new CkBTCErrorKey(error),
       });
     });
 

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -116,7 +116,9 @@ describe("ckbtc.utils", () => {
         infoData: undefined,
       })
     ).toThrow(
-      new NotEnoughAmountError(en.error__ckbtc.retrieve_btc_min_amount_unknown)
+      new CkBTCErrorRetrieveBtcMinAmount(
+        en.error__ckbtc.retrieve_btc_min_amount_unknown
+      )
     );
   });
 
@@ -130,7 +132,7 @@ describe("ckbtc.utils", () => {
         },
       })
     ).toThrow(
-      new NotEnoughAmountError(
+      new CkBTCErrorRetrieveBtcMinAmount(
         en.error__ckbtc.wait_ckbtc_info_parameters_certified
       )
     );


### PR DESCRIPTION
# Motivation

Vitest 2 doesn't compare errors correctly. This is fixed in Vitest 3.
So when trying to update to Vitest 3, some tests started failing because they expect incorrect errors.

This PR just fixes the error expectations but does not update the Vitest dependency yet.

# Changes

1. Fix error expectations that would break with Vitest 3.

# Tests

1. The changed tests pass.
2. They also pass in another branch which updates `vitest` to `3.0.5`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary