### PR TITLE
fix(tests): resolve flaky test due timing in the CI

### DIFF
--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -82,6 +82,13 @@ test("Test merge neurons", async ({ page, context }) => {
   step("Merge neurons");
   await appPo.goToNnsNeurons();
 
+  // We get for component to appear and the skeletong to go away
+  footerPo
+    .getMergeNeuronsModalPo()
+    .getConfirmNeuronsMergePo()
+    .getMergedNeuronDetailCardPo()
+    .waitFor();
+
   await footerPo.mergeNeurons({
     sourceNeurondId: neuronId1,
     targetNeuronId: neuronId2,

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -82,13 +82,6 @@ test("Test merge neurons", async ({ page, context }) => {
   step("Merge neurons");
   await appPo.goToNnsNeurons();
 
-  // We get for component to appear and the skeletong to go away
-  footerPo
-    .getMergeNeuronsModalPo()
-    .getConfirmNeuronsMergePo()
-    .getMergedNeuronDetailCardPo()
-    .waitFor();
-
   await footerPo.mergeNeurons({
     sourceNeurondId: neuronId1,
     targetNeuronId: neuronId2,

--- a/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
@@ -29,6 +29,11 @@ export class MergeNeuronsModalPo extends ModalPo {
       sourceNeurondId,
       targetNeuronId,
     });
+
+    // We get for component to appear and the skeletong to go away
+    await this.getConfirmNeuronsMergePo()
+      .getMergedNeuronDetailCardPo()
+      .waitFor();
     await this.getConfirmNeuronsMergePo().getConfirmMergeButtonPo().click();
     await this.waitForAbsent();
   }

--- a/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
@@ -30,7 +30,7 @@ export class MergeNeuronsModalPo extends ModalPo {
       targetNeuronId,
     });
 
-    // We get for component to appear and the skeletong to go away
+    // We wait for the component to appear to ensure the UI remains stable and the button is within the viewport
     await this.getConfirmNeuronsMergePo()
       .getMergedNeuronDetailCardPo()
       .waitFor();


### PR DESCRIPTION
# Motivation

In #6391, the merge queue failed due to a flaky test. The investigation revealed that the issue occurs when scrolling down to the button while the skeleton is present. At other times, the component loads, and the button moves out of the viewport, resulting in this strange behavior.

# Changes

- It waits for the component to render and for the skeleton to disappear before clicking.

# Tests

- Should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.