### PR TITLE
do not show toaster for out of cycles

### DIFF
--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -336,6 +336,19 @@ describe("icrc-accounts-services", () => {
       ]);
     });
 
+    it("should not display a toast on canister ouf of cycles", async () => {
+      vi.spyOn(ledgerApi, "queryIcrcBalance").mockRejectedValue(
+        new Error("IC0207")
+      );
+      expect(ledgerApi.queryIcrcBalance).not.toBeCalled();
+      expect(get(toastsStore)).toEqual([]);
+
+      await loadAccounts({ ledgerCanisterId });
+
+      expect(ledgerApi.queryIcrcBalance).toBeCalledTimes(2);
+      expect(get(toastsStore)).toEqual([]);
+    });
+
     it("doesn't load imported token if in failed imported tokens store", async () => {
       importedTokensStore.set({
         importedTokens: [


### PR DESCRIPTION
# Motivation

#6470 introduced a new visual element in the tokens table to indicate when the balance cannot be loaded. With this addition, we can omit the toaster message for this type of error.

# Changes

- Does not display the toaster for out-of-cycle errors.

# Tests

- Added a unit test to cover the out-of-cycle error and the absence of a toaster.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.