### PR TITLE
feat(inputs): integrate USD value display in amount fields

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -69,3 +69,4 @@ DFINITY
 Changelog
 changelog
 geolocation
+USD

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Simplified SNS neuron display by making voting power details expandable on demand
 * Added visual feedback while loading exchange rates in canister top-up form.
 * Simplified error message display for better readability in form inputs.
+* Added USD equivalent values to ICP amount inputs.
 
 #### Changed
 

--- a/frontend/src/lib/components/common/NewMaxButton.svelte
+++ b/frontend/src/lib/components/common/NewMaxButton.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  export let disabled = false;
+  // TODO(yhabib): remove duplication with MaxButton once designs are unified
+</script>
+
+<button data-tid="max-button" on:click|preventDefault type="button" {disabled}>
+  {$i18n.core.max}
+</button>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  button {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+    color: var(--button-primary);
+    text-decoration: none;
+    @include fonts.h5(true);
+  }
+</style>

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -88,7 +88,7 @@
     token={ICPToken}
   />
 
-  <AmountInput bind:amount on:nnsMax={stakeMaximum} {max} />
+  <AmountInput bind:amount on:nnsMax={stakeMaximum} {max} token={ICPToken} />
 
   <TransactionFormFee transactionFee={$mainTransactionFeeStoreAsToken} />
 

--- a/frontend/src/lib/components/ui/AmountInput.svelte
+++ b/frontend/src/lib/components/ui/AmountInput.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-  import MaxButton from "$lib/components/common/MaxButton.svelte";
+  import NewMaxButton from "$lib/components/common/NewMaxButton.svelte";
+  import AmountInputFiatValue from "$lib/components/ui/AmountInputFiatValue.svelte";
   import InputWithError from "$lib/components/ui/InputWithError.svelte";
   import { ICP_DISPLAYED_DECIMALS_DETAILED } from "$lib/constants/icp.constants";
   import { i18n } from "$lib/stores/i18n";
-  import { isNullish, type Token } from "@dfinity/utils";
+  import { isNullish, nonNullish, type Token } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let amount: number | undefined = undefined;
   export let max: number | undefined = undefined;
-  export let token: Token | undefined = undefined;
+  export let token: Token;
+  export let balance: bigint | undefined = undefined;
   export let errorMessage: string | undefined = undefined;
 
   let inputAmount: string | undefined = amount?.toString();
@@ -29,13 +31,28 @@
   bind:value={inputAmount}
   {max}
   inputType="currency"
-  decimals={Math.min(
-    token?.decimals ?? ICP_DISPLAYED_DECIMALS_DETAILED,
-    ICP_DISPLAYED_DECIMALS_DETAILED
-  )}
+  decimals={Math.min(token?.decimals, ICP_DISPLAYED_DECIMALS_DETAILED)}
   {errorMessage}
   on:nnsInput={onInput}
 >
-  <svelte:fragment slot="label">{$i18n.core.amount}</svelte:fragment>
-  <MaxButton on:click={setMax} slot="end" />
+  <span class="label" slot="label">{$i18n.core.amount}</span>
+
+  <NewMaxButton on:click={setMax} slot="inner-end" />
+
+  <div class="bottom" slot="bottom">
+    <AmountInputFiatValue
+      amount={amount ?? 0}
+      {token}
+      {balance}
+      errorState={nonNullish(errorMessage)}
+    />
+  </div>
 </InputWithError>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .bottom {
+    padding: var(--padding-2x);
+  }
+</style>

--- a/frontend/src/lib/components/ui/AmountInput.svelte
+++ b/frontend/src/lib/components/ui/AmountInput.svelte
@@ -31,7 +31,7 @@
   bind:value={inputAmount}
   {max}
   inputType="currency"
-  decimals={Math.min(token?.decimals, ICP_DISPLAYED_DECIMALS_DETAILED)}
+  decimals={Math.min(token.decimals, ICP_DISPLAYED_DECIMALS_DETAILED)}
   {errorMessage}
   on:nnsInput={onInput}
 >

--- a/frontend/src/lib/components/ui/Input.svelte
+++ b/frontend/src/lib/components/ui/Input.svelte
@@ -45,4 +45,5 @@
   <slot name="label" slot="label" />
   <slot name="end" slot="end" />
   <slot name="inner-end" slot="inner-end" />
+  <slot name="bottom" slot="bottom" />
 </Input>

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -45,6 +45,7 @@
     <slot name="label" slot="label" />
     <slot name="end" slot="end" />
     <slot name="inner-end" slot="inner-end" />
+    <slot name="bottom" slot="bottom" />
   </Input>
 
   {#if errorMessage || warningMessage}

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -95,7 +95,7 @@
   >
   <div class="wrapper" data-tid="split-neuron-modal">
     <CurrentBalance {balance} />
-    <AmountInput bind:amount on:nnsMax={onMax} {max} />
+    <AmountInput bind:amount on:nnsMax={onMax} {max} {token} />
     <TransactionFormFee
       transactionFee={TokenAmount.fromE8s({
         amount: transactionFee,

--- a/frontend/src/tests/lib/components/ui/AmountInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/AmountInput.spec.ts
@@ -12,7 +12,7 @@ import { fireEvent } from "@testing-library/svelte";
 describe("AmountInput", () => {
   const props = { amount: 10.25, max: 11, token: ICPToken };
 
-  // TODO(yhabib): Clean up tests and re-use renderCompont
+  // TODO(yhabib): Clean up tests and re-use renderComponent
   it("should render an input", () => {
     const { container } = render(AmountInput, { props });
 

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -26,6 +26,7 @@ import en from "$tests/mocks/i18n.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { CkBTCTransactionModalPo } from "$tests/page-objects/CkBTCTransactionModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { advanceTime } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { TokenAmountV2, nonNullish } from "@dfinity/utils";
@@ -511,5 +512,27 @@ describe("CkBTCTransactionModal", () => {
     await po.getTransactionFormPo().enterAddress(mockBTCAddressTestnet);
 
     await testMax(po);
+  });
+
+  it("should display the amount in fiat value", async () => {
+    setIcpSwapUsdPrices({
+      [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: 10,
+    });
+
+    const po = await renderModalToPo();
+    const formPo = po.getTransactionFormPo();
+    const amountInputPo = formPo.getAmountInputPo();
+
+    expect(await amountInputPo.getAmount()).toBe("");
+    expect(await amountInputPo.getAmountInputFiatValuePo().getFiatValue()).toBe(
+      "$0.00"
+    );
+
+    await amountInputPo.enterAmount(100);
+
+    expect(await amountInputPo.getAmount()).toEqual("100");
+    expect(await amountInputPo.getAmountInputFiatValuePo().getFiatValue()).toBe(
+      "$1’000.00"
+    );
   });
 });

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -29,6 +29,7 @@ import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsStakeNeuronModalPo } from "$tests/page-objects/NnsStakeNeuronModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
+import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -323,6 +324,25 @@ describe("NnsStakeNeuronModal", () => {
 
       await runResolvedPromises();
       expect(onClose).toBeCalledTimes(1);
+    });
+
+    it("should display the amount in fiat value", async () => {
+      setIcpPrice(10);
+
+      const po = await renderComponent({});
+      const amountInputPo = po.getNnsStakeNeuronPo().getAmountInputPo();
+
+      expect(await amountInputPo.getAmount()).toBe("");
+      expect(
+        await amountInputPo.getAmountInputFiatValuePo().getFiatValue()
+      ).toBe("$0.00");
+
+      await amountInputPo.enterAmount(100);
+
+      expect(await amountInputPo.getAmount()).toEqual("100");
+      expect(
+        await amountInputPo.getAmountInputFiatValuePo().getFiatValue()
+      ).toBe("$1’000.00");
     });
 
     describe("public neuron checkbox", () => {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
@@ -12,6 +12,7 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
 import { SnsStakeNeuronModalPo } from "$tests/page-objects/SnsStakeNeuronModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { Principal } from "@dfinity/principal";
@@ -124,6 +125,27 @@ describe("SnsStakeNeuronModal", () => {
       await po.getTransactionFormPo().getAmountInputPo().getErrorMessage()
     ).toBe(
       "Sorry, the amount is too small. You need to stake a minimum of 1 POP."
+    );
+  });
+
+  it("should display the amount in fiat value", async () => {
+    setIcpSwapUsdPrices({
+      [ledgerCanisterId.toText()]: 100,
+    });
+
+    const po = await renderComponent();
+    const amountInputPo = po.getTransactionFormPo().getAmountInputPo();
+
+    expect(await amountInputPo.getAmount()).toBe("");
+    expect(await amountInputPo.getAmountInputFiatValuePo().getFiatValue()).toBe(
+      "$0.00"
+    );
+
+    await amountInputPo.enterAmount(100);
+
+    expect(await amountInputPo.getAmount()).toEqual("100");
+    expect(await amountInputPo.getAmountInputFiatValuePo().getFiatValue()).toBe(
+      "$10’000.00"
     );
   });
 });

--- a/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
@@ -32,6 +32,7 @@ import { ParticipateSwapModalPo } from "$tests/page-objects/ParticipateSwapModal
 import type { TransactionReviewPo } from "$tests/page-objects/TransactionReview.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -244,6 +245,27 @@ describe("ParticipateSwapModal", () => {
       expect(await form.getAmountInputPo().getErrorMessage()).toBe(
         "Sorry, the amount is too small. You need a minimum of 1.00000278 ICP to participate in this swap."
       );
+    });
+
+    it("should display the amount in fiat value", async () => {
+      setIcpSwapUsdPrices({
+        [rootCanisterIdMock.toText()]: 100,
+      });
+
+      const po = await renderSwapModalPo();
+      const amountInputPo = po.getTransactionFormPo().getAmountInputPo();
+
+      expect(await amountInputPo.getAmount()).toBe("");
+      expect(
+        await amountInputPo.getAmountInputFiatValuePo().getFiatValue()
+      ).toBe("$0.00");
+
+      await amountInputPo.enterAmount(200);
+
+      expect(await amountInputPo.getAmount()).toEqual("200");
+      expect(
+        await amountInputPo.getAmountInputFiatValuePo().getFiatValue()
+      ).toBe("$2’000.00");
     });
 
     describe("when user has non-zero swap commitment", () => {

--- a/frontend/src/tests/page-objects/AmountInput.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountInput.page-object.ts
@@ -1,3 +1,4 @@
+import { AmountInputFiatValuePo } from "$tests/page-objects/AmountInputFiatValue.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -26,5 +27,9 @@ export class AmountInputPo extends BasePageObject {
 
   clickMaxButton(): Promise<void> {
     return this.click("max-button");
+  }
+
+  getAmountInputFiatValuePo(): AmountInputFiatValuePo {
+    return AmountInputFiatValuePo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

We want to display the USD value of a transaction being done in ICP. This PR follows up on #6599 and incorporates this new component in the `AmountInput`. Any component that uses it will automatically show the USD value. Displaying the balance or maximum value is already available but will be addressed in a follow-up PR, as it requires changes in the consumers.

https://github.com/user-attachments/assets/3ee55f1e-164b-4fc9-9232-e676b9d24029

[NNS1-3671](https://dfinity.atlassian.net/browse/NNS1-3671)

# Changes

- Expose the newly added slot Gix component `Input` to the nns-dapp `Input`.
- Created a new version of `MaxButton` to be used until the designs for the `DayInput` are ready.
- Display `AmountInputFiatValue` in the newly added slot of `InputWithError`.

# Tests

- Updated tests to check for the usd value.
- Manually tested with other changes in [devenv]()

# Todos

- [x] Add entry to changelog (if necessary).


[NNS1-3671]: https://dfinity.atlassian.net/browse/NNS1-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ