### PR TITLE
refactor(geo): replace fallback location service for SNS swap restrictions

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -68,3 +68,4 @@ backend
 DFINITY
 Changelog
 changelog
+geolocation

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Improve readability of monetary values by simplifying large numbers
 * Improved error handling by disabling neuron navigation when SNS governance canister is unavailable
+* Enhanced geolocation reliability for SNS swap participation checks by replacing fallback service
+
 
 #### Deprecated
 

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -200,7 +200,6 @@ const cspConnectSrc = () => {
     // We still allow users to access the app with the old URL
     "https://nns.ic0.app",
     // Location services
-    "https://api.geoiplookup.net",
     "https://api.iplocation.net",
     "https://api.ip.sb",
     "'self'",

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -202,6 +202,7 @@ const cspConnectSrc = () => {
     // Location services
     "https://api.geoiplookup.net",
     "https://api.iplocation.net",
+    "https://api.ip.sb",
     "'self'",
     "${{HOST}}",
     "${{SNS_AGGREGATOR_URL}}",

--- a/frontend/src/lib/api/location.api.ts
+++ b/frontend/src/lib/api/location.api.ts
@@ -1,18 +1,5 @@
 import type { CountryCode } from "$lib/types/location";
 
-// https://geoiplookup.net/
-const getLocationFromGeoIP = async (): Promise<CountryCode> => {
-  const URL = "https://api.geoiplookup.net/?json=true";
-  const response = await fetch(URL);
-
-  if (!response.ok) {
-    throw new Error("Failed to fetch user location from GeoIP");
-  }
-
-  const data = await response.json();
-  return data.countrycode;
-};
-
 // https://api.iplocation.net/
 const getLocationFromIpLocation = async (): Promise<CountryCode> => {
   const BASE_URL = "https://api.iplocation.net";

--- a/frontend/src/lib/api/location.api.ts
+++ b/frontend/src/lib/api/location.api.ts
@@ -32,6 +32,19 @@ const getLocationFromIpLocation = async (): Promise<CountryCode> => {
   return data.country_code2;
 };
 
+// https://api.ip.sb/geoip/
+const getLocationFromIpSb = async (): Promise<CountryCode> => {
+  const URL = "https://api.ip.sb/geoip/";
+  const response = await fetch(URL);
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch user location from Ip Sb Service");
+  }
+
+  const data = await response.json();
+  return data.country_code;
+};
+
 /**
  * Fetches the user's country location two different services.
  *
@@ -39,8 +52,8 @@ const getLocationFromIpLocation = async (): Promise<CountryCode> => {
  */
 export const queryUserCountryLocation = async (): Promise<CountryCode> => {
   try {
-    return await getLocationFromGeoIP();
-  } catch (_) {
     return await getLocationFromIpLocation();
+  } catch (_) {
+    return await getLocationFromIpSb();
   }
 };

--- a/frontend/src/lib/api/location.api.ts
+++ b/frontend/src/lib/api/location.api.ts
@@ -19,7 +19,7 @@ const getLocationFromIpLocation = async (): Promise<CountryCode> => {
   return data.country_code2;
 };
 
-// https://api.ip.sb/geoip/
+// https://api.ip.sb/geoip
 const getLocationFromIpSb = async (): Promise<CountryCode> => {
   const URL = "https://api.ip.sb/geoip";
   const response = await fetch(URL);

--- a/frontend/src/lib/api/location.api.ts
+++ b/frontend/src/lib/api/location.api.ts
@@ -34,7 +34,7 @@ const getLocationFromIpLocation = async (): Promise<CountryCode> => {
 
 // https://api.ip.sb/geoip/
 const getLocationFromIpSb = async (): Promise<CountryCode> => {
-  const URL = "https://api.ip.sb/geoip/";
+  const URL = "https://api.ip.sb/geoip";
   const response = await fetch(URL);
 
   if (!response.ok) {

--- a/frontend/src/tests/lib/api/location.api.spec.ts
+++ b/frontend/src/tests/lib/api/location.api.spec.ts
@@ -2,78 +2,73 @@ import { queryUserCountryLocation } from "$lib/api/location.api";
 
 describe("location api", () => {
   describe("queryUserCountryLocation", () => {
-    describe("if GeoIP service works", () => {
+    describe("if IPLocation service works", () => {
       it("should return country code", async () => {
-        const countryCode = "CH";
-        const mockFetch = vi.fn();
-        mockFetch.mockReturnValueOnce(
-          Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ countrycode: countryCode }),
-          })
-        );
-        global.fetch = mockFetch;
-
-        const result = await queryUserCountryLocation();
-        expect(result).toEqual(countryCode);
-        expect(mockFetch).toHaveBeenCalledWith(
-          "https://api.geoiplookup.net/?json=true"
-        );
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe("if GeoIP service fails", () => {
-      it("should call IPLocation service and return country code", async () => {
         const countryCode = "CH";
         const ip = "1.1.1.1";
         const mockFetch = vi.fn();
+
         mockFetch
-          .mockReturnValueOnce(
-            Promise.resolve({
-              ok: false,
-            })
-          )
-          .mockReturnValueOnce(
-            Promise.resolve({
-              ok: true,
-              json: () => Promise.resolve({ ip }),
-            })
-          )
-          .mockReturnValueOnce(
-            Promise.resolve({
-              ok: true,
-              json: () => Promise.resolve({ country_code2: countryCode }),
-            })
-          );
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ ip }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ country_code2: countryCode }),
+          });
         global.fetch = mockFetch;
 
         const BASE_URL = "https://api.iplocation.net";
         const result = await queryUserCountryLocation();
+
         expect(result).toEqual(countryCode);
-        expect(mockFetch).toHaveBeenCalledWith(
-          "https://api.geoiplookup.net/?json=true"
-        );
         expect(mockFetch).toHaveBeenCalledWith(`${BASE_URL}/?cmd=get-ip`);
         expect(mockFetch).toHaveBeenCalledWith(`${BASE_URL}/?ip=${ip}`);
-        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
       });
     });
 
-    describe("if GeoIP and IPLocation services fail", () => {
+    describe("if IPLocation service fails", () => {
+      it("should call IpSb service and return country code", async () => {
+        const countryCode = "CH";
+        const mockFetch = vi.fn();
+        mockFetch
+          .mockRejectedValueOnce(new Error("Failed"))
+          .mockReturnValueOnce(
+            Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({ country_code: countryCode }),
+            })
+          );
+        global.fetch = mockFetch;
+
+        const IP_LOCATION_URL = "https://api.iplocation.net/?cmd=get-ip";
+        const IP_SB_URL = "https://api.ip.sb/geoip";
+
+        const result = await queryUserCountryLocation();
+
+        expect(result).toEqual(countryCode);
+
+        expect(mockFetch).toHaveBeenCalledWith(IP_LOCATION_URL);
+        expect(mockFetch).toHaveBeenCalledWith(IP_SB_URL);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("if both services fail", () => {
       it("should raise error", async () => {
         const mockFetch = vi.fn();
-        mockFetch.mockReturnValue(
-          Promise.resolve({
-            ok: false,
-          })
+        mockFetch.mockRejectedValueOnce(
+          new Error("Failed to fetch ip from service 1")
+        );
+        mockFetch.mockRejectedValueOnce(
+          new Error("Failed to fetch ip from service 2")
         );
         global.fetch = mockFetch;
 
         const call = async () => queryUserCountryLocation();
-        await expect(call).rejects.toThrow(
-          "Failed to fetch ip from IP Location"
-        );
+        await expect(call).rejects.toThrow("Failed to fetch ip from service 2");
         expect(mockFetch).toHaveBeenCalledTimes(2);
       });
     });


### PR DESCRIPTION
# Motivation

We introduced location services in [GIX-1546](https://dfinity.atlassian.net/browse/GIX-1546) for SNS swaps to restrict participation from users in certain countries.

One of these services, `api.geoiplookup.net`, has been unreliable for a long time, so we plan to replace it with a new one.

In this PR, we introduce a new fallback service, `api.iplocation.net`, and remove the code related to the unreliable service.

[NNS1-3065](https://dfinity.atlassian.net/browse/NNS1-3065)

<img width="1903" alt="Screenshot 2025-03-05 at 11 01 44" src="https://github.com/user-attachments/assets/9bb10572-ddb1-4eb8-bfc6-019eda4db918" />

# Changes

- Sets `getLocationFromIpLocation` as the primary service for obtaining location.
- Adds `getLocationFromIpSb` as the secondary service in case the primary fails.
- Updates our CSP rules to include the new service domain.
- Removes `getLocationFromGeoIP` based on `api.geoiplookup.net` since it no longer functions.
- Eliminates the `api.geoiplookup.net` domain from our CSP rules.

# Tests

- Updates tests
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network) by changing the code to trigger both services when navigating [here](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/project/?project=7im6q-vx777-77776-qaacq-cai)

# Todos

- [x] Add entry to changelog (if necessary).


[GIX-1546]: https://dfinity.atlassian.net/browse/GIX-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NNS1-3065]: https://dfinity.atlassian.net/browse/NNS1-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ