### PR TITLE
CMC notify fallback only once per session

### DIFF
--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -31,6 +31,7 @@ import {
 } from "$lib/services/icp-accounts.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { canistersStore } from "$lib/stores/canisters.store";
+import { checkedAttachCanisterBlockIndicesStore } from "$lib/stores/checked-block-indices.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { LedgerErrorMessage } from "$lib/types/ledger.errors";
@@ -469,6 +470,9 @@ export const notifyAndAttachCanisterIfNeeded = async ({
   for (const blockIndex of newBlockIndices) {
     if (existingBlockIndices.has(blockIndex)) {
       continue;
+    }
+    if (!checkedAttachCanisterBlockIndicesStore.addBlockIndex(blockIndex)) {
+      return;
     }
     // This may also trigger for canisters that were created before we stored
     // the block_index of each canister. That will simply backfill the

--- a/frontend/src/lib/stores/checked-block-indices.store.ts
+++ b/frontend/src/lib/stores/checked-block-indices.store.ts
@@ -1,0 +1,38 @@
+import { writable } from "svelte/store";
+
+interface CheckedBlockIndicesStore {
+  [blockIndex: string]: true;
+}
+
+// Attaching a canister is a 3-step process. If the process gets
+// interrupted, we can re-notify the CMC to finish the process.
+//  Since this is just a fallback mechanism, we don't need to do it more than
+//  once per session. This store keeps track of the funding transaction that
+//  have already been checked this session.
+const initBlockIndicesStore = () => {
+  const { subscribe, update } = writable<CheckedBlockIndicesStore>({});
+
+  return {
+    subscribe,
+
+    // Returns true if the subaccount was added this time and false if it was
+    // already in the store.
+    addBlockIndex(blockIndex: bigint): boolean {
+      const blockIndexString = blockIndex.toString();
+      let result = true;
+      update((currentState: CheckedBlockIndicesStore) => {
+        const isPresent = blockIndexString in currentState;
+        result = !isPresent;
+        return isPresent
+          ? currentState
+          : {
+              ...currentState,
+              [blockIndexString]: true,
+            };
+      });
+      return result;
+    },
+  };
+};
+
+export const checkedAttachCanisterBlockIndicesStore = initBlockIndicesStore();

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -864,5 +864,25 @@ describe("canisters-services", () => {
 
       expect(api.notifyAndAttachCanister).toBeCalledTimes(0);
     });
+
+    it("should notify only once per session", async () => {
+      await notifyAndAttachCanisterIfNeeded({
+        transactions: [fundingTransaction],
+        canisters: [],
+      });
+
+      expect(api.notifyAndAttachCanister).toBeCalledWith({
+        blockIndex,
+        identity: mockIdentity,
+      });
+      expect(api.notifyAndAttachCanister).toBeCalledTimes(1);
+
+      await notifyAndAttachCanisterIfNeeded({
+        transactions: [fundingTransaction],
+        canisters: [],
+      });
+      // Still only called once.
+      expect(api.notifyAndAttachCanister).toBeCalledTimes(1);
+    });
   });
 });

--- a/frontend/src/tests/lib/stores/checked-block-indices.store.spec.ts
+++ b/frontend/src/tests/lib/stores/checked-block-indices.store.spec.ts
@@ -1,0 +1,32 @@
+import { checkedAttachCanisterBlockIndicesStore } from "$lib/stores/checked-block-indices.store";
+import { get } from "svelte/store";
+
+describe("checked-block-indices.store", () => {
+  describe("checkedAttachCanisterBlockIndicesStore", () => {
+    it("should initially be empty", () => {
+      expect(get(checkedAttachCanisterBlockIndicesStore)).toEqual({});
+    });
+
+    it("should add a block index", () => {
+      expect(get(checkedAttachCanisterBlockIndicesStore)).toEqual({});
+      const blockIndex = 1234567890n;
+      checkedAttachCanisterBlockIndicesStore.addBlockIndex(blockIndex);
+      expect(get(checkedAttachCanisterBlockIndicesStore)).toEqual({
+        [blockIndex.toString()]: true,
+      });
+    });
+
+    it("should return whether a block index was added", () => {
+      const blockIndex = 1234567890n;
+      expect(
+        checkedAttachCanisterBlockIndicesStore.addBlockIndex(blockIndex)
+      ).toBe(true);
+      expect(
+        checkedAttachCanisterBlockIndicesStore.addBlockIndex(blockIndex)
+      ).toBe(false);
+      expect(
+        checkedAttachCanisterBlockIndicesStore.addBlockIndex(blockIndex)
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

If canister creation gets interrupted and next time we see a canister funding transaction without a corresponding canister, we try to notify the CMC to create and attach the canister again.

Since this is only a fallback mechanism, we don't need to do this more than once per transaction per sessions.

Additionally, there is a bug in Svelte that causes `$:` blocks to sometimes not run, even though a dependency variable has changed. I've noticed this several times in `NnsWallet`. This bug seems to have been fixed (or at least changed) in Svelte 5. As a result, it actually tries to perform the canister creation fallback twice when the account balances are loaded uncertified and certified. This causes a test failure.

# Changes

1. Add a store to keep track of block indices for which we've tried canister notification.
2. Don't try canister notification for the same block index within the same session.

# Tests

1. Unit tests added.
2. Tested in https://github.com/dfinity/nns-dapp/pull/6020 that it makes `src/tests/lib/pages/NnsWallet.spec.ts` pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary