### PR TITLE
fix(ci): resolve broken pipe issue in merge queue

### DIFF
--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -93,7 +93,7 @@ lint_wasm() {
   } >&2
   wasm_info="$(get_wasm_info "$wasm_path")"
   test_method="get_toy_account"
-  echo "${wasm_info:-}" | grep -q "$test_method" || {
+  echo "${wasm_info:-}" | grep "$test_method" > /dev/null || {
     echo "ERROR: This test needs test builds of the Wasm."
     echo "Expected: Test methods including '$test_method'."
     echo "Actual:   The exported methods do not include '$test_method':"

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -93,7 +93,7 @@ lint_wasm() {
   } >&2
   wasm_info="$(get_wasm_info "$wasm_path")"
   test_method="get_toy_account"
-  echo "${wasm_info:-}" | grep "$test_method" > /dev/null || {
+  echo "${wasm_info:-}" | grep "$test_method" >/dev/null || {
     echo "ERROR: This test needs test builds of the Wasm."
     echo "Expected: Test methods including '$test_method'."
     echo "Actual:   The exported methods do not include '$test_method':"


### PR DESCRIPTION
# Motivation

In #6363, the merge queue [failed](https://github.com/dfinity/nns-dapp/actions/runs/13266920098/job/37036770632) due to a broken pipe. This PR implements the recommendation made [here](https://github.com/dfinity/nns-dapp/pull/6363#issuecomment-2651448888).

# Changes

- Changes `grep -q` `grep ... > /dev/null`.

# Tests

- Pipeline should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary