### PR TITLE
Fail on cargo audit error

### DIFF
--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -305,13 +305,8 @@ npm_audit() {
 }
 
 cargo_audit() {
-  local output
-  output="$(cargo audit --json | jq -r '[.vulnerabilities.list[] | .advisory.id] | sort | join(",")' || true)"
-
-  if [ -z "$output" ]; then
+  if cargo audit --json | jq -r '[.vulnerabilities.list[] | .advisory.id] | sort | join(",")'; then
     echo "no vulnerabilities"
-  else
-    echo "$output"
   fi
 }
 


### PR DESCRIPTION
# Motivation

`release-sop` assumes that `cargo audit --json` will either
* succeed and not output any issues, or
* fail and output issues

But `cargo audit` has been failing without outputting anything on stdout, and the following error on stderr:
```
error: not found: Couldn't load Cargo.lock: I/O operation failed: parse error: parse error: invalid Cargo.lock format version: `4`
```
This went unnoticed because the `release-sop` script assumed success because there was no output on stdout.

# Changes

1. Only assume there are no vulnerabilities if `cargo audit` succeeds.

# Tests

1. Manually ran the command on an old commit without issues, on an old commit with issues and on a new commit with the above error.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary