### PR TITLE
Topic filter sorting

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,6 +19,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * No missing rewards notification for neurons without a dissolve delay.
+* Display proposal topics in alphabetical order.
 
 #### Deprecated
 

--- a/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
+++ b/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
@@ -18,6 +18,7 @@
     getTopicTitle,
   } from "$lib/utils/neuron.utils";
   import { isNullish } from "@dfinity/utils";
+  import { sortNnsTopics } from "$lib/utils/proposals.utils";
 
   export let props: ProposalsFilterModalProps | undefined;
 
@@ -55,6 +56,7 @@
         .filter((value) =>
           category === "topics" ? !DEPRECATED_TOPICS.includes(value) : true
         )
+        .sort(sortNnsTopics($i18n))
         .map(mapToFilter)
     : [];
   $: selectedFilters = props?.selectedFilters || [];

--- a/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
+++ b/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
@@ -51,13 +51,14 @@
   $: category = props?.category ?? "uncategorized";
   $: filters = props?.filters;
   $: filtersValues = filters
-    ? enumValues(filters)
-        .filter((value) => value !== PROPOSAL_FILTER_UNSPECIFIED_VALUE)
-        .filter((value) =>
-          category === "topics" ? !DEPRECATED_TOPICS.includes(value) : true
-        )
-        .sort(sortNnsTopics($i18n))
-        .map(mapToFilter)
+    ? sortNnsTopics({
+        topics: enumValues(filters)
+          .filter((value) => value !== PROPOSAL_FILTER_UNSPECIFIED_VALUE)
+          .filter((value) =>
+            category === "topics" ? !DEPRECATED_TOPICS.includes(value) : true
+          ),
+        i18n: $i18n,
+      }).map(mapToFilter)
     : [];
   $: selectedFilters = props?.selectedFilters || [];
 

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -12,7 +12,13 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import { errorToString } from "$lib/utils/error.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { buildProposalUrl } from "$lib/utils/navigation.utils";
+import { getTopicTitle } from "$lib/utils/neuron.utils";
 import { toNnsVote } from "$lib/utils/sns-proposals.utils";
+import {
+  createAscendingComparator,
+  createDescendingComparator,
+  mergeComparators,
+} from "$lib/utils/sort.utils";
 import { isDefined, keyOf, keyOfOptional } from "$lib/utils/utils";
 import type {
   Ballot,
@@ -638,3 +644,26 @@ export const sortProposalsByIdDescendingOrder = (
     if (idB < idA) return -1;
     return 0;
   });
+
+/**
+ * Sort NNS topics by the following order:
+ *
+ * - Governance
+ * - SNS & Neurons' Fund
+ * - Unspecified (All Except Governance, and SNS & Neurons' Fund)
+ * - Rest topics sorted alphabetically
+ */
+export const sortNnsTopics = (i18n: I18n) =>
+  mergeComparators([
+    createDescendingComparator((topic: Topic) => topic === Topic.Governance),
+    createDescendingComparator(
+      (topic: Topic) => topic === Topic.SnsAndCommunityFund
+    ),
+    createDescendingComparator((topic: Topic) => topic === Topic.Unspecified),
+    createAscendingComparator((topic: Topic) =>
+      getTopicTitle({
+        topic,
+        i18n,
+      }).toLowerCase()
+    ),
+  ]);

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -646,24 +646,32 @@ export const sortProposalsByIdDescendingOrder = (
   });
 
 /**
- * Sort NNS topics by the following order:
+ * Sort NNS topics in the following order:
  *
  * - Governance
  * - SNS & Neurons' Fund
  * - Unspecified (All Except Governance, and SNS & Neurons' Fund)
  * - Rest topics sorted alphabetically
  */
-export const sortNnsTopics = (i18n: I18n) =>
-  mergeComparators([
-    createDescendingComparator((topic: Topic) => topic === Topic.Governance),
-    createDescendingComparator(
-      (topic: Topic) => topic === Topic.SnsAndCommunityFund
-    ),
-    createDescendingComparator((topic: Topic) => topic === Topic.Unspecified),
-    createAscendingComparator((topic: Topic) =>
-      getTopicTitle({
-        topic,
-        i18n,
-      }).toLowerCase()
-    ),
-  ]);
+export const sortNnsTopics = ({
+  topics,
+  i18n,
+}: {
+  topics: Topic[];
+  i18n: I18n;
+}) =>
+  topics.sort(
+    mergeComparators([
+      createDescendingComparator((topic: Topic) => topic === Topic.Governance),
+      createDescendingComparator(
+        (topic: Topic) => topic === Topic.SnsAndCommunityFund
+      ),
+      createDescendingComparator((topic: Topic) => topic === Topic.Unspecified),
+      createAscendingComparator((topic: Topic) =>
+        getTopicTitle({
+          topic,
+          i18n,
+        }).toLowerCase()
+      ),
+    ])
+  );

--- a/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
@@ -46,12 +46,25 @@ describe("ProposalsFilterModal", () => {
     const checkboxLabels = (
       await Promise.all(checkboxes.map((checkbox) => checkbox.getText()))
     ).map((s) => s.trim());
-    const expectedLabels = enumKeys(Topic)
-      .filter(
-        (key: string) =>
-          key !== "Unspecified" && key !== "SnsDecentralizationSale"
-      )
-      .map((key: string) => en.topics[key]);
+    const expectedLabels = [
+      "Governance",
+      "SNS & Neurons' Fund",
+      "API Boundary Node Management",
+      "Application Canister Management",
+      "Exchange Rate",
+      "IC OS Version Deployment",
+      "IC OS Version Election",
+      "KYC",
+      "Network Economics",
+      "Neuron Management",
+      "Node Admin",
+      "Node Provider Rewards",
+      "Participant Management",
+      "Protocol Canister Management",
+      "Service Nervous System Management",
+      "Subnet Management",
+      "Subnet Rental",
+    ];
 
     expect(checkboxLabels).toEqual(expectedLabels);
   });
@@ -92,8 +105,8 @@ describe("ProposalsFilterModal", () => {
 
     expect(get(proposalsFiltersStore).topics).toEqual([
       ...DEFAULT_PROPOSALS_FILTERS.topics,
-      1,
-      2,
+      Topic.Governance,
+      Topic.SnsAndCommunityFund,
     ]);
   });
 

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -24,6 +24,7 @@ import {
   replaceAndConcatenateProposals,
   replaceProposals,
   selectedNeuronsVotingPower,
+  sortNnsTopics,
   sortProposalsByIdDescendingOrder,
 } from "$lib/utils/proposals.utils";
 import en from "$tests/mocks/i18n.mock";
@@ -1149,6 +1150,52 @@ describe("proposals-utils", () => {
         proposal0,
       ]);
       expect(sortProposalsByIdDescendingOrder([])).toEqual([]);
+    });
+  });
+
+  describe("sortNnsTopics", () => {
+    it("sorts topics", () => {
+      const i18n = en;
+      // To ensure the correct order after Topic changes, enumValues is used.
+      expect(enumValues(Topic).sort(sortNnsTopics(i18n))).toEqual([
+        /* Governance 4 */ Topic.Governance,
+        /* SNS & Neurons' Fund 14 */ Topic.SnsAndCommunityFund,
+        /* Unspecified 0 */ Topic.Unspecified,
+
+        // Sorted alphabetically
+
+        /* API Boundary Node Management [15] */ Topic.ApiBoundaryNodeManagement,
+        /* Application Canister Management [8] */ Topic.NetworkCanisterManagement,
+        /* Exchange Rate [2] */ Topic.ExchangeRate,
+        /* IC OS Version Deployment [12] */ Topic.IcOsVersionDeployment,
+        /* IC OS Version Election [13] */ Topic.IcOsVersionElection,
+        /* KYC [9] */ Topic.Kyc,
+        /* Network Economics [3] */ Topic.NetworkEconomics,
+        /* Neuron Management [1] */ Topic.NeuronManagement,
+        /* Node Admin [5] */ Topic.NodeAdmin,
+        /* Node Provider Rewards [10] */ Topic.NodeProviderRewards,
+        /* Participant Management [6] */ Topic.ParticipantManagement,
+        /* Protocol Canister Management [17] */ Topic.ProtocolCanisterManagement,
+        /* Service Nervous System Management [18] */ Topic.ServiceNervousSystemManagement,
+        /* SNS Decentralization Swap [11] */ Topic.SnsDecentralizationSale,
+        /* Subnet Management [7] */ Topic.SubnetManagement,
+        /* Subnet Rental [16] */ Topic.SubnetRental,
+      ]);
+
+      expect([].sort(sortNnsTopics(i18n))).toEqual([]);
+    });
+
+    it("ignores letter case when sorting", () => {
+      const i18n = en;
+      expect(
+        [
+          /* SNS Decentralization Swap [11] */ Topic.SnsDecentralizationSale,
+          /* Service Nervous System Management [18] */ Topic.ServiceNervousSystemManagement,
+        ].sort(sortNnsTopics(i18n))
+      ).toEqual([
+        /* Service Nervous System Management [18] */ Topic.ServiceNervousSystemManagement,
+        /* SNS Decentralization Swap [11] */ Topic.SnsDecentralizationSale,
+      ]);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -1157,7 +1157,7 @@ describe("proposals-utils", () => {
     it("sorts topics", () => {
       const i18n = en;
       // To ensure the correct order after Topic changes, enumValues is used.
-      expect(enumValues(Topic).sort(sortNnsTopics(i18n))).toEqual([
+      expect(sortNnsTopics({ topics: enumValues(Topic), i18n })).toEqual([
         /* Governance 4 */ Topic.Governance,
         /* SNS & Neurons' Fund 14 */ Topic.SnsAndCommunityFund,
         /* Unspecified 0 */ Topic.Unspecified,
@@ -1182,16 +1182,19 @@ describe("proposals-utils", () => {
         /* Subnet Rental [16] */ Topic.SubnetRental,
       ]);
 
-      expect([].sort(sortNnsTopics(i18n))).toEqual([]);
+      expect(sortNnsTopics({ topics: [], i18n })).toEqual([]);
     });
 
     it("ignores letter case when sorting", () => {
       const i18n = en;
       expect(
-        [
-          /* SNS Decentralization Swap [11] */ Topic.SnsDecentralizationSale,
-          /* Service Nervous System Management [18] */ Topic.ServiceNervousSystemManagement,
-        ].sort(sortNnsTopics(i18n))
+        sortNnsTopics({
+          topics: [
+            /* SNS Decentralization Swap [11] */ Topic.SnsDecentralizationSale,
+            /* Service Nervous System Management [18] */ Topic.ServiceNervousSystemManagement,
+          ],
+          i18n,
+        })
       ).toEqual([
         /* Service Nervous System Management [18] */ Topic.ServiceNervousSystemManagement,
         /* SNS Decentralization Swap [11] */ Topic.SnsDecentralizationSale,


### PR DESCRIPTION
# Motivation

To improve the user experience, proposal topics need to be displayed in a sorted order ([the ticket](https://dfinity.atlassian.net/browse/NNS1-3491)). This applies to the topic filter and the follow neuron topic list.

In this PR, we address the topic filter sorting. The follow neurons modal will be updated in a separate PR.

**Expected order:**
1. Governance.
2. SNS & Neurons' Fund.
3. All Except Governance, and SNS & Neurons' Fund. (not available in Topic filter)
4. Rest topics (ExchangeRate included) sorted alphabetically.

# Changes

- Add sortNnsTopics util.
- Use it to sort topic filter.

# Tests

- Updated.

# Todos

- [x] Add entry to changelog (if necessary).
