### PR TITLE
chore(ci): update golden data for small-tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -343,7 +343,7 @@ jobs:
           Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
           Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
           Transaction fee:      1000
-          Minimum neuron stake: 100
+          Minimum neuron stake: 10000
           Proposal fee:         15000")
   checks-pass:
     needs:


### PR DESCRIPTION
# Motivation

Currently, the `small-tests` action fails on CI because of outdated [golden data](https://github.com/dfinity/nns-dapp/actions/runs/13790391836/job/38568471111?pr=6561)

# Changes

- Update the value.

# Tests

- All checks should be green.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.