### PR TITLE
refactor(analytics): conditionally load plausible based on domain presence

### DIFF
--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -11,7 +11,7 @@ export const SNS_AGGREGATOR_CANISTER_URL = envVars.snsAggregatorUrl ?? "";
 
 export const ICP_SWAP_URL = envVars.icpSwapUrl ?? "";
 
-export const PLAUSIBLE_DOMAIN = envVars.plausibleDomain ?? "";
+export const PLAUSIBLE_DOMAIN = envVars.plausibleDomain;
 
 export interface FeatureFlags<T> {
   ENABLE_CKTESTBTC: T;

--- a/frontend/src/lib/services/analytics.services.ts
+++ b/frontend/src/lib/services/analytics.services.ts
@@ -2,7 +2,9 @@ import { PLAUSIBLE_DOMAIN } from "$lib/constants/environment.constants";
 import { isNullish } from "@dfinity/utils";
 import Plausible from "plausible-tracker";
 
-export const initAnalytics = (domain = PLAUSIBLE_DOMAIN) => {
+const domain = PLAUSIBLE_DOMAIN;
+
+export const initAnalytics = () => {
   if (isNullish(domain)) return;
 
   const tracker = Plausible({

--- a/frontend/src/lib/services/analytics.services.ts
+++ b/frontend/src/lib/services/analytics.services.ts
@@ -1,9 +1,10 @@
 import { PLAUSIBLE_DOMAIN } from "$lib/constants/environment.constants";
+import { isNullish } from "@dfinity/utils";
 import Plausible from "plausible-tracker";
 
-const domain = PLAUSIBLE_DOMAIN;
+export const initAnalytics = (domain = PLAUSIBLE_DOMAIN) => {
+  if (isNullish(domain)) return;
 
-export const initAnalytics = () => {
   const tracker = Plausible({
     domain,
     hashMode: false,

--- a/frontend/src/tests/lib/services/analytics.services.spec.ts
+++ b/frontend/src/tests/lib/services/analytics.services.spec.ts
@@ -1,7 +1,5 @@
-import { PLAUSIBLE_DOMAIN } from "$lib/constants/environment.constants";
 import { initAnalytics } from "$lib/services/analytics.services";
 import Plausible from "plausible-tracker";
-import { describe, expect, it, vi } from "vitest";
 
 vi.mock("plausible-tracker", () => {
   const enableAutoPageviews = vi.fn(() => () => {});
@@ -16,11 +14,24 @@ vi.mock("plausible-tracker", () => {
 });
 
 describe("analytics service", () => {
-  it("should initialize Plausible with correct configuration", () => {
-    initAnalytics();
+  const plausibleDomain = "test-domain";
 
+  it("should not do anything if domain is not set", async () => {
+    expect(Plausible).toHaveBeenCalledTimes(0);
+
+    initAnalytics(undefined);
+
+    expect(Plausible).toHaveBeenCalledTimes(0);
+  });
+
+  it("should initialize Plausible with correct configuration", () => {
+    expect(Plausible).toHaveBeenCalledTimes(0);
+
+    initAnalytics(plausibleDomain);
+
+    expect(Plausible).toHaveBeenCalledTimes(1);
     expect(Plausible).toHaveBeenCalledWith({
-      domain: PLAUSIBLE_DOMAIN,
+      domain: plausibleDomain,
       hashMode: false,
       trackLocalhost: false,
     });
@@ -32,7 +43,7 @@ describe("analytics service", () => {
     expect(tracker.enableAutoPageviews).toHaveBeenCalledTimes(0);
     expect(tracker.enableAutoOutboundTracking).toHaveBeenCalledTimes(0);
 
-    initAnalytics();
+    initAnalytics(plausibleDomain);
 
     expect(tracker.enableAutoPageviews).toHaveBeenCalledTimes(1);
     expect(tracker.enableAutoOutboundTracking).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# Motivation

Now that we have confirmed the tool works, we can remove its configuration from the devenv and e2e environments. This way, we will only load it for the following networks:
- mainnet
- betta and app

# Changes

- Do not default the env. variable `PLAUSIBLE_DOMAIN` to empty string.
- Do not load Plausible if no domain has been loaded.

# Tests

- Unit test the behavior based on the presence of the `domain` property.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Next PR: #6458 