### PR TITLE
Make ProjectDetail.spec.ts more robust

### DIFF
--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -18,6 +18,7 @@ import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeLocationApi from "$tests/fakes/location-api.fake";
 import {
+  mockIdentity,
   mockPrincipal,
   resetIdentity,
   setNoIdentity,
@@ -633,26 +634,23 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           ],
           has_created_neuron_recipes: [],
         };
-        vi.spyOn(snsApi, "querySnsSwapCommitment")
-          // Query call
-          .mockResolvedValueOnce({
-            rootCanisterId,
-            myCommitment: initialCommitment,
-          } as SnsSwapCommitment)
-          // Update call
-          .mockResolvedValueOnce({
-            rootCanisterId,
-            myCommitment: initialCommitment,
-          } as SnsSwapCommitment)
-          .mockResolvedValue({
-            rootCanisterId,
-            myCommitment: finalCommitment,
-          } as SnsSwapCommitment);
+
+        const resolveQuerySnsSwapCommitment: Array<
+          (commitment: SnsSwapCommitment) => void
+        > = [];
+        vi.spyOn(snsApi, "querySnsSwapCommitment").mockImplementation(
+          async () => {
+            return new Promise<SnsSwapCommitment>((resolve) => {
+              resolveQuerySnsSwapCommitment.push(resolve);
+            });
+          }
+        );
         vi.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(testTicket);
 
         expect(snsApi.querySnsSwapCommitment).not.toBeCalled();
 
         const po = renderComponent(props);
+        await runResolvedPromises();
 
         expect(
           await po
@@ -661,14 +659,53 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
             .isPresent()
         ).toBe(false);
 
-        await po.getSaleInProgressModalPo().waitFor();
+        expect(await po.getSaleInProgressModalPo().isPresent()).toBe(false);
 
+        const expectedQueryCommitmentParams = {
+          rootCanisterId: rootCanisterId.toText(),
+          identity: mockIdentity,
+        };
+        expect(snsApi.querySnsSwapCommitment).toBeCalledWith({
+          ...expectedQueryCommitmentParams,
+          certified: false,
+        });
+        expect(snsApi.querySnsSwapCommitment).toBeCalledWith({
+          ...expectedQueryCommitmentParams,
+          certified: true,
+        });
         expect(snsApi.querySnsSwapCommitment).toBeCalledTimes(2);
 
-        await po
-          .getProjectStatusSectionPo()
-          .getCommitmentAmountDisplayPo()
-          .waitFor();
+        expect(resolveQuerySnsSwapCommitment).toHaveLength(2);
+        for (const resolve of resolveQuerySnsSwapCommitment) {
+          resolve({
+            rootCanisterId,
+            myCommitment: initialCommitment,
+          } as SnsSwapCommitment);
+        }
+        await runResolvedPromises();
+
+        expect(await po.getSaleInProgressModalPo().isPresent()).toBe(true);
+
+        expect(
+          await po
+            .getProjectStatusSectionPo()
+            .getCommitmentAmountDisplayPo()
+            .isPresent()
+        ).toBe(false);
+
+        expect(resolveQuerySnsSwapCommitment).toHaveLength(3);
+        resolveQuerySnsSwapCommitment[2]({
+          rootCanisterId,
+          myCommitment: finalCommitment,
+        } as SnsSwapCommitment);
+        await runResolvedPromises();
+
+        expect(
+          await po
+            .getProjectStatusSectionPo()
+            .getCommitmentAmountDisplayPo()
+            .isPresent()
+        ).toBe(true);
 
         expect(await po.getProjectStatusSectionPo().getCommitmentAmount()).toBe(
           formatTokenE8s({ value: testTicket.amount_icp_e8s })


### PR DESCRIPTION
# Motivation

During the `"should participate without user interaction if there is an open ticket."` test in `ProjectDetail.spec.ts`, the `SaleInProgressModal` becomes visible and then invisible, after which the commitment should have appeared. Meanwhile `querySnsSwapCommitment` is first called twice and then once more.

The test expects to catch all of this without making sure that the process is paused at any point in time. This is very brittle because it depends on the framework waiting asynchronously at various steps.

With the Svelte 5 update this breaks, unsurprisingly.

The solution is to make sure that the test is blocked in states that we want to expect on.

# Changes

1. Return unresolved promises from `querySnsSwapCommitment` and only resolve them after verifying the state of the component.
2. Verify that the 2 calls are for "query" and "update" instead of just claiming it in a comment.

# Tests

1. Still passes.
2. Now also passes in the [Svelte 5 branch](https://github.com/dfinity/nns-dapp/pull/6489).

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary