### PR TITLE
Topics separator

### DIFF
--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -13,7 +13,8 @@
     getTopicTitle,
   } from "$lib/utils/neuron.utils";
   import { IconClose, Value } from "@dfinity/gix-components";
-  import type { NeuronId, NeuronInfo, Topic } from "@dfinity/nns";
+  import { Topic, type NeuronId, type NeuronInfo } from "@dfinity/nns";
+  import Separator from "$lib/components/ui/Separator.svelte";
 
   export let topic: Topic;
   export let neuron: NeuronInfo;
@@ -83,6 +84,11 @@
       {/each}
     </ul>
   </FollowTopicSection>
+
+  {#if topic === Topic.Unspecified}
+    <Separator testId="separator" spacing="small" />
+  {/if}
+
   {#if showNewFolloweeModal}
     <NewFolloweeModal {neuron} {topic} on:nnsClose={closeNewFolloweeModal} />
   {/if}

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -2,10 +2,11 @@
   import { i18n } from "$lib/stores/i18n";
   import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
-  import type { ProposalStatus, Topic } from "@dfinity/nns";
+  import { Topic, type ProposalStatus } from "@dfinity/nns";
   import type { SnsProposalDecisionStatus } from "@dfinity/sns";
   import { isNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
+  import Separator from "$lib/components/ui/Separator.svelte";
 
   type FiltersData =
     | SnsProposalTypeFilterId
@@ -61,13 +62,16 @@
 
     {#if filters}
       <div class="filters">
-        {#each filters as { id, name, checked } (id)}
+        {#each filters as { id, name, checked, value, category } (id)}
           <Checkbox
             testId={`filter-modal-option-${id}`}
             inputId={id}
             {checked}
             on:nnsChange={() => onChange(id)}>{name}</Checkbox
           >
+          {#if category === "topics" && value === Topic.SnsAndCommunityFund}
+            <Separator testId={`separator-${id}`} spacing="medium" />
+          {/if}
         {/each}
       </div>
     {:else}

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
+  import type {
+    Filter,
+    NnsProposalFilterCategory,
+    SnsProposalTypeFilterId,
+  } from "$lib/types/filters";
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import { Topic, type ProposalStatus } from "@dfinity/nns";
   import type { SnsProposalDecisionStatus } from "@dfinity/sns";
@@ -16,6 +20,7 @@
   // `undefined` means the filters are not loaded yet.
   export let filters: Filter<FiltersData>[] | undefined;
   export let visible = true;
+  export let category: undefined | NnsProposalFilterCategory = undefined;
 
   let loading: boolean;
   $: loading = isNullish(filters);
@@ -62,7 +67,7 @@
 
     {#if filters}
       <div class="filters">
-        {#each filters as { id, name, checked, value, category } (id)}
+        {#each filters as { id, name, checked, value } (id)}
           <Checkbox
             testId={`filter-modal-option-${id}`}
             inputId={id}

--- a/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
+++ b/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
@@ -118,6 +118,7 @@
 
 <FilterModal
   {visible}
+  {category}
   on:nnsClose={close}
   on:nnsConfirm={filter}
   on:nnsChange={onChange}

--- a/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
+++ b/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
@@ -3,7 +3,7 @@
   import FilterModal from "$lib/modals/common/FilterModal.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { proposalsFiltersStore } from "$lib/stores/proposals.store";
-  import type { Filter } from "$lib/types/filters";
+  import type { Filter, NnsProposalFilterCategory } from "$lib/types/filters";
   import type {
     ProposalsFilterModalProps,
     ProposalsFilters,
@@ -23,7 +23,7 @@
   export let props: ProposalsFilterModalProps | undefined;
 
   let visible: boolean;
-  let category: string;
+  let category: NnsProposalFilterCategory;
   let filters: ProposalsFilters | undefined;
   let filtersValues: Filter<Topic | ProposalStatus>[];
   let selectedFilters: (Topic | ProposalStatus)[];
@@ -44,6 +44,7 @@
             })
           : getTopicTitle({ topic: value as Topic, i18n: $i18n }),
       checked: selectedFilters?.includes(value),
+      category,
     };
   };
 

--- a/frontend/src/lib/types/filters.ts
+++ b/frontend/src/lib/types/filters.ts
@@ -9,7 +9,6 @@ export type SnsProposalTypeFilterId =
 export type NnsProposalFilterCategory = "topics" | "status" | "uncategorized";
 
 export type Filter<T> = {
-  category: NnsProposalFilterCategory;
   name: string;
   value: T;
   id: string;

--- a/frontend/src/lib/types/filters.ts
+++ b/frontend/src/lib/types/filters.ts
@@ -6,7 +6,10 @@ export type SnsProposalTypeFilterId =
   | string
   | typeof ALL_SNS_GENERIC_PROPOSAL_TYPES_ID;
 
+export type NnsProposalFilterCategory = "topics" | "status" | "uncategorized";
+
 export type Filter<T> = {
+  category: NnsProposalFilterCategory;
   name: string;
   value: T;
   id: string;

--- a/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
@@ -83,6 +83,18 @@ describe("EditFollowNeurons", () => {
     ]);
   });
 
+  it("renders topics with separator", async () => {
+    const po = renderComponent();
+    const sectionPos = await po.getFollowNnsTopicSectionPos();
+
+    for (const sectionPo of sectionPos) {
+      expect(await sectionPo.hasSeparator()).toBe(
+        (await (await sectionPo.getFollowTopicSectionPo()).getTopicTitle()) ===
+          "All Except Governance, and SNS & Neurons' Fund"
+      );
+    }
+  });
+
   it("displays the followees of the user in specific topic", async () => {
     const po = renderComponent();
     const topicSectionPo = await po.getFollowTopicSectionPo(Topic.ExchangeRate);

--- a/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
@@ -2,7 +2,7 @@ import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import ProposalsFilterModal from "$lib/modals/proposals/NnsProposalsFilterModal.svelte";
 import { proposalsFiltersStore } from "$lib/stores/proposals.store";
 import type { ProposalsFilterModalProps } from "$lib/types/proposals";
-import { enumKeys } from "$lib/utils/enum.utils";
+import { enumKeys, enumValues } from "$lib/utils/enum.utils";
 import en from "$tests/mocks/i18n.mock";
 import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -67,6 +67,17 @@ describe("ProposalsFilterModal", () => {
     ];
 
     expect(checkboxLabels).toEqual(expectedLabels);
+  });
+
+  it("should render separator", async () => {
+    const po = renderComponent();
+
+    for (const value of enumValues(Topic)) {
+      const separator = await po.getFilterEntrySeparatorByIdPo(`${value}`);
+      expect(await separator.isPresent()).toEqual(
+        value === Topic.SnsAndCommunityFund
+      );
+    }
   });
 
   it("should not render filter Unspecified", async () => {

--- a/frontend/src/tests/page-objects/FilterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/FilterModal.page-object.ts
@@ -28,6 +28,10 @@ export class FilterModalPo extends ModalPo {
     });
   }
 
+  getFilterEntrySeparatorByIdPo(testId: string): PageObjectElement {
+    return this.root.byTestId(`separator-${testId}`);
+  }
+
   clickConfirmButton(): Promise<void> {
     return this.click("apply-filters");
   }

--- a/frontend/src/tests/page-objects/FollowNnsTopicSection.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowNnsTopicSection.page-object.ts
@@ -33,6 +33,10 @@ export class FollowNnsTopicSectionPo extends BasePageObject {
     });
   }
 
+  async hasSeparator(): Promise<boolean> {
+    return this.root.byTestId("separator").isPresent();
+  }
+
   getNewFolloweeModalPo(): NewFolloweeModalPo {
     return NewFolloweeModalPo.under(this.root);
   }


### PR DESCRIPTION
# Motivation

To improve UX, a divider should be displayed to visually separate popular topics from the other topics (which are sorted alphabetically).

# Changes

- Add separator to topic filter.
- Add separator to follow neuron list.

# Tests

- Added.

| Topic Filter | Following Modal |
|--------|--------|
| <img width="522" alt="image" src="https://github.com/user-attachments/assets/e68222ca-4537-4431-8425-5214221dbaac" /> | <img width="621" alt="image" src="https://github.com/user-attachments/assets/816b257f-d0be-45b6-a764-3c569dbed916" /> | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.