### PR TITLE
refactor(styles): standardize portfolio card links buttons with gix styles

### DIFF
--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -79,10 +79,12 @@
       height: 35px;
       border-radius: 50%;
       min-height: auto;
+      padding: 0;
 
       @include media.min-width(medium) {
         width: auto;
         height: auto;
+        padding: var(--padding) var(--padding-2x);
         border-radius: var(--border-radius);
         min-height: var(--button-min-height);
       }

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -27,7 +27,7 @@
       </p>
     </div>
   </div>
-  <a {href} class="button link" aria-label={linkText}>
+  <a {href} class="button secondary link" aria-label={linkText}>
     <span class="icon">
       <IconRight />
     </span>
@@ -78,23 +78,13 @@
       width: 35px;
       height: 35px;
       border-radius: 50%;
+      min-height: auto;
 
-      // TODO: This is necessary because using the button mixins from GIX generates warnings about unused styles.
-      // The styles in question relate to the disabled attribute, which does not apply to the anchor element.
-      // This is a temporary fix until those mixins are updated to include the disabled state as an additional mixin.
-      color: var(--button-secondary-color);
-      border: solid var(--button-border-size) var(--primary);
       @include media.min-width(medium) {
         width: auto;
         height: auto;
-        padding: var(--padding) var(--padding-2x);
         border-radius: var(--border-radius);
-        position: relative;
         min-height: var(--button-min-height);
-        font-weight: var(--font-weight-bold);
-        &:focus {
-          filter: contrast(1.25);
-        }
       }
 
       .icon {


### PR DESCRIPTION
# Motivation

We want to simplify and reuse the link button styles from Gix to make the portfolio tokens card more consistent with the rest of the app.

# Changes

-Reuse link classes from Gix and remove redundant styles.

# Tests

- E2E tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.