### PR TITLE
fix(transactions): suppress toaster for index canister out-of-cycles

### DIFF
--- a/frontend/src/lib/services/icrc-transactions.services.ts
+++ b/frontend/src/lib/services/icrc-transactions.services.ts
@@ -51,8 +51,8 @@ export const loadIcrcAccountTransactions = async ({
   } catch (err) {
     console.error(err);
 
-    const isCanisterOufOfCycles = isCanisterOutOfCyclesError(err);
-    if (isCanisterOufOfCycles) return;
+    const isCanisterOutOfCycles = isCanisterOutOfCyclesError(err);
+    if (isCanisterOutOfCycles) return;
 
     toastsError(
       toToastError({ fallbackErrorLabelKey: "error.fetch_transactions", err })

--- a/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
@@ -20,10 +20,13 @@ vi.mock("$lib/api/icrc-index.api");
 describe("icrc-transactions services", () => {
   const indexCanisterId = principal(0);
   const ledgerCanisterId = principal(1);
+  let consoleErrorSpy;
 
   beforeEach(() => {
     resetIdentity();
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
   });
 
   describe("loadIcrcAccountTransactions", () => {
@@ -193,9 +196,8 @@ describe("icrc-transactions services", () => {
     });
 
     it("swallows error if canister out-of-cycles", async () => {
-      vi.spyOn(indexApi, "getTransactions").mockRejectedValue(
-        new Error("IC0207")
-      );
+      const error = new Error("IC0207");
+      vi.spyOn(indexApi, "getTransactions").mockRejectedValue(error);
 
       expect(get(toastsStore)).toHaveLength(0);
 
@@ -205,6 +207,7 @@ describe("icrc-transactions services", () => {
         ledgerCanisterId,
       });
 
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
       expect(get(toastsStore)).toHaveLength(0);
     });
 


### PR DESCRIPTION
# Motivation

Following up on #6500, we want to stop displaying toaster messages for canisters that are out of cycles. 
In this PR, we address the index canister, which is responsible for facilitating information about transactions.

# Changes

- Logs errors to the console when fetching transactions.  
- Skips showing the banner for out-of-cycle errors.

# Tests

- Added a unit test.  
- Tested locally by depleting the index canister of the Alfa SNS of cycles.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary