### PR TITLE
feat(utils): add monetary value formatter with dynamic precision

### DIFF
--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -34,29 +34,26 @@ export const formatNumber = (
  * - 1'000'000 ≤ X < 1'000'000'000: Display millions with "M" and 2 decimal points (e.g., $1.50M)
  * - 1'000'000'000 ≤ X: Display billions with "B" and 2 decimal points (e.g., $1.50B)
  */
-export const formatCurrencyNumber = (
-  value: number,
-  currencySymbol: string = "$"
-): string => {
+export const formatCurrencyNumber = (value: number): string => {
   // For values less than 1'000
   if (value < 1000) {
-    return `${currencySymbol}${formatNumber(value, { minFraction: 2, maxFraction: 2 })}`;
+    return `${formatNumber(value, { minFraction: 2, maxFraction: 2 })}`;
   }
 
   // For values between 1'000 and 1'000'000
   if (value < 1000000) {
-    return `${currencySymbol}${formatNumber(value, { minFraction: 0, maxFraction: 0 })}`;
+    return `${formatNumber(value, { minFraction: 0, maxFraction: 0 })}`;
   }
 
   // For values between 1'000'000 and 1'000'000'000
   if (value < 1000000000) {
     const millions = value / 1000000;
-    return `${currencySymbol}${formatNumber(millions, { minFraction: 2, maxFraction: 2 })}M`;
+    return `${formatNumber(millions, { minFraction: 2, maxFraction: 2 })}M`;
   }
 
   // For values greater than or equal to 1'000'000'000
   const billions = value / 1000000000;
-  return `${currencySymbol}${formatNumber(billions, { minFraction: 2, maxFraction: 2 })}B`;
+  return `${formatNumber(billions, { minFraction: 2, maxFraction: 2 })}B`;
 };
 
 /**

--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -36,23 +36,23 @@ export const formatNumber = (
  */
 export const formatCurrencyNumber = (value: number): string => {
   // For values less than 1'000
-  if (value < 1000) {
+  if (value < 1_000) {
     return `${formatNumber(value, { minFraction: 2, maxFraction: 2 })}`;
   }
 
   // For values between 1'000 and 1'000'000
-  if (value < 1000000) {
+  if (value < 1_000_000) {
     return `${formatNumber(value, { minFraction: 0, maxFraction: 0 })}`;
   }
 
   // For values between 1'000'000 and 1'000'000'000
-  if (value < 1000000000) {
-    const millions = value / 1000000;
+  if (value < 1_000_000_000) {
+    const millions = value / 1_000_000;
     return `${formatNumber(millions, { minFraction: 2, maxFraction: 2 })}M`;
   }
 
   // For values greater than or equal to 1'000'000'000
-  const billions = value / 1000000000;
+  const billions = value / 1_000_000_000;
   return `${formatNumber(billions, { minFraction: 2, maxFraction: 2 })}B`;
 };
 

--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -28,6 +28,38 @@ export const formatNumber = (
 };
 
 /**
+ * Formats a number according to the following rules:
+ * - X < 1'000: Display 2 decimal points (e.g., $420.69)
+ * - 1'000 ≤ X < 1'000'000: Display whole number with 0 decimal points (e.g., $1'996)
+ * - 1'000'000 ≤ X < 1'000'000'000: Display millions with "M" and 2 decimal points (e.g., $1.50M)
+ * - 1'000'000'000 ≤ X: Display billions with "B" and 2 decimal points (e.g., $1.50B)
+ */
+export const formatCurrencyNumber = (
+  value: number,
+  currencySymbol: string = "$"
+): string => {
+  // For values less than 1'000
+  if (value < 1000) {
+    return `${currencySymbol}${formatNumber(value, { minFraction: 2, maxFraction: 2 })}`;
+  }
+
+  // For values between 1'000 and 1'000'000
+  if (value < 1000000) {
+    return `${currencySymbol}${formatNumber(value, { minFraction: 0, maxFraction: 0 })}`;
+  }
+
+  // For values between 1'000'000 and 1'000'000'000
+  if (value < 1000000000) {
+    const millions = value / 1000000;
+    return `${currencySymbol}${formatNumber(millions, { minFraction: 2, maxFraction: 2 })}M`;
+  }
+
+  // For values greater than or equal to 1'000'000'000
+  const billions = value / 1000000000;
+  return `${currencySymbol}${formatNumber(billions, { minFraction: 2, maxFraction: 2 })}B`;
+};
+
+/**
  * Default format: 0.150123 -> "15.012%"
  */
 export const formatPercentage = (

--- a/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -91,31 +91,31 @@ describe("format.utils", () => {
 
   describe("formatCurrencyNumber", () => {
     it("formats values less than 1,000 with 2 decimal points", () => {
-      expect(formatCurrencyNumber(0)).toBe("$0.00");
-      expect(formatCurrencyNumber(0.001)).toBe("$0.00");
-      expect(formatCurrencyNumber(0.009)).toBe("$0.01");
-      expect(formatCurrencyNumber(1)).toBe("$1.00");
-      expect(formatCurrencyNumber(9.9)).toBe("$9.90");
-      expect(formatCurrencyNumber(999.99)).toBe("$999.99");
+      expect(formatCurrencyNumber(0)).toBe("0.00");
+      expect(formatCurrencyNumber(0.001)).toBe("0.00");
+      expect(formatCurrencyNumber(0.009)).toBe("0.01");
+      expect(formatCurrencyNumber(1)).toBe("1.00");
+      expect(formatCurrencyNumber(9.9)).toBe("9.90");
+      expect(formatCurrencyNumber(999.99)).toBe("999.99");
     });
 
     it("formats values between 1,000 and 1,000,000 with 0 decimal points", () => {
-      expect(formatCurrencyNumber(1000)).toBe("$1’000");
-      expect(formatCurrencyNumber(1000.4)).toBe("$1’000");
-      expect(formatCurrencyNumber(1996.6)).toBe("$1’997");
-      expect(formatCurrencyNumber(999999)).toBe("$999’999");
+      expect(formatCurrencyNumber(1000)).toBe("1’000");
+      expect(formatCurrencyNumber(1000.4)).toBe("1’000");
+      expect(formatCurrencyNumber(1996.6)).toBe("1’997");
+      expect(formatCurrencyNumber(999999)).toBe("999’999");
     });
 
     it("formats values between 1,000,000 and 1,000,000,000 with M suffix and 2 decimal points", () => {
-      expect(formatCurrencyNumber(1000000)).toBe("$1.00M");
-      expect(formatCurrencyNumber(1550000)).toBe("$1.55M");
-      expect(formatCurrencyNumber(24800000)).toBe("$24.80M");
+      expect(formatCurrencyNumber(1000000)).toBe("1.00M");
+      expect(formatCurrencyNumber(1550000)).toBe("1.55M");
+      expect(formatCurrencyNumber(24800000)).toBe("24.80M");
     });
 
     it("formats values greater than or equal to 1,000,000,000 with B suffix and 2 decimal points", () => {
-      expect(formatCurrencyNumber(1000000000)).toBe("$1.00B");
-      expect(formatCurrencyNumber(9990000000)).toBe("$9.99B");
-      expect(formatCurrencyNumber(24800000000)).toBe("$24.80B");
+      expect(formatCurrencyNumber(1000000000)).toBe("1.00B");
+      expect(formatCurrencyNumber(9990000000)).toBe("9.99B");
+      expect(formatCurrencyNumber(24800000000)).toBe("24.80B");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -96,44 +96,26 @@ describe("format.utils", () => {
       expect(formatCurrencyNumber(0.009)).toBe("$0.01");
       expect(formatCurrencyNumber(1)).toBe("$1.00");
       expect(formatCurrencyNumber(9.9)).toBe("$9.90");
-      expect(formatCurrencyNumber(10)).toBe("$10.00");
-      expect(formatCurrencyNumber(99.99)).toBe("$99.99");
-      expect(formatCurrencyNumber(100)).toBe("$100.00");
-      expect(formatCurrencyNumber(420.69)).toBe("$420.69");
       expect(formatCurrencyNumber(999.99)).toBe("$999.99");
     });
 
     it("formats values between 1,000 and 1,000,000 with 0 decimal points", () => {
       expect(formatCurrencyNumber(1000)).toBe("$1’000");
-      expect(formatCurrencyNumber(1000.5)).toBe("$1’001");
-      expect(formatCurrencyNumber(1996)).toBe("$1’996");
-      expect(formatCurrencyNumber(9999)).toBe("$9’999");
-      expect(formatCurrencyNumber(10000)).toBe("$10’000");
-      expect(formatCurrencyNumber(100000)).toBe("$100’000");
+      expect(formatCurrencyNumber(1000.4)).toBe("$1’000");
+      expect(formatCurrencyNumber(1996.6)).toBe("$1’997");
       expect(formatCurrencyNumber(999999)).toBe("$999’999");
-      expect(formatCurrencyNumber(999999.99)).toBe("$1’000’000");
     });
 
     it("formats values between 1,000,000 and 1,000,000,000 with M suffix and 2 decimal points", () => {
       expect(formatCurrencyNumber(1000000)).toBe("$1.00M");
-      expect(formatCurrencyNumber(1500000)).toBe("$1.50M");
       expect(formatCurrencyNumber(1550000)).toBe("$1.55M");
-      expect(formatCurrencyNumber(9990000)).toBe("$9.99M");
-      expect(formatCurrencyNumber(10000000)).toBe("$10.00M");
       expect(formatCurrencyNumber(24800000)).toBe("$24.80M");
-      expect(formatCurrencyNumber(420690000)).toBe("$420.69M");
-      expect(formatCurrencyNumber(999999999)).toBe("$1’000.00M");
     });
 
     it("formats values greater than or equal to 1,000,000,000 with B suffix and 2 decimal points", () => {
       expect(formatCurrencyNumber(1000000000)).toBe("$1.00B");
-      expect(formatCurrencyNumber(1500000000)).toBe("$1.50B");
       expect(formatCurrencyNumber(9990000000)).toBe("$9.99B");
-      expect(formatCurrencyNumber(10000000000)).toBe("$10.00B");
       expect(formatCurrencyNumber(24800000000)).toBe("$24.80B");
-      expect(formatCurrencyNumber(420690000000)).toBe("$420.69B");
-      expect(formatCurrencyNumber(999999999999)).toBe("$1’000.00B");
-      expect(formatCurrencyNumber(1000000000000)).toBe("$1’000.00B");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  formatCurrencyNumber,
   formatNumber,
   formatPercentage,
   shortenWithMiddleEllipsis,
@@ -86,5 +87,53 @@ describe("format.utils", () => {
     expect(shortenWithMiddleEllipsis("1234567890123456", 6)).toEqual(
       "123456...123456"
     );
+  });
+
+  describe("formatCurrencyNumber", () => {
+    it("formats values less than 1,000 with 2 decimal points", () => {
+      expect(formatCurrencyNumber(0)).toBe("$0.00");
+      expect(formatCurrencyNumber(0.001)).toBe("$0.00");
+      expect(formatCurrencyNumber(0.009)).toBe("$0.01");
+      expect(formatCurrencyNumber(1)).toBe("$1.00");
+      expect(formatCurrencyNumber(9.9)).toBe("$9.90");
+      expect(formatCurrencyNumber(10)).toBe("$10.00");
+      expect(formatCurrencyNumber(99.99)).toBe("$99.99");
+      expect(formatCurrencyNumber(100)).toBe("$100.00");
+      expect(formatCurrencyNumber(420.69)).toBe("$420.69");
+      expect(formatCurrencyNumber(999.99)).toBe("$999.99");
+    });
+
+    it("formats values between 1,000 and 1,000,000 with 0 decimal points", () => {
+      expect(formatCurrencyNumber(1000)).toBe("$1’000");
+      expect(formatCurrencyNumber(1000.5)).toBe("$1’001");
+      expect(formatCurrencyNumber(1996)).toBe("$1’996");
+      expect(formatCurrencyNumber(9999)).toBe("$9’999");
+      expect(formatCurrencyNumber(10000)).toBe("$10’000");
+      expect(formatCurrencyNumber(100000)).toBe("$100’000");
+      expect(formatCurrencyNumber(999999)).toBe("$999’999");
+      expect(formatCurrencyNumber(999999.99)).toBe("$1’000’000");
+    });
+
+    it("formats values between 1,000,000 and 1,000,000,000 with M suffix and 2 decimal points", () => {
+      expect(formatCurrencyNumber(1000000)).toBe("$1.00M");
+      expect(formatCurrencyNumber(1500000)).toBe("$1.50M");
+      expect(formatCurrencyNumber(1550000)).toBe("$1.55M");
+      expect(formatCurrencyNumber(9990000)).toBe("$9.99M");
+      expect(formatCurrencyNumber(10000000)).toBe("$10.00M");
+      expect(formatCurrencyNumber(24800000)).toBe("$24.80M");
+      expect(formatCurrencyNumber(420690000)).toBe("$420.69M");
+      expect(formatCurrencyNumber(999999999)).toBe("$1’000.00M");
+    });
+
+    it("formats values greater than or equal to 1,000,000,000 with B suffix and 2 decimal points", () => {
+      expect(formatCurrencyNumber(1000000000)).toBe("$1.00B");
+      expect(formatCurrencyNumber(1500000000)).toBe("$1.50B");
+      expect(formatCurrencyNumber(9990000000)).toBe("$9.99B");
+      expect(formatCurrencyNumber(10000000000)).toBe("$10.00B");
+      expect(formatCurrencyNumber(24800000000)).toBe("$24.80B");
+      expect(formatCurrencyNumber(420690000000)).toBe("$420.69B");
+      expect(formatCurrencyNumber(999999999999)).toBe("$1’000.00B");
+      expect(formatCurrencyNumber(1000000000000)).toBe("$1’000.00B");
+    });
   });
 });


### PR DESCRIPTION
# Motivation

The nns-dapp displays monetary values in various sections: the portfolio, tokens, and projects page. These values can sometimes be large numbers with decimals that are overly detailed for these components. 

This first PR introduces a utility for displaying monetary values according to the following rules:
* For values less than CHF 1,000 — Display 2 decimal points. Example: CHF 420.69
* For values between CHF 1,000 and CHF 1,000,000 — Display the whole number with 0 decimal points. Example: CHF 1,996
* For values between CHF 1,000,000 and CHF 1,000,000,000 — Display millions with an “M” and 2 decimal points. Example: CHF 1.50M / CHF 24.8M / CHF 420.69M
* For values greater than CHF 1,000,000,000 — Display billions with a “B” and 2 decimal points. Example: CHF 1.50B / CHF 24.8B / CHF 420.69B

[NNS1-3604](https://dfinity.atlassian.net/browse/NNS1-3604)

# Changes

- New util to display for displaying monetary values.

# Tests

- Added unit tests for the new util.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3604]: https://dfinity.atlassian.net/browse/NNS1-3604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ