### PR TITLE
feat(portfolio): integrate failed SNS detection in projects table

### DIFF
--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -312,6 +312,7 @@ interface I18nStaking {
   title: string;
   text: string;
   nervous_systems: string;
+  actionable_proposal_error_table_tooltip: string;
 }
 
 interface I18nNeurons {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -312,7 +312,6 @@ interface I18nStaking {
   title: string;
   text: string;
   nervous_systems: string;
-  actionable_proposal_error_table_tooltip: string;
 }
 
 interface I18nNeurons {

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -171,7 +171,7 @@ export const getTableProjects = ({
   nnsNeurons: NeuronInfo[] | undefined;
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
   icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
-  failedActionableSnses?: FailedActionableSnsesStoreData;
+  failedActionableSnses: FailedActionableSnsesStoreData;
 }): TableProject[] => {
   return universes.map((universe) => {
     const token =

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -164,7 +164,7 @@ export const getTableProjects = ({
   nnsNeurons,
   snsNeurons,
   icpSwapUsdPrices,
-  failedActionableSnses = [],
+  failedActionableSnses,
 }: {
   universes: Universe[];
   isSignedIn: boolean;

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -16,6 +16,7 @@
   } from "$lib/services/accounts-balances.services";
   import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { UserToken } from "$lib/types/tokens-page";
@@ -61,6 +62,7 @@
       nnsNeurons: $neuronsStore?.neurons,
       snsNeurons: $snsNeuronsStore,
       icpSwapUsdPrices: $icpSwapUsdPricesStore,
+      failedActionableSnses: $failedActionableSnsesStore,
     })}
   /></TestIdWrapper
 >

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -11,6 +11,7 @@ import {
 import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { getAnonymousIdentity } from "$lib/services/auth.services";
+import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -271,121 +272,161 @@ describe("Portfolio route", () => {
       });
     });
 
-    it("should render the Portfolio page with the provided data", async () => {
-      setAccountsForTesting({
-        main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
+    describe("should render the Portfolio page with the provided data", async () => {
+      beforeEach(() => {
+        setAccountsForTesting({
+          main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
+        });
+
+        setIcpSwapUsdPrices({
+          [CKBTC_UNIVERSE_CANISTER_ID.toText()]: 100_000,
+          [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: 100_000,
+          [CKETH_UNIVERSE_CANISTER_ID.toText()]: 10_000,
+          [LEDGER_CANISTER_ID.toText()]: 10,
+          [importedToken1Id.toText()]: 10,
+          [tetrisSNS.ledgerCanisterId.toText()]: 10,
+        });
+
+        const nnsNeuronWithStake = {
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockNeuron.fullNeuron,
+            cachedNeuronStake: nnsNeuronStake,
+          },
+        };
+        neuronsStore.setNeurons({
+          neurons: [nnsNeuronWithStake],
+          certified: true,
+        });
+
+        const snsNeuronWithStake = createMockSnsNeuron({
+          stake: tetrisSnsNeuronStake,
+        });
+        snsNeuronsStore.setNeurons({
+          rootCanisterId: tetrisSNS.rootCanisterId,
+          neurons: [snsNeuronWithStake],
+          certified: true,
+        });
       });
-      setIcpSwapUsdPrices({
-        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: 100_000,
-        [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: 100_000,
-        [CKETH_UNIVERSE_CANISTER_ID.toText()]: 10_000,
-        [LEDGER_CANISTER_ID.toText()]: 10,
-        [importedToken1Id.toText()]: 10,
-        [tetrisSNS.ledgerCanisterId.toText()]: 10,
+
+      it("should render the Portfolio page with the provided data", async () => {
+        const po = await renderPage();
+        const portfolioPagePo = po.getPortfolioPagePo();
+
+        // 1BTC -> $100_000
+        // 1BTCTest -> $100_000
+        // 100ICP -> $1000
+        // 0.1ETH -> $1000
+        // 1USDC -> $1
+        // 100ZTOKEN1 -> $1000
+        // 2Tetris -> $20
+        // 1ICP Neuron -> 10$
+        // 20Tetris Neuron -> 200$
+        // --------------------
+        // Total: $203’231.00
+        expect(
+          await portfolioPagePo.getTotalAssetsCardPo().getPrimaryAmount()
+        ).toBe("$203’231.00");
+        // $1 -> 0.1ICP
+        expect(
+          await portfolioPagePo.getTotalAssetsCardPo().getSecondaryAmount()
+        ).toBe("20’323.10 ICP");
+
+        const heldTokensCardPo = portfolioPagePo.getHeldTokensCardPo();
+        const heldTokensTitles = await heldTokensCardPo.getHeldTokensTitles();
+        const heldTokensBalanceInUsdBalance =
+          await heldTokensCardPo.getHeldTokensBalanceInUsd();
+        const heldTokensBalanceInNativeBalance =
+          await heldTokensCardPo.getHeldTokensBalanceInNativeCurrency();
+
+        expect(heldTokensTitles.length).toBe(4);
+        expect(heldTokensTitles).toEqual([
+          "Internet Computer",
+          "ckBTC",
+          "ckTESTBTC",
+          "ckETH",
+        ]);
+
+        expect(heldTokensBalanceInUsdBalance.length).toBe(4);
+        expect(heldTokensBalanceInUsdBalance).toEqual([
+          "$1’000.00",
+          "$100’000.00",
+          "$100’000.00",
+          "$1’000.00",
+        ]);
+
+        expect(heldTokensBalanceInNativeBalance.length).toBe(4);
+        expect(heldTokensBalanceInNativeBalance).toEqual([
+          "100.00 ICP",
+          "1.00 ckBTC",
+          "1.00 ckTESTBTC",
+          "0.10 ckETH",
+        ]);
+
+        expect(await heldTokensCardPo.getInfoRow().isVisible()).toBe(false);
+
+        const stakedTokensCardPo = portfolioPagePo.getStakedTokensCardPo();
+        const stakedTokensTitles =
+          await stakedTokensCardPo.getStakedTokensTitle();
+        const stakedTokensMaturities =
+          await stakedTokensCardPo.getStakedTokensMaturity();
+        const stakedTokensStakeInUsd =
+          await stakedTokensCardPo.getStakedTokensStakeInUsd();
+        const stakedTokensStakeInNativeCurrency =
+          await stakedTokensCardPo.getStakedTokensStakeInNativeCurrency();
+
+        expect(stakedTokensTitles.length).toBe(2);
+        expect(stakedTokensTitles).toEqual(["Internet Computer", "Tetris"]);
+
+        expect(stakedTokensMaturities.length).toBe(2);
+        expect(stakedTokensMaturities).toEqual(["0", "2.00"]);
+
+        expect(stakedTokensStakeInUsd.length).toBe(2);
+        expect(stakedTokensStakeInUsd).toEqual(["$10.00", "$200.00"]);
+
+        expect(stakedTokensStakeInNativeCurrency.length).toBe(2);
+        expect(stakedTokensStakeInNativeCurrency).toEqual([
+          "1.00 ICP",
+          "20.00 TST",
+        ]);
+
+        expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(true);
       });
 
-      const nnsNeuronWithStake = {
-        ...mockNeuron,
-        fullNeuron: {
-          ...mockNeuron.fullNeuron,
-          cachedNeuronStake: nnsNeuronStake,
-        },
-      };
-      neuronsStore.setNeurons({
-        neurons: [nnsNeuronWithStake],
-        certified: true,
+      it("should not show failed SNS", async () => {
+        failedActionableSnsesStore.add(tetrisSNS.rootCanisterId.toText());
+
+        const po = await renderPage();
+        const portfolioPagePo = po.getPortfolioPagePo();
+
+        // 1BTC -> $100_000
+        // 1BTCTest -> $100_000
+        // 100ICP -> $1000
+        // 0.1ETH -> $1000
+        // 1USDC -> $1
+        // 100ZTOKEN1 -> $1000
+        // 2Tetris -> $20
+        // 1ICP Neuron -> 10$
+        // 20Tetris Neuron -> 200$ FAILED proposal
+        // --------------------
+        // Total: $203’031.00
+        expect(
+          await portfolioPagePo.getTotalAssetsCardPo().getPrimaryAmount()
+        ).toBe("$203’031.00");
+        // $1 -> 0.1ICP
+        expect(
+          await portfolioPagePo.getTotalAssetsCardPo().getSecondaryAmount()
+        ).toBe("20’303.10 ICP");
+
+        const stakedTokensCardPo = portfolioPagePo.getStakedTokensCardPo();
+        const stakedTokensTitles =
+          await stakedTokensCardPo.getStakedTokensTitle();
+
+        expect(stakedTokensTitles.length).toBe(1);
+        expect(stakedTokensTitles).not.toContain(["Tetris"]);
+
+        expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(true);
       });
-
-      const snsNeuronWithStake = createMockSnsNeuron({
-        stake: tetrisSnsNeuronStake,
-      });
-      snsNeuronsStore.setNeurons({
-        rootCanisterId: tetrisSNS.rootCanisterId,
-        neurons: [snsNeuronWithStake],
-        certified: true,
-      });
-
-      const po = await renderPage();
-      const portfolioPagePo = po.getPortfolioPagePo();
-
-      // 1BTC -> $100_000
-      // 1BTCTest -> $100_000
-      // 100ICP -> $1000
-      // 0.1ETH -> $1000
-      // 1USDC -> $1
-      // 100ZTOKEN1 -> $1000
-      // 2Tetris -> $20
-      // 1ICP Neuron -> 10$
-      // 20Tetris Neuron -> 200$
-      // --------------------
-      // Total: $203’231.00
-      expect(
-        await portfolioPagePo.getTotalAssetsCardPo().getPrimaryAmount()
-      ).toBe("$203’231.00");
-      // $1 -> 0.1ICP
-      expect(
-        await portfolioPagePo.getTotalAssetsCardPo().getSecondaryAmount()
-      ).toBe("20’323.10 ICP");
-
-      const heldTokensCardPo = portfolioPagePo.getHeldTokensCardPo();
-      const heldTokensTitles = await heldTokensCardPo.getHeldTokensTitles();
-      const heldTokensBalanceInUsdBalance =
-        await heldTokensCardPo.getHeldTokensBalanceInUsd();
-      const heldTokensBalanceInNativeBalance =
-        await heldTokensCardPo.getHeldTokensBalanceInNativeCurrency();
-
-      expect(heldTokensTitles.length).toBe(4);
-      expect(heldTokensTitles).toEqual([
-        "Internet Computer",
-        "ckBTC",
-        "ckTESTBTC",
-        "ckETH",
-      ]);
-
-      expect(heldTokensBalanceInUsdBalance.length).toBe(4);
-      expect(heldTokensBalanceInUsdBalance).toEqual([
-        "$1’000.00",
-        "$100’000.00",
-        "$100’000.00",
-        "$1’000.00",
-      ]);
-
-      expect(heldTokensBalanceInNativeBalance.length).toBe(4);
-      expect(heldTokensBalanceInNativeBalance).toEqual([
-        "100.00 ICP",
-        "1.00 ckBTC",
-        "1.00 ckTESTBTC",
-        "0.10 ckETH",
-      ]);
-
-      expect(await heldTokensCardPo.getInfoRow().isVisible()).toBe(false);
-
-      const stakedTokensCardPo = portfolioPagePo.getStakedTokensCardPo();
-      const stakedTokensTitles =
-        await stakedTokensCardPo.getStakedTokensTitle();
-      const stakedTokensMaturities =
-        await stakedTokensCardPo.getStakedTokensMaturity();
-      const stakedTokensStakeInUsd =
-        await stakedTokensCardPo.getStakedTokensStakeInUsd();
-      const stakedTokensStakeInNativeCurrency =
-        await stakedTokensCardPo.getStakedTokensStakeInNativeCurrency();
-
-      expect(stakedTokensTitles.length).toBe(2);
-      expect(stakedTokensTitles).toEqual(["Internet Computer", "Tetris"]);
-
-      expect(stakedTokensMaturities.length).toBe(2);
-      expect(stakedTokensMaturities).toEqual(["0", "2.00"]);
-
-      expect(stakedTokensStakeInUsd.length).toBe(2);
-      expect(stakedTokensStakeInUsd).toEqual(["$10.00", "$200.00"]);
-
-      expect(stakedTokensStakeInNativeCurrency.length).toBe(2);
-      expect(stakedTokensStakeInNativeCurrency).toEqual([
-        "1.00 ICP",
-        "20.00 TST",
-      ]);
-
-      expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Last PR in the series adds warnings and raises awareness of failed actionable proposals within the dapp. This final update introduces the `failedActionableSnsesStore` in the Portfolio route when calling `getTableProjects`, preventing failed sns from being loaded.

<img width="1480" alt="Screenshot 2025-02-24 at 08 20 45" src="https://github.com/user-attachments/assets/a64ac121-a465-482e-bfcf-804f29633117" />

You can find all changes in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/staking/).

# Changes

- Updates the Portfolio route to pass the `failedActionableSnsesStore` when calling `getTableProjects`.
-  Removes the default value for `failedActionableSnsesStore` in `getTableProjects`.

# Tests

- Added new unit test
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/staking/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

Prev. PR: #6504