### PR TITLE
feat(navigation): add contextual back navigation for project pages

### DIFF
--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -56,3 +56,18 @@ export const neuronsPageOrigin = derived(referrerPathStore, (paths) => {
 
   return AppPath.Staking;
 });
+
+/**
+ * Derives the origin page (Portfolio or Launchpad) to return from Project page.
+ * Looks at last entry to handle navigation flows:
+ * Portfolio -> Project -> (back) -> Portfolio
+ * Launchpad -> Project -> (back) -> Launchpad
+ *
+ * Returns AppPath.Launchpad as default if no matching page is found.
+ */
+export const projectPageOrigin = derived(referrerPathStore, (paths) => {
+  const lastPath = paths.at(-1);
+  if (lastPath === AppPath.Portfolio) return lastPath;
+
+  return AppPath.Launchpad;
+});

--- a/frontend/src/tests/lib/derived/routes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/routes.derived.spec.ts
@@ -3,6 +3,7 @@ import { AppPath, UNIVERSE_PARAM } from "$lib/constants/routes.constants";
 import {
   accountsPageOrigin,
   neuronsPageOrigin,
+  projectPageOrigin,
   walletPageOrigin,
 } from "$lib/derived/routes.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
@@ -94,6 +95,27 @@ describe("routes.derived", () => {
       referrerPathStore.pushPath(AppPath.Settings);
 
       expect(get(neuronsPageOrigin)).toBe(AppPath.Staking);
+    });
+  });
+
+  describe("projectPageOrigin.derived", () => {
+    it("should return to Portfolio page when it was the last page visited", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+
+      expect(get(projectPageOrigin)).toBe(AppPath.Portfolio);
+    });
+
+    it("should return to Launchpad page when it was the last page visited", () => {
+      referrerPathStore.pushPath(AppPath.Launchpad);
+
+      expect(get(projectPageOrigin)).toBe(AppPath.Launchpad);
+    });
+
+    it("should return Launchpad as default", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+      referrerPathStore.pushPath(AppPath.Settings);
+
+      expect(get(projectPageOrigin)).toBe(AppPath.Launchpad);
     });
   });
 });


### PR DESCRIPTION
# Motivation

The new Launchpad feature on the `Portfolio` page will display Cards that direct users to a specific `Project` page. This page includes a back button in the layout. Currently, this button always redirects the user to the `Launchpad` page. However, we want to redirect users to either the `Launchpad` or the `Portfolio` page, depending on their previous location.

This initial PR adds a derived store to determine the appropriate page for redirection.

[NNS1-3640](https://dfinity.atlassian.net/browse/NNS1-3640)

# Changes

- Added new derived route for the Projects page.

# Tests

- Added unit test

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3640]: https://dfinity.atlassian.net/browse/NNS1-3640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ