### PR TITLE
Update changelog after release

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -11,6 +11,12 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 Unreleased changes are added to `CHANGELOG-Nns-Dapp-unreleased.md` and moved
 here after a successful release.
 
+## Proposal 135749
+
+### Application
+
+### Operations
+
 ## Proposal 135695
 
 ### Application

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -15,6 +15,10 @@ here after a successful release.
 
 ### Application
 
+#### Fixed
+
+* Updated the Voting page to support SNS topics to fix the issue of proposals failing to load.
+
 ### Operations
 
 ## Proposal 135695

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,7 +3865,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nns-dapp"
-version = "2.0.106"
+version = "2.0.107"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "proposals"
-version = "2.0.106"
+version = "2.0.107"
 dependencies = [
  "anyhow",
  "candid",
@@ -5074,7 +5074,7 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "sns_aggregator"
-version = "2.0.106"
+version = "2.0.107"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.106"
+version = "2.0.107"
 
 [workspace.dependencies]
 ic-cdk = "0.17.1"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/nns-dapp",
-  "version": "2.0.106",
+  "version": "2.0.107",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/nns-dapp",
-      "version": "2.0.106",
+      "version": "2.0.107",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@dfinity/agent": "^2.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns-dapp",
-  "version": "2.0.106",
+  "version": "2.0.107",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {


### PR DESCRIPTION
# Motivation

A release has been deployed to production.

# Changes

- Changelog - split out the changes included in the release.
- Manually adding a missing changelog entry (ideally, this should be done when [bumping the ic-js](https://github.com/dfinity/nns-dapp/pull/6563) version, but better late than never).
- Increment the patch version of the nns-dapp.