### PR TITLE
Expose memory usage in bytes

### DIFF
--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -72,6 +72,16 @@ pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "Amount of wasm memory used by this canister, in binary gigabytes",
     )?;
     w.encode_gauge(
+        "stable_memory_bytes",
+        stable_memory_size_bytes() as f64,
+        "Amount of stable memory used by this canister, in bytes",
+    )?;
+    w.encode_gauge(
+        "heap_memory_bytes",
+        wasm_memory_size_bytes() as f64,
+        "Amount of wasm memory used by this canister, in bytes",
+    )?;
+    w.encode_gauge(
         "nns_dapp_migration_countdown",
         f64::from(stats.migration_countdown.unwrap_or(0)),
         "When non-zero, a migration is in progress.",


### PR DESCRIPTION
# Motivation

According to [this slack thread](https://dfinity.slack.com/archives/CH4CADCJX/p1731504006265059), by exposing heap and stable memory usage in bytes as metrics named `heap_memory_bytes` and `stable_memory_bytes`, we automatically get some alerts on high memory usage.

# Changes

1. Expose metrics.

# Tests

Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.raw.dskloet-ingress.devenv.dfinity.network/metrics

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary