### PR TITLE
feat(ui): add warning indicators for failed Projects

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Warning indicators for failed actionable SNS proposals.
+
 #### Changed
 
 #### Deprecated

--- a/frontend/src/lib/components/staking/ProjectTitleCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectTitleCell.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import Logo from "$lib/components/ui/Logo.svelte";
-  import type { TableProject } from "$lib/types/staking";
-  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import NnsNeuronsMissingRewardsBadge from "$lib/components/neurons/NnsNeuronsMissingRewardsBadge.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
+  import { i18n } from "$lib/stores/i18n";
+  import type { TableProject } from "$lib/types/staking";
+  import { FailedTokenAmount } from "$lib/utils/token.utils";
+  import { IconError, Tooltip } from "@dfinity/gix-components";
 
   export let rowData: TableProject;
 </script>
@@ -15,6 +18,13 @@
   </div>
   {#if $ENABLE_PERIODIC_FOLLOWING_CONFIRMATION && rowData.universeId === OWN_CANISTER_ID_TEXT}
     <NnsNeuronsMissingRewardsBadge />
+  {/if}
+  {#if rowData.stake instanceof FailedTokenAmount}
+    <div data-tid="failed-project-info" class="failed-project-info">
+      <Tooltip id="failed-project-info" text={$i18n.error.canister_tooltip}>
+        <IconError size="20px" />
+      </Tooltip>
+    </div>
   {/if}
 </div>
 
@@ -32,6 +42,11 @@
       display: flex;
       flex-direction: column;
       gap: var(--padding-0_5x);
+    }
+
+    .failed-project-info {
+      color: var(--orange);
+      line-height: 0;
     }
   }
 </style>

--- a/frontend/src/lib/components/staking/ProjectTitleCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectTitleCell.svelte
@@ -45,7 +45,7 @@
     }
 
     .failed-project-info {
-      color: var(--orange);
+      color: var(--warning-emphasis);
       line-height: 0;
     }
   }

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -10,6 +10,7 @@
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
   import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
@@ -93,6 +94,7 @@
     nnsNeurons: $neuronsStore?.neurons,
     snsNeurons: $snsNeuronsStore,
     icpSwapUsdPrices: $icpSwapUsdPricesStore,
+    failedActionableSnses: $failedActionableSnsesStore,
   });
 
   let sortedTableProjects: TableProject[];

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -132,7 +132,8 @@
     "index_canister_validation": "An error occurred while validating the index canister ID. It appears that $indexCanister might not be a valid index canister ID.",
     "refresh_voting_power": "An error occurred while confirming following.",
     "unknown_topic_title": "Unknown Topic ($topicId)",
-    "unknown_proposal_status_title": "Unknown Proposal Status ($statusId)"
+    "unknown_proposal_status_title": "Unknown Proposal Status ($statusId)",
+    "canister_tooltip": "The canister is not responding. This may be because it ran out of cycles. Please check back later."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired.",

--- a/frontend/src/lib/stores/actionable-sns-proposals.store.ts
+++ b/frontend/src/lib/stores/actionable-sns-proposals.store.ts
@@ -1,4 +1,5 @@
 import { removeKeys } from "$lib/utils/utils";
+import type { CanisterIdString } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { SnsProposalData } from "@dfinity/sns";
 import { writable, type Readable } from "svelte/store";
@@ -21,8 +22,9 @@ export interface ActionableSnsProposalsStore
   resetForSns: (rootCanisterId: Principal) => void;
   resetForTesting: () => void;
 }
-
-interface FailedActionableSnsesStore extends Readable<string[]> {
+export type FailedActionableSnsesStoreData = CanisterIdString[];
+interface FailedActionableSnsesStore
+  extends Readable<FailedActionableSnsesStoreData> {
   add: (rootCanisterId: string) => void;
   remove: (rootCanisterId: string) => void;
   resetForTesting: () => void;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -137,6 +137,7 @@ interface I18nError {
   refresh_voting_power: string;
   unknown_topic_title: string;
   unknown_proposal_status_title: string;
+  canister_tooltip: string;
 }
 
 interface I18nWarning {
@@ -311,6 +312,7 @@ interface I18nStaking {
   title: string;
   text: string;
   nervous_systems: string;
+  actionable_proposal_error_table_tooltip: string;
 }
 
 interface I18nNeurons {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -312,7 +312,6 @@ interface I18nStaking {
   title: string;
   text: string;
   nervous_systems: string;
-  actionable_proposal_error_table_tooltip: string;
 }
 
 interface I18nNeurons {

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -105,14 +105,14 @@ const getNeuronAggregateInfo = ({
   token,
   nnsNeurons,
   snsNeurons,
-  failedActionableSnsesStore,
+  failedActionableSnses,
 }: {
   isSignedIn: boolean;
   universe: Universe;
   token: Token;
   nnsNeurons: NeuronInfo[] | undefined;
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
-  failedActionableSnsesStore: FailedActionableSnsesStoreData;
+  failedActionableSnses: FailedActionableSnsesStoreData;
 }): {
   neuronCount: number | undefined;
   stake: TokenAmountV2 | UnavailableTokenAmount | FailedTokenAmount;
@@ -131,7 +131,7 @@ const getNeuronAggregateInfo = ({
     };
   }
 
-  if (failedActionableSnsesStore.includes(universe.canisterId)) {
+  if (failedActionableSnses.includes(universe.canisterId)) {
     return {
       neuronCount: undefined,
       stake: new FailedTokenAmount(token),
@@ -165,14 +165,14 @@ export const getTableProjects = ({
   nnsNeurons,
   snsNeurons,
   icpSwapUsdPrices,
-  failedActionableSnsesStore = [],
+  failedActionableSnses = [],
 }: {
   universes: Universe[];
   isSignedIn: boolean;
   nnsNeurons: NeuronInfo[] | undefined;
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
   icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
-  failedActionableSnsesStore?: FailedActionableSnsesStoreData;
+  failedActionableSnses?: FailedActionableSnsesStoreData;
 }): TableProject[] => {
   return universes.map((universe) => {
     const token =
@@ -192,7 +192,7 @@ export const getTableProjects = ({
       token,
       nnsNeurons,
       snsNeurons,
-      failedActionableSnsesStore,
+      failedActionableSnses,
     });
     const rowHref =
       nonNullish(neuronCount) && neuronCount > 0

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -3,6 +3,7 @@ import ProjectsTable from "$lib/components/staking/ProjectsTable.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -10,6 +11,7 @@ import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
@@ -175,6 +177,36 @@ describe("ProjectsTable", () => {
     expect(rowPos).toHaveLength(2);
     expect(await rowPos[0].getProjectMaturityCellPo().getText()).toBe("");
     expect(await rowPos[1].getProjectMaturityCellPo().getText()).toBe("");
+  });
+
+  it("should render failed project UI in the table", async () => {
+    failedActionableSnsesStore.add(snsCanisterId.toText());
+
+    const po = renderComponent();
+    const rowPos = await po.getProjectsTableRowPos();
+
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getProjectTitle()).toBe("Internet Computer");
+    expect(
+      await rowPos[0]
+        .getProjectTitleCellPo()
+        .getFailedProjectTooltipPo()
+        .isPresent()
+    ).toBe(false);
+
+    expect(await rowPos[1].getProjectTitle()).toBe(snsTitle);
+    expect(
+      await rowPos[1]
+        .getProjectTitleCellPo()
+        .getFailedProjectTooltipPo()
+        .isPresent()
+    ).toBe(true);
+    expect(
+      await rowPos[1]
+        .getProjectTitleCellPo()
+        .getFailedProjectTooltipPo()
+        .getTooltipText()
+    ).toEqual(en.error.canister_tooltip);
   });
 
   describe("with neurons", () => {

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -633,7 +633,7 @@ describe("staking.utils", () => {
           [universeId2]: undefined,
         },
         icpSwapUsdPrices: undefined,
-        failedActionableSnsesStore: [universeId2],
+        failedActionableSnses: [universeId2],
       });
 
       expect(tableProjects).toEqual([

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -12,7 +12,10 @@ import {
   getTotalStakeInUsd,
   sortTableProjects,
 } from "$lib/utils/staking.utils";
-import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import {
+  FailedTokenAmount,
+  UnavailableTokenAmount,
+} from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import {
@@ -617,6 +620,34 @@ describe("staking.utils", () => {
           availableMaturity: undefined,
           stakedMaturity: undefined,
           isStakeLoading: true,
+        },
+      ]);
+    });
+
+    it("should have FailedToken when failed actionable sns", () => {
+      const tableProjects = getTableProjects({
+        universes: [nnsUniverse, snsUniverse],
+        isSignedIn: true,
+        nnsNeurons: [],
+        snsNeurons: {
+          [universeId2]: undefined,
+        },
+        icpSwapUsdPrices: undefined,
+        failedActionableSnsesStore: [universeId2],
+      });
+
+      expect(tableProjects).toEqual([
+        {
+          ...defaultExpectedNnsTableProject,
+        },
+        {
+          ...defaultExpectedSnsTableProject,
+          neuronCount: undefined,
+          stake: new FailedTokenAmount(snsToken),
+          stakeInUsd: undefined,
+          availableMaturity: undefined,
+          stakedMaturity: undefined,
+          isStakeLoading: false,
         },
       ]);
     });

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -135,6 +135,7 @@ describe("staking.utils", () => {
           [universeId2]: { neurons: [] },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -160,6 +161,7 @@ describe("staking.utils", () => {
           [snsUniverseId]: { neurons: [] },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -194,6 +196,7 @@ describe("staking.utils", () => {
           [universeId2]: { neurons: [] },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -219,6 +222,7 @@ describe("staking.utils", () => {
         ],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -260,6 +264,7 @@ describe("staking.utils", () => {
         nnsNeurons: [neuron1, neuron2],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -300,6 +305,7 @@ describe("staking.utils", () => {
         nnsNeurons: [neuron1, neuron2],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -328,6 +334,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -369,6 +376,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -407,6 +415,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -444,6 +453,7 @@ describe("staking.utils", () => {
         icpSwapUsdPrices: {
           [LEDGER_CANISTER_ID.toText()]: icpPrice,
         },
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -483,6 +493,7 @@ describe("staking.utils", () => {
         icpSwapUsdPrices: {
           [snsUniverse.summary.ledgerCanisterId.toText()]: tokenPrice,
         },
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -510,6 +521,7 @@ describe("staking.utils", () => {
         ],
         snsNeurons: {},
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -542,6 +554,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -569,6 +582,7 @@ describe("staking.utils", () => {
           },
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([
@@ -600,6 +614,7 @@ describe("staking.utils", () => {
           [universeId2]: undefined,
         },
         icpSwapUsdPrices: undefined,
+        failedActionableSnses: [],
       });
 
       expect(tableProjects).toEqual([

--- a/frontend/src/tests/page-objects/ProjectTitleCell.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectTitleCell.page-object.ts
@@ -1,4 +1,5 @@
 import { NnsNeuronsMissingRewardsBadgePo } from "$tests/page-objects/NnsNeuronsMissingRewardsBadge.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -15,5 +16,9 @@ export class ProjectTitleCellPo extends BasePageObject {
 
   getNnsNeuronsMissingRewardsBadgePo(): NnsNeuronsMissingRewardsBadgePo {
     return NnsNeuronsMissingRewardsBadgePo.under(this.root);
+  }
+
+  getFailedProjectTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root.byTestId("failed-project-info"));
   }
 }


### PR DESCRIPTION
# Motivation

Follows up on #6502 to introduce the Warning and Tooltip in the Projects Table.

Note: The default value of `[]` remains set for `failedActionableSnsesStore` in `getTableProjects` due to https://github.com/dfinity/nns-dapp/blob/017d92c6cd860cac3114e991f9acd24fd2092bc4/frontend/src/routes/(app)/(nns)/portfolio/%2Bpage.svelte#L58

<img width="1480" alt="Screenshot 2025-02-24 at 08 20 45" src="https://github.com/user-attachments/assets/a64ac121-a465-482e-bfcf-804f29633117" />

# Changes

- Updates `ProjectTitleCell` to display a warning icon and a tooltip if the `stake` is of type `FailedTokenAmount`.  
-  Updates `ProjectsTable` to pass `failedActionableSnses` to `getTableProjects`.  
-  Exposes a `TooltipPo` through the `ProjectsTableRowPo`.

# Tests

- Added new unit test
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/staking/)

# Todos

- [x] Add entry to changelog (if necessary).

Prev. PR: #6502 | Next PR: #6505