### PR TITLE
feat(errors): util for canister out-of-cycles errors

### DIFF
--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -207,7 +207,8 @@ export const isCanisterOutOfCyclesError = (error: unknown): boolean => {
   if (!errorMessage) return false;
 
   // https://github.com/dfinity/ic/blob/6e327863fd0e72d8cf9c5c46fc1263f548fad4f5/rs/protobuf/src/gen/state/state.ingress.v1.rs#L146
-  if (errorMessage.includes("IC0207")) return true;
+  const errorCodeRegex = /\bIC0207\b/;
+  if (errorCodeRegex.test(errorMessage)) return true;
 
   return false;
 };

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -200,7 +200,7 @@ export const isMethodNotSupportedError = (err: unknown): boolean =>
  *   "Reject code": "2"
  *   "Reject message": "Canister 75lp5-u7777-77776-qaaba-cai is out of cycles""
  */
-export const isCanisterOutOfCycles = (error: unknown): boolean => {
+export const isCanisterOutOfCyclesError = (error: unknown): boolean => {
   if (!error || typeof error !== "object") return false;
 
   const errorMessage = (error as Error).message;

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -181,3 +181,33 @@ export const isPayloadSizeError = (err: unknown): boolean => {
 
 export const isMethodNotSupportedError = (err: unknown): boolean =>
   err instanceof UnsupportedMethodError;
+
+/**
+ * Identifies errors of canisters out-of-cycles
+ * Below expamples of error messages for both query and update calls
+ * "Call failed:
+ *   Canister: 75lp5-u7777-77776-qaaba-cai
+ *   Method: icrc1_balance_of (query)
+ *   "Status": "rejected"
+ *   "Code": "SysTransient"
+ *   "Message": "IC0207: Canister 75lp5-u7777-77776-qaaba-cai is unable to process query calls because it's frozen. Please top up the canister with cycles and try again.""
+ *
+ * "Call failed:
+ *   Canister: 75lp5-u7777-77776-qaaba-cai
+ *   Method: icrc1_balance_of (update)
+ *   "Request ID": "476ad2adfb1e755277240038da963f54d16093d2d4b1d370e82c1cd1a089e73f"
+ *   "Error code": "IC0207"
+ *   "Reject code": "2"
+ *   "Reject message": "Canister 75lp5-u7777-77776-qaaba-cai is out of cycles""
+ */
+export const isCanisterOutOfCycles = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") return false;
+
+  const errorMessage = (error as Error).message;
+  if (!errorMessage) return false;
+
+  // https://github.com/dfinity/ic/blob/6e327863fd0e72d8cf9c5c46fc1263f548fad4f5/rs/protobuf/src/gen/state/state.ingress.v1.rs#L146
+  if (errorMessage.includes("IC0207")) return true;
+
+  return false;
+};

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -152,9 +152,10 @@ describe("error-utils", () => {
     });
 
     it("returns false for other errors and non errors", () => {
-      expect(isCanisterOutOfCyclesError(new Error("test"))).toBe(false);
       expect(isCanisterOutOfCyclesError(undefined)).toBe(false);
       expect(isCanisterOutOfCyclesError({})).toBe(false);
+      expect(isCanisterOutOfCyclesError(new Error("test"))).toBe(false);
+      expect(isCanisterOutOfCyclesError(new Error("IC02070"))).toBe(false);
     });
 
     it("returns false for different error codes", () => {

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -3,7 +3,7 @@ import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { HardwareWalletAttachError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import {
   errorToString,
-  isCanisterOutOfCycles,
+  isCanisterOutOfCyclesError,
   isMethodNotSupportedError,
   isPayloadSizeError,
   toToastError,
@@ -136,7 +136,7 @@ describe("error-utils", () => {
         "Code": "SysTransient"
         "Message": "IC0207: Canister 75lp5-u7777-77776-qaaba-cai is unable to process query calls because it's frozen. Please top up the canister with cycles and try again."`;
       const err = new Error(message);
-      expect(isCanisterOutOfCycles(err)).toBe(true);
+      expect(isCanisterOutOfCyclesError(err)).toBe(true);
     });
 
     it("returns true for out of cycles update error", () => {
@@ -148,13 +148,13 @@ describe("error-utils", () => {
         "Reject code": "2"
         "Reject message": "Canister 75lp5-u7777-77776-qaaba-cai is out of cycles"`;
       const err = new Error(message);
-      expect(isCanisterOutOfCycles(err)).toBe(true);
+      expect(isCanisterOutOfCyclesError(err)).toBe(true);
     });
 
     it("returns false for other errors and non errors", () => {
-      expect(isCanisterOutOfCycles(new Error("test"))).toBe(false);
-      expect(isCanisterOutOfCycles(undefined)).toBe(false);
-      expect(isCanisterOutOfCycles({})).toBe(false);
+      expect(isCanisterOutOfCyclesError(new Error("test"))).toBe(false);
+      expect(isCanisterOutOfCyclesError(undefined)).toBe(false);
+      expect(isCanisterOutOfCyclesError({})).toBe(false);
     });
 
     it("returns false for different error codes", () => {
@@ -165,7 +165,7 @@ describe("error-utils", () => {
         "Code": "SysTransient"
         "Message": "IC0503: Some other error message"`;
       const err = new Error(message);
-      expect(isCanisterOutOfCycles(err)).toBe(false);
+      expect(isCanisterOutOfCyclesError(err)).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -3,6 +3,7 @@ import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { HardwareWalletAttachError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import {
   errorToString,
+  isCanisterOutOfCycles,
   isMethodNotSupportedError,
   isPayloadSizeError,
   toToastError,
@@ -123,6 +124,48 @@ describe("error-utils", () => {
       expect(isMethodNotSupportedError(new Error("another error"))).toBe(false);
       expect(isMethodNotSupportedError(undefined)).toBe(false);
       expect(isMethodNotSupportedError({})).toBe(false);
+    });
+  });
+
+  describe("isCanisterOutOfCycles", () => {
+    it("returns true for out of cycles query error", () => {
+      const message = `Call failed:
+        Canister: 75lp5-u7777-77776-qaaba-cai
+        Method: icrc1_balance_of (query)
+        "Status": "rejected"
+        "Code": "SysTransient"
+        "Message": "IC0207: Canister 75lp5-u7777-77776-qaaba-cai is unable to process query calls because it's frozen. Please top up the canister with cycles and try again."`;
+      const err = new Error(message);
+      expect(isCanisterOutOfCycles(err)).toBe(true);
+    });
+
+    it("returns true for out of cycles update error", () => {
+      const message = `Call failed:
+        Canister: 75lp5-u7777-77776-qaaba-cai
+        Method: icrc1_balance_of (update)
+        "Request ID": "476ad2adfb1e755277240038da963f54d16093d2d4b1d370e82c1cd1a089e73f"
+        "Error code": "IC0207"
+        "Reject code": "2"
+        "Reject message": "Canister 75lp5-u7777-77776-qaaba-cai is out of cycles"`;
+      const err = new Error(message);
+      expect(isCanisterOutOfCycles(err)).toBe(true);
+    });
+
+    it("returns false for other errors and non errors", () => {
+      expect(isCanisterOutOfCycles(new Error("test"))).toBe(false);
+      expect(isCanisterOutOfCycles(undefined)).toBe(false);
+      expect(isCanisterOutOfCycles({})).toBe(false);
+    });
+
+    it("returns false for different error codes", () => {
+      const message = `Call failed:
+        Canister: 75lp5-u7777-77776-qaaba-cai
+        Method: icrc1_balance_of (query)
+        "Status": "rejected"
+        "Code": "SysTransient"
+        "Message": "IC0503: Some other error message"`;
+      const err = new Error(message);
+      expect(isCanisterOutOfCycles(err)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

We want to track canisters being out of cycles so we can display appropriate information in the ui. For that we need first to be able to identify an error as a canister out-of-cycles error.

This PR adds a util to identify such an error. Follow-up PRs will make use of it to fill the store introduce in #6464.

# Changes

- Util to identify canisters out-of-cycle errors based on the error.message. 

# Tests

- Unit test for the util.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary