### PR TITLE
Use page objects in TextInputForm.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
+++ b/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
@@ -2,19 +2,46 @@ import TextInputFormTest from "$tests/lib/components/common/TextInputFormTest.sv
 import { TextInputFormPo } from "$tests/page-objects/TextInputForm.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
-import { clickByTestId } from "$tests/utils/utils.test-utils";
 
 describe("TextInputForm", () => {
   const mandatoryProps = {
     placeholderLabelKey: "test",
   };
 
-  const renderComponent = (props) => {
-    const testId = props.testId ?? "text-input-form";
+  const renderComponent = ({
+    placeholderLabelKey,
+    text,
+    disabledConfirm,
+    disabledInput,
+    required,
+    errorMessage,
+    onClose,
+    onConfirm,
+    testId = "text-input-form",
+  }: {
+    placeholderLabelKey: string;
+    text?: string;
+    disabledConfirm?: boolean;
+    disabledInput?: boolean;
+    required?: boolean;
+    errorMessage?: string;
+    onClose?: () => void;
+    onConfirm?: () => void;
+    testId?: string;
+  }) => {
     const { container } = render(TextInputFormTest, {
       props: {
         testId,
-        ...props,
+        placeholderLabelKey,
+        text,
+        disabledConfirm,
+        disabledInput,
+        required,
+        errorMessage,
+      },
+      events: {
+        nnsClose: onClose,
+        nnsConfirmText: onConfirm,
       },
     });
 
@@ -62,31 +89,27 @@ describe("TextInputForm", () => {
     expect(await po.getErrorMessage()).toBe(errorMessage);
   });
 
-  it("should trigger nnsClose when cancel is clicked", () => {
+  it("should trigger nnsClose when cancel is clicked", async () => {
     const callback = vi.fn();
-
-    const { getByTestId } = render(TextInputFormTest, {
-      props: mandatoryProps,
-      events: {
-        nnsClose: callback,
-      },
+    const po = renderComponent({
+      ...mandatoryProps,
+      onClose: callback,
     });
 
-    clickByTestId(getByTestId, "cancel");
-    expect(callback).toHaveBeenCalled();
+    expect(callback).toBeCalledTimes(0);
+    await po.clickCancelButton();
+    expect(callback).toBeCalledTimes(1);
   });
 
-  it("should trigger nnsConfirmText when confirm is clicked", () => {
+  it("should trigger nnsConfirmText when confirm is clicked", async () => {
     const callback = vi.fn();
-
-    const { getByTestId } = render(TextInputFormTest, {
-      props: mandatoryProps,
-      events: {
-        nnsConfirmText: callback,
-      },
+    const po = renderComponent({
+      ...mandatoryProps,
+      onConfirm: callback,
     });
 
-    clickByTestId(getByTestId, "confirm-text-input-screen-button");
-    expect(callback).toHaveBeenCalled();
+    expect(callback).toBeCalledTimes(0);
+    await po.clickSubmitButton();
+    expect(callback).toBeCalledTimes(1);
   });
 });

--- a/frontend/src/tests/page-objects/TextInputForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TextInputForm.page-object.ts
@@ -28,8 +28,16 @@ export class TextInputFormPo extends BasePageObject {
     return this.getButton("confirm-text-input-screen-button");
   }
 
+  getCancelButtonPo(): ButtonPo {
+    return this.getButton("cancel");
+  }
+
   clickSubmitButton(): Promise<void> {
     return this.getConfirmButtonPo().click();
+  }
+
+  clickCancelButton(): Promise<void> {
+    return this.getCancelButtonPo().click();
   }
 
   getErrorMessage(): Promise<string | null> {


### PR DESCRIPTION
# Motivation

Most tests in `TextInputForm.spec.ts` were already using page objects, but not all of them.

# Changes

Make the remaining tests also use page objects.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary