### PR TITLE
fix: lint self closing tag

### DIFF
--- a/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
@@ -5,40 +5,40 @@
 </script>
 
 <Card {testId}>
-  <div class="wrapper">
+  <span class="wrapper">
     <div class="header">
       <div class="header-wrapper">
-        <div class="icon skeleton" />
+        <div class="icon skeleton"></div>
         <div class="text-content">
-          <div class="title skeleton" />
-          <div class="amount skeleton" />
+          <div class="title skeleton"></div>
+          <div class="amount skeleton"></div>
         </div>
       </div>
-      <div class="link skeleton" />
+      <div class="link skeleton"></div>
     </div>
 
-    <div class="body">
-      <div class="header">
-        <span class="skeleton" />
-        <span class="skeleton justify-end" />
-        <span class="skeleton justify-end tablet-up" />
-      </div>
+    <span class="body">
+      <span class="header">
+        <span class="skeleton"></span>
+        <span class="skeleton justify-end"></span>
+        <span class="skeleton justify-end tablet-up"></span>
+      </span>
 
       <div class="list">
         {#each Array(4) as _, i (i)}
           <div class="row">
             <div class="info">
-              <div class="logo-skeleton skeleton" />
-              <div class="title-skeleton skeleton" />
+              <div class="logo-skeleton skeleton"></div>
+              <div class="title-skeleton skeleton"></div>
             </div>
 
-            <div class="balance-native skeleton" />
-            <div class="balance-usd skeleton" />
+            <div class="balance-native skeleton"></div>
+            <div class="balance-usd skeleton"></div>
           </div>
         {/each}
       </div>
-    </div>
-  </div>
+    </span>
+  </span>
 </Card>
 
 <style lang="scss">

--- a/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <Card {testId}>
-  <span class="wrapper">
+  <div class="wrapper">
     <div class="header">
       <div class="header-wrapper">
         <div class="icon skeleton"></div>
@@ -17,12 +17,12 @@
       <div class="link skeleton"></div>
     </div>
 
-    <span class="body">
-      <span class="header">
+    <div class="body">
+      <div class="header">
         <span class="skeleton"></span>
         <span class="skeleton justify-end"></span>
         <span class="skeleton justify-end tablet-up"></span>
-      </span>
+      </div>
 
       <div class="list">
         {#each Array(4) as _, i (i)}
@@ -37,8 +37,8 @@
           </div>
         {/each}
       </div>
-    </span>
-  </span>
+    </div>
+  </div>
 </Card>
 
 <style lang="scss">


### PR DESCRIPTION
# Motivation

Reported in the Svelte v5 branch

```
ESLint:

Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
https://svelte.dev/e/element_invalid_self_closing_tag(element_invalid_self_closing_tag)
(svelte/valid-compile)
```

