### PR TITLE
Fix universe select gaps

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -50,8 +50,8 @@
   // 2. add some gap, because the Nav title is hidden on mobile
   .select-universe {
     margin: var(--padding-1_5x) var(--padding) 0;
-    @include media.min-width(large) {
-      margin-top: var(--padding-1_5x) 0 0;
+    @include media.min-width(medium) {
+      margin: var(--padding-1_5x) 0 0;
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

While the mobile gaps were reduced, the universe selector gaps on tablet and larger screens were [affected negatively](https://github.com/dfinity/nns-dapp/pull/6327/files#diff-dbb5a4699f2c5c767017edd873a5f737fcfa8cbcda4d587641c25fe2345d49fcL52) (see the screenshots).

# Changes

- Restore the initial tablet+ margins.

# Tests

- Tested locally.

| | |
|--------|--------|
| Before | ![Screenshot 2025-02-12 at 10 26 41](https://github.com/user-attachments/assets/94f97732-a1b0-4802-9656-173add9c927e) |
| After | ![Screenshot 2025-02-12 at 10 20 40](https://github.com/user-attachments/assets/e0b7fdf2-045c-4f18-842d-3c9e50b3b303) | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.