### PR TITLE
fix(ci): adapt docker build to new rustup behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,16 +61,12 @@ RUN curl --fail https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
 # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
 # Parse version and manage toolchain
 RUN rust_version=$(grep 'channel' rust-toolchain.toml | awk -F'"' '{print $2}') && \
-    components=$(grep 'components' rust-toolchain.toml | awk -F'= ' '{print $2}') && \
     targets=$(grep 'targets' rust-toolchain.toml | tr -d '[]," ' | awk -F'=' '{print $2}') && \
-    { \
-        echo "Installing Rust $rust_version"; \
-        rustup toolchain install "$rust_version"; \
-        # rustup component add --toolchain "$rust_version" $components; \
-        echo "Installing targets $targets"; \
-        rustup target add $targets --toolchain "$rust_version";  \
-        rustup default "$rust_version"; \
-    }
+    rustup toolchain install "$rust_version"; \
+    # New changes also don't install targets
+    rustup target add $targets --toolchain "$rust_version";  \
+    rustup default "$rust_version"; \
+
 RUN cargo --version
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,10 @@ RUN curl --fail https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
 # Parse version and manage toolchain
 RUN rust_version=$(grep 'channel' rust-toolchain.toml | awk -F'"' '{print $2}') && \
     targets=$(grep 'targets' rust-toolchain.toml | tr -d '[]," ' | awk -F'=' '{print $2}') && \
-    rustup toolchain install "$rust_version"; \
+    rustup toolchain install "$rust_version" && \
     # New changes also don't install targets
-    rustup target add $targets --toolchain "$rust_version";  \
-    rustup default "$rust_version"; \
+    rustup target add $targets --toolchain "$rust_version" &&  \
+    rustup default "$rust_version"
 
 RUN cargo --version
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,22 @@ COPY rust-toolchain.toml .
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH
-RUN curl --fail https://sh.rustup.rs -sSf \
-        | sh -s -- -y --no-modify-path
-ENV PATH=/cargo/bin:$PATH
+
+RUN curl --fail https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
+
+# https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+# Parse version and manage toolchain
+RUN rust_version=$(grep 'channel' rust-toolchain.toml | awk -F'"' '{print $2}') && \
+    components=$(grep 'components' rust-toolchain.toml | awk -F'= ' '{print $2}') && \
+    targets=$(grep 'targets' rust-toolchain.toml | tr -d '[]," ' | awk -F'=' '{print $2}') && \
+    { \
+        echo "Installing Rust $rust_version"; \
+        rustup toolchain install "$rust_version"; \
+        # rustup component add --toolchain "$rust_version" $components; \
+        echo "Installing targets $targets"; \
+        rustup target add $targets --toolchain "$rust_version";  \
+        rustup default "$rust_version"; \
+    }
 RUN cargo --version
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH
 
-RUN curl --fail https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
+RUN curl --fail https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.0/rustup-init.sh -sSf | sh -s -- -y --no-modify-path
 
 # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
 # Parse version and manage toolchain


### PR DESCRIPTION
# Motivation

The Reproducible Docker Builds job started [failing](https://github.com/dfinity/nns-dapp/actions/runs/13643019276) last night due a new version of [rustup](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html). 

The main change is:
> rustup will no longer automatically install the active toolchain if it is not installed.

<img width="856" alt="Screenshot 2025-03-04 at 14 41 11" src="https://github.com/user-attachments/assets/e1105d75-32b3-4c38-a9f6-335f11ec0f86" />

# Changes

- Parse `rust-toolchain.toml` to obtain the Rust version and targets.  
- Fix the `rustup` version to prevent similar problems in the future.
- Install the toolchain for the version specified in `rust-toolchain`.  
- Install the targets defined in `rust-toolchain`.

# Tests

- CI should pass
- [Reproducible Docker Build should pass](https://github.com/dfinity/nns-dapp/actions/runs/13655885529)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary