### PR TITLE
feat(transactions): display fee amount in USD

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -1,27 +1,73 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import { i18n } from "$lib/stores/i18n";
-  import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { getUsdValue } from "$lib/utils/token.utils";
+  import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
+  import type { Principal } from "@dfinity/principal";
+  import { nonNullish, type TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
   export let transactionFee: TokenAmount | TokenAmountV2;
+
+  let ledgerCanisterId: Principal | undefined;
+  $: ledgerCanisterId = getLedgerCanisterIdFromUniverse($selectedUniverseStore);
+
+  let tokenPrice: number | undefined;
+  $: tokenPrice =
+    nonNullish(ledgerCanisterId) &&
+    nonNullish($icpSwapUsdPricesStore) &&
+    $icpSwapUsdPricesStore !== "error"
+      ? $icpSwapUsdPricesStore[ledgerCanisterId.toText()]
+      : undefined;
+
+  let usdValue: number;
+  $: usdValue = getUsdValue({ amount: transactionFee, tokenPrice }) ?? 0;
+
+  let isAlmostZero: boolean;
+  $: isAlmostZero = usdValue > 0 && usdValue < 0.01;
+
+  let formattedUsdValue: string;
+  $: formattedUsdValue = isAlmostZero ? "0.01" : formatNumber(usdValue);
+
+  let usdValueDisplay: string;
+  $: usdValueDisplay = `(${isAlmostZero ? "< " : ""}$${formattedUsdValue})`;
 </script>
 
 <div data-tid="transaction-form-fee">
   <p class="fee label no-margin">
-    <slot name="label">{$i18n.accounts.transaction_fee}</slot>
+    <slot name="label">{$i18n.core.transaction_fee}</slot>
   </p>
 
-  <p class="no-margin">
+  <p class="value">
     <AmountDisplay
       amount={transactionFee}
       singleLine
       detailed="height_decimals"
     />
+    <span class="usd-value" data-tid="transaction-form-fee-usd-value">
+      {usdValueDisplay}
+    </span>
   </p>
 </div>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
   .fee {
     padding: var(--padding-0_5x) 0;
+    color: var(--text-description);
+    @include fonts.small();
+  }
+
+  .value {
+    margin: 0;
+
+    --amount-weight: var(--font-weight-bold);
+
+    .usd-value {
+      color: var(--text-description);
+    }
   }
 </style>

--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -37,7 +37,7 @@
 
 <div data-tid="transaction-form-fee">
   <p class="fee label no-margin">
-    <slot name="label">{$i18n.core.transaction_fee}</slot>
+    <slot name="label">{$i18n.accounts.transaction_fee}</slot>
   </p>
 
   <p class="value">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -36,8 +36,7 @@
     "collapse_all": "Collapse All",
     "or": "or",
     "add": "Add",
-    "not_applicable": "N/A",
-    "transaction_fee": "Transaction Fee"
+    "not_applicable": "N/A"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
@@ -249,6 +248,7 @@
     "to_address": "To Address",
     "hardware_wallet_text": "Ledger device",
     "token_transaction_fee": "$tokenSymbol Ledger Fee",
+    "transaction_fee": "Transaction Fee",
     "review_transaction": "Review Transaction",
     "you_are_sending": "You are sending",
     "current_balance": "Current balance",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -36,7 +36,8 @@
     "collapse_all": "Collapse All",
     "or": "or",
     "add": "Add",
-    "not_applicable": "N/A"
+    "not_applicable": "N/A",
+    "transaction_fee": "Transaction Fee"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
@@ -248,7 +249,6 @@
     "to_address": "To Address",
     "hardware_wallet_text": "Ledger device",
     "token_transaction_fee": "$tokenSymbol Ledger Fee",
-    "transaction_fee": "Transaction Fee (billed to source)",
     "review_transaction": "Review Transaction",
     "you_are_sending": "You are sending",
     "current_balance": "Current balance",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -40,7 +40,6 @@ interface I18nCore {
   or: string;
   add: string;
   not_applicable: string;
-  transaction_fee: string;
 }
 
 interface I18nError {
@@ -259,6 +258,7 @@ interface I18nAccounts {
   to_address: string;
   hardware_wallet_text: string;
   token_transaction_fee: string;
+  transaction_fee: string;
   review_transaction: string;
   you_are_sending: string;
   current_balance: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -40,6 +40,7 @@ interface I18nCore {
   or: string;
   add: string;
   not_applicable: string;
+  transaction_fee: string;
 }
 
 interface I18nError {
@@ -258,7 +259,6 @@ interface I18nAccounts {
   to_address: string;
   hardware_wallet_text: string;
   token_transaction_fee: string;
-  transaction_fee: string;
   review_transaction: string;
   you_are_sending: string;
   current_balance: string;

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -349,7 +349,7 @@ export const getUsdValue = ({
   amount,
   tokenPrice,
 }: {
-  amount: TokenAmountV2;
+  amount: TokenAmountV2 | TokenAmount;
   tokenPrice?: number;
 }): number | undefined => {
   const amountE8s = Number(amount.toE8s());

--- a/frontend/src/tests/lib/components/transaction/TransactionFormFee.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionFormFee.spec.ts
@@ -1,0 +1,68 @@
+import TransactionFormFee from "$lib/components/transaction/TransactionFormFee.svelte";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { TransactionFormFeePo } from "$tests/page-objects/TransactionFormFee.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+import { render } from "@testing-library/svelte";
+
+describe("TransactionFormFee", () => {
+  const renderComponent = (props: { transactionFee: TokenAmountV2 }) => {
+    const { container } = render(TransactionFormFee, {
+      props,
+    });
+    return TransactionFormFeePo.under(new JestPageObjectElement(container));
+  };
+
+  it("should display the transaction fee label", async () => {
+    const transactionFee = TokenAmountV2.fromNumber({
+      amount: 0.1,
+      token: ICPToken,
+    });
+    const po = renderComponent({ transactionFee });
+
+    // TODO(yhabib): Fix the implementation to not show so many decimals
+    expect(await po.getAmountDisplayPo().getText()).toBe("0.10000000 ICP");
+  });
+
+  it("should display the USD value without 'less than' sign when above or equal to $0.01", async () => {
+    const icpPrice = 0.1;
+    setIcpPrice(icpPrice);
+
+    const transactionFee = TokenAmountV2.fromNumber({
+      amount: 0.1,
+      token: ICPToken,
+    });
+    const po = renderComponent({ transactionFee });
+
+    // USD value is 0.1 * 0.1 = 0.01
+    expect(await po.getUsdAmountDisplay()).toBe("($0.01)");
+  });
+
+  it("should display the USD value with 'less than' sign when below $0.01", async () => {
+    const icpPrice = 0.09;
+    setIcpPrice(icpPrice);
+
+    const transactionFee = TokenAmountV2.fromNumber({
+      amount: 0.1,
+      token: ICPToken,
+    });
+    const po = renderComponent({ transactionFee });
+
+    // USD value is 0.1 * 0.09 = 0.009, which is less than 0.01
+    expect(await po.getUsdAmountDisplay()).toBe("(< $0.01)");
+  });
+
+  it("should display higher USD values correctly formatted", async () => {
+    const icpPrice = 100;
+    setIcpPrice(icpPrice);
+
+    const transactionFee = TokenAmountV2.fromNumber({
+      amount: 0.1,
+      token: ICPToken,
+    });
+    const po = renderComponent({ transactionFee });
+
+    // USD value is 0.1 * 100 = 10
+    expect(await po.getUsdAmountDisplay()).toBe("($10.00)");
+  });
+});

--- a/frontend/src/tests/page-objects/TransactionFormFee.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFormFee.page-object.ts
@@ -12,4 +12,8 @@ export class TransactionFormFeePo extends BasePageObject {
   getAmountDisplayPo(): AmountDisplayPo {
     return AmountDisplayPo.under(this.root);
   }
+
+  getUsdAmountDisplay(): Promise<string> {
+    return this.getText("transaction-form-fee-usd-value");
+  }
 }


### PR DESCRIPTION
# Motivation

Following up on #6597, we want to display the USD value for transactions. In this PR, we are adding a new section to the `TransactionFormFee` to show the fee in dollars. 
We use the same data source for the token prices as in the rest of the application, icp-swap.

<img width="640" alt="Screenshot 2025-03-19 at 11 34 25" src="https://github.com/user-attachments/assets/7985d053-bccf-4dba-9d23-fc957391224b" />

[NNS1-3671](https://dfinity.atlassian.net/browse/NNS1-3671)

# Changes

- Displays the USD value of the transaction fee

# Tests

- Adds unit tests for the component

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3671]: https://dfinity.atlassian.net/browse/NNS1-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ