### PR TITLE
Scripts to (un)freeze canisters

### DIFF
--- a/scripts/freeze
+++ b/scripts/freeze
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+  Freezes a canister by setting a very high freezing threshold.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+clap.define long=network desc="dfx network to use" variable="DFX_NETWORK" default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+
+MAX_FREEZING_THRESHOLD=18446744073709551615
+
+CANISTER="$1"
+
+CURRENT_CONTROLLER="$(dfx canister info "$CANISTER" | grep '^Controllers:' | awk '{print $2}')"
+
+dfx canister update-settings "$CANISTER" --freezing-threshold "$MAX_FREEZING_THRESHOLD" --confirm-very-long-freezing-threshold --impersonate "$CURRENT_CONTROLLER"
+
+echo "Freezing threshold was set to $MAX_FREEZING_THRESHOLD seconds."

--- a/scripts/unfreeze
+++ b/scripts/unfreeze
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+  Unfreezes a canister by setting a normal freezing threshold and making sure
+  the canister has cycles.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+clap.define long=freezing-threshold desc="Passed to dfx canister update-settings" variable=DFX_FREEZING_THRESHOLD default="2592000"
+clap.define long=cycles desc="Target cycles balance of canister" variable=DFX_CYCLES default="1000000000000"
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="snsdemo8"
+clap.define long=network desc="dfx network to use" variable="DFX_NETWORK" default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+export DFX_IDENTITY
+
+CANISTER="$1"
+
+CURRENT_CONTROLLER="$(dfx canister info "$CANISTER" | grep '^Controllers:' | awk '{print $2}')"
+
+dfx canister update-settings "$CANISTER" --freezing-threshold "$DFX_FREEZING_THRESHOLD" --impersonate "$CURRENT_CONTROLLER"
+
+echo "Freezing threshold was set to $DFX_FREEZING_THRESHOLD seconds."
+
+CURRENT_CYCLES=$(dfx canister status "$CANISTER" | grep 'Balance:' | awk '{ print $2 }' | sed -e 's/_//g')
+
+if [[ "$CURRENT_CYCLES" -ge "$DFX_CYCLES" ]]; then
+  exit 0
+fi
+
+CYCLES_TO_ADD=$((DFX_CYCLES - CURRENT_CYCLES))
+CYCLES_PER_E8=$(dfx canister call nns-cycles-minting get_icp_xdr_conversion_rate | idl2json | jq -r '.data.xdr_permyriad_per_icp')
+E8S_TO_ADD=$((CYCLES_TO_ADD / CYCLES_PER_E8))
+
+dfx ledger top-up "$CANISTER" --e8s "$E8S_TO_ADD"


### PR DESCRIPTION
# Motivation

To test NNS dapp behavior with frozen canisters.
Canisters must be on a subnet where they use cycles.

# Changes

1. `scripts/freeze` to set freezing threshold to the maximum.
2. `scripts/unfreeze` to set freezing threshold lower and top up cycles if necessary.

# Tests

Tested manually.
```
$ ALFA_LEDGER="$(scripts/sns/aggregator/get-sns --network local --json alfa | jq -r '.canister_ids.ledger_canister_id')"

$ scripts/freeze $ALFA_LEDGER
Freezing threshold was set to 18446744073709551615 seconds.

$ scripts/unfreeze $ALFA_LEDGER 
Freezing threshold was set to 2592000 seconds.

$ scripts/unfreeze  --cycles 58826881309068 $ALFA_LEDGER 
Freezing threshold was set to 2592000 seconds.
Transfer sent at block height 77
Using transfer at block height 77
Canister was topped up with 508000000 cycles!
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary