### PR TITLE
Responsive table sort control

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
@@ -1,0 +1,100 @@
+<script lang="ts" generics="RowDataType extends ResponsiveTableRowData">
+  import { i18n } from "$lib/stores/i18n";
+  import type {
+    ResponsiveTableColumn,
+    ResponsiveTableOrder,
+    ResponsiveTableRowData,
+  } from "$lib/types/responsive-table";
+  import { selectPrimaryOrder } from "$lib/utils/responsive-table.utils";
+  import { IconSouth, ChipGroup, type ChipData } from "@dfinity/gix-components";
+  import { assertNonNullish, nonNullish } from "@dfinity/utils";
+
+  export let columns: ResponsiveTableColumn<RowDataType>[];
+  export let order: ResponsiveTableOrder;
+
+  const orderBy = async (selectedColumnId: string) => {
+    assertNonNullish(selectedColumnId);
+    order = selectPrimaryOrder({ order, selectedColumnId });
+  };
+
+  let chips: ChipData[] = [];
+  $: chips = columns
+    .filter(({ comparator }) => nonNullish(comparator))
+    .map(({ id, title }) => ({
+      id: id,
+      label: title,
+      selected: order[0]?.columnId === id,
+    }));
+
+  let isReversed: boolean;
+  $: isReversed = order[0]?.reversed ?? false;
+
+  const onNnsSelect = ({ detail: selectedId }: CustomEvent<string>) =>
+    orderBy(selectedId);
+  const reverseOrder = () => orderBy(order[0].columnId);
+</script>
+
+<div
+  class="responsive-table-sort-control"
+  data-tid="responsive-table-sort-control-component"
+>
+  <div class="header">
+    <h5>{$i18n.responsive_table.sorting}</h5>
+    <button
+      class="direction-button ghost with-icon"
+      data-tid="sort-direction-button"
+      on:click={reverseOrder}
+    >
+      {#if isReversed}
+        {$i18n.responsive_table.ascending_order}
+        <div class="icon icon-north"><IconSouth size="20px" /></div>
+      {:else}
+        {$i18n.responsive_table.descending_order}
+        <div class="icon"><IconSouth size="20px" /></div>
+      {/if}
+    </button>
+  </div>
+
+  <ChipGroup {chips} on:nnsSelect={onNnsSelect} />
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .responsive-table-sort-control {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--padding);
+  }
+
+  h5 {
+    margin: 0;
+    @include fonts.standard(true);
+    color: var(--description-color);
+  }
+
+  .direction-button {
+    display: flex;
+    gap: var(--padding-0_5x);
+    align-items: center;
+
+    @include fonts.small(true);
+    color: var(--description-color);
+  }
+
+  .icon {
+    display: flex;
+    color: var(--primary);
+
+    &.icon-north {
+      transform: rotate(180deg);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
@@ -1,22 +1,30 @@
+<script lang="ts" context="module">
+  import type { ResponsiveTableRowData } from "$lib/types/responsive-table";
+  type RowDataType = ResponsiveTableRowData;
+</script>
+
 <script lang="ts" generics="RowDataType extends ResponsiveTableRowData">
   import { i18n } from "$lib/stores/i18n";
   import type {
     ResponsiveTableColumn,
     ResponsiveTableOrder,
-    ResponsiveTableRowData,
   } from "$lib/types/responsive-table";
   import { selectPrimaryOrder } from "$lib/utils/responsive-table.utils";
-  import { IconSouth, ChipGroup, type ChipData } from "@dfinity/gix-components";
+  import {
+    IconSouth,
+    ChipGroup,
+    type ChipGroupItem,
+  } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
 
   export let columns: ResponsiveTableColumn<RowDataType>[];
   export let order: ResponsiveTableOrder;
 
-  let chips: ChipData[] = [];
+  let chips: ChipGroupItem[] = [];
   $: chips = columns
     .filter(({ comparator }) => nonNullish(comparator))
     .map(({ id, title }) => ({
-      id: id,
+      id: id ?? title,
       label: title,
       selected: order[0]?.columnId === id,
     }));

--- a/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
@@ -7,15 +7,10 @@
   } from "$lib/types/responsive-table";
   import { selectPrimaryOrder } from "$lib/utils/responsive-table.utils";
   import { IconSouth, ChipGroup, type ChipData } from "@dfinity/gix-components";
-  import { assertNonNullish, nonNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
 
   export let columns: ResponsiveTableColumn<RowDataType>[];
   export let order: ResponsiveTableOrder;
-
-  const orderBy = async (selectedColumnId: string) => {
-    assertNonNullish(selectedColumnId);
-    order = selectPrimaryOrder({ order, selectedColumnId });
-  };
 
   let chips: ChipData[] = [];
   $: chips = columns
@@ -29,6 +24,8 @@
   let isReversed: boolean;
   $: isReversed = order[0]?.reversed ?? false;
 
+  const orderBy = async (selectedColumnId: string) =>
+    (order = selectPrimaryOrder({ order, selectedColumnId }));
   const onNnsSelect = ({ detail: selectedId }: CustomEvent<string>) =>
     orderBy(selectedId);
   const reverseOrder = () => orderBy(order[0].columnId);
@@ -45,13 +42,12 @@
       data-tid="sort-direction-button"
       on:click={reverseOrder}
     >
-      {#if isReversed}
-        {$i18n.responsive_table.ascending_order}
-        <div class="icon icon-north"><IconSouth size="20px" /></div>
-      {:else}
-        {$i18n.responsive_table.descending_order}
-        <div class="icon"><IconSouth size="20px" /></div>
-      {/if}
+      {isReversed
+        ? $i18n.responsive_table.ascending_order
+        : $i18n.responsive_table.descending_order}
+      <div class="icon" class:reversed={isReversed}
+        ><IconSouth size="20px" /></div
+      >
     </button>
   </div>
 
@@ -93,7 +89,7 @@
     display: flex;
     color: var(--primary);
 
-    &.icon-north {
+    &.reversed {
       transform: rotate(180deg);
     }
   }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -875,6 +875,9 @@
   },
   "responsive_table": {
     "sort_by": "Sort by",
+    "sorting": "Sorting",
+    "descending_order": "High to Low",
+    "ascending_order": "Low to Hight",
     "tap_to_reverse": "Tap to reverse"
   },
   "time": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -912,6 +912,9 @@ interface I18nSns_neurons {
 
 interface I18nResponsive_table {
   sort_by: string;
+  sorting: string;
+  descending_order: string;
+  ascending_order: string;
   tap_to_reverse: string;
 }
 

--- a/frontend/src/tests/lib/components/ui/ResponsiveTableSortControl.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTableSortControl.spec.ts
@@ -47,7 +47,6 @@ describe("ResponsiveTableSortControl", () => {
     columns: ResponsiveTableColumn<TestRowData>[];
     orderStore?: Writable<ResponsiveTableOrder>;
   }) => {
-    orderStore?.set(order);
     const { container } = render(ResponsiveTableSortControlTest, {
       props: {
         columns,

--- a/frontend/src/tests/lib/components/ui/ResponsiveTableSortControl.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTableSortControl.spec.ts
@@ -1,0 +1,122 @@
+import type {
+  ResponsiveTableColumn,
+  ResponsiveTableOrder,
+} from "$lib/types/responsive-table";
+import { createAscendingComparator } from "$lib/utils/sort.utils";
+import ResponsiveTableSortControlTest from "$tests/lib/components/ui/ResponsiveTableSortControlTest.svelte";
+import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
+import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
+import { ResponsiveTableSortControlPo } from "$tests/page-objects/ResponsiveTableSortControl.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import { get, writable, type Writable } from "svelte/store";
+
+describe("ResponsiveTableSortControl", () => {
+  type TestRowData = {
+    domKey: string;
+    rowHref?: string;
+    name: string;
+    age: number;
+  };
+
+  const columns: ResponsiveTableColumn<TestRowData>[] = [
+    {
+      id: "name",
+      title: "Name",
+      cellComponent: TestTableNameCell,
+      alignment: "left",
+      templateColumns: ["1fr", "max-content"],
+      comparator: createAscendingComparator((rowData) => rowData.name),
+    },
+    {
+      id: "age",
+      title: "Age",
+      cellComponent: TestTableAgeCell,
+      alignment: "left",
+      templateColumns: ["1fr"],
+      comparator: createAscendingComparator((rowData) => rowData.age),
+    },
+  ];
+
+  const order = [{ columnId: "name" }, { columnId: "age" }];
+
+  const renderComponent = ({
+    columns,
+    orderStore,
+  }: {
+    columns: ResponsiveTableColumn<TestRowData>[];
+    orderStore?: Writable<ResponsiveTableOrder>;
+  }) => {
+    orderStore?.set(order);
+    const { container } = render(ResponsiveTableSortControlTest, {
+      props: {
+        columns,
+        orderStore,
+      },
+    });
+
+    return ResponsiveTableSortControlPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render chips", async () => {
+    const orderStore = writable(order);
+    const po = renderComponent({
+      columns,
+      orderStore,
+    });
+    expect(await po.getSortChipLabels()).toEqual(["Name", "Age"]);
+  });
+
+  it("should change order", async () => {
+    const orderStore = writable(order);
+    const po = renderComponent({
+      columns,
+      orderStore,
+    });
+    expect(get(orderStore)).toEqual([
+      { columnId: "name" },
+      { columnId: "age" },
+    ]);
+
+    await po.clickSortChip("Age");
+    expect(get(orderStore)).toEqual([
+      { columnId: "age" },
+      { columnId: "name" },
+    ]);
+
+    await po.clickSortChip("Name");
+    expect(get(orderStore)).toEqual([
+      { columnId: "name" },
+      { columnId: "age" },
+    ]);
+  });
+
+  it("should reverse order", async () => {
+    const orderStore = writable(order);
+    const po = renderComponent({
+      columns,
+      orderStore,
+    });
+    expect(get(orderStore)).toEqual([
+      { columnId: "name" },
+      { columnId: "age" },
+    ]);
+    expect(await po.isSortDirectionButtonReversed()).toBe(false);
+
+    await po.getSortDirectionButtonPo().click();
+    expect(get(orderStore)).toEqual([
+      { columnId: "name", reversed: true },
+      { columnId: "age" },
+    ]);
+    expect(await po.isSortDirectionButtonReversed()).toBe(true);
+
+    await po.getSortDirectionButtonPo().click();
+    expect(get(orderStore)).toEqual([
+      { columnId: "name" },
+      { columnId: "age" },
+    ]);
+    expect(await po.isSortDirectionButtonReversed()).toBe(false);
+  });
+});

--- a/frontend/src/tests/lib/components/ui/ResponsiveTableSortControlTest.svelte
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTableSortControlTest.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import ResponsiveTableSortControl from "$lib/components/ui/ResponsiveTableSortControl.svelte";
+  import type {
+    ResponsiveTableColumn,
+    ResponsiveTableOrder,
+  } from "$lib/types/responsive-table";
+  import type { Writable } from "svelte/store";
+
+  type TestRowData = {
+    domKey: string;
+    rowHref?: string;
+    name: string;
+    age: number;
+  };
+
+  export let columns: ResponsiveTableColumn<TestRowData>[];
+  export let orderStore: Writable<ResponsiveTableOrder>;
+</script>
+
+<ResponsiveTableSortControl {columns} bind:order={$orderStore} />

--- a/frontend/src/tests/page-objects/Chip.page-object.ts
+++ b/frontend/src/tests/page-objects/Chip.page-object.ts
@@ -1,0 +1,20 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ChipPo extends BasePageObject {
+  private static TID = "chip-component";
+
+  static under(element: PageObjectElement): ChipPo {
+    return new ChipPo(element.byTestId(ChipPo.TID));
+  }
+
+  static async allUnder(element: PageObjectElement): Promise<ChipPo[]> {
+    return Array.from(await element.allByTestId(ChipPo.TID)).map(
+      (el) => new ChipPo(el)
+    );
+  }
+
+  async isSelected(): Promise<boolean> {
+    return (await this.root.getAttribute("aria-checked")) === "true";
+  }
+}

--- a/frontend/src/tests/page-objects/ChipGroup.page-object.ts
+++ b/frontend/src/tests/page-objects/ChipGroup.page-object.ts
@@ -1,0 +1,27 @@
+import { ChipPo } from "$tests/page-objects/Chip.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ChipGroupPo extends BasePageObject {
+  private static TID = "chip-group-component";
+
+  static under(element: PageObjectElement): ChipGroupPo {
+    return new ChipGroupPo(element.byTestId(ChipGroupPo.TID));
+  }
+
+  async getChipPos(): Promise<ChipPo[]> {
+    return ChipPo.allUnder(this.root);
+  }
+
+  async getChipByLabel(label: string): Promise<ChipPo> {
+    const chipPos = await this.getChipPos();
+    const chipLabels = await Promise.all(
+      chipPos.map((chipPo) => chipPo.getText())
+    );
+    const index = chipLabels.indexOf(label);
+    if (index === -1) {
+      throw new Error(`Chip with label "${label}" not found`);
+    }
+    return chipPos[index];
+  }
+}

--- a/frontend/src/tests/page-objects/ResponsiveTableSortControl.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableSortControl.page-object.ts
@@ -30,7 +30,7 @@ export class ResponsiveTableSortControlPo extends BasePageObject {
 
   async isSortDirectionButtonReversed(): Promise<boolean> {
     return (await this.getSortDirectionButtonIconPo().getClasses()).includes(
-      "icon-north"
+      "reversed"
     );
   }
 

--- a/frontend/src/tests/page-objects/ResponsiveTableSortControl.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableSortControl.page-object.ts
@@ -1,0 +1,50 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ChipPo } from "$tests/page-objects/Chip.page-object";
+import { ChipGroupPo } from "$tests/page-objects/ChipGroup.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ResponsiveTableSortControlPo extends BasePageObject {
+  private static TID = "responsive-table-sort-control-component";
+
+  static under(element: PageObjectElement): ResponsiveTableSortControlPo {
+    return new ResponsiveTableSortControlPo(
+      element.byTestId(ResponsiveTableSortControlPo.TID)
+    );
+  }
+
+  getSortDirectionButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "sort-direction-button",
+    });
+  }
+
+  getSortDirectionButtonIconPo(): PageObjectElement {
+    return this.getSortDirectionButtonPo().root.querySelector(".icon");
+  }
+
+  getSortChipGroup(): ChipGroupPo {
+    return ChipGroupPo.under(this.root);
+  }
+
+  async isSortDirectionButtonReversed(): Promise<boolean> {
+    return (await this.getSortDirectionButtonIconPo().getClasses()).includes(
+      "icon-north"
+    );
+  }
+
+  async getSortChipPos(): Promise<ChipPo[]> {
+    return this.getSortChipGroup().getChipPos();
+  }
+
+  async getSortChipLabels(): Promise<string[]> {
+    const chipPos = await this.getSortChipPos();
+    return Promise.all(chipPos.map((chipPo) => chipPo.getText()));
+  }
+
+  async clickSortChip(label: string): Promise<void> {
+    const chipPo = await this.getSortChipGroup().getChipByLabel(label);
+    return chipPo.click();
+  }
+}


### PR DESCRIPTION
# Motivation

To improve the UX, we are introducing the ability to control table sorting from the settings popover. This ensures that table visibility can also be managed on mobile devices, where sorting headers are not available. With this PR, we add a chip-based sorting control component, which will be used in the table settings popover.

Demo: https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/tokens/

# Changes

- Add ResponsiveTableSortControl component.

# Tests

- Chip and ChipGroup POs.
- ResponsiveTableSortControl specs.
- Tested in draft PR: https://github.com/dfinity/nns-dapp/pull/6524
<img width="884" alt="image" src="https://github.com/user-attachments/assets/b9f3e4da-e496-400f-a971-e0829ce2d849" />

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.