### PR TITLE
feat(portfolio): add ongoing swap status card

### DIFF
--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -79,7 +79,7 @@
         <h3 data-tid="project-name">{summary.metadata.name}</h3>
       </div>
       <Tag size="medium">
-        <span>{$i18n.portfolio.project_status_adopted}</span>
+        <span>{$i18n.portfolio.project_status_open}</span>
         <IconRocketLaunch size="14px" />
       </Tag>
     </div>

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -3,7 +3,6 @@
   import Logo from "$lib/components/ui/Logo.svelte";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
-  import { getNeuronsFundParticipation } from "$lib/getters/sns-summary";
   import { i18n } from "$lib/stores/i18n";
   import type { SnsSummarySwap } from "$lib/types/sns";
   import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
@@ -37,23 +36,27 @@
     ulps: projectCommitment.directCommitmentE8s,
     token: ICPToken,
   });
+
   let formattedDirectCommitment: string;
   $: formattedDirectCommitment = formatCurrencyNumber(directCommitment);
 
   let formattedMinCommitmentIcp: string;
-  $: formattedMinCommitmentIcp = formatParticipation(summary.getMinIcpE8s());
+  $: formattedMinCommitmentIcp = formatParticipation(
+    projectCommitment.minDirectCommitmentE8s
+  );
 
   let formattedMaxCommitmentIcp: string;
-  $: formattedMaxCommitmentIcp = formatParticipation(summary.getMaxIcpE8s());
+  $: formattedMaxCommitmentIcp = formatParticipation(
+    projectCommitment.maxDirectCommitmentE8s
+  );
 
   let nfCommitment: bigint | undefined;
-  $: nfCommitment = getNeuronsFundParticipation(summary);
+  $: nfCommitment = projectCommitment.nfCommitmentE8s;
 
   let formattedNfCommitmentPercentage: string | null;
-  $: formattedNfCommitmentPercentage =
-    nonNullish(nfCommitment) && projectCommitment.isNFParticipating
-      ? formatParticipation(nfCommitment)
-      : null;
+  $: formattedNfCommitmentPercentage = nonNullish(nfCommitment)
+    ? formatParticipation(nfCommitment)
+    : null;
 
   let durationTillDeadline: bigint;
   $: durationTillDeadline = durationTillSwapDeadline(swap) ?? 0n;
@@ -107,7 +110,7 @@
           <span class="stat-label">
             {$i18n.portfolio.open_project_card_min_icp}
           </span>
-          <span class="stat-value" data-tid="min-icp-commitment">
+          <span class="stat-value" data-tid="min-direct-commitment">
             {formattedMinCommitmentIcp}
           </span>
         </div>
@@ -116,13 +119,13 @@
           <span class="stat-label">
             {$i18n.portfolio.open_project_card_max_icp}
           </span>
-          <span class="stat-value" data-tid="max-icp-commitment">
+          <span class="stat-value" data-tid="max-direct-commitment">
             {formattedMaxCommitmentIcp}
           </span>
         </div>
 
-        {#if nonNullish(nfCommitment)}
-          <div class="stat-item">
+        {#if nonNullish(formattedNfCommitmentPercentage)}
+          <div class="stat-item" data-tid="nf-commitment-field">
             <div class="stat-label"
               >{$i18n.portfolio.open_project_card_nf}
               <TooltipIcon
@@ -130,7 +133,7 @@
                 tooltipId="main-icp-account-id-tooltip"
               />
             </div>
-            <div class="stat-value" data-tid="nf-icp-commitment"
+            <div class="stat-value" data-tid="nf-commitment"
               >{formattedNfCommitmentPercentage}</div
             >
           </div>
@@ -144,7 +147,7 @@
           <IconClockNoFill />
         </span>
 
-        <span data-tid="duration">
+        <span data-tid="time-remaining">
           {secondsToDuration({
             seconds: durationTillDeadline,
             i18n: $i18n.time,

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -96,8 +96,8 @@
             {$i18n.portfolio.open_project_current_commitment}
           </span>
           <span
-            class="stat-value current-commitment"
-            data-tid="current-commitment">{formattedDirectCommitment}</span
+            class="stat-value direct-commitment"
+            data-tid="direct-commitment">{formattedDirectCommitment}</span
           >
         </div>
 
@@ -238,7 +238,7 @@
           font-weight: var(--font-weight-bold);
         }
 
-        .funding-percentage {
+        .direct-commitment {
           @include fonts.h2(true);
           line-height: 1;
         }

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+  import Card from "$lib/components/portfolio/Card.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { getNeuronsFundParticipation } from "$lib/getters/sns-summary";
+  import { i18n } from "$lib/stores/i18n";
+  import type { SnsSummarySwap } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
+  import { formatPercentage } from "$lib/utils/format.utils";
+  import {
+      formatParticipation,
+      getMinCommitmentPercentage,
+  } from "$lib/utils/portfolio.utils";
+  import {
+      durationTillSwapDeadline,
+      getProjectCommitmentSplit,
+      type FullProjectCommitmentSplit,
+  } from "$lib/utils/projects.utils";
+  import {
+      IconClockNoFill,
+      IconRight,
+      IconRocketLaunch,
+      Tag,
+  } from "@dfinity/gix-components";
+  import { nonNullish, secondsToDuration } from "@dfinity/utils";
+
+  export let summary: SnsSummaryWrapper;
+  let swap: SnsSummarySwap;
+  $: ({ swap } = summary);
+
+  let projectCommitment: FullProjectCommitmentSplit;
+  $: projectCommitment = getProjectCommitmentSplit(
+    summary
+  ) as FullProjectCommitmentSplit;
+
+  let currentCommitmentPercentage: number;
+  $: currentCommitmentPercentage =
+    getMinCommitmentPercentage(projectCommitment);
+
+  let formattedCurrentCommitmentPercentage: string;
+  $: formattedCurrentCommitmentPercentage = formatPercentage(
+    currentCommitmentPercentage
+  );
+
+  let formattedMinCommitmentIcp: string;
+  $: formattedMinCommitmentIcp = formatParticipation(summary.getMinIcpE8s());
+
+  let formattedMaxCommitmentIcp: string;
+  $: formattedMaxCommitmentIcp = formatParticipation(summary.getMaxIcpE8s());
+
+  let nfCommitment: bigint | undefined;
+  $: nfCommitment = getNeuronsFundParticipation(summary);
+
+  let formattedNfCommitmentPercentage: string | null;
+  $: formattedNfCommitmentPercentage =
+    nonNullish(nfCommitment) && projectCommitment.isNFParticipating
+      ? formatParticipation(nfCommitment)
+      : null;
+
+  console.log(nfCommitment);
+
+  let durationTillDeadline: bigint | undefined;
+  $: durationTillDeadline = durationTillSwapDeadline(swap);
+
+  let href: string;
+  $: href = `${AppPath.Project}/?project=${summary.rootCanisterId.toText()}`;
+</script>
+
+<Card testId="open-projects-card">
+  <div class="wrapper">
+    <div class="header">
+      <div class="title-wrapper">
+        <div>
+          <Logo
+            src={summary.metadata.logo}
+            alt={summary.metadata.name}
+            size="medium"
+          />
+        </div>
+        <h3>{summary.metadata.name}</h3>
+      </div>
+      <Tag size="medium">
+        <span>{$i18n.portfolio.project_status_adopted}</span>
+        <IconRocketLaunch size="14px" />
+      </Tag>
+    </div>
+
+    <p class="description">{summary.metadata.description}</p>
+
+    <div class="commitment-section">
+      <h4 class="section-title">
+        {$i18n.portfolio.open_project_card_title}
+      </h4>
+
+      <div class="stats">
+        <div class="stat-item">
+          <span class="stat-label">
+            {$i18n.portfolio.open_project_card_min_fund}
+          </span>
+          <span class="stat-value funding-percentage"
+            >{formattedCurrentCommitmentPercentage}</span
+          >
+        </div>
+
+        <div class="vertical-divider"></div>
+
+        <div class="stat-item">
+          <span class="stat-label">
+            {$i18n.portfolio.open_project_card_min_icp}
+          </span>
+          <span class="stat-value">
+            {formattedMinCommitmentIcp}
+          </span>
+        </div>
+
+        <div class="stat-item">
+          <span class="stat-label">
+            {$i18n.portfolio.open_project_card_max_icp}
+          </span>
+          <span class="stat-value">
+            {formattedMaxCommitmentIcp}
+          </span>
+        </div>
+
+        {#if nonNullish(nfCommitment)}
+          <div class="stat-item">
+            <div class="stat-label"
+              >{$i18n.portfolio.open_project_card_nf}
+              <TooltipIcon
+                text={$i18n.header.account_id_tooltip}
+                tooltipId="main-icp-account-id-tooltip"
+              />
+            </div>
+            <div class="stat-value">{formattedNfCommitmentPercentage}</div>
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <div class="footer">
+      <div class="time-remaining">
+        <span class="icon">
+          <IconClockNoFill />
+        </span>
+
+        {secondsToDuration({
+          seconds: durationTillDeadline ?? 0n,
+          i18n: $i18n.time,
+        })}
+      </div>
+      <a {href} class="link" aria-label="something">
+        <span>{$i18n.portfolio.open_project_card_link}</span>
+        <IconRight />
+      </a>
+    </div>
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    height: 100%;
+    background-color: var(--card-background-tint);
+
+    gap: var(--padding-2x);
+    padding: var(--padding-2x);
+
+    @include media.min-width(medium) {
+      padding: var(--padding-3x);
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .title-wrapper {
+        display: flex;
+        align-items: center;
+
+        gap: var(--padding);
+
+        h3 {
+          margin: 0;
+          padding: 0;
+        }
+      }
+    }
+
+    .description {
+      margin: 0;
+      color: var(--color-text-secondary);
+      flex-grow: 1;
+
+      @include text.clamp(2);
+    }
+
+    .commitment-section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-0_5x);
+    }
+
+    .section-title {
+      color: var(--text-description);
+      @include fonts.small(true);
+    }
+
+    .stats {
+      display: flex;
+      gap: var(--padding-2x);
+
+      .stat-item {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: var(--padding-0_5x);
+
+        .stat-label {
+          display: flex;
+          align-items: center;
+          height: 16px;
+          gap: var(--padding-0_5x);
+          @include fonts.small(false);
+        }
+
+        .stat-value {
+          font-size: var(--font-size-standard);
+          font-weight: var(--font-weight-bold);
+        }
+
+        .funding-percentage {
+          @include fonts.h2(true);
+          line-height: 1;
+        }
+      }
+      .vertical-divider {
+        border-right: 1px solid var(--elements-divider);
+      }
+    }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .time-remaining {
+        display: flex;
+        align-items: center;
+        gap: var(--padding);
+
+        .icon {
+          width: 20px;
+          height: 20px;
+          color: var(--text-description);
+        }
+      }
+
+      .link {
+        display: flex;
+        align-items: center;
+        color: var(--button-secondary-color);
+        font-weight: var(--font-weight-bold);
+        text-decoration: none;
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -144,7 +144,7 @@
     <div class="footer">
       <div class="time-remaining">
         <span class="icon">
-          <IconClockNoFill />
+          <IconClockNoFill size="20px" />
         </span>
 
         <span data-tid="time-remaining">
@@ -262,8 +262,6 @@
         gap: var(--padding);
 
         .icon {
-          width: 20px;
-          height: 20px;
           color: var(--text-description);
         }
       }

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -9,19 +9,19 @@
   import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import { formatPercentage } from "$lib/utils/format.utils";
   import {
-      formatParticipation,
-      getMinCommitmentPercentage,
+    formatParticipation,
+    getMinCommitmentPercentage,
   } from "$lib/utils/portfolio.utils";
   import {
-      durationTillSwapDeadline,
-      getProjectCommitmentSplit,
-      type FullProjectCommitmentSplit,
+    durationTillSwapDeadline,
+    getProjectCommitmentSplit,
+    type FullProjectCommitmentSplit,
   } from "$lib/utils/projects.utils";
   import {
-      IconClockNoFill,
-      IconRight,
-      IconRocketLaunch,
-      Tag,
+    IconClockNoFill,
+    IconRight,
+    IconRocketLaunch,
+    Tag,
   } from "@dfinity/gix-components";
   import { nonNullish, secondsToDuration } from "@dfinity/utils";
 
@@ -58,8 +58,6 @@
       ? formatParticipation(nfCommitment)
       : null;
 
-  console.log(nfCommitment);
-
   let durationTillDeadline: bigint | undefined;
   $: durationTillDeadline = durationTillSwapDeadline(swap);
 
@@ -67,7 +65,7 @@
   $: href = `${AppPath.Project}/?project=${summary.rootCanisterId.toText()}`;
 </script>
 
-<Card testId="open-projects-card">
+<Card testId="launch-project-card">
   <div class="wrapper">
     <div class="header">
       <div class="title-wrapper">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1198,8 +1198,6 @@
     "staked_tokens_card_info_row": "Earn voting rewards by staking your tokens in neurons and participating in the Internet Computer’s onchain governance",
     "total_assets_title": "Total Holdings",
     "project_status_open": "Ongoing",
-    "project_status_adopted": "Upcoming",
-    "project_status_proposal": "Open",
     "open_project_card_title": "COMMITMENT",
     "open_project_current_commitment": "ICP raised",
     "open_project_card_min_icp": "Min ICP",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1196,6 +1196,15 @@
     "staked_tokens_card_list_second_column": "Maturity",
     "staked_tokens_card_list_third_column": "Staked",
     "staked_tokens_card_info_row": "Earn voting rewards by staking your tokens in neurons and participating in the Internet Computer’s onchain governance",
-    "total_assets_title": "Total Holdings"
+    "total_assets_title": "Total Holdings",
+    "project_status_open": "Ongoing",
+    "project_status_adopted": "Upcoming",
+    "project_status_proposal": "Open",
+    "open_project_card_title": "COMMITMENT",
+    "open_project_current_commitment": "ICP raised",
+    "open_project_card_min_icp": "Min ICP",
+    "open_project_card_max_icp": "Max ICP",
+    "open_project_card_nf": "Neuron Fund",
+    "open_project_card_link": "View"
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1263,6 +1263,15 @@ interface I18nPortfolio {
   staked_tokens_card_list_third_column: string;
   staked_tokens_card_info_row: string;
   total_assets_title: string;
+  project_status_open: string;
+  project_status_adopted: string;
+  project_status_proposal: string;
+  open_project_card_title: string;
+  open_project_current_commitment: string;
+  open_project_card_min_icp: string;
+  open_project_card_max_icp: string;
+  open_project_card_nf: string;
+  open_project_card_link: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1264,8 +1264,6 @@ interface I18nPortfolio {
   staked_tokens_card_info_row: string;
   total_assets_title: string;
   project_status_open: string;
-  project_status_adopted: string;
-  project_status_proposal: string;
   open_project_card_title: string;
   open_project_current_commitment: string;
   open_project_card_min_icp: string;

--- a/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
@@ -1,122 +1,80 @@
 import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
-import { AppPath } from "$lib/constants/routes.constants";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
+import { createSummary } from "$tests/mocks/sns-projects.mock";
 import { LaunchProjectCardPo } from "$tests/page-objects/LaunchProjectCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 
 describe("LaunchProjectCard", () => {
-  const mockRootCanisterId = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
-
-  const createMockSummary = (overrides = {}) => {
-    const defaultSummary = {
-      rootCanisterId: mockRootCanisterId,
-      metadata: {
-        name: "Test Project",
-        description: "This is a test project description",
-        logo: "test-logo.png",
-      },
-      getMinIcpE8s: () => 1000_00000000n,
-      getMaxIcpE8s: () => 5000_00000000n,
-      swap: {
-        deadline: BigInt(Date.now()) / 1000n + 86400n, // 1 day from now
-      },
-    };
-
-    const merged = { ...defaultSummary, ...overrides };
-
-    // Create a mock for getProjectCommitmentSplit
-    const result = {
-      ...merged,
-    };
-
-    // Mock the necessary functions
-    result.getProjectCommitmentSplit = jest.fn().mockReturnValue({
-      isNFParticipating: false,
-      current: 30_00,
-      min: 30_00,
-      max: 100_00,
-    });
-
-    return result;
-  };
-
-  const renderComponent = (summaryOverrides = {}) => {
-    const summary = createMockSummary(summaryOverrides);
-
+  const renderComponent = (summary: SnsSummaryWrapper) => {
     const { container } = render(LaunchProjectCard, {
       props: {
         summary,
       },
     });
 
-    return {
-      po: LaunchProjectCardPo.under(new JestPageObjectElement(container)),
-      summary,
-    };
+    return LaunchProjectCardPo.under(new JestPageObjectElement(container));
   };
 
   it("should display project name and description", async () => {
-    const { po } = renderComponent();
+    const projectName = "Test Project";
+    const projectDescription = "This is a test project description";
+    const summary = createSummary({
+      projectName,
+      projectDescription,
+    });
+    const po = renderComponent(summary);
 
-    expect(await po.getTitle()).toBe("Test Project");
+    expect(await po.getTitle()).toBe(projectName);
     expect(await po.getDescription()).toBe(
       "This is a test project description"
     );
   });
 
-  it("should display minimum funding percentage", async () => {
-    const { po } = renderComponent();
+  it.only("should display direct funding", async () => {
+    const summary = createSummary({
+      directCommitment: 100_000_000n,
+    });
+    console.log(summary);
 
-    expect(await po.getMinFundingPercentage()).toBe("30%");
+    const po = renderComponent(summary);
+
+    expect(await po.getDirectCommitment()).toBe("100");
   });
 
   it("should display min and max ICP amounts", async () => {
-    const { po } = renderComponent();
+    const summary = createSummary({});
+    const po = renderComponent(summary);
 
     expect(await po.getMinIcp()).toBe("1'000 ICP");
     expect(await po.getMaxIcp()).toBe("5'000 ICP");
   });
 
   it("should not display NF participation when it doesn't exist", async () => {
-    const { po } = renderComponent();
+    const summary = createSummary({});
+    const po = renderComponent(summary);
 
     expect(await po.hasNfParticipation()).toBe(false);
     expect(await po.getNfParticipation()).toBeNull();
   });
 
   it("should display NF participation when it exists", async () => {
-    const mockSummaryWithNF = {
-      swap: {
-        neurons_fund_participation: {
-          amount_icp_e8s: 500_00000000n,
-        },
-      },
-    };
-
-    // Mock the getNeuronsFundParticipation function result
-    const { po } = renderComponent({
-      ...mockSummaryWithNF,
-      getNeuronsFundParticipation: () => 500_00000000n,
-      getProjectCommitmentSplit: () => ({
-        isNFParticipating: true,
-        current: 30_00,
-        min: 30_00,
-        max: 100_00,
-      }),
-    });
+    const summary = createSummary({});
+    const po = renderComponent(summary);
 
     expect(await po.hasNfParticipation()).toBe(true);
     expect(await po.getNfParticipation()).toBe("500 ICP");
   });
 
   it("should display time remaining until deadline", async () => {
+    const summary = createSummary({});
+    const po = renderComponent(summary);
     const deadline = BigInt(Date.now()) / 1000n + 86400n; // 1 day from now
-    const { po } = renderComponent({
-      swap: {
-        deadline,
-      },
-    });
+    // const po = renderComponent({
+    //   swap: {
+    //     deadline,
+    //   },
+    // });
 
     const timeRemaining = await po.getTimeRemaining();
     // We can't exactly test the string since it depends on the current time
@@ -124,66 +82,66 @@ describe("LaunchProjectCard", () => {
     expect(timeRemaining).toContain("day");
   });
 
-  it("should have proper link to project page", async () => {
-    const { po, summary } = renderComponent();
+  // it("should have proper link to project page", async () => {
+  //   const  po = renderComponent();
 
-    const expectedHref = `${AppPath.Project}/?project=${summary.rootCanisterId.toText()}`;
-    expect(await po.getLinkHref()).toBe(expectedHref);
-    expect(await po.getLinkText()).toContain("View project");
-  });
+  //   const expectedHref = `${AppPath.Project}/?project=${summary.rootCanisterId.toText()}`;
+  //   expect(await po.getLinkHref()).toBe(expectedHref);
+  //   expect(await po.getLinkText()).toContain("View project");
+  // });
 
-  it("should display tooltip for NF participation when it exists", async () => {
-    const { po } = renderComponent({
-      getNeuronsFundParticipation: () => 500_00000000n,
-      getProjectCommitmentSplit: () => ({
-        isNFParticipating: true,
-        current: 30_00,
-        min: 30_00,
-        max: 100_00,
-      }),
-    });
+  // it("should display tooltip for NF participation when it exists", async () => {
+  //   const po = renderComponent({
+  //     getNeuronsFundParticipation: () => 500_00000000n,
+  //     getProjectCommitmentSplit: () => ({
+  //       isNFParticipating: true,
+  //       current: 30_00,
+  //       min: 30_00,
+  //       max: 100_00,
+  //     }),
+  //   });
 
-    expect(await po.getNfTooltip().isPresent()).toBe(true);
-  });
+  //   expect(await po.getNfTooltip().isPresent()).toBe(true);
+  // });
 
-  it("should display custom funding percentage when provided", async () => {
-    const { po } = renderComponent({
-      getProjectCommitmentSplit: () => ({
-        isNFParticipating: false,
-        current: 75_00,
-        min: 30_00,
-        max: 100_00,
-      }),
-    });
+  // it("should display custom funding percentage when provided", async () => {
+  //   const po = renderComponent({
+  //     getProjectCommitmentSplit: () => ({
+  //       isNFParticipating: false,
+  //       current: 75_00,
+  //       min: 30_00,
+  //       max: 100_00,
+  //     }),
+  //   });
 
-    expect(await po.getMinFundingPercentage()).toBe("75%");
-  });
+  //   expect(await po.getMinFundingPercentage()).toBe("75%");
+  // });
 
-  it("should display custom ICP amounts when provided", async () => {
-    const { po } = renderComponent({
-      getMinIcpE8s: () => 2500_00000000n,
-      getMaxIcpE8s: () => 10000_00000000n,
-    });
+  // it("should display custom ICP amounts when provided", async () => {
+  //   const po = renderComponent({
+  //     getMinIcpE8s: () => 2500_00000000n,
+  //     getMaxIcpE8s: () => 10000_00000000n,
+  //   });
 
-    expect(await po.getMinIcp()).toBe("2'500 ICP");
-    expect(await po.getMaxIcp()).toBe("10'000 ICP");
-  });
+  //   expect(await po.getMinIcp()).toBe("2'500 ICP");
+  //   expect(await po.getMaxIcp()).toBe("10'000 ICP");
+  // });
 
-  // Testing edge cases
-  it("should handle zero values correctly", async () => {
-    const { po } = renderComponent({
-      getMinIcpE8s: () => 0n,
-      getMaxIcpE8s: () => 0n,
-      getProjectCommitmentSplit: () => ({
-        isNFParticipating: false,
-        current: 0,
-        min: 0,
-        max: 100_00,
-      }),
-    });
+  // // Testing edge cases
+  // it("should handle zero values correctly", async () => {
+  //   const po = renderComponent({
+  //     getMinIcpE8s: () => 0n,
+  //     getMaxIcpE8s: () => 0n,
+  //     getProjectCommitmentSplit: () => ({
+  //       isNFParticipating: false,
+  //       current: 0,
+  //       min: 0,
+  //       max: 100_00,
+  //     }),
+  //   });
 
-    expect(await po.getMinFundingPercentage()).toBe("0%");
-    expect(await po.getMinIcp()).toBe("0 ICP");
-    expect(await po.getMaxIcp()).toBe("0 ICP");
-  });
+  //   expect(await po.getMinFundingPercentage()).toBe("0%");
+  //   expect(await po.getMinIcp()).toBe("0 ICP");
+  //   expect(await po.getMaxIcp()).toBe("0 ICP");
+  // });
 });

--- a/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
@@ -1,0 +1,189 @@
+import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
+import { AppPath } from "$lib/constants/routes.constants";
+import { LaunchProjectCardPo } from "$tests/page-objects/LaunchProjectCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Principal } from "@dfinity/principal";
+import { render } from "@testing-library/svelte";
+
+describe("LaunchProjectCard", () => {
+  const mockRootCanisterId = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
+
+  const createMockSummary = (overrides = {}) => {
+    const defaultSummary = {
+      rootCanisterId: mockRootCanisterId,
+      metadata: {
+        name: "Test Project",
+        description: "This is a test project description",
+        logo: "test-logo.png",
+      },
+      getMinIcpE8s: () => 1000_00000000n,
+      getMaxIcpE8s: () => 5000_00000000n,
+      swap: {
+        deadline: BigInt(Date.now()) / 1000n + 86400n, // 1 day from now
+      },
+    };
+
+    const merged = { ...defaultSummary, ...overrides };
+
+    // Create a mock for getProjectCommitmentSplit
+    const result = {
+      ...merged,
+    };
+
+    // Mock the necessary functions
+    result.getProjectCommitmentSplit = jest.fn().mockReturnValue({
+      isNFParticipating: false,
+      current: 30_00,
+      min: 30_00,
+      max: 100_00,
+    });
+
+    return result;
+  };
+
+  const renderComponent = (summaryOverrides = {}) => {
+    const summary = createMockSummary(summaryOverrides);
+
+    const { container } = render(LaunchProjectCard, {
+      props: {
+        summary,
+      },
+    });
+
+    return {
+      po: LaunchProjectCardPo.under(new JestPageObjectElement(container)),
+      summary,
+    };
+  };
+
+  it("should display project name and description", async () => {
+    const { po } = renderComponent();
+
+    expect(await po.getTitle()).toBe("Test Project");
+    expect(await po.getDescription()).toBe(
+      "This is a test project description"
+    );
+  });
+
+  it("should display minimum funding percentage", async () => {
+    const { po } = renderComponent();
+
+    expect(await po.getMinFundingPercentage()).toBe("30%");
+  });
+
+  it("should display min and max ICP amounts", async () => {
+    const { po } = renderComponent();
+
+    expect(await po.getMinIcp()).toBe("1'000 ICP");
+    expect(await po.getMaxIcp()).toBe("5'000 ICP");
+  });
+
+  it("should not display NF participation when it doesn't exist", async () => {
+    const { po } = renderComponent();
+
+    expect(await po.hasNfParticipation()).toBe(false);
+    expect(await po.getNfParticipation()).toBeNull();
+  });
+
+  it("should display NF participation when it exists", async () => {
+    const mockSummaryWithNF = {
+      swap: {
+        neurons_fund_participation: {
+          amount_icp_e8s: 500_00000000n,
+        },
+      },
+    };
+
+    // Mock the getNeuronsFundParticipation function result
+    const { po } = renderComponent({
+      ...mockSummaryWithNF,
+      getNeuronsFundParticipation: () => 500_00000000n,
+      getProjectCommitmentSplit: () => ({
+        isNFParticipating: true,
+        current: 30_00,
+        min: 30_00,
+        max: 100_00,
+      }),
+    });
+
+    expect(await po.hasNfParticipation()).toBe(true);
+    expect(await po.getNfParticipation()).toBe("500 ICP");
+  });
+
+  it("should display time remaining until deadline", async () => {
+    const deadline = BigInt(Date.now()) / 1000n + 86400n; // 1 day from now
+    const { po } = renderComponent({
+      swap: {
+        deadline,
+      },
+    });
+
+    const timeRemaining = await po.getTimeRemaining();
+    // We can't exactly test the string since it depends on the current time
+    // but we can check it contains some duration text
+    expect(timeRemaining).toContain("day");
+  });
+
+  it("should have proper link to project page", async () => {
+    const { po, summary } = renderComponent();
+
+    const expectedHref = `${AppPath.Project}/?project=${summary.rootCanisterId.toText()}`;
+    expect(await po.getLinkHref()).toBe(expectedHref);
+    expect(await po.getLinkText()).toContain("View project");
+  });
+
+  it("should display tooltip for NF participation when it exists", async () => {
+    const { po } = renderComponent({
+      getNeuronsFundParticipation: () => 500_00000000n,
+      getProjectCommitmentSplit: () => ({
+        isNFParticipating: true,
+        current: 30_00,
+        min: 30_00,
+        max: 100_00,
+      }),
+    });
+
+    expect(await po.getNfTooltip().isPresent()).toBe(true);
+  });
+
+  it("should display custom funding percentage when provided", async () => {
+    const { po } = renderComponent({
+      getProjectCommitmentSplit: () => ({
+        isNFParticipating: false,
+        current: 75_00,
+        min: 30_00,
+        max: 100_00,
+      }),
+    });
+
+    expect(await po.getMinFundingPercentage()).toBe("75%");
+  });
+
+  it("should display custom ICP amounts when provided", async () => {
+    const { po } = renderComponent({
+      getMinIcpE8s: () => 2500_00000000n,
+      getMaxIcpE8s: () => 10000_00000000n,
+    });
+
+    expect(await po.getMinIcp()).toBe("2'500 ICP");
+    expect(await po.getMaxIcp()).toBe("10'000 ICP");
+  });
+
+  // Testing edge cases
+  it("should handle zero values correctly", async () => {
+    const { po } = renderComponent({
+      getMinIcpE8s: () => 0n,
+      getMaxIcpE8s: () => 0n,
+      getProjectCommitmentSplit: () => ({
+        isNFParticipating: false,
+        current: 0,
+        min: 0,
+        max: 100_00,
+      }),
+    });
+
+    expect(await po.getMinFundingPercentage()).toBe("0%");
+    expect(await po.getMinIcp()).toBe("0 ICP");
+    expect(await po.getMaxIcp()).toBe("0 ICP");
+  });
+});

--- a/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
@@ -108,7 +108,7 @@ describe("LaunchProjectCard", () => {
     expect(await linkPo.getHref()).toBe(expectedHref);
   });
 
-  it("should display tooltip when NF is parcipagint", async () => {
+  it("should display tooltip when NF is participating", async () => {
     const summary = createSummary({
       neuronsFundIsParticipating: [true],
       directCommitment: 1_000_000_000_000n,
@@ -121,7 +121,7 @@ describe("LaunchProjectCard", () => {
     expect(await po.getNFTooltipPo().isPresent()).toBe(true);
   });
 
-  it("should not display tooltip when NF is not parcipagint", async () => {
+  it("should not display tooltip when NF is not participating", async () => {
     const summary = createSummary({
       neuronsFundIsParticipating: [false],
     });

--- a/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
@@ -81,6 +81,10 @@ describe("LaunchProjectCard", () => {
   });
 
   it("should display time remaining until deadline", async () => {
+    const mockDate = new Date("2025-03-11T00:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+
     const swapDueTimestampSeconds = BigInt(Date.now()) / 1000n + 86400n; // 1 day from now
     const summary = createSummary({
       swapDueTimestampSeconds,

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -344,6 +344,7 @@ type SnsSummaryParams = {
   nnsProposalId?: bigint;
   rootCanisterId?: Principal;
   projectName?: string;
+  projectDescription?: string;
   logo?: string;
 };
 
@@ -370,6 +371,7 @@ export const createSummary = ({
   nnsProposalId,
   rootCanisterId,
   projectName,
+  projectDescription,
   logo,
 }: SnsSummaryParams): SnsSummaryWrapper => {
   const init: SnsSwapInit = {
@@ -420,6 +422,7 @@ export const createSummary = ({
     ...mockMetadata,
     name: projectName ?? mockMetadata.name,
     logo: logo ?? mockMetadata.logo,
+    description: projectDescription ?? mockMetadata.description,
   };
   const summary = summaryForLifecycle(lifecycle);
   return summary.override({

--- a/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
@@ -17,8 +17,8 @@ export class LaunchProjectCardPo extends BasePageObject {
     return this.getText("project-description");
   }
 
-  getMinFundingPercentage(): Promise<string> {
-    return this.getText("min-funding-percentage");
+  getDirectCommitment(): Promise<string> {
+    return this.getText("direct-commitment");
   }
 
   getMinIcp(): Promise<string> {

--- a/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { LinkPo } from "./Link.page-object";
 
 export class LaunchProjectCardPo extends BasePageObject {
   private static readonly TID = "launch-project-card";
@@ -22,16 +23,16 @@ export class LaunchProjectCardPo extends BasePageObject {
   }
 
   getMinIcp(): Promise<string> {
-    return this.getText("min-icp-amount");
+    return this.getText("min-direct-commitment");
   }
 
   getMaxIcp(): Promise<string> {
-    return this.getText("max-icp-amount");
+    return this.getText("max-direct-commitment");
   }
 
   async getNfParticipation(): Promise<string | null> {
     try {
-      return await this.getText("nf-participation-amount");
+      return await this.getText("nf-commitment");
     } catch (_) {
       return null;
     }
@@ -39,7 +40,7 @@ export class LaunchProjectCardPo extends BasePageObject {
 
   async hasNfParticipation(): Promise<boolean> {
     try {
-      return await this.isPresent("nf-participation-amount");
+      return await this.isPresent("nf-commitment-field");
     } catch (_) {
       return false;
     }
@@ -52,7 +53,11 @@ export class LaunchProjectCardPo extends BasePageObject {
   getLinkPo(): LinkPo {
     return LinkPo.under({
       element: this.root,
-      testId: "project-link-text",
+      testId: "project-link",
     });
+  }
+
+  getNFTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
@@ -1,0 +1,58 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { LinkPo } from "./Link.page-object";
+
+export class LaunchProjectCardPo extends BasePageObject {
+  private static readonly TID = "launch-project-card";
+
+  static under(element: PageObjectElement): LaunchProjectCardPo {
+    return new LaunchProjectCardPo(element.byTestId(LaunchProjectCardPo.TID));
+  }
+
+  getTitle(): Promise<string> {
+    return this.getText("project-name");
+  }
+
+  getDescription(): Promise<string> {
+    return this.getText("project-description");
+  }
+
+  getMinFundingPercentage(): Promise<string> {
+    return this.getText("min-funding-percentage");
+  }
+
+  getMinIcp(): Promise<string> {
+    return this.getText("min-icp-amount");
+  }
+
+  getMaxIcp(): Promise<string> {
+    return this.getText("max-icp-amount");
+  }
+
+  async getNfParticipation(): Promise<string | null> {
+    try {
+      return await this.getText("nf-participation-amount");
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async hasNfParticipation(): Promise<boolean> {
+    try {
+      return await this.isPresent("nf-participation-amount");
+    } catch (_) {
+      return false;
+    }
+  }
+
+  getTimeRemaining(): Promise<string> {
+    return this.getText("time-remaining");
+  }
+
+  getLinkPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "project-link-text",
+    });
+  }
+}


### PR DESCRIPTION
# Motivation

We want to display all ongoing swaps on the Portfolio page. This first PR introduces a new Card component that will be used to present information about the ongoing launch, including details about the commitment, neuron fund, and time remaining.

[NNS1-3640](https://dfinity.atlassian.net/browse/NNS1-3640)

![Screenshot 2025-03-11 at 09 28 38](https://github.com/user-attachments/assets/34ef8d4b-098a-4993-8ff7-fdd6c2ebcc6d)

![Screenshot 2025-03-11 at 09 29 24](https://github.com/user-attachments/assets/73a24dac-0c82-44e7-9326-076333bb5790)


# Changes

- Added a new Card component.  
-  Created a purchase order for the new component.  
-  Extended the mock utility `createSummary` to support testing.  

# Tests

- Added unit tests for the new component
- Manually tested together with other changes in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3640]: https://dfinity.atlassian.net/browse/NNS1-3640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ