### PR TITLE
refactor(ui): unify AmountDisplay for unavailable and failed token amounts

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import {
+    FailedTokenAmount,
     formatTokenV2,
     UnavailableTokenAmount,
   } from "$lib/utils/token.utils";
   import { Copy } from "@dfinity/gix-components";
-  import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+  import { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
   export let amount: TokenAmount | TokenAmountV2 | UnavailableTokenAmount;
   export let label: string | undefined = undefined;
@@ -16,6 +17,15 @@
   export let size: "inherit" | "huge" | undefined = undefined;
   export let sign: "+" | "-" | "" = "";
   export let detailed: boolean | "height_decimals" = false;
+
+  const isValidAmount = (
+    amount:
+      | TokenAmount
+      | TokenAmountV2
+      | UnavailableTokenAmount
+      | FailedTokenAmount
+  ): amount is TokenAmount | TokenAmountV2 =>
+    amount instanceof TokenAmount || amount instanceof TokenAmountV2;
 </script>
 
 <div
@@ -33,14 +43,14 @@
     data-tid="token-value"
     class="value"
     class:tabular-num={detailed === "height_decimals"}
-    >{#if amount instanceof UnavailableTokenAmount}
+    >{#if !isValidAmount(amount)}
       -/-
     {:else}
       {`${sign}${formatTokenV2({ value: amount, detailed })}`}
     {/if}</span
   >
   <span class="label">{label !== undefined ? label : amount.token.symbol}</span
-  >{#if copy && !(amount instanceof UnavailableTokenAmount)}
+  >{#if copy && isValidAmount(amount)}
     {" "}
     <Copy value={formatTokenV2({ value: amount, detailed: true })} />
   {/if}

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -305,6 +305,14 @@ export function toTokenAmountV2(
   });
 }
 
+export class FailedTokenAmount {
+  public token: Token;
+
+  constructor(token: Token) {
+    this.token = token;
+  }
+}
+
 export class UnavailableTokenAmount {
   public token: Token;
 

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -1,5 +1,8 @@
 import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
-import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import {
+    FailedTokenAmount,
+    UnavailableTokenAmount,
+} from "$lib/utils/token.utils";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -21,12 +24,12 @@ describe("AmountDisplay", () => {
     return AmountDisplayPo.under(new JestPageObjectElement(container));
   };
 
-  it("should render an token amount", async () => {
+  it("should render a token amount", async () => {
     const po = renderComponent(props);
     expect(await po.getAmount()).toEqual("1'234'567.89");
   });
 
-  it("should render an token symbol", async () => {
+  it("should render a token symbol", async () => {
     const po = renderComponent(props);
     expect(await po.getText()).toEqual("1'234'567.89 ICP");
   });
@@ -110,6 +113,17 @@ describe("AmountDisplay", () => {
     expect(await po.getText()).toBe("-/- TOKEN");
   });
 
+  it("should render failed token amount", async () => {
+    const token = {
+      ...mockSnsToken,
+      symbol: "TOKEN",
+    };
+    const po = renderComponent({
+      amount: new FailedTokenAmount(token),
+    });
+    expect(await po.getText()).toBe("-/- TOKEN");
+  });
+
   it("should never render a copy button for unavailable amount", async () => {
     const po = renderComponent({
       amount: new UnavailableTokenAmount(ICPToken),
@@ -117,4 +131,12 @@ describe("AmountDisplay", () => {
     });
     expect(await po.getCopyButtonPo().isPresent()).toBe(false);
   });
+
+  it("should never render a copy button for failed amount", async () => {
+      const po = renderComponent({
+        amount: new FailedTokenAmount(ICPToken),
+        copy: true,
+      });
+      expect(await po.getCopyButtonPo().isPresent()).toBe(false);
+    });
 });

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -1,7 +1,7 @@
 import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
 import {
-    FailedTokenAmount,
-    UnavailableTokenAmount,
+  FailedTokenAmount,
+  UnavailableTokenAmount,
 } from "$lib/utils/token.utils";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
@@ -133,10 +133,10 @@ describe("AmountDisplay", () => {
   });
 
   it("should never render a copy button for failed amount", async () => {
-      const po = renderComponent({
-        amount: new FailedTokenAmount(ICPToken),
-        copy: true,
-      });
-      expect(await po.getCopyButtonPo().isPresent()).toBe(false);
+    const po = renderComponent({
+      amount: new FailedTokenAmount(ICPToken),
+      copy: true,
     });
+    expect(await po.getCopyButtonPo().isPresent()).toBe(false);
+  });
 });


### PR DESCRIPTION
# Motivation

We may encounter issues loading SNS governance-related information; for instance, their canister might be out of cycles. We want to differentiate these scenarios to display an appropriate visual indicator in the UI.

This first PR updates `AmountDisplay` to accommodate the new Token type that will be used in later PRs to represent failed loaded actionable SNSs.

<img width="790" alt="Screenshot 2025-02-25 at 13 04 08" src="https://github.com/user-attachments/assets/37b4fbff-1ad5-493f-bad1-216d19030d6f" />

# Changes

- Updates `AmountDisplay` to behave the same if `UnavailableTokenAmount` or `FailedTokenAmount`

# Tests

- Updated tests for the new type of Token.
- Manually tested with #6485

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet

Next PR: #6502 