### PR TITLE
test(portfolio): stabilize screenshot tests by normalizing TVL value

### DIFF
--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -1,9 +1,9 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
-    replaceContent,
-    signInWithNewUser,
-    step,
+  replaceContent,
+  signInWithNewUser,
+  step,
 } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
@@ -22,7 +22,6 @@ test("Visual test Landing Page", async ({ page, browser }) => {
   await expect(page).toHaveTitle("Portfolio / NNS Dapp");
 
   await page.setViewportSize(VIEWPORT_SIZES.desktop);
-
 
   // The governance metrics are only updated once a day so for the first 24h
   // after a snapshot is created, the metrics might be different than what

--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -1,6 +1,10 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+    replaceContent,
+    signInWithNewUser,
+    step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 const VIEWPORT_SIZES = {
@@ -18,6 +22,19 @@ test("Visual test Landing Page", async ({ page, browser }) => {
   await expect(page).toHaveTitle("Portfolio / NNS Dapp");
 
   await page.setViewportSize(VIEWPORT_SIZES.desktop);
+
+
+  // The governance metrics are only updated once a day so for the first 24h
+  // after a snapshot is created, the metrics might be different than what
+  // we expectand we need to replace them with the expected value.
+  if ((await appPo.getMenuItemsPo().getTvlMetric()) === "$99") {
+    await replaceContent({
+      page,
+      selectors: ['[data-tid="tvl-metric"]'],
+      pattern: /\$[0-9’]+/,
+      replacements: ["$4’500’001’000"],
+    });
+  }
   await expect(page).toHaveScreenshot(`initial_desktop.png`);
 
   await page.setViewportSize(VIEWPORT_SIZES.mobile);


### PR DESCRIPTION
# Motivation

The Portfolio page is expose to the same issues as in #6093. This PR applies the same solution.

# Changes

- In the screenshot test, if the `TVL` is "$99", replace it in the DOM with "$4'500'001'000".

# Tests

- Tested in [6498](https://github.com/dfinity/nns-dapp/pull/6498)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.