### PR TITLE
feat(ui): add loading indicators to canister topup exchange fields

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Added the option to hide projects in the neurons table that have no neurons.
 * Added ongoing SNS launch previews to Portfolio page.
+* Added visual feedback while loading exchange rates in canister top-up form.
 
 #### Changed
 

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -6,6 +6,8 @@
     convertIcpToTCycles,
     convertTCyclesToIcpNumber,
   } from "$lib/utils/token.utils";
+  import { Spinner } from "@dfinity/gix-components";
+  import { isNullish } from "@dfinity/utils";
   import { createEventDispatcher, onMount } from "svelte";
 
   export let amount: number | undefined = undefined;
@@ -77,7 +79,13 @@
       disabled={icpToCyclesExchangeRate === undefined}
     >
       <svelte:fragment slot="label">{$i18n.core.icp}</svelte:fragment>
+      <svelte:fragment slot="inner-end">
+        {#if isNullish(icpToCyclesExchangeRate)}
+          <Spinner inline size="small" />
+        {/if}
+      </svelte:fragment>
     </Input>
+
     <Input
       placeholderLabelKey="canisters.t_cycles"
       inputType="icp"
@@ -89,6 +97,12 @@
     >
       <svelte:fragment slot="label">
         {$i18n.canisters.t_cycles}
+      </svelte:fragment>
+
+      <svelte:fragment slot="inner-end">
+        {#if isNullish(icpToCyclesExchangeRate)}
+          <Spinner inline size="small" />
+        {/if}
       </svelte:fragment>
     </Input>
   </div>


### PR DESCRIPTION
# Motivation

As reported in [Slack](https://dfinity.slack.com/archives/C01S03NBM7S/p1742021219737869), the TopUp canister flow can be confusing. This is because both input fields remain disabled until the frontend receives the exchange rate from ICP to Cycles.

We want to inform users that something is happening by displaying a spinner.

https://github.com/user-attachments/assets/39bfb86c-d497-4969-90a0-bf0f912b1599

# Changes

- Add `Spinner` to both input field as long as there is not value for `icpToCyclesExchangeRate`

# Tests

- Tests should pass as before

# Todos

- [x] Add entry to changelog (if necessary).
