### PR TITLE
refactor(transactions): reuse transaction fee component in SplitStake modals

### DIFF
--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -90,11 +90,7 @@
 
   <AmountInput bind:amount on:nnsMax={stakeMaximum} {max} />
 
-  <TransactionFormFee transactionFee={$mainTransactionFeeStoreAsToken}>
-    <svelte:fragment slot="label"
-      >{$i18n.neurons.transaction_fee}</svelte:fragment
-    >
-  </TransactionFormFee>
+  <TransactionFormFee transactionFee={$mainTransactionFeeStoreAsToken} />
 
   <Separator spacing="small" />
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -330,7 +330,6 @@
     "confirm_dissolve_delay": "Confirm Dissolve Delay",
     "follow_neurons_screen": "Follow neurons",
     "stake_icp": "Stake ICP",
-    "transaction_fee": "Transaction Fee",
     "may_take_while": "This may take a moment",
     "create": "Create",
     "community_fund": "Neurons' fund",

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -89,7 +89,6 @@
         token: ICPToken,
       })}
     />
-    />
 
     <div class="toolbar">
       <button class="secondary" on:click={close}>

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CurrentBalance from "$lib/components/accounts/CurrentBalance.svelte";
+  import TransactionFormFee from "$lib/components/transaction/TransactionFormFee.svelte";
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
@@ -12,13 +13,10 @@
     isValidInputAmount,
     neuronStake,
   } from "$lib/utils/neuron.utils";
-  import {
-    formattedTransactionFeeICP,
-    ulpsToNumber,
-  } from "$lib/utils/token.utils";
-  import { Modal, Value, busy } from "@dfinity/gix-components";
+  import { ulpsToNumber } from "$lib/utils/token.utils";
+  import { Modal, busy } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+  import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let neuron: NeuronInfo;
@@ -84,16 +82,14 @@
   >
   <div class="wrapper" data-tid="split-neuron-modal">
     <CurrentBalance {balance} />
-
-    <AmountInput bind:amount on:nnsMax={onMax} {max} />
-
-    <div>
-      <p class="label">{$i18n.neurons.transaction_fee}</p>
-      <p>
-        <Value>{formattedTransactionFeeICP($mainTransactionFeeE8sStore)}</Value>
-        ICP
-      </p>
-    </div>
+    <AmountInput bind:amount on:nnsMax={onMax} {max} token={ICPToken} />
+    <TransactionFormFee
+      transactionFee={TokenAmount.fromE8s({
+        amount: BigInt($mainTransactionFeeE8sStore),
+        token: ICPToken,
+      })}
+    />
+    />
 
     <div class="toolbar">
       <button class="secondary" on:click={close}>

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -94,20 +94,13 @@
   >
   <div class="wrapper" data-tid="split-neuron-modal">
     <CurrentBalance {balance} />
-
     <AmountInput bind:amount on:nnsMax={onMax} {max} />
-
-    <div>
-      <p class="label">{$i18n.neurons.transaction_fee}</p>
-      <p>
-        <Value>
-          {formatTokenE8s({
-            value: transactionFee,
-          })}
-        </Value>
-        {token.symbol}
-      </p>
-    </div>
+    <TransactionFormFee
+      transactionFee={TokenAmount.fromE8s({
+        amount: transactionFee,
+        token,
+      })}
+    />
 
     <div class="toolbar">
       <button class="secondary" on:click={close}>

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CurrentBalance from "$lib/components/accounts/CurrentBalance.svelte";
+  import TransactionFormFee from "$lib/components/transaction/TransactionFormFee.svelte";
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
   import { E8S_PER_ICP } from "$lib/constants/icp.constants";
   import { splitNeuron } from "$lib/services/sns-neurons.services";
@@ -8,13 +9,13 @@
   import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
   import { isValidInputAmount } from "$lib/utils/neuron.utils";
   import { getSnsNeuronStake } from "$lib/utils/sns-neuron.utils";
-  import { formatTokenE8s } from "$lib/utils/token.utils";
-  import { busy, Modal, Value } from "@dfinity/gix-components";
+  import { busy, Modal } from "@dfinity/gix-components";
   import type { E8s } from "@dfinity/nns";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import {
     fromDefinedNullable,
+    TokenAmount,
     TokenAmountV2,
     type Token,
   } from "@dfinity/utils";

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -343,7 +343,6 @@ interface I18nNeurons {
   confirm_dissolve_delay: string;
   follow_neurons_screen: string;
   stake_icp: string;
-  transaction_fee: string;
   may_take_while: string;
   create: string;
   community_fund: string;


### PR DESCRIPTION
# Motivation

In the scope of [NNS1-3671](https://dfinity.atlassian.net/browse/NNS1-3671), we aim to display the USD value of transaction fees. We already have a component for this purpose, but it is not utilized consistently. This PR eliminates redundant one-time implementations and reuses the existing component. A follow-up PR will introduce the new logic to display the USD fee value.

# Changes

- Reuse `TransactionFormFee` in the SplitNeuronModals components for both NNs and SNs.
- Remove redundant translations since they all use the same key.

# Tests

- Test should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3671]: https://dfinity.atlassian.net/browse/NNS1-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ