### PR TITLE
update node to 18.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ SHELL ["bash", "-c"]
 RUN mkdir -p config
 COPY dfx.json dfx.json
 COPY config.json config.json
-ENV NODE_VERSION=16.17.1
+ENV NODE_VERSION=18.20.5
 RUN jq -r .dfx dfx.json > config/dfx_version
 RUN jq -r '.defaults.build.config.NODE_VERSION' config.json > config/node_version
 RUN jq -r '.defaults.build.config.DIDC_RELEASE' config.json > config/didc_version

--- a/config.json
+++ b/config.json
@@ -97,7 +97,7 @@
     },
     "build": {
       "config": {
-        "NODE_VERSION": "18.14.2",
+        "NODE_VERSION": "18.20.5",
         "IC_WASM_VERSION": "0.6.0",
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",


### PR DESCRIPTION
# Motivation

We have a version mismatch of Node between our Dockerfile and dfx. Node 16 has not been supported for some time. This PR updates both the Dockerfile and dfx to the same version we use for [development]((https://github.com/dfinity/nns-dapp/blob/0b588ce77c56d267be73fd159996bf73d2d3853b/frontend/.nvmrc)).

Additionally, we could upgrade to the latest patch, which addresses some security vulnerabilities ([v18.20.6]((https://github.com/nodejs/node/releases/tag/v18.20.6).)).

# Changes

- Bump version of node in `dockerfile` and `config.json` to `18.20.5`

# Tests

- It should build
- Tested in [devenv]()

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary