### PR TITLE
WIP 

### DIFF
--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -10,6 +10,7 @@
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { canistersErrorsStore } from "$lib/stores/canisters-errors.store";
   import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
@@ -93,6 +94,7 @@
     nnsNeurons: $neuronsStore?.neurons,
     snsNeurons: $snsNeuronsStore,
     icpSwapUsdPrices: $icpSwapUsdPricesStore,
+    canistersErrors: $canistersErrorsStore,
   });
 
   let sortedTableProjects: TableProject[];

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -9,6 +9,11 @@ import { failedExistentImportedTokenLedgerIdsStore } from "$lib/derived/imported
 import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
 import { tokensByUniverseIdStore } from "$lib/derived/tokens.derived";
 import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
+import {
+  canistersErrorsStore,
+  type CanistersErrorsStore,
+  type CanistersErrorsStoreData,
+} from "$lib/stores/canisters-errors.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import {
   UserTokenAction,
@@ -19,7 +24,7 @@ import { sumAccounts } from "$lib/utils/accounts.utils";
 import { buildAccountsUrl, buildWalletUrl } from "$lib/utils/navigation.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
 import { toUserTokenFailed } from "$lib/utils/user-token.utils";
-import { isNullish, TokenAmountV2 } from "@dfinity/utils";
+import { isNullish, nonNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
 const getUsdValue = ({
@@ -50,11 +55,13 @@ const convertToUserTokenData = ({
   tokensByUniverse,
   baseTokenData,
   icpSwapUsdPrices,
+  canistersErrors,
 }: {
   accounts: UniversesAccounts;
   tokensByUniverse: Record<string, IcrcTokenMetadata>;
   baseTokenData: UserTokenBase;
   icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
+  canistersErrors: CanistersErrorsStoreData;
 }): UserToken => {
   const token = tokensByUniverse[baseTokenData.universeId.toText()];
   const rowHref = isUniverseNns(baseTokenData.universeId)
@@ -64,6 +71,16 @@ const convertToUserTokenData = ({
       });
   const accountsList = accounts[baseTokenData.universeId.toText()];
   const mainAccount = accountsList?.find(({ type }) => type === "main");
+  const ledgerCanisterError =
+    canistersErrors[baseTokenData.ledgerCanisterId.toString()];
+
+  if (nonNullish(ledgerCanisterError)) {
+    return {
+      ...baseTokenData,
+      balance: "failed",
+      domKey: rowHref,
+    };
+  }
   if (isNullish(token) || isNullish(accountsList) || isNullish(mainAccount)) {
     return {
       ...baseTokenData,
@@ -114,6 +131,7 @@ export const tokensListUserStore = derived<
     Readable<Record<string, IcrcTokenMetadata>>,
     Readable<Array<string>>,
     IcpSwapUsdPricesStore,
+    CanistersErrorsStore,
   ],
   UserToken[]
 >(
@@ -123,6 +141,7 @@ export const tokensListUserStore = derived<
     tokensByUniverseIdStore,
     failedExistentImportedTokenLedgerIdsStore,
     icpSwapUsdPricesStore,
+    canistersErrorsStore,
   ],
   ([
     tokensList,
@@ -130,6 +149,7 @@ export const tokensListUserStore = derived<
     tokensByUniverse,
     failedImportedTokenLedgerIds,
     icpSwapUsdPrices,
+    canistersErrors,
   ]) => [
     ...tokensList.map((baseTokenData) =>
       convertToUserTokenData({
@@ -137,6 +157,7 @@ export const tokensListUserStore = derived<
         accounts,
         tokensByUniverse,
         icpSwapUsdPrices,
+        canistersErrors,
       })
     ),
     ...failedImportedTokenLedgerIds.map(toUserTokenFailed),

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -71,7 +71,7 @@
 
   let areStakedTokensLoading: boolean;
   $: areStakedTokensLoading = tableProjects.some(
-    (project) => project.isStakeLoading
+    (project) => project.isStakeLoading && !project.hasError
   );
 
   // Determines the display state of the staked tokens card

--- a/frontend/src/lib/services/actionable-sns-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-sns-proposals.services.ts
@@ -3,11 +3,12 @@ import { MAX_ACTIONABLE_REQUEST_COUNT } from "$lib/constants/constants";
 import { DEFAULT_SNS_PROPOSALS_PAGE_SIZE } from "$lib/constants/sns-proposals.constants";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
-import { loadSnsNeurons } from "$lib/services/sns-neurons.services";
+import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
 import {
   actionableSnsProposalsStore,
   failedActionableSnsesStore,
 } from "$lib/stores/actionable-sns-proposals.store";
+import { canistersErrorsStore } from "$lib/stores/canisters-errors.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { votableSnsNeurons } from "$lib/utils/sns-neuron.utils";
 import {
@@ -67,8 +68,13 @@ export const loadActionableProposalsForSns = async (
   } catch (err) {
     console.error(err);
 
+    // do we also need this store to handle failed canisters? rootCanister and governanceCanister are different though
     // Store the failed root canister ID to provide the correct loading state.
     failedActionableSnsesStore.add(rootCanisterId.toText());
+    canistersErrorsStore.set({
+      canisterId: rootCanisterId.toText(),
+      rawError: err,
+    });
   }
 };
 

--- a/frontend/src/lib/services/actionable-sns-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-sns-proposals.services.ts
@@ -3,7 +3,7 @@ import { MAX_ACTIONABLE_REQUEST_COUNT } from "$lib/constants/constants";
 import { DEFAULT_SNS_PROPOSALS_PAGE_SIZE } from "$lib/constants/sns-proposals.constants";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
-import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
+import { loadSnsNeurons } from "$lib/services/sns-neurons.services";
 import {
   actionableSnsProposalsStore,
   failedActionableSnsesStore,

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -106,6 +106,7 @@ export const loadIcrcToken = ({
           importedTokens: get(importedTokensStore)?.importedTokens,
         })
       ) {
+        // this could be handled by the new store.
         // Do not display error toasts for imported tokens.
         // Failed imported tokens will be shown with a warning icon in the UI.
         failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
@@ -203,12 +204,14 @@ export const loadAccounts = async ({
       icrcAccountsStore.resetUniverse(ledgerCanisterId);
       icrcTransactionsStore.resetUniverse(ledgerCanisterId);
 
+      //this could be handled by the new store
       if (
         isImportedToken({
           ledgerCanisterId,
           importedTokens: get(importedTokensStore)?.importedTokens,
         })
       ) {
+        //this could be handled by the new store
         // Do not display error toasts for imported tokens.
         // Failed imported tokens will be shown with a warning icon in the UI.
         failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
@@ -221,8 +224,20 @@ export const loadAccounts = async ({
         );
       }
 
+      // maybe expose has method in the store
+      // if (!get(canistersErrorsStore)[ledgerCanisterId.toText()]) {
+      //   // this executes before adding to the store. we could check if there is an error, and then not show the toast as it was already shown
+      //   toastsError(
+      //     toToastError({
+      //       err,
+      //       fallbackErrorLabelKey: "error.accounts_load",
+      //     })
+      //   );
+      // }
+
       handleError?.();
     },
+    canisterId: ledgerCanisterId.toText(),
     logMessage: "Syncing Accounts",
   });
 };

--- a/frontend/src/lib/stores/canisters-errors.store.ts
+++ b/frontend/src/lib/stores/canisters-errors.store.ts
@@ -1,0 +1,45 @@
+import { writable, type Readable } from "svelte/store";
+
+type CanisterId = string;
+type CanisterError = {
+  raw: unknown;
+};
+export type CanistersErrorsStoreData = Record<CanisterId, CanisterError>;
+
+export interface CanistersErrorsStore
+  extends Readable<CanistersErrorsStoreData> {
+  set: (params: { canisterId: CanisterId; rawError: unknown }) => void;
+  delete: (canisterId: CanisterId) => void;
+}
+
+export const initCanistersErrorsStore = (): CanistersErrorsStore => {
+  const initialCanistersErrors: CanistersErrorsStoreData = {};
+
+  const { subscribe, update } = writable<CanistersErrorsStoreData>(
+    initialCanistersErrors
+  );
+
+  return {
+    subscribe,
+    set: ({ canisterId, rawError }) => {
+      update((currentState: CanistersErrorsStoreData) => ({
+        ...currentState,
+        [canisterId]: {
+          raw: rawError,
+        },
+      }));
+    },
+    delete: (canisterId) => {
+      update(
+        ({
+          [canisterId]: _,
+          ...restOfCanisters
+        }: CanistersErrorsStoreData) => ({
+          ...restOfCanisters,
+        })
+      );
+    },
+  };
+};
+
+export const canistersErrorsStore = initCanistersErrorsStore();

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -1,5 +1,6 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { type IcpSwapUsdPricesStoreData } from "$lib/derived/icp-swap.derived";
+import type { CanistersErrorsStoreData } from "$lib/stores/canisters-errors.store";
 import type { TableNeuron } from "$lib/types/neurons-table";
 import type { TableProject } from "$lib/types/staking";
 import type { Universe } from "$lib/types/universe";
@@ -147,12 +148,14 @@ export const getTableProjects = ({
   nnsNeurons,
   snsNeurons,
   icpSwapUsdPrices,
+  canistersErrors,
 }: {
   universes: Universe[];
   isSignedIn: boolean;
   nnsNeurons: NeuronInfo[] | undefined;
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
   icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
+  canistersErrors: CanistersErrorsStoreData;
 }): TableProject[] => {
   return universes.map((universe) => {
     const token =
@@ -183,6 +186,10 @@ export const getTableProjects = ({
       isNullish(icpSwapUsdPrices) || icpSwapUsdPrices === "error"
         ? undefined
         : icpSwapUsdPrices[ledgerCanisterId.toText()];
+
+    const hasCanisterAnError =
+      canistersErrors[universe.summary?.rootCanisterId.toText() ?? ""];
+
     const stakeInUsd =
       stake instanceof TokenAmountV2
         ? getUsdValue({
@@ -203,6 +210,7 @@ export const getTableProjects = ({
       availableMaturity,
       stakedMaturity,
       isStakeLoading,
+      hasError: hasCanisterAnError,
     };
   });
 };

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -16,6 +16,7 @@
   } from "$lib/services/accounts-balances.services";
   import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { canistersErrorsStore } from "$lib/stores/canisters-errors.store";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { UserToken } from "$lib/types/tokens-page";
@@ -61,6 +62,7 @@
       nnsNeurons: $neuronsStore?.neurons,
       snsNeurons: $snsNeuronsStore,
       icpSwapUsdPrices: $icpSwapUsdPricesStore,
+      canistersErrors: $canistersErrorsStore,
     })}
   /></TestIdWrapper
 >

--- a/frontend/src/tests/lib/stores/canisters-errors.store.spec.ts
+++ b/frontend/src/tests/lib/stores/canisters-errors.store.spec.ts
@@ -1,0 +1,50 @@
+import { canistersErrorsStore } from "$lib/stores/canisters-errors.store";
+import { get } from "svelte/store";
+
+describe("canisters-errors.store", () => {
+  it("should initialize it empty", () => {
+    expect(get(canistersErrorsStore)).toEqual({});
+  });
+
+  it("should set error", () => {
+    const canisterId = "canister-id";
+    const error = "something went wrong";
+
+    canistersErrorsStore.set({ canisterId, rawError: error });
+
+    expect(get(canistersErrorsStore)).toEqual({
+      [canisterId]: {
+        raw: error,
+      },
+    });
+  });
+
+  it("should remove error", () => {
+    const canisterId = "canister-id";
+    const anotherCanisterId = "another-canister-id";
+    const error = "something went wrong";
+
+    canistersErrorsStore.set({ canisterId, rawError: error });
+    canistersErrorsStore.set({
+      canisterId: anotherCanisterId,
+      rawError: error,
+    });
+
+    expect(get(canistersErrorsStore)).toEqual({
+      [canisterId]: {
+        raw: error,
+      },
+      [anotherCanisterId]: {
+        raw: error,
+      },
+    });
+
+    canistersErrorsStore.delete(anotherCanisterId);
+
+    expect(get(canistersErrorsStore)).toEqual({
+      [canisterId]: {
+        raw: error,
+      },
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We track canister errors in the dapp in multiple ways:
- Imported tokens have their own store, where we track them as a list of `canisterId`s https://github.com/dfinity/nns-dapp/blob/1320117b8417aa5676e42ff504e20f6a91023b80/frontend/src/lib/stores/imported-tokens.store.ts#L60
- Failed actionable sns proposals store that we also track as a list of `canisterId`s https://github.com/dfinity/nns-dapp/blob/1320117b8417aa5676e42ff504e20f6a91023b80/frontend/src/lib/stores/actionable-sns-proposals.store.ts#L75

#6418 introduced the idea of one store that could be used to track any kind of canister error as a map of canisterIds to errors.

This PR shows how this store could be use to track all this different problems:
* `query-and-update` centralized most of the canister calls. Adding there an additional property `canisterId` allows to keep track within the same promise.
* some other calls will required to add them manually like for example the list of proposals.
* consumers can check the store for errors and decide how to transform the data, eg: token balance

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
