### PR TITLE
fix(ui): disable navigation for unresponsive SNS neurons

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Improve readability of monetary values by simplifying large numbers
+* Improved error handling by disabling neuron navigation when SNS governance canister is unavailable
 
 #### Deprecated
 

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -193,7 +193,10 @@ export const getTableProjects = ({
       snsNeurons,
       failedActionableSnses,
     });
-    const rowHref = buildNeuronsUrl({ universe: universe.canisterId });
+    const rowHref =
+      stake instanceof FailedTokenAmount
+        ? undefined
+        : buildNeuronsUrl({ universe: universe.canisterId });
     const universeId = universe.canisterId;
     const ledgerCanisterId = getLedgerCanisterIdFromUniverse(universe);
     const tokenPrice =

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -662,6 +662,7 @@ describe("staking.utils", () => {
         },
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: undefined,
           neuronCount: undefined,
           stake: new FailedTokenAmount(snsToken),
           stakeInUsd: undefined,


### PR DESCRIPTION
# Motivation

Sometimes SNS canisters may be down, preventing us from receiving the requested information. For example, when a canister goes out of cycles, we cannot retrieve the stake from the governance canister. In such situations, we want to avoid allowing any user interactions that are meaningless. 

This PR disables row navigation for SNS whose governance canister is unresponsive.

# Changes

- Sets the Neurons table row link to undefined if the canister doesn't respond.

# Tests

- Updates the test.

# Todos

- [x] Add entry to changelog (if necessary).
