### PR TITLE
chore(ci): upgrade github actions runner to ubuntu-22.04

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -1,4 +1,4 @@
-1
+60
 Monterey
 IC
 ICP

--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -4,6 +4,13 @@ IC
 ICP
 IDL
 schemas
+subnet
+favicon
+JSON
+UI
+CSP
+APIs
+API
 WASM
 Wasm
 Wasms

--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -66,3 +66,5 @@ se
 TVL
 backend
 DFINITY
+Changelog
+changelog

--- a/.config/spellcheck.toml
+++ b/.config/spellcheck.toml
@@ -1,4 +1,4 @@
 [Hunspell]
-lang = "en_GB"
+lang = "en_US"
 search_dirs = [".", ".config"]
-extra_dictionaries = [ "spellcheck.dic", "en_US.dic" ]
+extra_dictionaries = [ "spellcheck.dic" ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           retention-days: 3
   test-playwright-e2e-shard-1-of-2:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp
@@ -88,7 +88,7 @@ jobs:
           shard_count: 2
   test-playwright-e2e-shard-2-of-2:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp
@@ -100,7 +100,7 @@ jobs:
           shard_count: 2
   test-upgrade-downgrade:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
@@ -123,7 +123,7 @@ jobs:
         run: ./scripts/nns-dapp/upgrade-downgrade-test --wasm out/nns-dapp_test.wasm.gz --args out/nns-dapp-arg-local.did --github_step_summary "$GITHUB_STEP_SUMMARY"
   test-upgrade-stable:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
@@ -153,7 +153,7 @@ jobs:
           path: test-upgrade-stable-dfx.log
   test-test-account-api:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
@@ -173,7 +173,7 @@ jobs:
         run: ./scripts/nns-dapp/test-account.test
   test-rest:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
@@ -355,7 +355,7 @@ jobs:
           }
   aggregator_test:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout nns-dapp
@@ -461,7 +461,7 @@ jobs:
   assets:
     name: "Upload assets"
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Get docker build outputs
@@ -532,7 +532,7 @@ jobs:
   build-pass:
     needs: ["build", "test-playwright-e2e-shard-1-of-2", "test-playwright-e2e-shard-2-of-2", "test-rest", "network_independent_wasm", "aggregator_test", "assets", "test-upgrade-downgrade", "test-test-account-api", "test-upgrade-stable"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,9 +55,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -yy hunspell hunspell-en-gb hunspell-en-us clang libclang-dev
-          cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.15.1
+          cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.13.1
+      - name: Verify dictionary
+        run: |
+          echo "File exists: $(ls -la .config/spellcheck.dic)"
+          echo "First line: $(head -n1 .config/spellcheck.dic)"
+          echo "Hex dump: $(head -c4 .config/spellcheck.dic | hexdump -C)"
+          # Validate numeric first line
+          [[ $(head -n1 .config/spellcheck.dic) =~ ^[0-9]+$ ]] || exit 1
       - name: Spellcheck Rust
-        run: cargo spellcheck --code 1
+        run: cargo spellcheck -- --code 1 --dict .config/spellcheck.dic
       - name: Spellcheck changelog
         run: scripts/spellcheck-changelog
   cargo-tests:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -yy hunspell hunspell-en-gb hunspell-en-us clang libclang-dev
-          cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.13.1
+          cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.15.1
       - name: Spellcheck Rust
         run: cargo spellcheck --code 1
       - name: Spellcheck changelog
@@ -367,4 +367,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success
         with:
-          needs: '${{ toJson(needs) }}'
+          needs: "${{ toJson(needs) }}"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -367,4 +367,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success
         with:
-          needs: "${{ toJson(needs) }}"
+          needs: '${{ toJson(needs) }}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,13 +56,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -yy hunspell hunspell-en-gb hunspell-en-us clang libclang-dev
           cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.13.1
-      - name: Verify dictionary
-        run: |
-          echo "File exists: $(ls -la .config/spellcheck.dic)"
-          echo "First line: $(head -n1 .config/spellcheck.dic)"
-          echo "Hex dump: $(head -c4 .config/spellcheck.dic | hexdump -C)"
-          # Validate numeric first line
-          [[ $(head -n1 .config/spellcheck.dic) =~ ^[0-9]+$ ]] || exit 1
       - name: Spellcheck Rust
         run: cargo spellcheck -- --code 1 --verbose
       - name: Spellcheck changelog

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get install -yy hunspell hunspell-en-gb hunspell-en-us clang libclang-dev
           cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.13.1
       - name: Spellcheck Rust
-        run: cargo spellcheck -- --code 1 --verbose
+        run: cargo spellcheck -- --code 1
       - name: Spellcheck changelog
         run: scripts/spellcheck-changelog
   cargo-tests:
@@ -367,4 +367,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success
         with:
-          needs: '${{ toJson(needs) }}'
+          needs: "${{ toJson(needs) }}"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,7 +64,7 @@ jobs:
           # Validate numeric first line
           [[ $(head -n1 .config/spellcheck.dic) =~ ^[0-9]+$ ]] || exit 1
       - name: Spellcheck Rust
-        run: cargo spellcheck -- --code 1 --dict .config/spellcheck.dic
+        run: cargo spellcheck -- --code 1 --dict .config/spellcheck.dic --no-default-dicts --verbose
       - name: Spellcheck changelog
         run: scripts/spellcheck-changelog
   cargo-tests:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash -euxlo pipefail {0}
 jobs:
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DFX_NETWORK: mainnet
     steps:
@@ -38,7 +38,7 @@ jobs:
                   exit 1
           }
   relative-imports:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DFX_NETWORK: mainnet
     steps:
@@ -47,7 +47,7 @@ jobs:
       - name: Checks for the presence of relative imports
         run: ./scripts/check-relative-imports
   spelling:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
       - name: Spellcheck changelog
         run: scripts/spellcheck-changelog
   cargo-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -102,7 +102,7 @@ jobs:
           shard_number: 2
           shard_count: 2
   svelte-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -124,7 +124,7 @@ jobs:
         working-directory: ./frontend
   shell-checks:
     name: ShellCheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
@@ -134,7 +134,7 @@ jobs:
           ./scripts/lint-sh
   ic-commit-consistency:
     name: IC Commit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install didc
@@ -158,7 +158,7 @@ jobs:
           fi
   release-templating-works:
     name: Release template
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -180,7 +180,7 @@ jobs:
           ./scripts/nns-dapp/release-check
   config-check:
     name: Config is as expected
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install dfx
@@ -194,7 +194,7 @@ jobs:
         run: bash -x config.test
   migration-test-utils-work:
     name: Migration test utilities work
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install cargo binstall
@@ -209,7 +209,7 @@ jobs:
     # TODO: Re-enable (add it in line 338) once fixed, should it depend on mainnet?
     if: false
     name: Can get NNS proposal args
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install didc
@@ -225,7 +225,7 @@ jobs:
       - name: Test getting proposal args
         run: scripts/dfx-nns-proposal-args.test
   minor-version-bump-works:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install yq
@@ -257,7 +257,7 @@ jobs:
           # TODO: Verify that the commits contain the expected changes.
   version-match:
     name: The nns-dapp npm and cargo versions should match
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Backend and frontend have the same version
@@ -274,7 +274,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
     env:
       # Used by download-ci-wasm.test
@@ -362,7 +362,7 @@ jobs:
       - version-match
       - small-tests
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,7 +64,7 @@ jobs:
           # Validate numeric first line
           [[ $(head -n1 .config/spellcheck.dic) =~ ^[0-9]+$ ]] || exit 1
       - name: Spellcheck Rust
-        run: cargo spellcheck -- --code 1 --dict .config/spellcheck.dic --no-default-dicts --verbose
+        run: cargo spellcheck -- --code 1 --verbose
       - name: Spellcheck changelog
         run: scripts/spellcheck-changelog
   cargo-tests:

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   builder:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       # We use `buildx` and its GitHub Actions caching support `type=gha`. For

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tag-main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
   nightly-passes:
     needs: ["tag-main"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -27,7 +27,6 @@ jobs:
         os:
           # - macos-11
           # - macos-12
-          - ubuntu-20.04
           - ubuntu-22.04
     steps:
       - name: Unbork mac
@@ -99,7 +98,7 @@ jobs:
   check_passes:
     needs: ["docker_build", "compare_hashes"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   tag_tip:
     if: github.event.pull_request.merged
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Tag main as tip


### PR DESCRIPTION
# Motivation

The nns-dapp uses an Ubuntu runner that will be deprecated on April 1st. We need to upgrade it to a later version before that date. Full message can be found [here](https://dfinity.slack.com/archives/CH4CADCJX/p1740558752499169).

Note: Upgrading the version of Ubuntu caused `cargo spellcheck` to [fail](https://github.com/dfinity/nns-dapp/actions/runs/13569728867/job/37935146081) while attempting to load the `en-GB` dictionary.

# Changes

- Upgraded the version to `ubuntu-22.04`.
- Changed the `spellcheck.toml` language to American English.
- Added missing words to the spellcheck dictionary.

# Tests

- CI should pass

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.