### PR TITLE
Add comment about increasing account limit

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -21,6 +21,8 @@ pub mod histogram;
 
 // This limit is for DoS protection but should be increased if we get close to
 // the limit.
+// When you increase this limit, make sure to also increase the limit on the alerts.
+// See for example https://github.com/dfinity-ops/k8s/pull/731
 const ACCOUNT_LIMIT: u64 = 330_000;
 
 const MAX_SUB_ACCOUNT_ID: u8 = u8::MAX - 1;


### PR DESCRIPTION
# Motivation

We have a hard account limit after which no more accounts can be added.
This is to prevent too many accounts being created at once.
But when we approach that number organically, the number should be increased.
We have alerts set up to warn us when we approach the limit.
So those alerts should be increased as well when the limit is increased.

# Changes

Add a comment pointing to an example of how to increase the alert limits.

# Tests

No tested

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary