### PR TITLE
chore(analytics): restrict plausible to mainnet, app and beta networks

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,7 +18,8 @@
         "STATIC_HOST": "https://icp0.io",
         "FEATURE_FLAGS": {
           "ENABLE_CKTESTBTC": false
-        }
+        },
+        "PLAUSIBLE_DOMAIN": "test.nns.ic0.app"
       }
     },
     "beta": {
@@ -28,7 +29,8 @@
         "STATIC_HOST": "https://icp0.io",
         "FEATURE_FLAGS": {
           "ENABLE_CKTESTBTC": false
-        }
+        },
+        "PLAUSIBLE_DOMAIN": "test.nns.ic0.app"
       }
     },
     "devenv_llorenc": {
@@ -93,8 +95,7 @@
           "ENABLE_USD_VALUES_FOR_NEURONS": true,
           "ENABLE_PORTFOLIO_PAGE": true,
           "ENABLE_IMPORT_TOKEN_BY_URL": true
-        },
-        "PLAUSIBLE_DOMAIN": "test.nns.ic0.app"
+        }
       }
     },
     "build": {


### PR DESCRIPTION
# Motivation

We want to only load Plausible for `mainnet`, `beta` and `app` networks.

# Changes

- Moved Plausible test domain from the default to the app and beta section in config.json.
- Ran `./scripts/nns-dapp/test-config --update` but no changes were generated.

# Tests

- Ran config scripts and observed:
  - `DFX_NETWORK=mainnet ./config.sh` -> `VITE_PLAUSIBLE_DOMAIN=nns.ic0.app`
  - `DFX_NETWORK=beta ./config.sh` -> `VITE_PLAUSIBLE_DOMAIN=test.nns.ic0.app`
  - `DFX_NETWORK=app ./config.sh` -> `VITE_PLAUSIBLE_DOMAIN=test.nns.ic0.app`
  - `DFX_NETWORK=local ./config.sh` -> `VITE_PLAUSIBLE_DOMAIN=`

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev. PR: #6459 