### PR TITLE
fix(errors): update cycles detection to use error codes

### DIFF
--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -292,7 +292,7 @@ describe("icrc-accounts-services", () => {
           ok: false,
           status: 500,
           statusText: "",
-          body: { certificate: new ArrayBuffer() },
+          body: { certificate: new ArrayBuffer(0) },
           headers: [],
         },
         ReplicaRejectCode.CanisterError,

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -377,7 +377,7 @@ describe("icrc-accounts-services", () => {
       ]);
     });
 
-    it("should not display a toast on canister ouf of cycles", async () => {
+    it("should not display a toast message if the canister is out-of-cycles", async () => {
       vi.spyOn(ledgerApi, "queryIcrcBalance").mockRejectedValue(
         new QueryCallRejectedError(CKBTC_LEDGER_CANISTER_ID, "methodName", {
           error_code: "IC0207",

--- a/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
@@ -12,6 +12,7 @@ import {
   mockIcrcTransactionWithId,
 } from "$tests/mocks/icrc-transactions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { QueryCallRejectedError, ReplicaRejectCode } from "@dfinity/agent";
 import { toastsStore } from "@dfinity/gix-components";
 import { get } from "svelte/store";
 
@@ -196,7 +197,17 @@ describe("icrc-transactions services", () => {
     });
 
     it("swallows error if canister out-of-cycles", async () => {
-      const error = new Error("IC0207");
+      const error = new QueryCallRejectedError(
+        indexCanisterId,
+        "getTransactions",
+        {
+          error_code: "IC0207",
+          // @ts-expect-error: We can't use the enum from agent-js as it was exported as a const.
+          status: "rejected",
+          reject_message: "Canister out of cycles",
+          reject_code: ReplicaRejectCode.CanisterError,
+        }
+      );
       vi.spyOn(indexApi, "getTransactions").mockRejectedValue(error);
 
       expect(get(toastsStore)).toHaveLength(0);

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -9,6 +9,10 @@ import {
   toToastError,
 } from "$lib/utils/error.utils";
 import en from "$tests/mocks/i18n.mock";
+import {
+  type QueryCallRejectedError,
+  type UpdateCallRejectedError,
+} from "@dfinity/agent";
 import { UnsupportedMethodError } from "@dfinity/sns";
 
 class TestError extends Error {
@@ -128,45 +132,49 @@ describe("error-utils", () => {
   });
 
   describe("isCanisterOutOfCycles", () => {
-    it("returns true for out of cycles query error", () => {
-      const message = `Call failed:
-        Canister: 75lp5-u7777-77776-qaaba-cai
-        Method: icrc1_balance_of (query)
-        "Status": "rejected"
-        "Code": "SysTransient"
-        "Message": "IC0207: Canister 75lp5-u7777-77776-qaaba-cai is unable to process query calls because it's frozen. Please top up the canister with cycles and try again."`;
-      const err = new Error(message);
-      expect(isCanisterOutOfCyclesError(err)).toBe(true);
+    it("should return true for query error with IC0207 code", () => {
+      const queryError = {
+        type: "query",
+        result: {
+          error_code: "IC0207",
+        },
+      } as QueryCallRejectedError;
+      expect(isCanisterOutOfCyclesError(queryError)).toBe(true);
     });
 
-    it("returns true for out of cycles update error", () => {
-      const message = `Call failed:
-        Canister: 75lp5-u7777-77776-qaaba-cai
-        Method: icrc1_balance_of (update)
-        "Request ID": "476ad2adfb1e755277240038da963f54d16093d2d4b1d370e82c1cd1a089e73f"
-        "Error code": "IC0207"
-        "Reject code": "2"
-        "Reject message": "Canister 75lp5-u7777-77776-qaaba-cai is out of cycles"`;
-      const err = new Error(message);
-      expect(isCanisterOutOfCyclesError(err)).toBe(true);
+    it("should return false for query error with different error code", () => {
+      const queryError = {
+        type: "query",
+        result: {
+          error_code: "IC0503",
+        },
+      } as QueryCallRejectedError;
+      expect(isCanisterOutOfCyclesError(queryError)).toBe(false);
     });
 
-    it("returns false for other errors and non errors", () => {
+    it("should return true for update error with IC0207 code", () => {
+      const updateError = {
+        type: "update",
+        error_code: "IC0207",
+      } as UpdateCallRejectedError;
+      expect(isCanisterOutOfCyclesError(updateError)).toBe(true);
+    });
+
+    it("should return false for update error with different error code", () => {
+      const updateError = {
+        type: "update",
+        error_code: "IC0503",
+      } as UpdateCallRejectedError;
+      expect(isCanisterOutOfCyclesError(updateError)).toBe(false);
+    });
+
+    it("should return false for invalid inputs", () => {
+      expect(isCanisterOutOfCyclesError(null)).toBe(false);
       expect(isCanisterOutOfCyclesError(undefined)).toBe(false);
+      expect(isCanisterOutOfCyclesError("string error")).toBe(false);
+      expect(isCanisterOutOfCyclesError(123)).toBe(false);
       expect(isCanisterOutOfCyclesError({})).toBe(false);
-      expect(isCanisterOutOfCyclesError(new Error("test"))).toBe(false);
-      expect(isCanisterOutOfCyclesError(new Error("IC02070"))).toBe(false);
-    });
-
-    it("returns false for different error codes", () => {
-      const message = `Call failed:
-        Canister: 75lp5-u7777-77776-qaaba-cai
-        Method: icrc1_balance_of (query)
-        "Status": "rejected"
-        "Code": "SysTransient"
-        "Message": "IC0503: Some other error message"`;
-      const err = new Error(message);
-      expect(isCanisterOutOfCyclesError(err)).toBe(false);
+      expect(isCanisterOutOfCyclesError({ type: "unknown" })).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -51,6 +51,7 @@ import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setCkUSDCCanisters } from "$tests/utils/ckusdc.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { QueryCallRejectedError, ReplicaRejectCode } from "@dfinity/agent";
 import { AuthClient } from "@dfinity/auth-client";
 import { MinterNoNewUtxosError, type UpdateBalanceOk } from "@dfinity/ckbtc";
 import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger-icrc";
@@ -721,9 +722,13 @@ describe("Tokens route", () => {
             };
 
             if (canisterId.toText() === ledgerCanisterIdTetris.toText()) {
-              throw new Error(
-                `IC0207: Out of cycles for ${canisterId.toText()}`
-              );
+              throw new QueryCallRejectedError(canisterId, "getTransactions", {
+                error_code: "IC0207",
+                // @ts-expect-error: We can't use the enum from agent-js as it was exported as a const.
+                status: "rejected",
+                reject_message: "Canister out of cycles",
+                reject_code: ReplicaRejectCode.CanisterError,
+              });
             }
             return balancesMap[canisterId.toText()];
           }


### PR DESCRIPTION
# Motivation

#6465 introduced a method for tracking specific errors based on the error message payload. This functionality broke after the following change: https://github.com/dfinity/ic/pull/3465.

The [recommendation](https://dfinity.slack.com/archives/CGA566TPV/p1741614348749269?thread_ts=1741613964.837469&cid=CGA566TPV) is to utilize the fields instead of parsing the message.

Please note that we need to use type guards to retrieve information about the errors, as it is not currently propagated to the client app.

# Changes

- Refactor `isCanisterOutOfCyclesError` to narrow down  error's type and utilize the `error_code` information.

# Tests

- Updated tests based on new implementation.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary