### PR TITLE
chore(ci): update rustup to 1.28.1 and remove toolchain install workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,17 +56,8 @@ ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH
 
-RUN curl --fail https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.0/rustup-init.sh -sSf | sh -s -- -y --no-modify-path
-
-# https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
-# Parse version and manage toolchain
-RUN rust_version=$(grep 'channel' rust-toolchain.toml | awk -F'"' '{print $2}') && \
-    targets=$(grep 'targets' rust-toolchain.toml | tr -d '[]," ' | awk -F'=' '{print $2}') && \
-    rustup toolchain install "$rust_version" && \
-    # New changes also don't install targets
-    rustup target add $targets --toolchain "$rust_version" &&  \
-    rustup default "$rust_version"
-
+RUN curl --fail https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.1/rustup-init.sh -sSf \
+    | sh -s -- -y --no-modify-path
 RUN cargo --version
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty


### PR DESCRIPTION
# Motivation

The Reproducible Docker Builds [failed](https://github.com/dfinity/nns-dapp/actions/runs/13643019276)due a new version of [rustup](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html) due to a new version of rustup. 

#6529 introduced this new version but also required additional changes because the auto-installation of the toolchain is no longer done automatically.

This change appears to be unintended, as it has been addressed in the latest [patch](https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#1281---2025-03-05) of rustup.

This PR updates the `rustup` version to the fixed release and cleans the unnecessary code.

# Changes

- Updates the `rustup` version to the latest patch.
- Removes unnecessary code that was used to install the toolchain with `rustup`.

# Tests

- The pipeline should pass.
- Manually trigger the failed job for this branch: https://github.com/dfinity/nns-dapp/actions/runs/13722208821

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.