### PR TITLE
chore(workflows): remove reviewers

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -63,7 +63,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
-          reviewers: mstrasinskis, dskloetd, anchpop, aterga, yhabib
+          reviewers: mstrasinskis, aterga, yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json


### PR DESCRIPTION
# Motivation

This [workflow](https://github.com/dfinity/nns-dapp/actions/runs/13460808242/job/37615415855) failed due to a missing reviewer.

Note: The PR was successfully created [here](https://github.com/dfinity/nns-dapp/pull/6473), and we were notified via Slack about this [issue](https://dfinity.slack.com/archives/C05G2RZFJAJ/p1740154645386359). I believe the flow is correct, as it does not block the changes while also notifying the team to update the file.

# Changes

- Removes reviewers.

# Tests

- Manually tested in [here](https://github.com/dfinity/nns-dapp/actions/runs/13461983809)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary