### PR TITLE
feat(store): add support for failed actionable SNS proposals in TableProjects

### DIFF
--- a/frontend/src/lib/stores/actionable-sns-proposals.store.ts
+++ b/frontend/src/lib/stores/actionable-sns-proposals.store.ts
@@ -1,4 +1,5 @@
 import { removeKeys } from "$lib/utils/utils";
+import type { CanisterIdString } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { SnsProposalData } from "@dfinity/sns";
 import { writable, type Readable } from "svelte/store";
@@ -21,8 +22,9 @@ export interface ActionableSnsProposalsStore
   resetForSns: (rootCanisterId: Principal) => void;
   resetForTesting: () => void;
 }
-
-interface FailedActionableSnsesStore extends Readable<string[]> {
+export type FailedActionableSnsesStoreData = CanisterIdString[];
+interface FailedActionableSnsesStore
+  extends Readable<FailedActionableSnsesStoreData> {
   add: (rootCanisterId: string) => void;
   remove: (rootCanisterId: string) => void;
   resetForTesting: () => void;

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -105,14 +105,14 @@ const getNeuronAggregateInfo = ({
   token,
   nnsNeurons,
   snsNeurons,
-  failedActionableSnsesStore,
+  failedActionableSnses,
 }: {
   isSignedIn: boolean;
   universe: Universe;
   token: Token;
   nnsNeurons: NeuronInfo[] | undefined;
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
-  failedActionableSnsesStore: FailedActionableSnsesStoreData;
+  failedActionableSnses: FailedActionableSnsesStoreData;
 }): {
   neuronCount: number | undefined;
   stake: TokenAmountV2 | UnavailableTokenAmount | FailedTokenAmount;
@@ -131,7 +131,7 @@ const getNeuronAggregateInfo = ({
     };
   }
 
-  if (failedActionableSnsesStore.includes(universe.canisterId)) {
+  if (failedActionableSnses.includes(universe.canisterId)) {
     return {
       neuronCount: undefined,
       stake: new FailedTokenAmount(token),
@@ -165,14 +165,14 @@ export const getTableProjects = ({
   nnsNeurons,
   snsNeurons,
   icpSwapUsdPrices,
-  failedActionableSnsesStore = [],
+  failedActionableSnses = [],
 }: {
   universes: Universe[];
   isSignedIn: boolean;
   nnsNeurons: NeuronInfo[] | undefined;
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
   icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
-  failedActionableSnsesStore?: FailedActionableSnsesStoreData;
+  failedActionableSnses?: FailedActionableSnsesStoreData;
 }): TableProject[] => {
   return universes.map((universe) => {
     const token =
@@ -192,7 +192,7 @@ export const getTableProjects = ({
       token,
       nnsNeurons,
       snsNeurons,
-      failedActionableSnsesStore,
+      failedActionableSnses,
     });
     const rowHref =
       nonNullish(neuronCount) && neuronCount > 0

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -633,7 +633,7 @@ describe("staking.utils", () => {
           [universeId2]: undefined,
         },
         icpSwapUsdPrices: undefined,
-        failedActionableSnsesStore: [universeId2],
+        failedActionableSnses: [universeId2],
       });
 
       expect(tableProjects).toEqual([

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -12,7 +12,10 @@ import {
   getTotalStakeInUsd,
   sortTableProjects,
 } from "$lib/utils/staking.utils";
-import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import {
+  FailedTokenAmount,
+  UnavailableTokenAmount,
+} from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import {
@@ -617,6 +620,34 @@ describe("staking.utils", () => {
           availableMaturity: undefined,
           stakedMaturity: undefined,
           isStakeLoading: true,
+        },
+      ]);
+    });
+
+    it("should have FailedToken when failed actionable sns", () => {
+      const tableProjects = getTableProjects({
+        universes: [nnsUniverse, snsUniverse],
+        isSignedIn: true,
+        nnsNeurons: [],
+        snsNeurons: {
+          [universeId2]: undefined,
+        },
+        icpSwapUsdPrices: undefined,
+        failedActionableSnsesStore: [universeId2],
+      });
+
+      expect(tableProjects).toEqual([
+        {
+          ...defaultExpectedNnsTableProject,
+        },
+        {
+          ...defaultExpectedSnsTableProject,
+          neuronCount: undefined,
+          stake: new FailedTokenAmount(snsToken),
+          stakeInUsd: undefined,
+          availableMaturity: undefined,
+          stakedMaturity: undefined,
+          isStakeLoading: false,
         },
       ]);
     });

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -135,6 +135,7 @@ describe("staking.utils", () => {
           [universeId2]: { neurons: [] },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -160,6 +161,7 @@ describe("staking.utils", () => {
           [snsUniverseId]: { neurons: [] },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -194,6 +196,7 @@ describe("staking.utils", () => {
           [universeId2]: { neurons: [] },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -219,6 +222,7 @@ describe("staking.utils", () => {
         ],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -260,6 +264,7 @@ describe("staking.utils", () => {
         nnsNeurons: [neuron1, neuron2],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -300,6 +305,7 @@ describe("staking.utils", () => {
         nnsNeurons: [neuron1, neuron2],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -328,6 +334,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -369,6 +376,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -407,6 +415,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -444,6 +453,7 @@ describe("staking.utils", () => {
         icpSwapUsdPrices: {
           [LEDGER_CANISTER_ID.toText()]: icpPrice,
         },
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -483,6 +493,7 @@ describe("staking.utils", () => {
         icpSwapUsdPrices: {
           [snsUniverse.summary.ledgerCanisterId.toText()]: tokenPrice,
         },
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -510,6 +521,7 @@ describe("staking.utils", () => {
         ],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -542,6 +554,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -569,6 +582,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -600,6 +614,7 @@ describe("staking.utils", () => {
           [universeId2]: undefined,
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([


### PR DESCRIPTION
# Motivation

Follow up on #6503 to introduce the Failed token when building the `TableProjects` if the actionable SNS fails.

Subsequent PRs will utilize this new field in the UI to display a warning message with a tooltip.

Note: A default value of `[]` has been defined for `failedActionableSnsesStore` in `getTableProjects` to minimize the changes required for this PR.

<img width="1480" alt="Screenshot 2025-02-24 at 08 20 45" src="https://github.com/user-attachments/assets/a64ac121-a465-482e-bfcf-804f29633117" />

# Changes

- Updates `actionable-sns-proposals.store.ts` to expose the data type of the `FailedActionableSnsesStore`
- Updates `getNeuronAggregateInfo` to return a payload with a `FailedTokenValue` for the stake if the actionable proposal failed.

# Tests

- Added new unit test
- Manually tested with https://github.com/dfinity/nns-dapp/pull/6485

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet

Prev. PR: #6503 | Next PR: #6504