### PR TITLE
chore(metrics): add plausible domain configuration per network

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
         "STATIC_HOST": "https://icp0.io",
         "FEATURE_FLAGS": {
           "ENABLE_CKTESTBTC": false
-        }
+        },
+        "PLAUSIBLE_DOMAIN": "nns.ic0.app"
       }
     },
     "app": {
@@ -92,7 +93,8 @@
           "ENABLE_USD_VALUES_FOR_NEURONS": true,
           "ENABLE_PORTFOLIO_PAGE": true,
           "ENABLE_IMPORT_TOKEN_BY_URL": true
-        }
+        },
+        "PLAUSIBLE_DOMAIN": "test.nns.ic0.app"
       }
     },
     "build": {

--- a/config.sh
+++ b/config.sh
@@ -207,6 +207,7 @@ ckethLedgerCanisterId=$(echo "$json" | jq -r '.CKETH_LEDGER_CANISTER_ID // ""')
 ckethIndexCanisterId=$(echo "$json" | jq -r '.CKETH_INDEX_CANISTER_ID // ""')
 ckusdcLedgerCanisterId=$(echo "$json" | jq -r '.CKUSDC_LEDGER_CANISTER_ID // ""')
 ckusdcIndexCanisterId=$(echo "$json" | jq -r '.CKUSDC_INDEX_CANISTER_ID // ""')
+plausibleDomain=$(echo "$json" | jq -r '.PLAUSIBLE_DOMAIN // ""')
 
 echo "VITE_DFX_NETWORK=$dfxNetwork
 VITE_CYCLES_MINTING_CANISTER_ID=$cmcCanisterId
@@ -221,6 +222,7 @@ VITE_FEATURE_FLAGS=$featureFlags
 VITE_HOST=$host
 VITE_IDENTITY_SERVICE_URL=$identityServiceUrl
 VITE_ICP_SWAP_URL=$icpSwapUrl
+VITE_PLAUSIBLE_DOMAIN=$plausibleDomain
 VITE_AGGREGATOR_CANISTER_URL=${aggregatorCanisterUrl:-}
 VITE_CKBTC_LEDGER_CANISTER_ID=${ckbtcLedgerCanisterId:-}
 VITE_CKBTC_MINTER_CANISTER_ID=${ckbtcMinterCanisterId:-}

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -11,6 +11,8 @@ export const SNS_AGGREGATOR_CANISTER_URL = envVars.snsAggregatorUrl ?? "";
 
 export const ICP_SWAP_URL = envVars.icpSwapUrl ?? "";
 
+export const PLAUSIBLE_DOMAIN = envVars.plausibleDomain ?? "";
+
 export interface FeatureFlags<T> {
   ENABLE_CKTESTBTC: T;
   DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING: T;

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -28,6 +28,7 @@ type EnvironmentVars = {
   wasmCanisterId: string;
   // Environments without TVL are valid
   tvlCanisterId?: string;
+  plausibleDomain?: string;
 };
 
 const mandatoryEnvVarKeys: EnvironmentVars = {
@@ -151,6 +152,9 @@ const getBuildEnvVars = (): EnvironmentVars => {
     ),
     tvlCanisterId: convertEmtpyStringToUndefined(
       import.meta.env.VITE_TVL_CANISTER_ID
+    ),
+    plausibleDomain: convertEmtpyStringToUndefined(
+      import.meta.env.VITE_PLAUSIBLE_DOMAIN
     ),
   };
   assertEnvVars(envVars);

--- a/scripts/nns-dapp/test-config-assets/app/arg.did
+++ b/scripts/nns-dapp/test-config-assets/app/arg.did
@@ -19,6 +19,7 @@
     record{ 0="INDEX_CANISTER_ID"; 1="qhbym-qaaaa-aaaaa-aaafq-cai" };
     record{ 0="LEDGER_CANISTER_ID"; 1="ryjl3-tyaaa-aaaaa-aaaba-cai" };
     record{ 0="OWN_CANISTER_ID"; 1="xnjld-hqaaa-aaaal-qb56q-cai" };
+    record{ 0="PLAUSIBLE_DOMAIN"; 1="test.nns.ic0.app" };
     record{ 0="ROBOTS"; 1="<meta name=\"robots\" content=\"noindex, nofollow\" />" };
     record{ 0="SNS_AGGREGATOR_URL"; 1="https://otgyv-wyaaa-aaaak-qcgba-cai.icp0.io" };
     record{ 0="STATIC_HOST"; 1="https://icp0.io" };

--- a/scripts/nns-dapp/test-config-assets/app/env
+++ b/scripts/nns-dapp/test-config-assets/app/env
@@ -11,6 +11,7 @@ VITE_FEATURE_FLAGS="{\"DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING\":false,\"ENA
 VITE_HOST=https://icp-api.io
 VITE_IDENTITY_SERVICE_URL=https://identity.internetcomputer.org/
 VITE_ICP_SWAP_URL=https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/
+VITE_PLAUSIBLE_DOMAIN=test.nns.ic0.app
 VITE_AGGREGATOR_CANISTER_URL=https://otgyv-wyaaa-aaaak-qcgba-cai.icp0.io
 VITE_CKBTC_LEDGER_CANISTER_ID=mxzaz-hqaaa-aaaar-qaada-cai
 VITE_CKBTC_MINTER_CANISTER_ID=mqygn-kiaaa-aaaar-qaadq-cai

--- a/scripts/nns-dapp/test-config-assets/mainnet/arg.did
+++ b/scripts/nns-dapp/test-config-assets/mainnet/arg.did
@@ -19,6 +19,7 @@
     record{ 0="INDEX_CANISTER_ID"; 1="qhbym-qaaaa-aaaaa-aaafq-cai" };
     record{ 0="LEDGER_CANISTER_ID"; 1="ryjl3-tyaaa-aaaaa-aaaba-cai" };
     record{ 0="OWN_CANISTER_ID"; 1="qoctq-giaaa-aaaaa-aaaea-cai" };
+    record{ 0="PLAUSIBLE_DOMAIN"; 1="nns.ic0.app" };
     record{ 0="ROBOTS"; 1="" };
     record{ 0="SNS_AGGREGATOR_URL"; 1="https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io" };
     record{ 0="STATIC_HOST"; 1="https://icp0.io" };

--- a/scripts/nns-dapp/test-config-assets/mainnet/env
+++ b/scripts/nns-dapp/test-config-assets/mainnet/env
@@ -11,6 +11,7 @@ VITE_FEATURE_FLAGS="{\"DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING\":false,\"ENA
 VITE_HOST=https://icp-api.io
 VITE_IDENTITY_SERVICE_URL=https://identity.internetcomputer.org/
 VITE_ICP_SWAP_URL=https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/
+VITE_PLAUSIBLE_DOMAIN=nns.ic0.app
 VITE_AGGREGATOR_CANISTER_URL=https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io
 VITE_CKBTC_LEDGER_CANISTER_ID=mxzaz-hqaaa-aaaar-qaada-cai
 VITE_CKBTC_MINTER_CANISTER_ID=mqygn-kiaaa-aaaar-qaadq-cai


### PR DESCRIPTION
# Motivation

We want to integrate Plausible to the nns-dapp. We also want to use two different accounts one for mainnet and another one for everything else. For that we need an env. variable.

The rest of the setup can be found in #6445.

Note: the plausible domain is used to send the data to a particular Plausible account. 

# Changes

1. Add an `plausible-domain`  in `mainnet` and `general` sections of `config.json`.
2. Support Plausible Domain in `config.sh`.
3. Create `PLAUSIBLE_DOMAIN` in `frontend/src/lib/constants/environment.constants.ts`.
4. Ran `./scripts/nns-dapp/test-config --update` to update golden files.

# Tests

1. Ran config scripts and observed:
  1. `DFX_NETWORK=mainnet ./config.sh` -> `VITE_PLAUSIBLE_DOMAIN=nns.ic0.app`
  2. `DFX_NETWORK=local ./config.sh` -> `VITE_PLAUSIBLE_DOMAIN=test.nns.ic0.app`
2. Tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/) with #6445 


# Todos

- [ ] Add entry to changelog (if necessary).
Not yet