### PR TITLE
chore(ci): migrate remaining node version references to config.json

### DIFF
--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -23,9 +23,8 @@ jobs:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - uses: actions/checkout@v4
-      - name: Read Node.js version from .nvmrc
-        id: node-version
-        run: echo "NODE_VERSION=$(cat frontend/.nvmrc)" >> $GITHUB_ENV
+      - name: Get node version
+        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -22,9 +22,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update the SNS aggregator response files
         run: scripts/nns-dapp/replace-sns-aggregator-response.sh
-      - name: Read Node.js version from .nvmrc
-        id: node-version
-        run: echo "NODE_VERSION=$(cat frontend/.nvmrc)" >> $GITHUB_ENV
+      - name: Get node version
+        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
# Motivation

Following up on #6479, we want to use the Node version defined in `config.json` throughout our project to maintain a consistent approach to the Node version. 
This PR updates the last two references to `.nvmrc`.

# Changes

- Changes `NODE_VERSION` source from `.nvmrc` to `config.json`.

# Tests

- Actions should run as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary