### PR TITLE
style(ui): simplify input error message presentation

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Simplified SNS neuron display by making voting power details expandable on demand
 * Added visual feedback while loading exchange rates in canister top-up form.
+* Simplified error message display for better readability in form inputs.
 
 #### Changed
 

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Input from "$lib/components/ui/Input.svelte";
-  import { IconInfo } from "@dfinity/gix-components";
 
   // Same props as Input
   export let name: string;
@@ -50,7 +49,6 @@
 
   {#if errorMessage || warningMessage}
     <p class="error-message" data-tid="input-error-message">
-      <IconInfo />
       <span>
         {errorMessage ?? warningMessage}
       </span>
@@ -84,13 +82,5 @@
     gap: var(--padding-0_5x);
 
     color: var(--negative-emphasis);
-
-    span {
-      color: var(--background-contrast);
-    }
-
-    @include media.min-width(medium) {
-      padding: 0 var(--padding-2x);
-    }
   }
 </style>


### PR DESCRIPTION
# Motivation

We want to simplify the errors displayed by the `InputWithError` component.

Before:

<img width="646" alt="Screenshot 2025-03-19 at 13 25 36" src="https://github.com/user-attachments/assets/825f3467-4d96-45c0-acc1-077a2a644fdc" />

After:

<img width="698" alt="Screenshot 2025-03-19 at 13 26 01" src="https://github.com/user-attachments/assets/f5596da1-cc0f-4311-9ca0-f01ff7c296a3" />

# Changes

- Removes icon and color text overrides from the error message.

# Tests

- Existing tests should continue to pass as they did before.

# Todos

- [x] Add entry to changelog (if necessary).
