### PR TITLE
feat(neurons): collapse SNS voting power details into expandable section

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Added the option to hide projects in the neurons table that have no neurons.
 * Added ongoing SNS launch previews to Portfolio page.
+* Simplified SNS neuron display by making voting power details expandable on demand
 
 #### Changed
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -8,21 +8,21 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import {
-      ageMultiplier,
-      dissolveDelayMultiplier,
-      formattedStakedMaturity,
-      getSnsNeuronStake,
-      neuronDashboardUrl,
-      snsNeuronVotingPower,
+    ageMultiplier,
+    dissolveDelayMultiplier,
+    formattedStakedMaturity,
+    getSnsNeuronStake,
+    neuronDashboardUrl,
+    snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
   import { formatTokenE8s } from "$lib/utils/token.utils";
   import { Html, KeyValuePairInfo, Section } from "@dfinity/gix-components";
   import { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import {
-      fromDefinedNullable,
-      secondsToDuration,
-      type Token,
+    fromDefinedNullable,
+    secondsToDuration,
+    type Token,
   } from "@dfinity/utils";
 
   export let parameters: SnsNervousSystemParameters;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -8,21 +8,21 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import {
-    ageMultiplier,
-    dissolveDelayMultiplier,
-    formattedStakedMaturity,
-    getSnsNeuronStake,
-    neuronDashboardUrl,
-    snsNeuronVotingPower,
+      ageMultiplier,
+      dissolveDelayMultiplier,
+      formattedStakedMaturity,
+      getSnsNeuronStake,
+      neuronDashboardUrl,
+      snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
   import { formatTokenE8s } from "$lib/utils/token.utils";
-  import { Html, Section } from "@dfinity/gix-components";
+  import { Html, KeyValuePairInfo, Section } from "@dfinity/gix-components";
   import { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import {
-    fromDefinedNullable,
-    secondsToDuration,
-    type Token,
+      fromDefinedNullable,
+      secondsToDuration,
+      type Token,
   } from "@dfinity/utils";
 
   export let parameters: SnsNervousSystemParameters;
@@ -40,67 +40,74 @@
 </script>
 
 <Section testId="sns-neuron-voting-power-section-component">
-  <h3 slot="title">{$i18n.neurons.voting_power}</h3>
-  <p slot="end" class="title-value" data-tid="voting-power">
-    {#if votingPower > 0}
-      {formatVotingPower(votingPower)}
-    {:else}
-      {$i18n.neuron_detail.voting_power_zero}
-    {/if}
-  </p>
-  <svelte:fragment slot="description">
-    {#if canVote}
-      <p class="description">
-        {$i18n.neuron_detail.calculated_as}
-      </p>
-      <p class="description calculation">
-        {$i18n.neuron_detail.voting_power_section_calculation_generic}
-      </p>
-      <p class="description">
-        {$i18n.neuron_detail.this_neuron_calculation}
-      </p>
-      <p class="description calculation" data-tid="voting-power-description">
-        {replacePlaceholders(
-          $i18n.neuron_detail.voting_power_section_calculation_specific,
-          {
-            $stake: formatTokenE8s({
-              value: getSnsNeuronStake(neuron),
-            }),
-            $maturityStaked: formattedStakedMaturity(neuron),
-            $ageMultiplier: ageMultiplier({
-              neuron,
-              snsParameters: parameters,
-            }).toFixed(2),
-            $dissolveMultiplier: dissolveDelayMultiplier({
-              neuron,
-              snsParameters: parameters,
-            }).toFixed(2),
-            $votingPower: formatVotingPower(votingPower),
-          }
-        )}
-      </p>
-    {:else}
-      <p class="description" data-tid="voting-power-description">
-        <Html
-          text={replacePlaceholders(
-            $i18n.neuron_detail.voting_power_section_description_expanded_zero,
+  <KeyValuePairInfo slot="description">
+    <h3 slot="key">{$i18n.neurons.voting_power}</h3>
+    <p slot="value" class="title-value" data-tid="voting-power">
+      {#if votingPower > 0}
+        {formatVotingPower(votingPower)}
+      {:else}
+        {$i18n.neuron_detail.voting_power_zero}
+      {/if}
+    </p>
+    <span slot="info">
+      {#if canVote}
+        <span class="description">
+          {$i18n.neuron_detail.calculated_as}
+        </span>
+        <span class="description calculation">
+          {$i18n.neuron_detail.voting_power_section_calculation_generic}
+        </span>
+        <span class="description">
+          {$i18n.neuron_detail.this_neuron_calculation}
+        </span>
+        <span
+          class="description calculation"
+          data-tid="voting-power-description"
+        >
+          {replacePlaceholders(
+            $i18n.neuron_detail.voting_power_section_calculation_specific,
             {
-              $minDuration: secondsToDuration({
-                seconds: fromDefinedNullable(
-                  parameters.neuron_minimum_dissolve_delay_to_vote_seconds
-                ),
-                i18n: $i18n.time,
+              $stake: formatTokenE8s({
+                value: getSnsNeuronStake(neuron),
               }),
-              $dashboardLink: neuronDashboardUrl({
+              $maturityStaked: formattedStakedMaturity(neuron),
+              $ageMultiplier: ageMultiplier({
                 neuron,
-                rootCanisterId: Principal.fromText(universe.canisterId),
-              }),
+                snsParameters: parameters,
+              }).toFixed(2),
+              $dissolveMultiplier: dissolveDelayMultiplier({
+                neuron,
+                snsParameters: parameters,
+              }).toFixed(2),
+              $votingPower: formatVotingPower(votingPower),
             }
           )}
-        />
-      </p>
-    {/if}
-  </svelte:fragment>
+        </span>
+      {:else}
+        <span class="description" data-tid="voting-power-description">
+          <Html
+            text={replacePlaceholders(
+              $i18n.neuron_detail
+                .voting_power_section_description_expanded_zero,
+              {
+                $minDuration: secondsToDuration({
+                  seconds: fromDefinedNullable(
+                    parameters.neuron_minimum_dissolve_delay_to_vote_seconds
+                  ),
+                  i18n: $i18n.time,
+                }),
+                $dashboardLink: neuronDashboardUrl({
+                  neuron,
+                  rootCanisterId: Principal.fromText(universe.canisterId),
+                }),
+              }
+            )}
+          />
+        </span>
+      {/if}
+    </span>
+  </KeyValuePairInfo>
+
   <ul class="content">
     <SnsStakeItemAction {neuron} {token} {universe} />
     <SnsNeuronStateItemAction {neuron} snsParameters={parameters} {token} />


### PR DESCRIPTION
# Motivation

Following up on the work done in #6138, we also want to hide details about voting power behind an accordion-like component for SNS neurons. This way, users must proactively click to expand and see the details. This change will simplify the complexity of the UI.

Before:
![Screenshot 2025-03-16 at 10 08 38](https://github.com/user-attachments/assets/e980efa3-d348-4ab9-9d2a-a1b27ab239de)

After:

https://github.com/user-attachments/assets/806512ef-9044-49c7-8f2c-e28b3be6cd63

[NNS1-3660](https://dfinity.atlassian.net/browse/NNS1-3660)

# Changes

Use `KeyValuePairInfo` to conceal the voting calculation logic.

# Tests

- Should pass as before

# Todos

- [x] Add entry to changelog (if necessary).


[NNS1-3660]: https://dfinity.atlassian.net/browse/NNS1-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ