### PR TITLE
feat: optional onClick

### DIFF
--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -40,7 +40,7 @@
   role={isClickable ? "button" : undefined}
   noMargin
   ariaLabel={$i18n.missing_rewards_modal.goto_neuron}
-  on:click={onClick}
+  on:click={() => onClick?.()}
 >
   <div class="wrapper">
     <div class="header">


### PR DESCRIPTION
# Motivation

Not an issue on main but, in the Svelte v5 branch the linter notice that an optional property function is not handled.

# Changes

- `onClick` => `() => onClick?.()`
