### PR TITLE
Automatically derive PR for github-mark-ready

### DIFF
--- a/scripts/github-mark-ready
+++ b/scripts/github-mark-ready
@@ -7,6 +7,7 @@ print_help() {
   Mark a GitHub PR as ready for review once all checks have passed.
   EXAMPLE USAGE:
 		$0 --merge-when-ready https://github.com/dfinity/nns-dapp/pull/6425
+		$0 --merge-when-ready # Will use the current PR and repo
 	EOF
 }
 

--- a/scripts/github-mark-ready
+++ b/scripts/github-mark-ready
@@ -22,19 +22,19 @@ source "$(clap.build)"
 URL="${1:-}"
 URL_PATTERN="https://github.com/([^/]*/[^/]*)/pull/([^/]*).*"
 
-if [[ -z "${URL:-}" ]]; then
-  print_help
-  exit 0
-fi
+if [[ -n "${URL:-}" ]]; then
+  if ! [[ "$URL" =~ $URL_PATTERN ]]; then
+    echo "Invalid URL: $URL" >&2
+    echo "URL should match the pattern: $URL_PATTERN" >&2
+    exit 1
+  fi
 
-if ! [[ "$URL" =~ $URL_PATTERN ]]; then
-  echo "Invalid URL: $URL" >&2
-  echo "URL should match the pattern: $URL_PATTERN" >&2
-  exit 1
+  REPO=$(echo "$URL" | sed -E "s|$URL_PATTERN|\\1|")
+  PR=$(echo "$URL" | sed -E "s|$URL_PATTERN|\\2|")
+else
+  PR=$(gh pr view --json number --jq '.number')
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 fi
-
-REPO=$(echo "$URL" | sed -E "s|$URL_PATTERN|\\1|")
-PR=$(echo "$URL" | sed -E "s|$URL_PATTERN|\\2|")
 
 echo "Watching PR $PR on $REPO..."
 


### PR DESCRIPTION
# Motivation

`scripts/github-mark-ready` lets you automatically mark a PR as "Ready for review" once all the checks has passed.
Currently you need to pass the URL of which PR you want to mark as ready.
With this PR you don't have to pass a URL if you want it to apply to the PR of your current branch.

# Changes

1. Determine `$PR` and `$REPO` automatically from the current branch when no argument is passed.

# Tests

Manually

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary