### PR TITLE
style(portfolio): improve LaunchProjectCard mobile styles

### DIFF
--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -155,7 +155,7 @@
         </span>
       </div>
       <a {href} class="link" aria-label="something" data-tid="project-link">
-        <span>{$i18n.portfolio.open_project_card_link}</span>
+        <span class="text">{$i18n.portfolio.open_project_card_link} </span>
         <IconRight />
       </a>
     </div>
@@ -173,28 +173,32 @@
     box-sizing: border-box;
     height: 100%;
     background-color: var(--card-background-tint);
+    min-height: 240px;
 
     gap: var(--padding-2x);
     padding: var(--padding-2x);
+    padding-bottom: var(--padding-3x);
 
     @include media.min-width(medium) {
       padding: var(--padding-3x);
+      padding-bottom: var(--padding-4x);
     }
 
     .header {
-      display: flex;
-      justify-content: space-between;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
+      gap: var(--padding-0_5x);
 
       .title-wrapper {
         display: flex;
         align-items: center;
-
         gap: var(--padding);
 
         h3 {
           margin: 0;
           padding: 0;
+          @include text.truncate;
         }
       }
     }
@@ -269,9 +273,30 @@
       .link {
         display: flex;
         align-items: center;
+        justify-content: center;
+
         color: var(--button-secondary-color);
         font-weight: var(--font-weight-bold);
         text-decoration: none;
+
+        width: 35px;
+        height: 35px;
+        border: solid var(--button-border-size) var(--primary);
+        border-radius: 50%;
+        box-sizing: border-box;
+
+        @include media.min-width(medium) {
+          width: auto;
+          height: auto;
+          border: none;
+        }
+
+        .text {
+          display: none;
+          @include media.min-width(medium) {
+            display: inline;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
# Motivation

We want to update some styles of the `LaunchProjectCard`, specifically how it renders the link to the swap page on small screens and how long titles can affect the size of the card.

Before:

https://github.com/user-attachments/assets/5a6b9fb7-8678-4629-8e1e-98ad5acf2e1d

After:

https://github.com/user-attachments/assets/99fa16a2-86cc-45f8-9cc7-52f2991b5486

[NNS1-3640](https://dfinity.atlassian.net/browse/NNS1-3640)

# Changes

- Adds styles to render the swap link as a button instead of a link on small screens.  
- Adds styles to truncate the card titles to prevent breaking the card size.  
- Modifies the styles for the dot buttons.

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3640]: https://dfinity.atlassian.net/browse/NNS1-3640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ