### PR TITLE
feat(navigation): implement dynamic back navigation for Project page

### DIFF
--- a/frontend/src/routes/(app)/(nns)/project/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/project/+layout.svelte
@@ -2,9 +2,9 @@
   import { goto } from "$app/navigation";
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
-  import { AppPath } from "$lib/constants/routes.constants";
+  import { projectPageOrigin } from "$lib/derived/routes.derived";
 
-  const back = (): Promise<void> => goto(AppPath.Launchpad);
+  const back = (): Promise<void> => goto($projectPageOrigin);
 </script>
 
 <Layout>

--- a/frontend/src/tests/routes/app/project/layout.spec.ts
+++ b/frontend/src/tests/routes/app/project/layout.spec.ts
@@ -1,0 +1,37 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import { referrerPathStore } from "$lib/stores/routes.store";
+import { page } from "$mocks/$app/stores";
+import ProjectLayout from "$routes/(app)/(nns)/project/+layout.svelte";
+import { fireEvent, render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("Project layout", () => {
+  describe("back button", () => {
+    it("should navigate to Portfolio page if previous page was Portfolio page", async () => {
+      page.mock({
+        routeId: AppPath.Project,
+      });
+      referrerPathStore.pushPath(AppPath.Portfolio);
+
+      const { queryByTestId } = render(ProjectLayout);
+
+      expect(get(pageStore).path).toEqual(AppPath.Project);
+      await fireEvent.click(queryByTestId("back"));
+
+      expect(get(pageStore).path).toEqual(AppPath.Portfolio);
+    });
+
+    it("should navigate to Launchpad", async () => {
+      page.mock({
+        routeId: AppPath.Project,
+      });
+      const { queryByTestId } = render(ProjectLayout);
+
+      expect(get(pageStore).path).toEqual(AppPath.Project);
+      await fireEvent.click(queryByTestId("back"));
+
+      expect(get(pageStore).path).toEqual(AppPath.Launchpad);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

This PR follows up on #6543 by utilizing the new derive store to redirect the user to the correct page after clicking the back button on the layout.

[NNS1-3640](https://dfinity.atlassian.net/browse/NNS1-3640)

# Changes

- Implement back navigation in Project page layout.

# Tests

- Added unit test

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3640]: https://dfinity.atlassian.net/browse/NNS1-3640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ