### PR TITLE
Use page objects in DisburseSnsNeuronModal.spec.ts

### DIFF
--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -109,7 +109,12 @@
   };
 </script>
 
-<WizardModal bind:currentStep on:nnsClose {steps}>
+<WizardModal
+  bind:currentStep
+  on:nnsClose
+  {steps}
+  testId="disburse-sns-neuron-modal-component"
+>
   <svelte:fragment slot="title"
     ><span data-tid="disburse-sns-neuron-modal">{currentStep?.title}</span
     ></svelte:fragment

--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -15,11 +15,13 @@ import {
 } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsNeuron, mockSnsNeuronId } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { DisburseSnsNeuronModalPo } from "$tests/page-objects/DisburseSnsNeuronModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
+import type { RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
 vi.mock("$lib/api/sns-governance.api");
@@ -31,6 +33,7 @@ describe("DisburseSnsNeuronModal", () => {
   const rootCanisterId = principal(1);
   const ledgerCanisterId = principal(2);
   const principalString = rootCanisterId.toText();
+
   const renderDisburseModal = async (
     neuron: SnsNeuron,
     reloadNeuron: () => Promise<void> = () => Promise.resolve()
@@ -43,6 +46,18 @@ describe("DisburseSnsNeuronModal", () => {
         reloadNeuron: reloadNeuron,
       },
     });
+  };
+
+  const renderComponent = async ({
+    neuron,
+    reloadNeuron,
+  }: {
+    neuron: SnsNeuron;
+    reloadNeuron?: () => Promise<void>;
+  }): Promise<DisburseSnsNeuronModalPo> => {
+    const { container } = await renderDisburseModal(neuron, reloadNeuron);
+
+    return DisburseSnsNeuronModalPo.under(new JestPageObjectElement(container));
   };
 
   beforeEach(() => {
@@ -70,33 +85,31 @@ describe("DisburseSnsNeuronModal", () => {
   it("should display modal", async () => {
     page.mock({ data: { universe: principalString, neuron: "12344" } });
 
-    const { container } = await renderDisburseModal(mockSnsNeuron);
+    const po = await renderComponent({ neuron: mockSnsNeuron });
 
-    expect(container.querySelector("div.modal")).not.toBeNull();
+    expect(await po.isPresent()).toBe(true);
   });
 
   it("should render a confirmation screen", async () => {
     page.mock({ data: { universe: principalString, neuron: "12344" } });
 
-    const { queryByTestId } = await renderDisburseModal(mockSnsNeuron);
+    const po = await renderComponent({ neuron: mockSnsNeuron });
 
-    await waitFor(() =>
-      expect(queryByTestId("confirm-disburse-screen")).not.toBeNull()
-    );
+    expect(await po.getConfirmDisburseNeuronPo().isPresent()).toBe(true);
   });
 
   it("should call disburse service", async () => {
     page.mock({ data: { universe: principalString, neuron: "12344" } });
 
-    const { queryByTestId } = await renderDisburseModal(mockSnsNeuron);
+    const po = await renderComponent({ neuron: mockSnsNeuron });
 
-    expect(queryByTestId("confirm-disburse-screen")).not.toBeNull();
+    expect(await po.getConfirmDisburseNeuronPo().isPresent()).toBe(true);
 
-    const confirmButton = queryByTestId("disburse-neuron-button");
-    expect(confirmButton).not.toBeNull();
+    expect(snsGovernanceApi.disburse).toBeCalledTimes(0);
 
-    confirmButton && (await fireEvent.click(confirmButton));
-    await waitFor(() => expect(snsGovernanceApi.disburse).toBeCalledTimes(1));
+    await po.getConfirmDisburseNeuronPo().clickConfirm();
+
+    expect(snsGovernanceApi.disburse).toBeCalledTimes(1);
     expect(snsGovernanceApi.disburse).toBeCalledWith({
       rootCanisterId: mockSnsMainAccount.principal,
       identity: testIdentity,
@@ -108,19 +121,15 @@ describe("DisburseSnsNeuronModal", () => {
     page.mock({ data: { universe: principalString, neuron: "12344" } });
 
     const reloadNeuron = vi.fn().mockResolvedValue(null);
-    const { queryByTestId } = await renderDisburseModal(
-      mockSnsNeuron,
-      reloadNeuron
-    );
+    const po = await renderComponent({ neuron: mockSnsNeuron, reloadNeuron });
 
-    expect(queryByTestId("confirm-disburse-screen")).not.toBeNull();
+    expect(await po.getConfirmDisburseNeuronPo().isPresent()).toBe(true);
 
-    const confirmButton = queryByTestId("disburse-neuron-button");
-    expect(confirmButton).not.toBeNull();
+    expect(reloadNeuron).toBeCalledTimes(0);
 
-    confirmButton && (await fireEvent.click(confirmButton));
+    await po.getConfirmDisburseNeuronPo().clickConfirm();
 
-    await waitFor(() => expect(reloadNeuron).toBeCalled());
+    expect(reloadNeuron).toBeCalledTimes(1);
   });
 
   it("should trigger the project account load", async () => {
@@ -128,8 +137,10 @@ describe("DisburseSnsNeuronModal", () => {
 
     page.mock({ data: { universe: principalString, neuron: "12344" } });
 
+    expect(loadSnsAccounts).toBeCalledTimes(0);
+
     const reloadNeuron = vi.fn().mockResolvedValue(null);
-    await renderDisburseModal(mockSnsNeuron, reloadNeuron);
+    await renderComponent({ neuron: mockSnsNeuron, reloadNeuron });
 
     await runResolvedPromises();
     expect(loadSnsAccounts).toBeCalledTimes(1);
@@ -140,8 +151,10 @@ describe("DisburseSnsNeuronModal", () => {
 
     page.mock({ data: { universe: principalString, neuron: "12344" } });
 
+    expect(loadSnsAccounts).toBeCalledTimes(0);
+
     const reloadNeuron = vi.fn().mockResolvedValue(null);
-    await renderDisburseModal(mockSnsNeuron, reloadNeuron);
+    await renderComponent({ neuron: mockSnsNeuron, reloadNeuron });
 
     await runResolvedPromises();
     expect(loadSnsAccounts).toBeCalledTimes(0);

--- a/frontend/src/tests/page-objects/DisburseSnsNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseSnsNeuronModal.page-object.ts
@@ -1,0 +1,17 @@
+import { ConfirmDisburseNeuronPo } from "$tests/page-objects/ConfirmDisburseNeuron.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class DisburseSnsNeuronModalPo extends ModalPo {
+  private static readonly TID = "disburse-sns-neuron-modal-component";
+
+  static under(element: PageObjectElement): DisburseSnsNeuronModalPo {
+    return new DisburseSnsNeuronModalPo(
+      element.byTestId(DisburseSnsNeuronModalPo.TID)
+    );
+  }
+
+  getConfirmDisburseNeuronPo(): ConfirmDisburseNeuronPo {
+    return ConfirmDisburseNeuronPo.under(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

Make the test easier to read and maintain.

# Changes

1. Add test ID in `DisburseSnsNeuronModal.svelte`.
2. Add `DisburseSnsNeuronModalPo` page object.
3. Use page object in `DisburseSnsNeuronModal.spec.ts`.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary