### PR TITLE
Move settings popover to ResponsiveTable

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -15,6 +15,7 @@
   export let userTokensData: Array<UserToken>;
   export let firstColumnHeader: string;
   export let order: TokensTableOrder = [];
+  export let displayTableSettings = false;
 
   let enableSorting: boolean;
   $: enableSorting = order.length > 0;
@@ -62,8 +63,9 @@
   {columns}
   bind:order
   disableMobileSorting
+  {displayTableSettings}
   on:nnsAction
 >
   <slot name="last-row" slot="last-row" />
-  <slot name="header-icon" slot="header-icon" />
+  <slot name="settings-popover" slot="settings-popover" />
 </ResponsiveTable>

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -305,14 +305,6 @@
           }
         }
       }
-
-      .header-icon {
-        // Prevents the element taking up more height than the icon by adding
-        // space for descenders.
-        line-height: 0;
-
-        color: var(--primary);
-      }
     }
 
     [role="rowgroup"],

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <script lang="ts" generics="RowDataType extends ResponsiveTableRowData">
+  import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import ResponsiveTableRow from "$lib/components/ui/ResponsiveTableRow.svelte";
   import ResponsiveTableSortModal from "$lib/modals/common/ResponsiveTableSortModal.svelte";
@@ -17,7 +18,12 @@
     sortTableData,
   } from "$lib/utils/responsive-table.utils";
   import { heightTransition } from "$lib/utils/transition.utils";
-  import { IconSort, IconSouth } from "@dfinity/gix-components";
+  import {
+    IconSettings,
+    IconSort,
+    IconSouth,
+    Popover,
+  } from "@dfinity/gix-components";
   import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
 
   export let testId = "responsive-table-component";
@@ -28,6 +34,7 @@
   export let getRowStyle: (rowData: RowDataType) => string | undefined = (_) =>
     undefined;
   export let disableMobileSorting = false;
+  export let displayTableSettings = false;
 
   let nonLastColumns: ResponsiveTableColumn<RowDataType>[];
   let lastColumn: ResponsiveTableColumn<RowDataType> | undefined;
@@ -87,6 +94,11 @@
   let tableStyle: string;
   $: tableStyle = getTableStyle(columns);
 
+  let settingsButton: HTMLButtonElement | undefined;
+  let settingsPopupVisible = false;
+  const openSettings = () => (settingsPopupVisible = true);
+
+  // TODO(mstr): Update/remove this comment after sorting redesign is done.
   // In mobile view, we only show the first column header and it should never be
   // sortable by clicking on it. So depending on whether the first column is
   // sortable we have or don't have separate first column headers for desktop
@@ -137,7 +149,15 @@
                 data-tid="open-sort-modal"
                 class="mobile-only icon-only"
                 on:click={openSortModal}><IconSort /></button
-              >{/if}<slot name="header-icon" />
+              >{/if}{#if displayTableSettings}
+              <button
+                data-tid="settings-button"
+                class="settings-button icon-only"
+                aria-label={$i18n.tokens.settings_button}
+                bind:this={settingsButton}
+                on:click={openSettings}><IconSettings /></button
+              >
+            {/if}
           </span>
         {/if}
       </div>
@@ -164,6 +184,15 @@
     {/if}
   </div>
 
+  <Popover
+    bind:visible={settingsPopupVisible}
+    anchor={settingsButton}
+    direction="rtl"
+    invisibleBackdrop
+  >
+    <slot name="settings-popover" />
+  </Popover>
+
   {#if showSortModal}
     <ResponsiveTableSortModal
       {columns}
@@ -174,6 +203,7 @@
 </TestIdWrapper>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/effect";
   @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "../../themes/mixins/grid-table";
 
@@ -255,6 +285,23 @@
               transform: rotate(180deg);
               transform-origin: center center;
             }
+          }
+        }
+
+        .settings-button {
+          --content-color: var(--text-description);
+
+          @include effect.ripple-effect(
+            --primary-tint,
+            var(--primary-contrast)
+          );
+
+          &:focus {
+            background: var(--primary-tint);
+            @include effect.ripple-effect(
+              --primary-tint,
+              var(--primary-contrast)
+            );
           }
         }
       }

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -19,13 +19,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { isImportedToken } from "$lib/utils/imported-tokens.utils";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
-  import {
-    IconHeldTokens,
-    IconPlus,
-    IconSettings,
-    Popover,
-    Tooltip,
-  } from "@dfinity/gix-components";
+  import { IconHeldTokens, IconPlus, Tooltip } from "@dfinity/gix-components";
   import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
 
   export let userTokensData: UserToken[];
@@ -102,16 +96,12 @@
     on:nnsAction
     firstColumnHeader={$i18n.tokens.projects_header}
     bind:order={$tokensTableOrderStore}
+    displayTableSettings
   >
-    <div slot="header-icon">
-      <button
-        data-tid="settings-button"
-        class="settings-button icon-only"
-        aria-label={$i18n.tokens.settings_button}
-        bind:this={settingsButton}
-        on:click={openSettings}><IconSettings /></button
-      >
+    <div slot="settings-popover">
+      <HideZeroBalancesToggle />
     </div>
+
     <div slot="last-row" class="last-row">
       {#if shouldHideZeroBalances}
         <div class="show-all-button-container">
@@ -148,14 +138,6 @@
       {/if}
     </div>
   </TokensTable>
-  <Popover
-    bind:visible={settingsPopupVisible}
-    anchor={settingsButton}
-    direction="rtl"
-    invisibleBackdrop
-  >
-    <HideZeroBalancesToggle />
-  </Popover>
 
   {#if showImportTokenModal || ($ENABLE_IMPORT_TOKEN_BY_URL && nonNullish($pageStore.importTokenLedgerId))}
     <ImportTokenModal on:nnsClose={() => (showImportTokenModal = false)} />
@@ -170,17 +152,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
-  }
-
-  .settings-button {
-    --content-color: var(--text-description);
-
-    @include effect.ripple-effect(--primary-tint, var(--primary-contrast));
-
-    &:focus {
-      background: var(--primary-tint);
-      @include effect.ripple-effect(--primary-tint, var(--primary-contrast));
-    }
   }
 
   [slot="last-row"] {

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -35,13 +35,6 @@
       (!("balanceInUsd" in token) || isNullish(token.balanceInUsd))
   );
 
-  let settingsButton: HTMLButtonElement | undefined;
-  let settingsPopupVisible = false;
-
-  const openSettings = () => {
-    settingsPopupVisible = true;
-  };
-
   let shouldHideZeroBalances: boolean;
   $: shouldHideZeroBalances = $hideZeroBalancesStore === "hide";
 


### PR DESCRIPTION
# Motivation

Since the tokens table now displays fiat values alongside token balances, users may want to sort by them instead of being restricted to the fixed alphabetical order currently enforced. To enable this, we need to allow users to sort the table via the extended table settings popover, as there are no column headers on mobile.

Besides sorting, the settings popover will also include table-specific controls, such as the HideZeroBalancesToggle for the tokens table.

The task: https://dfinity.atlassian.net/browse/NNS1-3603

# Changes

- Refactor: Move the settings popover to ResponsiveTable, adding a slot for custom controls (used for HideZeroBalancesToggle in the tokens table).

# Tests

- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.