### PR TITLE
Anonymous get_stats call

### DIFF
--- a/scripts/nns-dapp/estimate-upgrade-cycles
+++ b/scripts/nns-dapp/estimate-upgrade-cycles
@@ -20,7 +20,7 @@ source "$(clap.build)"
 : "Collect data from the local run, and from mainnet to get counts for a realistic state size."
 for network in mainnet local; do
   : "## $network stats"
-  dfx canister call nns-dapp get_stats --network $network | idl2json >,counts-$network.json
+  dfx canister call nns-dapp get_stats --identity anonymous --network $network | idl2json >,counts-$network.json
   : "## $network post_upgrade instruction counts"
   jq '[.performance_counts | map (.instruction_count = (.instruction_count | tonumber)) | foreach .[] as $record ( {this: 0}; {last: .this, this: $record.instruction_count}; {key: $record.name, value: {increase: (.this - .last), cumulative: .this}} )] | from_entries' ,counts-$network.json >,postupgrade-$network.json
 done


### PR DESCRIPTION
# Motivation

Starting with `dfx` 0.25.0, canister calls to mainnet using unencrypted identities is no longer allowed.

# Changes

Use `--identity anonymous` when getting mainnet stats.

# Tests

This partially unbroke https://github.com/dfinity/nns-dapp/pull/6494

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary