### PR TITLE
test: fix dropdown selector

### DIFF
--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -70,7 +70,7 @@ describe("NnsDestinationAddress", () => {
     await po
       .getSelectDestinationAddressPo()
       .getDropdownPo()
-      .select(mockSubAccount2.name);
+      .select(mockSubAccount2.identifier);
 
     expect(onAccountSelectedSpy).not.toBeCalled();
     await po.clickContinue();


### PR DESCRIPTION
# Motivation

Don't know why it passes on main currently but in the Svelte v5 branch the following test is failing because it cannot select the option because instead of providing the value, the test provide the name displayed as selector.

```
 FAIL  src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts > NnsDestinationAddress > should dispatch event with selected account identifier
TestingLibraryElementError: Value "Subaccount2" not found in options

Ignored nodes: comments, script, style
<select
  class="svelte-fd9o1e"
  data-tid="select-account-dropdown"
  name="account"
>
  <option
    value="d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f"
  >
    Main
  </option>
  <option
    value="b505b85da7d92b7d72e48a38edb31a2a8e1f28bb0d5432a3d6e24aae798b5136"
  >
    Subaccount1
  </option>
  <option
    value="72c0fde366c2ae6128591316d66429b99373bd2e5485aa07224a7b3f6fbe7104"
  >
    Subaccount2
  </option>
  
</select>
```

# Changes

- Use option value identitifier as selector for the test