### PR TITLE
Enter text in TextInputForm.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
+++ b/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
@@ -108,6 +108,8 @@ describe("TextInputForm", () => {
       onConfirm: callback,
     });
 
+    await po.enterText("test");
+
     expect(callback).toBeCalledTimes(0);
     await po.clickSubmitButton();
     expect(callback).toBeCalledTimes(1);


### PR DESCRIPTION
# Motivation

The `required` attribute on `input` elements is not enforced in unit tests.
But after updating to Svelte 5 and related dependency updates, it is required.
This causes `TextInputForm.spec.ts` to fail because it tries to submit a form without required input.

# Changes

1. Enter some text before trying to submit the form.

# Tests

1. Test still passes.
2. Test now also passes in https://github.com/dfinity/nns-dapp/pull/6020

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary