### PR TITLE
improvements to the tests

### DIFF
--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -1,9 +1,9 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
-  replaceContent,
-  signInWithNewUser,
-  step,
+    replaceContent,
+    signInWithNewUser,
+    step,
 } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
@@ -22,6 +22,9 @@ test("Visual test Landing Page", async ({ page, browser }) => {
   await expect(page).toHaveTitle("Portfolio / NNS Dapp");
 
   await page.setViewportSize(VIEWPORT_SIZES.desktop);
+
+  await portfolioPo.getPortfolioPagePo().getTotalAssetsCardPo().waitForLoaded();
+    await appPo.getMenuItemsPo().getTotalValueLockedLinkPo().waitFor();
 
   // The governance metrics are only updated once a day so for the first 24h
   // after a snapshot is created, the metrics might be different than what

--- a/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
@@ -37,4 +37,8 @@ export class TotalAssetsCardPo extends BasePageObject {
   async hasError(): Promise<boolean> {
     return this.getIcpExchangeRatePo().hasError();
   }
+
+  async waitForLoaded(): Promise<void> {
+    await this.waitForAbsent("spinner");
+  }
 }

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -111,6 +111,11 @@ export const replaceContent = async ({
   pattern: RegExp;
   replacements: string[];
 }): Promise<void> => {
+  await Promise.all(
+    selectors.map((selector) =>
+      page.locator(selector).first().waitFor({ state: "attached" })
+    )
+  );
   const replacementCount = await page.evaluate(
     ({ selectors, pattern, replacements }) => {
       let replacementCount = 0;


### PR DESCRIPTION
# Motivation

#6494 has exhibited some instability in the Portfolio end-to-end tests due to timeouts. This PR cherry-picks improvements introduced in #6494 to enhance the resilience of the tests. Note that this does not yet resolve the issues with PocketIc. A recommendation was made [here](https://dfinity.slack.com/archives/CGA566TPV/p1740583658038659?thread_ts=1740552440.901949&cid=CGA566TPV) on achieving similar behavior in the CI.

# Changes

1. Wait for assets to be loaded in portfolio e2e test before taking screenshot.
2. Wait for selectors to be attached before replacing their content.

# Tests

- CI should pass

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.