### PR TITLE
refactor(ui): centralize token card amount formatting

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -38,7 +38,6 @@
     <TokensCardHeader
       {href}
       {usdAmount}
-      {usdAmountFormatted}
       title={$i18n.portfolio.held_tokens_card_title}
       linkText={$i18n.portfolio.held_tokens_card_link}
     >

--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -19,11 +19,6 @@
 
   const href = AppPath.Tokens;
 
-  let usdAmountFormatted: string;
-  $: usdAmountFormatted = $authSignedInStore
-    ? formatNumber(usdAmount)
-    : PRICE_NOT_AVAILABLE_PLACEHOLDER;
-
   let numberOfTopHeldTokens: number;
   $: numberOfTopHeldTokens = topHeldTokens.length;
 

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -19,10 +19,6 @@
   export let numberOfTopHeldTokens: number;
 
   const href = AppPath.Staking;
-  let usdAmountFormatted: string;
-  $: usdAmountFormatted = $authSignedInStore
-    ? formatNumber(usdAmount)
-    : PRICE_NOT_AVAILABLE_PLACEHOLDER;
 
   let numberOfTopStakedTokens: number;
   $: numberOfTopStakedTokens = topStakedTokens.length;

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -39,7 +39,6 @@
     <TokensCardHeader
       {href}
       {usdAmount}
-      {usdAmountFormatted}
       title={$i18n.portfolio.staked_tokens_card_title}
       linkText={$i18n.portfolio.staked_tokens_card_link}
     >

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
+  import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { formatNumber } from "$lib/utils/format.utils";
   import { IconRight } from "@dfinity/gix-components";
 
   export let usdAmount: number;
-  export let usdAmountFormatted: string;
   export let href: string;
   export let title: string;
   export let linkText: string;
+
+  let usdAmountFormatted: string;
+  $: usdAmountFormatted = $authSignedInStore
+    ? formatNumber(usdAmount)
+    : PRICE_NOT_AVAILABLE_PLACEHOLDER;
 </script>
 
 <div class="header">


### PR DESCRIPTION
# Motivation

We aim to centralize the formatting of amounts for the HeldTokens and StakedTokens cards. This will be utilized in a follow-up PR to format currencies using the new utility.

# Changes

- Moves formatting logic to the shared card header component.

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary