### PR TITLE
Update snsdemo to release-2025-02-12 (+fix e2e test)

### DIFF
--- a/config.json
+++ b/config.json
@@ -106,7 +106,7 @@
         "DIDC_VERSION": "didc 0.4.0",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2025-02-05",
+        "SNSDEMO_RELEASE": "release-2025-02-12",
         "IC_COMMIT_FOR_PROPOSALS": "release-2025-02-06_12-26-revert-hashes-in-blocks",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2025-02-06_12-26-revert-hashes-in-blocks"
       },

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -68,19 +68,23 @@ test("Test proposals", async ({ page, context }) => {
   await appPo
     .getProposalsPo()
     .getNnsProposalFiltersPo()
-    .selectTopicFilter([Topic.ExchangeRate]);
+    .selectTopicFilter([Topic.ProtocolCanisterManagement]);
   await nnsProposalListPo.waitForContentLoaded();
 
-  expect(await getVisibleCardTopics()).toEqual(["Exchange Rate"]);
+  expect(await getVisibleCardTopics()).toEqual([
+    "Protocol Canister Management",
+  ]);
 
   // Invert topic filter
   await appPo
     .getProposalsPo()
     .getNnsProposalFiltersPo()
-    .selectAllTopicsExcept([Topic.ExchangeRate]);
+    .selectAllTopicsExcept([Topic.ProtocolCanisterManagement]);
   await nnsProposalListPo.waitForContentLoaded();
 
-  expect((await getVisibleCardTopics()).includes("Exchange Rate")).toBe(false);
+  expect(
+    (await getVisibleCardTopics()).includes("Protocol Canister Management")
+  ).toBe(false);
 
   step("Filter proposals by Status");
   const getVisibleCardStatuses = () => nnsProposalListPo.getCardStatuses();


### PR DESCRIPTION
# Motivation

The [automatic snsdemo update PR](https://github.com/dfinity/nns-dapp/pull/6422) [failed](https://github.com/dfinity/nns-dapp/actions/runs/13322014060/job/37208355756?pr=6422) because an exchange rate proposal is no longer created during snapshot creation.

# Changes

1. Update snsdemo.
2. Change the e2e test to use a different proposal type (ProtocolCanisterManagement).

# Tests

Fixed.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary