### PR TITLE
feat(ui): create fiat value display component for inputs

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -75,7 +75,7 @@
     }
 
     &.singleLine span:first-of-type {
-      font-weight: normal;
+      font-weight: var(--amount-weight, normal);
       font-size: var(--font-size-h5);
     }
 

--- a/frontend/src/lib/components/ui/AmountInputFiatValue.svelte
+++ b/frontend/src/lib/components/ui/AmountInputFiatValue.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { getUsdValue } from "$lib/utils/token.utils";
+  import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
+  import type { Principal } from "@dfinity/principal";
+  import { nonNullish, TokenAmountV2, type Token } from "@dfinity/utils";
+
+  export let amount: number = 0;
+  export let balance: bigint | undefined = undefined;
+  export let token: Token;
+  export let errorState: boolean = false;
+
+  let ledgerCanisterId: Principal | undefined;
+  $: ledgerCanisterId = getLedgerCanisterIdFromUniverse($selectedUniverseStore);
+
+  let tokenPrice: number | undefined;
+  $: tokenPrice =
+    nonNullish(ledgerCanisterId) &&
+    nonNullish($icpSwapUsdPricesStore) &&
+    $icpSwapUsdPricesStore !== "error"
+      ? $icpSwapUsdPricesStore[ledgerCanisterId.toText()]
+      : undefined;
+
+  let tokens: TokenAmountV2;
+  $: tokens = TokenAmountV2.fromNumber({ amount, token });
+
+  let usdValue: number;
+  $: usdValue = getUsdValue({ amount: tokens, tokenPrice }) ?? 0;
+
+  let usdValueFormatted: string;
+  $: usdValueFormatted = formatNumber(usdValue);
+</script>
+
+<div
+  class="wrapper"
+  class:has-error={errorState}
+  data-tid="amount-input-fiat-value-component"
+>
+  <span class="fiat" data-tid="fiat-value">
+    ${usdValueFormatted}
+  </span>
+  {#if nonNullish(balance)}
+    <span class="balance" data-tid="balance">
+      <span>
+        {$i18n.accounts.balance}:
+      </span>
+      <AmountDisplay
+        singleLine
+        amount={TokenAmountV2.fromUlps({
+          amount: balance,
+          token,
+        })}
+      />
+    </span>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+    @include media.min-width(medium) {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    .fiat {
+      color: var(--text-description);
+      @include fonts.standard(true);
+    }
+
+    .balance {
+      margin: 0;
+      padding: 0;
+      color: var(--text-description);
+      --amount-color: var(--text-description);
+      --amount-weight: var(--font-weight-bold);
+      @include fonts.standard(true);
+    }
+  }
+
+  .wrapper.has-error {
+    .balance {
+      color: var(--negative-emphasis);
+      --amount-color: var(--negative-emphasis);
+    }
+  }
+</style>

--- a/frontend/src/tests/lib/components/ui/AmountInputFiatValue.spec.ts
+++ b/frontend/src/tests/lib/components/ui/AmountInputFiatValue.spec.ts
@@ -1,0 +1,120 @@
+import AmountInputFiatValue from "$lib/components/ui/AmountInputFiatValue.svelte";
+import { AmountInputFiatValuePo } from "$tests/page-objects/AmountInputFiatValue.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
+import { ICPToken } from "@dfinity/utils";
+import { render } from "@testing-library/svelte";
+
+describe("AmountInputFiatValue", () => {
+  const renderComponent = (props: {
+    amount?: number;
+    token: typeof ICPToken;
+    balance?: bigint;
+    errorState?: boolean;
+  }) => {
+    const { container } = render(AmountInputFiatValue, {
+      props,
+    });
+    return AmountInputFiatValuePo.under(new JestPageObjectElement(container));
+  };
+
+  it("should display 0 USD when no amount is provided", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      token: ICPToken,
+    });
+
+    expect(await po.getFiatValue()).toBe("$0.00");
+  });
+
+  it("should display the USD value correctly", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5_000,
+      token: ICPToken,
+    });
+
+    expect(await po.getFiatValue()).toBe("$50’000.00");
+  });
+
+  it("should not display balance when balance prop is not provided", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5,
+      token: ICPToken,
+    });
+
+    expect(await po.hasBalance()).toBe(false);
+  });
+
+  it("should display balance when balance prop is provided", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5,
+      token: ICPToken,
+      balance: 1000000000n,
+    });
+
+    expect(await po.hasBalance()).toBe(true);
+    expect(await po.getBalancePo().getText()).toBe("10.00 ICP");
+  });
+
+  it("should apply error class when errorState is true", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5,
+      token: ICPToken,
+      balance: BigInt(1000000000),
+      errorState: true,
+    });
+
+    expect(await po.hasError()).toBe(true);
+  });
+
+  it("should not apply error class when errorState is false", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5,
+      token: ICPToken,
+      balance: BigInt(1000000000),
+      errorState: false,
+    });
+
+    expect(await po.hasError()).toBe(false);
+  });
+
+  it("should update USD value when amount changes", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5,
+      token: ICPToken,
+    });
+
+    expect(await po.getFiatValue()).toBe("$50.00");
+
+    const updatedPo = renderComponent({
+      amount: 10,
+      token: ICPToken,
+    });
+
+    expect(await updatedPo.getFiatValue()).toBe("$100.00");
+  });
+
+  it("should update USD value when token price changes", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5,
+      token: ICPToken,
+    });
+
+    expect(await po.getFiatValue()).toBe("$50.00");
+
+    setIcpPrice(20);
+    const updatedPo = renderComponent({
+      amount: 5,
+      token: ICPToken,
+    });
+
+    expect(await updatedPo.getFiatValue()).toBe("$100.00");
+  });
+});

--- a/frontend/src/tests/page-objects/AmountInputFiatValue.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountInputFiatValue.page-object.ts
@@ -1,0 +1,30 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AmountDisplayPo } from "./AmountDisplay.page-object";
+
+export class AmountInputFiatValuePo extends BasePageObject {
+  private static readonly TID = "amount-input-fiat-value-component";
+
+  static under(element: PageObjectElement): AmountInputFiatValuePo {
+    return new AmountInputFiatValuePo(
+      element.byTestId(AmountInputFiatValuePo.TID)
+    );
+  }
+
+  getFiatValue(): Promise<string> {
+    return this.getText("fiat-value");
+  }
+
+  getBalancePo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
+  }
+
+  hasBalance(): Promise<boolean> {
+    return this.getBalancePo().isPresent();
+  }
+
+  async hasError(): Promise<boolean> {
+    const classes = await this.root.getClasses();
+    return classes.includes("has-error");
+  }
+}

--- a/frontend/src/tests/page-objects/AmountInputFiatValue.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountInputFiatValue.page-object.ts
@@ -1,6 +1,6 @@
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AmountDisplayPo } from "./AmountDisplay.page-object";
 
 export class AmountInputFiatValuePo extends BasePageObject {
   private static readonly TID = "amount-input-fiat-value-component";


### PR DESCRIPTION
# Motivation

In the scope of [NNS1-3671](https://dfinity.atlassian.net/browse/NNS1-3671), we want to display the USD value of inputs when the user enters a non-fiat value. This PR introduces a new component that will later be used by the `AmountInput` to show the fiat value.

<img width="902" alt="Screenshot 2025-03-19 at 13 15 53" src="https://github.com/user-attachments/assets/aaaf33b9-c718-45df-b2b6-14973f4fea79" />

# Changes

- Adds a new component, `AmountInputFiatValue`, to display the USD value and balance.  
- Exposes a CSS variable to style the `font-weight` of `AmountDisplay` for consumers.

# Tests

- Added unit tests.  
-  Manually tested alongside other changes in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3671]: https://dfinity.atlassian.net/browse/NNS1-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ