### PR TITLE
Import question-mark.svg in test

### DIFF
--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -1,3 +1,4 @@
+import UNKNOWN_LOGO from "$lib/assets/question-mark.svg";
 import {
   CKETHSEPOLIA_INDEX_CANISTER_ID,
   CKETHSEPOLIA_LEDGER_CANISTER_ID,
@@ -95,7 +96,7 @@ describe("icrcTokensUniversesStore", () => {
     });
     expect(get(icrcTokensUniversesStore)).toMatchObject([
       {
-        logo: "/src/lib/assets/question-mark.svg",
+        logo: UNKNOWN_LOGO,
       },
     ]);
   });


### PR DESCRIPTION
# Motivation

Currently
```
import UNKNOWN_LOGO from "$lib/assets/question-mark.svg";
```
results in `UNKNOWN_LOGO` having value `/src/lib/assets/question-mark.svg`.

But after updating Vite and Svelte, it gets a value which is a data URL, breaking the test.
By importing the expected value instead of hard coding it, the test passes both before and after updating Vite and Svelte.

# Changes

1. Use `import UNKNOWN_LOGO from "$lib/assets/question-mark.svg"` to determine the expected value of the unknown logo.

# Tests

Test only.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary