### PR TITLE
feat(portfolio): add minimum commitment percentage calculator

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,6 +1,7 @@
 import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+import type { FullProjectCommitmentSplit } from "$lib/utils/projects.utils";
 import {
   createDescendingComparator,
   mergeComparators,
@@ -16,7 +17,6 @@ import {
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
 import { ICPToken } from "@dfinity/utils";
-import type { FullProjectCommitmentSplit } from "./projects.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -133,8 +133,7 @@ export const formatParticipation = (ulps: bigint) => {
 export const getMinCommitmentPercentage = (
   projectCommitments: FullProjectCommitmentSplit
 ) => {
-  if (!projectCommitments) return 0;
-  if (!projectCommitments.minDirectCommitmentE8s) return 0;
+  if (projectCommitments.minDirectCommitmentE8s === 0n) return 0;
 
   return (
     ulpsToNumber({

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -16,6 +16,7 @@ import {
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
 import { ICPToken } from "@dfinity/utils";
+import type { FullProjectCommitmentSplit } from "./projects.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 
@@ -127,4 +128,22 @@ export const formatParticipation = (ulps: bigint) => {
     return Number.isInteger(value) ? value.toString() : value.toFixed(2);
 
   return `${(value / 1_000).toFixed(0)}K`;
+};
+
+export const getMinCommitmentPercentage = (
+  projectCommitments: FullProjectCommitmentSplit
+) => {
+  if (!projectCommitments) return 0;
+  if (!projectCommitments.minDirectCommitmentE8s) return 0;
+
+  return (
+    ulpsToNumber({
+      ulps: projectCommitments.directCommitmentE8s,
+      token: ICPToken,
+    }) /
+    ulpsToNumber({
+      ulps: projectCommitments.minDirectCommitmentE8s,
+      token: ICPToken,
+    })
+  );
 };

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -469,28 +469,14 @@ describe("Portfolio utils", () => {
       isNFParticipating: true,
     };
 
-    it("should return 0 when projectCommitments is null or undefined", () => {
-      expect(getMinCommitmentPercentage(null)).toBe(0);
-      expect(getMinCommitmentPercentage(undefined)).toBe(0);
-    });
-
-    it("should return 0 when minDirectCommitmentE8s is null or undefined", () => {
-      const projectCommitments: FullProjectCommitmentSplit = {
-        ...baseProjectCommitmentProps,
-        directCommitmentE8s: 500_000_000n,
-        minDirectCommitmentE8s: null,
-      };
-      expect(getMinCommitmentPercentage(projectCommitments)).toBe(0);
-
-      const projectCommitments2: FullProjectCommitmentSplit = {
-        ...baseProjectCommitmentProps,
-        directCommitmentE8s: 500_000_000n,
-        minDirectCommitmentE8s: undefined,
-      };
-      expect(getMinCommitmentPercentage(projectCommitments2)).toBe(0);
-    });
-
     it("should calculate the correct percentage ratio", () => {
+      const zeroMinDirectCommitment: FullProjectCommitmentSplit = {
+        ...baseProjectCommitmentProps,
+        directCommitmentE8s: 500_000_000n,
+        minDirectCommitmentE8s: 0n,
+      };
+      expect(getMinCommitmentPercentage(zeroMinDirectCommitment)).toBe(0);
+
       const zeroCommitment: FullProjectCommitmentSplit = {
         ...baseProjectCommitmentProps,
         directCommitmentE8s: 0n,


### PR DESCRIPTION
# Motivation

For the upcoming changes to the Portfolio page, we need a percentage of a project's minimum ICP participation for the project to be successful. 

This PR introduces a new utility to extract values from a `FullProjectCommitmentSplit` and perform the calculation.

<img width="202" alt="Screenshot 2025-03-05 at 13 16 07" src="https://github.com/user-attachments/assets/f1b25f2a-5ca1-4fcc-8d16-cd9c449a9b8e" />

# Changes

- New portfolio utility to calculate the percentage of the minimum commitment that has already been raised.

# Tests

- Added unit tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary