### PR TITLE
test: import logo

### DIFF
--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -5,6 +5,7 @@ import { page } from "$mocks/$app/stores";
 import { ProposalNavigationPo } from "$tests/page-objects/ProposalNavigation.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
+import ICPLogo from "/src/lib/assets/icp-rounded.svg";
 
 describe("ProposalNavigation", () => {
   const toNavigationId = (proposalId: bigint): ProposalsNavigationId => ({
@@ -32,9 +33,7 @@ describe("ProposalNavigation", () => {
           selectProposal: vi.fn(),
         });
 
-        expect(await po.getLogoSource()).toEqual(
-          "/src/lib/assets/icp-rounded.svg"
-        );
+        expect(await po.getLogoSource()).toEqual(ICPLogo);
       });
 
       it("should render proposal status", async () => {


### PR DESCRIPTION
# Motivation

In the Svelte v5 branch, a test for a logo is failing because, instead of referencing the SVG, the content is inlined. I assume you don't want to test whether the SVG is inlined or not, but rather test if the expected logo is used. Therefore, this PR imports the logo and uses the result for comparison purposes.
