### PR TITLE
feat(portfolio): add participation amount formatter util

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -9,13 +9,13 @@ import {
   compareByProjectTitle,
   compareIcpFirst,
 } from "$lib/utils/staking.utils";
+import { ulpsToNumber } from "$lib/utils/token.utils";
 import {
   compareTokensByImportance,
   compareTokensIcpFirst,
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
 import { ICPToken } from "@dfinity/utils";
-import { ulpsToNumber } from "./token.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -14,6 +14,8 @@ import {
   compareTokensIcpFirst,
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
+import { ICPToken } from "@dfinity/utils";
+import { ulpsToNumber } from "./token.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 
@@ -117,4 +119,12 @@ export const shouldShowInfoRow = ({
     (otherCardNumberOfTokens === 0 && currentCardNumberOfTokens < 4) ||
     (currentCardNumberOfTokens < 3 && otherCardNumberOfTokens < 3)
   );
+};
+
+export const formatParticipation = (ulps: bigint) => {
+  const value = ulpsToNumber({ ulps, token: ICPToken });
+  if (value < 10_000)
+    return Number.isInteger(value) ? value.toString() : value.toFixed(2);
+
+  return `${(value / 1_000).toFixed(0)}K`;
 };

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -454,8 +454,8 @@ describe("Portfolio utils", () => {
 
     it("should format values >= 10,000 with K suffix", () => {
       expect(formatParticipation(1_000_000_000_000n)).toBe("10K");
-      expect(formatParticipation(1_234_500_000_000n)).toBe("12K");
-      expect(formatParticipation(99_999_900_000_000n)).toBe("1000K");
+      expect(formatParticipation(1_200_000_000_000n)).toBe("12K");
+      expect(formatParticipation(40_000_000_000_000n)).toBe("400K");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -4,6 +4,7 @@ import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken } from "$lib/types/tokens-page";
 import {
+  formatParticipation,
   getTopHeldTokens,
   getTopStakedTokens,
   shouldShowInfoRow,
@@ -434,6 +435,27 @@ describe("Portfolio utils", () => {
           otherCardNumberOfTokens: 3,
         })
       ).toBe(false);
+    });
+  });
+
+  describe("formatParticipation", () => {
+    it("should return integer values as strings without decimal places", () => {
+      expect(formatParticipation(0n)).toBe("0");
+      expect(formatParticipation(100_000_000n)).toBe("1");
+      expect(formatParticipation(10_000_000_000n)).toBe("100");
+      expect(formatParticipation(999_000_000_000n)).toBe("9990");
+    });
+
+    it("should format decimal values less than 10,000 with 2 decimal places", () => {
+      expect(formatParticipation(12_345_000_000n)).toBe("123.45");
+      expect(formatParticipation(10_000_000n)).toBe("0.10");
+      expect(formatParticipation(999_999_000_000n)).toBe("9999.99");
+    });
+
+    it("should format values >= 10,000 with K suffix", () => {
+      expect(formatParticipation(1_000_000_000_000n)).toBe("10K");
+      expect(formatParticipation(1_234_500_000_000n)).toBe("12K");
+      expect(formatParticipation(99_999_900_000_000n)).toBe("1000K");
     });
   });
 });


### PR DESCRIPTION
# Motivation

For the upcoming changes to the Portfolio page, we need to display certain values of the Open Proposals, such as the minimum and maximum commitment. We want to present these with special formatting. Please see the attached screenshot.

This PR introduces a new utility for the Portfolio page to format numbers accordingly.

<img width="681" alt="Screenshot 2025-03-04 at 15 56 51" src="https://github.com/user-attachments/assets/14b4cc79-b730-43bb-a861-60af3fedf1e1" />

# Changes

- Adds a new utility to format participation on the portfolio page.

# Tests

- New unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.