### PR TITLE
refactor(portfolio): increase participation amount precision

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,6 +1,7 @@
 import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+import { formatNumber } from "$lib/utils/format.utils";
 import type { FullProjectCommitmentSplit } from "$lib/utils/projects.utils";
 import {
   createDescendingComparator,
@@ -17,7 +18,6 @@ import {
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
 import { ICPToken } from "@dfinity/utils";
-import { formatNumber } from "./format.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -17,6 +17,7 @@ import {
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
 import { ICPToken } from "@dfinity/utils";
+import { formatNumber } from "./format.utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 
@@ -124,10 +125,17 @@ export const shouldShowInfoRow = ({
 
 export const formatParticipation = (ulps: bigint) => {
   const value = ulpsToNumber({ ulps, token: ICPToken });
-  if (value < 10_000)
-    return Number.isInteger(value) ? value.toString() : value.toFixed(2);
+  if (value < 1_000) {
+    return formatNumber(value, { minFraction: 0, maxFraction: 2 });
+  }
 
-  return `${(value / 1_000).toFixed(0)}K`;
+  if (value < 1_000_000) {
+    const thousands = value / 1_000;
+    return `${formatNumber(thousands, { minFraction: 0, maxFraction: 2 })}k`;
+  }
+
+  const millions = value / 1_000_000;
+  return `${formatNumber(millions, { minFraction: 0, maxFraction: 2 })}M`;
 };
 
 export const getMinCommitmentPercentage = (

--- a/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/LaunchProjectCard.spec.ts
@@ -55,7 +55,7 @@ describe("LaunchProjectCard", () => {
     const po = renderComponent(summary);
 
     expect(await po.getMinIcp()).toBe("500");
-    expect(await po.getMaxIcp()).toBe("150K");
+    expect(await po.getMaxIcp()).toBe("150k");
   });
 
   it("should not display NF participation when it doesn't exist", async () => {

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -441,23 +441,37 @@ describe("Portfolio utils", () => {
   });
 
   describe("formatParticipation", () => {
-    it("should return integer values as strings without decimal places", () => {
+    it("should format values < 1,000 as plain numbers", () => {
       expect(formatParticipation(0n)).toBe("0");
       expect(formatParticipation(100_000_000n)).toBe("1");
-      expect(formatParticipation(10_000_000_000n)).toBe("100");
-      expect(formatParticipation(999_000_000_000n)).toBe("9990");
+      expect(formatParticipation(105_000_000n)).toBe("1.05");
+      expect(formatParticipation(150_000_000n)).toBe("1.5");
+      expect(formatParticipation(99_900_000_000n)).toBe("999");
     });
 
-    it("should format decimal values less than 10,000 with 2 decimal places", () => {
-      expect(formatParticipation(12_345_000_000n)).toBe("123.45");
-      expect(formatParticipation(10_000_000n)).toBe("0.10");
-      expect(formatParticipation(999_999_000_000n)).toBe("9999.99");
+    it("should format values between 1,000 and 999,999 with decimal k suffix", () => {
+      expect(formatParticipation(100_001_000_000n)).toBe("1k");
+      expect(formatParticipation(105_000_000_000n)).toBe("1.05k");
+      expect(formatParticipation(110_000_000_000n)).toBe("1.1k");
+      expect(formatParticipation(990_000_000_000n)).toBe("9.9k");
+
+      expect(formatParticipation(1_000_001_000_000n)).toBe("10k");
+      expect(formatParticipation(1_050_001_000_000n)).toBe("10.5k");
+      expect(formatParticipation(1_055_001_000_000n)).toBe("10.55k");
+      expect(formatParticipation(9_990_001_000_000n)).toBe("99.9k");
+
+      expect(formatParticipation(10_000_000_000_000n)).toBe("100k");
+      expect(formatParticipation(10_500_000_000_000n)).toBe("105k");
+      expect(formatParticipation(10_505_000_000_000n)).toBe("105.05k");
+      expect(formatParticipation(10_550_000_000_000n)).toBe("105.5k");
+      expect(formatParticipation(99_900_000_000_000n)).toBe("999k");
     });
 
-    it("should format values >= 10,000 with K suffix", () => {
-      expect(formatParticipation(1_000_000_000_000n)).toBe("10K");
-      expect(formatParticipation(1_200_000_000_000n)).toBe("12K");
-      expect(formatParticipation(40_000_000_000_000n)).toBe("400K");
+    it("should format values >= 1,000,000 with M suffix", () => {
+      expect(formatParticipation(100_000_000_000_000n)).toBe("1M");
+      expect(formatParticipation(100_005_000_000_000n)).toBe("1M");
+      expect(formatParticipation(105_000_000_000_000n)).toBe("1.05M");
+      expect(formatParticipation(150_000_000_000_000n)).toBe("1.5M");
     });
   });
 


### PR DESCRIPTION
# Motivation

New requirements have been established for displaying minimum and maximum participation in the new Launch cards on the Portfolio page. 

This PR refactors #6531 to accommodate these changes.

# Changes

- Increase granularity of `formatParticipation`

# Tests

- Updates tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary