### PR TITLE
style(ui): adjust stacked card navigation dots spacing

### DIFF
--- a/frontend/src/lib/components/portfolio/StackedCards.svelte
+++ b/frontend/src/lib/components/portfolio/StackedCards.svelte
@@ -106,13 +106,13 @@
     .dots-container {
       display: flex;
       justify-content: center;
-      gap: var(--padding-1_5x);
+      gap: var(--padding-2x);
       position: absolute;
       bottom: var(--padding-1_5x);
 
       .dot {
-        width: var(--padding-1_5x);
-        height: var(--padding-1_5x);
+        width: 10px;
+        height: 10px;
         border-radius: 50%;
         // TODO(yhabib): Reconciliate colors with GIX
         background-color: rgba(#3d4d99, 0.35);


### PR DESCRIPTION
# Motivation

We want to introduce visual improvements to the dots displayed in the `StackedCard`.

Before:

<img width="565" alt="Screenshot 2025-03-18 at 10 51 37" src="https://github.com/user-attachments/assets/702b3c3f-1f6b-435d-b840-c18b98e0a47f" />

After:

<img width="560" alt="Screenshot 2025-03-18 at 10 51 16" src="https://github.com/user-attachments/assets/b73fe185-681e-4fa6-9ac5-56944b19cbf2" />

[NNS1-3641](https://dfinity.atlassian.net/browse/NNS1-3641)

# Changes

- Adjusts the spacing for the dot buttons in the footer of the `StackedCard`.

# Tests

- Updates screenshots.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3641]: https://dfinity.atlassian.net/browse/NNS1-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ