### PR TITLE
Fix bug in DisburseSnsNeuronModal.spec.ts

### DIFF
--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -16,6 +16,7 @@ import {
 import { mockSnsNeuron, mockSnsNeuronId } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
@@ -130,24 +131,19 @@ describe("DisburseSnsNeuronModal", () => {
     const reloadNeuron = vi.fn().mockResolvedValue(null);
     await renderDisburseModal(mockSnsNeuron, reloadNeuron);
 
-    await waitFor(() => expect(loadSnsAccounts).toBeCalled());
+    await runResolvedPromises();
+    expect(loadSnsAccounts).toBeCalledTimes(1);
   });
 
   it("should not trigger the project account load if already available", async () => {
+    // Here we don't reset icrcAccountsStore.
+
     page.mock({ data: { universe: principalString, neuron: "12344" } });
 
     const reloadNeuron = vi.fn().mockResolvedValue(null);
-    const { queryByTestId } = await renderDisburseModal(
-      mockSnsNeuron,
-      reloadNeuron
-    );
+    await renderDisburseModal(mockSnsNeuron, reloadNeuron);
 
-    await waitFor(() =>
-      expect(queryByTestId("disburse-neuron-button")).not.toBeNull()
-    );
-
-    await fireEvent.click(queryByTestId("disburse-neuron-button") as Element);
-
-    await waitFor(() => expect(loadSnsAccounts).not.toBeCalled());
+    await runResolvedPromises();
+    expect(loadSnsAccounts).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/1409 added a test with the following line in `DisburseSnsNeuronModal.spec.ts`:
```
await waitFor(() => expect(syncSnsAccounts).not.toBeCalled());
```
This doesn't work because if `syncSnsAccounts` has not already been called, this will pass immediately.
The test will not wait to see if perhaps `syncSnsAccounts` will be called soon after.

Later https://github.com/dfinity/nns-dapp/pull/4455 refactored the code to remove `syncSnsAccounts`. It changed the code to call `loadSnsAccounts` (a subset of the functionality of `syncSnsAccounts`) instead. And it changed the test to replace `syncSnsAccounts` with `loadSnsAccounts`.
But `loadSnsAccounts` is in fact called during the test, inside `executeTransaction` in `DisburseSnsNeuronModal.svelte`.
But this was not caught by the test because of how the `waitFor` line is broken.

On closer inspection, it seems that this test is a counterpart of the test before, where it checks that `loadSnsAccounts` is being called, even without clicking the confirm button. It seems that the next test should test that this doesn't happen if accounts are already loaded because `icrcAccountsStore.reset();` is not called.

# Changes

1. Make the `"should not trigger the project account load if already available"` test more similar to the `"should trigger the project account load"` test by not clicking the confirm button.
2. Add a comment pointing out that `icrcAccountsStore` is not reset in `"should trigger the project account load"`.
3. Use `runResolvedPromises` instead of `waitFor` to have the same conditions in both tests.

# Tests

Before, the test would fail if an extra `await runResolvedPromises();` was added. Now the test passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary