### PR TITLE
Advance specific time to pass transition

### DIFF
--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -101,7 +101,7 @@ describe("MenuItems", () => {
     menuStore.toggle();
 
     // Wait for the animation.
-    await advanceTime();
+    await advanceTime(500);
 
     expect(get(menuCollapsed)).toBe(true);
     expect(await po.hasFooter()).toBe(false);
@@ -121,7 +121,7 @@ describe("MenuItems", () => {
 
     menuStore.toggle();
     // Wait for the animation.
-    await advanceTime();
+    await advanceTime(500);
 
     expect(get(menuCollapsed)).toBe(true);
     expect(await po.hasFooter()).toBe(false);
@@ -134,7 +134,7 @@ describe("MenuItems", () => {
 
     layoutMenuOpen.set(false);
     // Wait for the animation.
-    await advanceTime();
+    await advanceTime(500);
 
     expect(get(menuCollapsed)).toBe(true);
     expect(await po.hasFooter()).toBe(false);

--- a/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/LosingRewardsBanner.spec.ts
@@ -10,7 +10,10 @@ import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { LosingRewardsBannerPo } from "$tests/page-objects/LosingRewardsBanner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import {
+  advanceTime,
+  runResolvedPromises,
+} from "$tests/utils/timers.test-utils";
 
 describe("LosingRewardsBanner", () => {
   const nowSeconds = nowInSeconds();
@@ -202,7 +205,7 @@ describe("LosingRewardsBanner", () => {
         .getLosingRewardNeuronsModalPo()
         .getNnsLosingRewardsNeuronCardPos()
     ).toHaveLength(0);
-    vi.advanceTimersToNextFrame();
+    await advanceTime(500);
     expect(spyRefreshVotingPower).toBeCalledTimes(1);
     expect(await po.getLosingRewardNeuronsModalPo().isPresent()).toEqual(false);
   });

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -273,7 +273,7 @@ describe("NnsProposals", () => {
         await filterModal.clickConfirmButton();
 
         // Finish the fade transition of the modal.
-        await advanceTime(25);
+        await advanceTime(500);
         await filterModal.waitForAbsent();
 
         // Stop waiting for the debounce to reload proposals.
@@ -295,7 +295,6 @@ describe("NnsProposals", () => {
         // should not result in displaying old data which doesn't match the
         // current filters.
         proposalRequests[1].resolve([matchingProposal]);
-        //await advanceTime(500);
         await runResolvedPromises();
         // We should still see both proposals from the request from after the
         // filter was removed.

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -115,7 +115,7 @@ describe("Tokens page", () => {
     await po.getBackdropPo().click();
 
     // Finish transitions
-    await advanceTime();
+    await advanceTime(500);
 
     expect(await po.getHideZeroBalancesTogglePo().isPresent()).toBe(false);
     expect(await po.getBackdropPo().isPresent()).toBe(false);
@@ -133,7 +133,7 @@ describe("Tokens page", () => {
     await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
 
     // Finish transitions
-    await advanceTime();
+    await advanceTime(500);
 
     expect(await po.getTokensTable().getTokenNames()).toEqual([
       "Positive balance",
@@ -161,7 +161,7 @@ describe("Tokens page", () => {
     await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
 
     // Finish transitions
-    await advanceTime();
+    await advanceTime(500);
 
     expect(await po.getTokensTable().getTokenNames()).toEqual([
       "Positive balance",
@@ -181,7 +181,7 @@ describe("Tokens page", () => {
     await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
 
     // Finish transitions
-    await advanceTime();
+    await advanceTime(500);
 
     expect(await po.getTokensTable().getTokenNames()).toEqual([
       "Positive balance",
@@ -214,7 +214,7 @@ describe("Tokens page", () => {
     await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
 
     // Finish transitions
-    await advanceTime();
+    await advanceTime(500);
 
     expect(await po.getTokensTable().getTokenNames()).toEqual([
       "Positive balance",
@@ -224,7 +224,7 @@ describe("Tokens page", () => {
     await po.getShowAllButtonPo().click();
 
     // Finish transitions
-    await advanceTime();
+    await advanceTime(500);
 
     expect(await po.getShowAllButtonPo().isPresent()).toBe(false);
     expect(await po.getTokensTable().getTokenNames()).toEqual([


### PR DESCRIPTION
# Motivation

In several tests we use `advanceTime()`, [which calls](https://github.com/dfinity/nns-dapp/blob/164f78620a9c9e420bd02a661548ad19cb3fe6be/frontend/src/tests/utils/timers.test-utils.ts#L22) `await vi.runOnlyPendingTimersAsync()` to make a UI transition finish before continuing with the test.

Using `advanceTime()` without parameter, makes time advance as much as is necessary to run the currently pending timers.

With Vitest 3, this no longer works in certain cases. I'm not sure why exactly but it's possible that there or additional timers before the transition timers, such that only those are passed and we're still waiting for the transition timers.

Passing an explicit number of milliseconds to `advanceTime()` makes sure that the transition timers are included in the timers being run.

# Changes

1. Pass explicit number of milliseconds to `advanceTime` in tests for which this is necessary to make the tests pass if we update to Vitest 3.
2. Also remove one `//await advanceTime(500);` which was commented out and apparently not necessary.

# Tests

1. Updated tests still pass.
3. Tests also pass in another branch where `vitest` is updated to `3.0.5`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary