### PR TITLE
feat(metrics): service to initialize plausible analytics

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,8 @@
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.8",
         "@ledgerhq/hw-transport-webhid": "^6.27.8",
         "@zondax/ledger-icp": "^0.6.1",
-        "buffer": "^6.0.3"
+        "buffer": "^6.0.3",
+        "plausible-tracker": "^0.3.9"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -5003,6 +5004,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plausible-tracker": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.9.tgz",
+      "integrity": "sha512-hMhneYm3GCPyQon88SZrVJx+LlqhM1kZFQbuAgXPoh/Az2YvO1B6bitT9qlhpiTdJlsT5lsr3gPmzoVjb5CDXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/playwright": {
@@ -10167,6 +10177,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "plausible-tracker": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.9.tgz",
+      "integrity": "sha512-hMhneYm3GCPyQon88SZrVJx+LlqhM1kZFQbuAgXPoh/Az2YvO1B6bitT9qlhpiTdJlsT5lsr3gPmzoVjb5CDXA=="
     },
     "playwright": {
       "version": "1.49.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "@ledgerhq/hw-transport-webhid": "^6.27.8",
         "@zondax/ledger-icp": "^0.6.1",
         "buffer": "^6.0.3",
-        "plausible-tracker": "^0.3.9"
+        "plausible-tracker": "0.3.9"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,7 +88,8 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.8",
     "@ledgerhq/hw-transport-webhid": "^6.27.8",
     "@zondax/ledger-icp": "^0.6.1",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "plausible-tracker": "^0.3.9"
   },
   "overrides": {
     "semver": "^7.5.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,7 @@
     "@ledgerhq/hw-transport-webhid": "^6.27.8",
     "@zondax/ledger-icp": "^0.6.1",
     "buffer": "^6.0.3",
-    "plausible-tracker": "^0.3.9"
+    "plausible-tracker": "0.3.9"
   },
   "overrides": {
     "semver": "^7.5.3",

--- a/frontend/src/lib/services/analytics.services.ts
+++ b/frontend/src/lib/services/analytics.services.ts
@@ -1,13 +1,9 @@
 import { PLAUSIBLE_DOMAIN } from "$lib/constants/environment.constants";
 import Plausible from "plausible-tracker";
 
-type Cleanup = () => void;
-
 const domain = PLAUSIBLE_DOMAIN;
 
-export const initAnalytics = (): Cleanup[] => {
-  const cleanUpFunctions: Cleanup[] = [];
-
+export const initAnalytics = () => {
   const tracker = Plausible({
     domain,
     hashMode: false,
@@ -15,8 +11,6 @@ export const initAnalytics = (): Cleanup[] => {
     trackLocalhost: false,
   });
 
-  cleanUpFunctions.push(tracker.enableAutoPageviews());
-  cleanUpFunctions.push(tracker.enableAutoOutboundTracking());
-
-  return cleanUpFunctions;
+  tracker.enableAutoPageviews();
+  tracker.enableAutoOutboundTracking();
 };

--- a/frontend/src/lib/services/analytics.services.ts
+++ b/frontend/src/lib/services/analytics.services.ts
@@ -1,0 +1,22 @@
+import { PLAUSIBLE_DOMAIN } from "$lib/constants/environment.constants";
+import Plausible from "plausible-tracker";
+
+type Cleanup = () => void;
+
+const domain = PLAUSIBLE_DOMAIN;
+
+export const initAnalytics = (): Cleanup[] => {
+  const cleanUpFunctions: Cleanup[] = [];
+
+  const tracker = Plausible({
+    domain,
+    hashMode: false,
+    // Change to true for local development and see traffic at https://plausible.io/test.nns.ic0.app/
+    trackLocalhost: false,
+  });
+
+  cleanUpFunctions.push(tracker.enableAutoPageviews());
+  cleanUpFunctions.push(tracker.enableAutoOutboundTracking());
+
+  return cleanUpFunctions;
+};

--- a/frontend/src/tests/lib/services/analytics.services.spec.ts
+++ b/frontend/src/tests/lib/services/analytics.services.spec.ts
@@ -29,6 +29,9 @@ describe("analytics service", () => {
   it("should enable auto page views and outbound tracking", () => {
     const tracker = Plausible();
 
+    expect(tracker.enableAutoPageviews).toHaveBeenCalledTimes(0);
+    expect(tracker.enableAutoOutboundTracking).toHaveBeenCalledTimes(0);
+
     initAnalytics();
 
     expect(tracker.enableAutoPageviews).toHaveBeenCalledTimes(1);

--- a/frontend/src/tests/lib/services/analytics.services.spec.ts
+++ b/frontend/src/tests/lib/services/analytics.services.spec.ts
@@ -1,0 +1,48 @@
+import { PLAUSIBLE_DOMAIN } from "$lib/constants/environment.constants";
+import { initAnalytics } from "$lib/services/analytics.services";
+import Plausible from "plausible-tracker";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("plausible-tracker", () => {
+  const enableAutoPageviews = vi.fn(() => () => {});
+  const enableAutoOutboundTracking = vi.fn(() => () => {});
+
+  return {
+    default: vi.fn(() => ({
+      enableAutoPageviews,
+      enableAutoOutboundTracking,
+    })),
+  };
+});
+
+describe("analytics service", () => {
+  it("should initialize Plausible with correct configuration", () => {
+    initAnalytics();
+
+    expect(Plausible).toHaveBeenCalledWith({
+      domain: PLAUSIBLE_DOMAIN,
+      hashMode: false,
+      trackLocalhost: false,
+    });
+  });
+
+  it("should enable auto page views and outbound tracking", () => {
+    const tracker = Plausible();
+
+    initAnalytics();
+
+    expect(tracker.enableAutoPageviews).toHaveBeenCalledTimes(1);
+    expect(tracker.enableAutoOutboundTracking).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return cleanup functions", () => {
+    const cleanupFunctions = initAnalytics();
+
+    expect(Array.isArray(cleanupFunctions)).toBe(true);
+    expect(cleanupFunctions).toHaveLength(2);
+
+    cleanupFunctions.forEach((cleanup) => {
+      expect(typeof cleanup).toBe("function");
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/analytics.services.spec.ts
+++ b/frontend/src/tests/lib/services/analytics.services.spec.ts
@@ -34,15 +34,4 @@ describe("analytics service", () => {
     expect(tracker.enableAutoPageviews).toHaveBeenCalledTimes(1);
     expect(tracker.enableAutoOutboundTracking).toHaveBeenCalledTimes(1);
   });
-
-  it("should return cleanup functions", () => {
-    const cleanupFunctions = initAnalytics();
-
-    expect(Array.isArray(cleanupFunctions)).toBe(true);
-    expect(cleanupFunctions).toHaveLength(2);
-
-    cleanupFunctions.forEach((cleanup) => {
-      expect(typeof cleanup).toBe("function");
-    });
-  });
 });


### PR DESCRIPTION
# Motivation

As announced in this [forum post](https://forum.dfinity.org/t/internet-identity-and-nns-dapp-analytics/40859), we aim to integrate an online analytics solution to monitor errors and aggregate usage data for the NNS dapp.

Here are some key points about Plausible:
-  No cookies or personal data collection.
-  Aggregates anonymized metrics.
-  Data sovereignty.
-  Hosted in the EU, ensuring strong privacy protections.
-  Complies with GDPR, PECR, and CCPA.
-  Publicly accessible analytics dashboard for community oversight.
-  Minimal data collection focused on critical metrics.
-  Lightweight.

This PR follows up on #6450 by using this new env. variable to expose a service that allows initializing the tool.

# Changes

- New service to initialize the tool and return a list of cleanup functions.

# Tests

- Added unit test for the service
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/) with #6445 

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.