### PR TITLE
feat(store): new store to track canister errors

### DIFF
--- a/frontend/src/lib/stores/canisters-errors.store.ts
+++ b/frontend/src/lib/stores/canisters-errors.store.ts
@@ -1,0 +1,45 @@
+import { writable, type Readable } from "svelte/store";
+
+type CanisterId = string;
+type CanisterError = {
+  raw: unknown;
+};
+export type CanistersErrorsStoreData = Record<CanisterId, CanisterError>;
+
+export interface CanistersErrorsStore
+  extends Readable<CanistersErrorsStoreData> {
+  set: (params: { canisterId: CanisterId; rawError: unknown }) => void;
+  delete: (canisterId: CanisterId) => void;
+}
+
+export const initCanistersErrorsStore = (): CanistersErrorsStore => {
+  const initialCanistersErrors: CanistersErrorsStoreData = {};
+
+  const { subscribe, update } = writable<CanistersErrorsStoreData>(
+    initialCanistersErrors
+  );
+
+  return {
+    subscribe,
+    set: ({ canisterId, rawError }) => {
+      update((currentState: CanistersErrorsStoreData) => ({
+        ...currentState,
+        [canisterId]: {
+          raw: rawError,
+        },
+      }));
+    },
+    delete: (canisterId) => {
+      update(
+        ({
+          [canisterId]: _,
+          ...restOfCanisters
+        }: CanistersErrorsStoreData) => ({
+          ...restOfCanisters,
+        })
+      );
+    },
+  };
+};
+
+export const canistersErrorsStore = initCanistersErrorsStore();

--- a/frontend/src/tests/lib/stores/canisters-errors.store.spec.ts
+++ b/frontend/src/tests/lib/stores/canisters-errors.store.spec.ts
@@ -1,0 +1,50 @@
+import { canistersErrorsStore } from "$lib/stores/canisters-errors.store";
+import { get } from "svelte/store";
+
+describe("canisters-errors.store", () => {
+  it("should initialize it empty", () => {
+    expect(get(canistersErrorsStore)).toEqual({});
+  });
+
+  it("should set error", () => {
+    const canisterId = "canister-id";
+    const error = "something went wrong";
+
+    canistersErrorsStore.set({ canisterId, rawError: error });
+
+    expect(get(canistersErrorsStore)).toEqual({
+      [canisterId]: {
+        raw: error,
+      },
+    });
+  });
+
+  it("should remove error", () => {
+    const canisterId = "canister-id";
+    const anotherCanisterId = "another-canister-id";
+    const error = "something went wrong";
+
+    canistersErrorsStore.set({ canisterId, rawError: error });
+    canistersErrorsStore.set({
+      canisterId: anotherCanisterId,
+      rawError: error,
+    });
+
+    expect(get(canistersErrorsStore)).toEqual({
+      [canisterId]: {
+        raw: error,
+      },
+      [anotherCanisterId]: {
+        raw: error,
+      },
+    });
+
+    canistersErrorsStore.delete(anotherCanisterId);
+
+    expect(get(canistersErrorsStore)).toEqual({
+      [canisterId]: {
+        raw: error,
+      },
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Sometimes, canisters may become non-operative, such as when they run out-of-cycles. We need to be aware of these situations so we can update the UI accordingly.

This new store contains a map of canisters and their errors.

Out of scope: Parsing errors and making them usable.

# Changes

- New store `canistersErrorsStore`

# Tests

- Unit tests for the store

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary