### PR TITLE
Fix flag description of add-controller

### DIFF
--- a/scripts/add-controller
+++ b/scripts/add-controller
@@ -16,7 +16,7 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=c long=canister desc="Name or ID of the canister to control" variable=CANISTER default=""
-clap.define short=p long=principal desc="Name or ID of the canister to control" variable=PRINCIPAL_TO_ADD default="$(dfx identity get-principal)"
+clap.define short=p long=principal desc="Principal of the controller to add" variable=PRINCIPAL_TO_ADD default="$(dfx identity get-principal)"
 clap.define long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"


### PR DESCRIPTION
# Motivation

In `scripts/add-controller`, I accidentally copied the description of `--canister` for `--principal`.

# Changes

Give `--principal` its own description.

# Tests

Manually ran `scripts/add-controller --help`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary