### PR TITLE
Avoid failing orphaned promises in AccountMenu.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -6,10 +6,14 @@ import {
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { AccountMenuPo } from "$tests/page-objects/AccountMenu.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { advanceTime } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("AccountMenu", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
   const renderComponent = () => {
     const { container } = render(AccountMenu);
 
@@ -98,8 +102,8 @@ describe("AccountMenu", () => {
       await preventLinkNavigation(accountMenuPo);
       await linkToSettingsPo.click();
 
-      //wait for goto to be triggered
-      await runResolvedPromises();
+      // Wait for the popover closing transition to finish.
+      await advanceTime(250);
 
       expect(await accountMenuPo.isOpen()).toBe(false);
     });
@@ -126,8 +130,8 @@ describe("AccountMenu", () => {
       await preventLinkNavigation(accountMenuPo);
       await canistersLinkPo.click();
 
-      //wait for goto to be triggered
-      await runResolvedPromises();
+      // Wait for the popover closing transition to finish.
+      await advanceTime(250);
 
       expect(await accountMenuPo.isOpen()).toBe(false);
     });
@@ -153,8 +157,8 @@ describe("AccountMenu", () => {
         await preventLinkNavigation(accountMenuPo);
         await linkToReportingPo.click();
 
-        //wait for goto to be triggered
-        await runResolvedPromises();
+        // Wait for the popover closing transition to finish.
+        await advanceTime(250);
 
         expect(await accountMenuPo.isOpen()).toBe(false);
       });

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -6,14 +6,10 @@ import {
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { AccountMenuPo } from "$tests/page-objects/AccountMenu.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { advanceTime } from "$tests/utils/timers.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("AccountMenu", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
   const renderComponent = () => {
     const { container } = render(AccountMenu);
 
@@ -102,8 +98,8 @@ describe("AccountMenu", () => {
       await preventLinkNavigation(accountMenuPo);
       await linkToSettingsPo.click();
 
-      // Wait for the popover closing transition to finish.
-      await advanceTime(250);
+      //wait for goto to be triggered
+      await runResolvedPromises();
 
       expect(await accountMenuPo.isOpen()).toBe(false);
     });
@@ -130,8 +126,8 @@ describe("AccountMenu", () => {
       await preventLinkNavigation(accountMenuPo);
       await canistersLinkPo.click();
 
-      // Wait for the popover closing transition to finish.
-      await advanceTime(250);
+      //wait for goto to be triggered
+      await runResolvedPromises();
 
       expect(await accountMenuPo.isOpen()).toBe(false);
     });
@@ -157,8 +153,8 @@ describe("AccountMenu", () => {
         await preventLinkNavigation(accountMenuPo);
         await linkToReportingPo.click();
 
-        // Wait for the popover closing transition to finish.
-        await advanceTime(250);
+        //wait for goto to be triggered
+        await runResolvedPromises();
 
         expect(await accountMenuPo.isOpen()).toBe(false);
       });

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -20,16 +20,22 @@ describe("AccountMenu", () => {
     const linkToSettingsPo = accountMenuPo.getLinkToSettingsPo();
     const linkToReportingPo = accountMenuPo.getLinkToReportingPo();
 
-    canistersLinkPo.root.addEventListener("click", mockLinkClickEvent);
-    linkToSettingsPo.root.addEventListener("click", mockLinkClickEvent);
-    linkToReportingPo.root.addEventListener("click", mockLinkClickEvent);
-
     return {
       accountMenuPo,
       canistersLinkPo,
       linkToSettingsPo,
       linkToReportingPo,
     };
+  };
+
+  const preventLinkNavigation = async (accountMenuPo: AccountMenuPo) => {
+    const canistersLinkPo = accountMenuPo.getCanistersLinkPo();
+    const linkToSettingsPo = accountMenuPo.getLinkToSettingsPo();
+    const linkToReportingPo = accountMenuPo.getLinkToReportingPo();
+
+    await canistersLinkPo.root.addEventListener("click", mockLinkClickEvent);
+    await linkToSettingsPo.root.addEventListener("click", mockLinkClickEvent);
+    await linkToReportingPo.root.addEventListener("click", mockLinkClickEvent);
   };
 
   it("should be closed by default", async () => {
@@ -89,6 +95,7 @@ describe("AccountMenu", () => {
       const { accountMenuPo, linkToSettingsPo } = renderComponent();
       await accountMenuPo.openMenu();
 
+      await preventLinkNavigation(accountMenuPo);
       await linkToSettingsPo.click();
 
       //wait for goto to be triggered
@@ -116,6 +123,7 @@ describe("AccountMenu", () => {
 
       expect(await accountMenuPo.getAccountDetailsPo().isPresent()).toBe(true);
 
+      await preventLinkNavigation(accountMenuPo);
       await canistersLinkPo.click();
 
       //wait for goto to be triggered
@@ -142,6 +150,7 @@ describe("AccountMenu", () => {
         const { accountMenuPo, linkToReportingPo } = renderComponent();
         await accountMenuPo.openMenu();
 
+        await preventLinkNavigation(accountMenuPo);
         await linkToReportingPo.click();
 
         //wait for goto to be triggered


### PR DESCRIPTION
# Motivation

`AccountMenu.spec.ts` tries to add event listeners on elements that may not exist.
If the menu is not opened during a test, the `addEventListener` call will wait for the element to appear, which will fail.
But because the `addEventListener` call is not awaited, the test passes before it fails.
However, with the Svelte 5 (and related dependencies) update, this is caught and causes the test to fail.

# Changes

1. Only add the `addEventListener("click", mockLinkClickEvent)` in tests that actually click on links and only after the menu is opened.

# Tests

1. Test still passes.
2. Test now also passes in https://github.com/dfinity/nns-dapp/pull/6020 if I add some extra `advanceTime()` calls.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary