### PR TITLE
Removing anything related to SnsAction

### DIFF
--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -18,10 +18,9 @@ import {
   isSnsGenericNervousSystemFunction,
   isSnsNativeNervousSystemFunction,
 } from "$lib/utils/sns.utils";
-import { basisPointsToPercent, keyOfOptional } from "$lib/utils/utils";
+import { basisPointsToPercent } from "$lib/utils/utils";
 import { Vote } from "@dfinity/nns";
 import type {
-  SnsAction,
   SnsBallot,
   SnsNervousSystemFunction,
   SnsNeuron,
@@ -70,7 +69,6 @@ export type SnsProposalDataMap = {
   title: string;
   url?: string;
   summary: string;
-  actionData?: SnsAction;
 
   // TODO: Should come from backend
   status: SnsProposalDecisionStatus;
@@ -119,8 +117,6 @@ export const mapProposalInfo = ({
   } = proposalData;
 
   const proposalInfo = fromNullable(proposal);
-  const actionData =
-    proposalInfo !== undefined ? fromNullable(proposalInfo.action) : undefined;
 
   const nsFunction = nsFunctions?.find(({ id }) => id === action);
 
@@ -160,7 +156,6 @@ export const mapProposalInfo = ({
     title: proposalInfo?.title ?? "",
     url: proposalInfo?.url,
     summary: proposalInfo?.summary ?? "",
-    actionData,
 
     // TODO: Ideally this should come from the backend and we didn't need to calculate it
     status: decisionStatus,
@@ -344,80 +339,6 @@ export const sortSnsProposalsById = <P extends SnsProposalData>(
     : [...proposals].sort(({ id: idA }, { id: idB }) =>
         (fromNullable(idA)?.id ?? 0n) > (fromNullable(idB)?.id ?? 0n) ? -1 : 1
       );
-
-const getAction = (proposal: SnsProposalData): SnsAction | undefined =>
-  fromNullable(fromNullable(proposal?.proposal)?.action ?? []);
-
-/**
- * Returns the key of the action in the proposal.
- *
- * An `action` is a variant of the `SnsAction` type.
- * Reference: https://github.com/dfinity/ic-js/blob/8e9695411cab2c9480224baa968743466342ab13/packages/sns/candid/sns_governance.did#L3
- *
- * They variant follows this convetion: { [actionKey: string]: <action data> }
- * Therefore, this function returns the `actionKey`.
- *
- * @param {SnsProposalData} proposal
- * @returns {string} `actionKey` of the action
- */
-export const proposalOnlyActionKey = (
-  proposal: SnsProposalData
-): string | undefined => {
-  const actionKeys = Object.keys(getAction(proposal) ?? {});
-  // Edge case: Variant of SnsAction has always one key only.
-  // We can't test this because an `SnsProposalData` with two action keys is not a valid type.
-  if (actionKeys.length > 1) {
-    throw new Error("Actions have only have one key.");
-  }
-  return actionKeys[0];
-};
-
-/**
- * Returns a list of tuples with the properties of the action.
- *
- * From the proposal data:
- *  {
- *   id: ...
- *   ...
- *   proposal: [{
- *     title: "title",
- *     summary: "summary",
- *     url: "...",
- *     action: [{
- *       Motion: {
- *         motion_text: "Test motion"
- *       }
- *     }]
- *   }]
- *  }
- * It returns: [["motion_text", "Test motion"]]
- *
- * @param {SnsProposalData} proposal
- * @returns {[string, unknown][]}
- */
-export const proposalActionFields = (
-  proposal: SnsProposalData
-): [string, unknown][] => {
-  const key = proposalOnlyActionKey(proposal);
-  if (key === undefined) {
-    return [];
-  }
-  // TODO: Convert action types to use `undefined | T` instead of `[] | [T]`.
-  const actionData = keyOfOptional({ obj: getAction(proposal), key }) ?? {};
-  return Object.entries(actionData).filter(([, value]) => {
-    switch (typeof value) {
-      case "object":
-        return (value && Object.keys(value).length > 0) || Array.isArray(value);
-      case "undefined":
-      case "string":
-      case "bigint":
-      case "boolean":
-      case "number":
-        return true;
-    }
-    return false;
-  });
-};
 
 export const snsProposalIdString = (proposal: SnsProposalData): string =>
   fromDefinedNullable(proposal.id).id.toString();

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -11,8 +11,6 @@ import {
   isAccepted,
   lastProposalId,
   mapProposalInfo,
-  proposalActionFields,
-  proposalOnlyActionKey,
   snsDecisionStatus,
   snsNeuronToVotingNeuron,
   snsProposalAcceptingVotes,
@@ -37,7 +35,6 @@ import {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
   SnsVote,
-  type SnsAction,
   type SnsNervousSystemFunction,
   type SnsNeuron,
   type SnsPercentage,
@@ -298,7 +295,6 @@ describe("sns-proposals utils", () => {
       expect(mappedProposal.title).toBe(proposal.title);
       expect(mappedProposal.url).toBe(proposal.url);
       expect(mappedProposal.summary).toBe(proposal.summary);
-      expect(mappedProposal.actionData).toBe(proposal.action[0]);
       expect(mappedProposal.current_deadline_timestamp_seconds).toBe(
         current_deadline_timestamp_seconds
       );
@@ -373,112 +369,6 @@ describe("sns-proposals utils", () => {
 
     it("returns empty array when array is empty", () => {
       expect(sortSnsProposalsById([])).toEqual([]);
-    });
-  });
-
-  describe("proposalOnlyActionKey", () => {
-    it("should find fist action key", () => {
-      const firstKey = "UpgradeSnsToNextVersion";
-      const proposal: SnsProposalData = {
-        ...mockSnsProposal,
-        proposal: [
-          {
-            ...mockSnsProposal.proposal[0],
-            action: [{ [firstKey]: {} }],
-          },
-        ],
-      };
-      expect(proposalOnlyActionKey(proposal)).toEqual(firstKey);
-    });
-
-    it("should return undefined if no action or no proposal", () => {
-      const proposalWithoutAction: SnsProposalData = {
-        ...mockSnsProposal,
-        proposal: [
-          {
-            ...mockSnsProposal.proposal[0],
-            action: [],
-          },
-        ],
-      };
-      expect(proposalOnlyActionKey(proposalWithoutAction)).toBeUndefined();
-
-      const proposalWithoutProposal: SnsProposalData = {
-        ...mockSnsProposal,
-        proposal: [],
-      };
-      expect(proposalOnlyActionKey(proposalWithoutProposal)).toBeUndefined();
-    });
-  });
-
-  describe("proposalActionFields", () => {
-    it("should return the properties of the action in a list", () => {
-      const action = {
-        Motion: {
-          motion_text: "Test motion",
-        },
-      };
-      const proposal: SnsProposalData = {
-        ...mockSnsProposal,
-        proposal: [
-          {
-            ...mockSnsProposal.proposal[0],
-            action: [action],
-          },
-        ],
-      };
-      const fields = proposalActionFields(proposal);
-
-      expect(fields).toEqual([["motion_text", "Test motion"]]);
-    });
-
-    it("should include undefined action fields", () => {
-      // TODO: Convert action types to use `undefined | T` instead of `[] | [T]`.
-      // That will mean that subaccount below shuold be rendered as `undefined` instead of not being present in the final array.
-      const action: SnsAction = {
-        ManageSnsMetadata: {
-          url: ["www.internetcomputer.org"],
-          logo: [],
-          name: [],
-          description: [],
-        },
-      };
-      const proposal: SnsProposalData = {
-        ...mockSnsProposal,
-        proposal: [
-          {
-            ...mockSnsProposal.proposal[0],
-            action: [action],
-          },
-        ],
-      };
-      const fields = proposalActionFields(proposal);
-
-      expect(fields).toEqual([
-        ["url", ["www.internetcomputer.org"]],
-        ["logo", []],
-        ["name", []],
-        ["description", []],
-      ]);
-    });
-
-    it("should return empty array if no action or no proposal", () => {
-      const proposalWithoutAction: SnsProposalData = {
-        ...mockSnsProposal,
-        proposal: [
-          {
-            ...mockSnsProposal.proposal[0],
-            action: [],
-          },
-        ],
-      };
-      expect(proposalActionFields(proposalWithoutAction)).toHaveLength(0);
-
-      const proposalWithoutProposal: SnsProposalData = {
-        ...mockSnsProposal,
-        proposal: [],
-      };
-      expect(proposalActionFields(proposalWithoutProposal)).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
# Motivation

There was an outage when the `action` field from the `ProposalData` (from SNS Governance) cannot be parsed. There is an agent-js bug which makes the candid parsing fail. However, even if the candid parsing bug is fixed, it was unclear whether the NNS Dapp would be able to show the SNS proposal correctly if it's unaware of the new action variant (and `action` is decoded to null). This PR tries to prove that it indeed can, by removing any access to the `action` field.

# Changes

- Remove `SnsProposalDataMap::actionData`
- Remove any access to `actionData`, which all happen to be dead code
- Stop converting `action` in `mapProposalInfo`

Note that after those changes, the only place `SnsAction` (from `@dfinity/sns`) is used is `frontend/src/lib/api/sns-dummy.api.ts`, which is for SUBMITTING proposals, and those will still work if the field `ProposalData::action` (in the list_proposals RESPONSE) does not exist. However, the PR does not definitively prove that NNS Dapp still works if `ProposalData::action` does not exist, since `.action` can still be called somewhere and I cannot find a reliable way to finding them

# Tests

N/A

# Todos

- [ ] Add entry to changelog (if necessary).
