### PR TITLE
Remove this.waitForAbsent() from page objects

### DIFF
--- a/frontend/src/tests/e2e/following.spec.ts
+++ b/frontend/src/tests/e2e/following.spec.ts
@@ -53,13 +53,7 @@ test("Test neuron following", async ({ page, context }) => {
   followNnsTopicSections.reverse();
   const followee = "123";
   for (const followNnsTopicSection of followNnsTopicSections) {
-    const followTopicSection =
-      await followNnsTopicSection.getFollowTopicSectionPo();
-    await followTopicSection.getCollapsiblePo().expand();
-    await followTopicSection.getAddFolloweeButtonPo().click();
-    await followNnsTopicSection
-      .getNewFolloweeModalPo()
-      .followNeuronId(followee);
+    await followNnsTopicSection.addFollowee(followee);
     const followees = await followNnsTopicSection.getFollowees();
     expect(followees).toContain(followee);
   }

--- a/frontend/src/tests/page-objects/AddHotkeyModal.page-object.ts
+++ b/frontend/src/tests/page-objects/AddHotkeyModal.page-object.ts
@@ -15,6 +15,5 @@ export class AddHotkeyModalPo extends ModalPo {
 
   async addHotkey(principal: string): Promise<void> {
     await this.getAddPrincipalPo().addPrincipal(principal);
-    await this.waitForClosed();
   }
 }

--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -33,7 +33,9 @@ export class CanisterDetailPo extends BasePageObject {
   }
 
   async renameCanister(newName: string): Promise<void> {
-    await this.getRenameCanisterModalPo().rename(newName);
+    const modal = this.getRenameCanisterModalPo();
+    await modal.rename(newName);
+    await modal.waitForAbsent();
   }
 
   getCanisterPageHeading(): CanisterPageHeadingPo {

--- a/frontend/src/tests/page-objects/ConfirmationModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmationModal.page-object.ts
@@ -30,9 +30,4 @@ export class ConfirmationModalPo extends ModalPo {
   async clickYes(): Promise<void> {
     await this.getConfirmYesButton().click();
   }
-
-  async confirmYes(): Promise<void> {
-    await this.clickYes();
-    await this.waitForClosed();
-  }
 }

--- a/frontend/src/tests/page-objects/FollowNnsTopicSection.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowNnsTopicSection.page-object.ts
@@ -48,4 +48,14 @@ export class FollowNnsTopicSectionPo extends BasePageObject {
       )
     );
   }
+
+  async addFollowee(followee: string): Promise<void> {
+    const followTopicSection = await this.getFollowTopicSectionPo();
+    await followTopicSection.getCollapsiblePo().expand();
+    await followTopicSection.getAddFolloweeButtonPo().click();
+
+    const modal = this.getNewFolloweeModalPo();
+    await modal.followNeuronId(followee);
+    await modal.waitForAbsent();
+  }
 }

--- a/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
@@ -35,6 +35,5 @@ export class MergeNeuronsModalPo extends ModalPo {
       .getMergedNeuronDetailCardPo()
       .waitFor();
     await this.getConfirmNeuronsMergePo().getConfirmMergeButtonPo().click();
-    await this.waitForAbsent();
   }
 }

--- a/frontend/src/tests/page-objects/NewFolloweeModal.page-object.ts
+++ b/frontend/src/tests/page-objects/NewFolloweeModal.page-object.ts
@@ -16,6 +16,5 @@ export class NewFolloweeModalPo extends ModalPo {
   async followNeuronId(neuronId: string): Promise<void> {
     await this.getTextInputPo().typeText(neuronId);
     await this.click("follow-neuron-button");
-    await this.waitForClosed();
   }
 }

--- a/frontend/src/tests/page-objects/NnsAddMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAddMaturityModal.page-object.ts
@@ -18,6 +18,5 @@ export class NnsAddMaturityModalPo extends ModalPo {
   async addMaturity(amount: number): Promise<void> {
     await this.getTextInputPo().typeText(amount.toString());
     await this.click("confirm-add-maturity-button");
-    await this.waitForClosed();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -112,38 +112,39 @@ export class NnsNeuronDetailPo extends BasePageObject {
       .getDissolveButtonPo()
       .click();
     const modal = this.getNnsNeuronModalsPo().getDissolveActionButtonModalPo();
-    await modal.confirmYes();
+    await modal.clickYes();
+    await modal.waitForClosed();
   }
 
   async addHotkey(principal: string): Promise<void> {
     await this.getNnsNeuronHotkeysCardPo().clickAddHotkey();
-    await this.getNnsNeuronModalsPo()
-      .getAddHotkeyModalPo()
-      .addHotkey(principal);
+    const modal = this.getNnsNeuronModalsPo().getAddHotkeyModalPo();
+    await modal.addHotkey(principal);
+    await modal.waitForClosed();
   }
 
   async joinCommunityFund(): Promise<void> {
     await this.getAdvancedSectionPo().clickJoinCommunityFundCheckbox();
     const modal =
       await this.getNnsNeuronModalsPo().getJoinCommunityFundModalPo();
-    await modal.confirmYes();
+    await modal.clickYes();
+    await modal.waitForClosed();
   }
 
   async addMaturity(amount: number): Promise<void> {
     await this.getNnsNeuronTestnetFunctionsCardPo().clickAddMaturity();
-    await this.getNnsNeuronModalsPo()
-      .getNnsAddMaturityModalPo()
-      .addMaturity(amount);
+    const modal = this.getNnsNeuronModalsPo().getNnsAddMaturityModalPo();
+    await modal.addMaturity(amount);
+    await modal.waitForClosed();
   }
 
   async updateVotingPowerRefreshedTimestamp(timestamp: number): Promise<void> {
     await this.getNnsNeuronTestnetFunctionsCardPo().clickUpdateVotingPowerRefreshedTimestamp();
-    await this.getNnsNeuronModalsPo()
-      .getUpdateVotingPowerRefreshedModalPo()
-      .waitFor();
-    await this.getNnsNeuronModalsPo()
-      .getUpdateVotingPowerRefreshedModalPo()
-      .updateTimestampSeconds(timestamp);
+    const modal =
+      this.getNnsNeuronModalsPo().getUpdateVotingPowerRefreshedModalPo();
+    await modal.waitFor();
+    await modal.updateTimestampSeconds(timestamp);
+    await modal.waitForClosed();
   }
 
   async spawnNeuron({ percentage }: { percentage: number }): Promise<void> {
@@ -151,8 +152,8 @@ export class NnsNeuronDetailPo extends BasePageObject {
       .getAvailableMaturityItemActionPo()
       .getSpawnButton()
       .click();
-    await this.getNnsNeuronModalsPo()
-      .getSpawnNeuronModalPo()
-      .spawnNeuron({ percentage });
+    const modal = this.getNnsNeuronModalsPo().getSpawnNeuronModalPo();
+    await modal.spawnNeuron({ percentage });
+    await modal.waitForClosed();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
@@ -52,9 +52,8 @@ export class NnsNeuronsFooterPo extends BasePageObject {
     targetNeuronId: string;
   }): Promise<void> {
     await this.clickMergeNeuronsButton();
-    await this.getMergeNeuronsModalPo().mergeNeurons({
-      sourceNeurondId,
-      targetNeuronId,
-    });
+    const modal = this.getMergeNeuronsModalPo();
+    await modal.mergeNeurons({ sourceNeurondId, targetNeuronId });
+    await modal.waitForClosed();
   }
 }

--- a/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
@@ -34,6 +34,5 @@ export class RenameCanisterModalPo extends ModalPo {
   async rename(newName: string): Promise<void> {
     await this.enterName(newName);
     await this.clickRenameButton();
-    await this.waitForAbsent();
   }
 }

--- a/frontend/src/tests/page-objects/SpawnNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SpawnNeuronModal.page-object.ts
@@ -15,6 +15,5 @@ export class SpawnNeuronModalPo extends ModalPo {
 
   async spawnNeuron({ percentage }: { percentage: number }): Promise<void> {
     await this.getNeuronSelectPercentagePo().spawnNeuron({ percentage });
-    await this.waitForClosed();
   }
 }

--- a/frontend/src/tests/page-objects/UpdateVotingPowerRefreshedModal.page-object.ts
+++ b/frontend/src/tests/page-objects/UpdateVotingPowerRefreshedModal.page-object.ts
@@ -27,6 +27,5 @@ export class UpdateVotingPowerRefreshedModalPo extends ModalPo {
       .byTestId("update-voting-power-refreshed-seconds-input")
       .typeText(seconds.toString());
     await this.click("confirm-update-voting-power-refreshed-button");
-    await this.waitForClosed();
   }
 }


### PR DESCRIPTION
# Motivation

We have several page object function that wait for the component to be absent by calling `await this.waitForAbsent()` or `await this.waitForClosed()`.
But a component can't control its own presence; it must be controlled by the parent component.
So these functions don't work when the component is tested directly but only if the parent is tested.
This makes some page object method less useful than they could be.
The right thing to do it to move the `waitForAbsent()` call to the page object of the parent component.

# Changes

1. Remove `this.waitForAbsent()` calls from page objects and instead wait for the component to be absent on the calling side.

# Tests

1. All the changed code is test-only code.
2. I made sure I didn't miss any callers by renaming the affected method and then renaming them back after everything compiled.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary