### PR TITLE
feat(validation): add ICP stake amount verification

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Replaces the toaster error with an input error message for the split neuron modal flow.
+* Added client-side validation for staking ICP.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,8 +16,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Added client-side validation for staking ICP.
 * Replaces the toaster error with an input error message for the split neuron modal flow.
+* Added client-side validation for staking ICP.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,6 +19,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Simplified error message display for better readability in form inputs.
 * Added USD equivalent values to amount inputs.
 * Added frontend validation staking ICP.
+* Added client-side validation for staking ICP.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,7 +18,6 @@ proposal is successful, the changes it released will be moved from this file to
 * Added visual feedback while loading exchange rates in canister top-up form.
 * Simplified error message display for better readability in form inputs.
 * Added USD equivalent values to amount inputs.
-* Added frontend validation staking ICP.
 * Added client-side validation for staking ICP.
 
 #### Changed

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,12 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Simplified SNS neuron display by making voting power details expandable on demand
+* Added visual feedback while loading exchange rates in canister top-up form.
+* Simplified error message display for better readability in form inputs.
+* Added USD equivalent values to amount inputs.
+* Added frontend validation staking ICP.
+
 #### Changed
 
 * Replaces the toaster error with an input error message for the split neuron modal flow.

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,12 +14,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Simplified SNS neuron display by making voting power details expandable on demand
-* Added visual feedback while loading exchange rates in canister top-up form.
-* Simplified error message display for better readability in form inputs.
-* Added USD equivalent values to amount inputs.
-* Added client-side validation for staking ICP.
-
 #### Changed
 
 * Replaces the toaster error with an input error message for the split neuron modal flow.

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Added client-side validation for staking ICP.
+* Replaces the toaster error with an input error message for the split neuron modal flow.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -88,6 +88,14 @@
     }
   })();
 
+  let disableButton: boolean;
+  $: disableButton =
+    isNullish(amount) ||
+    isNullish(account) ||
+    nonNullish(errorMessage) ||
+    amount <= 0 ||
+    $busy;
+
   const stakeMaximum = () => (amount = max);
   const close = () => dispatcher("nnsClose");
 
@@ -113,6 +121,7 @@
     token={ICPToken}
     {max}
     {balance}
+    {errorMessage}
   />
 
   <TransactionFormFee transactionFee={$mainTransactionFeeStoreAsToken} />

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -16,9 +16,10 @@
   import { toastsError } from "$lib/stores/toasts.store";
   import type { Account } from "$lib/types/account";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
-  import { getMaxTransactionAmount } from "$lib/utils/token.utils";
-  import { Checkbox, busy } from "@dfinity/gix-components";
-  import { ICPToken, isNullish } from "@dfinity/utils";
+  import { isEnoughToStakeNeuron } from "$lib/utils/neuron.utils";
+  import { getMaxTransactionAmount, numberToE8s } from "$lib/utils/token.utils";
+  import { busy, Checkbox } from "@dfinity/gix-components";
+  import { ICPToken, isNullish, nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let account: Account | undefined;
@@ -70,8 +71,24 @@
     token: ICPToken,
   });
 
-  const stakeMaximum = () => (amount = max);
+  let errorMessage: string | undefined = undefined;
+  $: (() => {
+    if (isNullish(amount) || isNullish(account)) {
+      errorMessage = undefined;
+      return;
+    }
 
+    if (amount > max) {
+      errorMessage = $i18n.error.insufficient_funds;
+      return;
+    }
+    if (!isEnoughToStakeNeuron({ stakeE8s: numberToE8s(amount) })) {
+      errorMessage = $i18n.error.amount_not_enough_stake_neuron;
+      return;
+    }
+  })();
+
+  const stakeMaximum = () => (amount = max);
   const close = () => dispatcher("nnsClose");
 
   let balance: bigint | undefined;
@@ -130,10 +147,7 @@
       class="primary"
       type="submit"
       data-tid="create-neuron-button"
-      disabled={amount === undefined ||
-        amount <= 0 ||
-        $busy ||
-        isNullish(account)}
+      disabled={disableButton}
     >
       {$i18n.neurons.create}
     </button>

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -17,6 +17,7 @@ import {
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
@@ -160,6 +161,52 @@ describe("NnsStakeNeuronModal", () => {
         loadNeuron: true,
         asPublicNeuron: false,
       });
+    });
+
+    it("should show an error if amount is less than min stake", async () => {
+      const po = await renderComponent({});
+
+      expect(
+        await po.getNnsStakeNeuronPo().getCreateButtonPo().isDisabled()
+      ).toBe(true);
+      expect(await po.getNnsStakeNeuronPo().getAmountInputPo().hasError()).toBe(
+        false
+      );
+
+      await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(0.1);
+
+      expect(
+        await po.getNnsStakeNeuronPo().getCreateButtonPo().isDisabled()
+      ).toBe(true);
+      expect(await po.getNnsStakeNeuronPo().getAmountInputPo().hasError()).toBe(
+        true
+      );
+      expect(
+        await po.getNnsStakeNeuronPo().getAmountInputPo().getErrorMessage()
+      ).toBe(en.error.amount_not_enough_stake_neuron);
+    });
+
+    it("should show an error if amount is more than min balance", async () => {
+      const po = await renderComponent({});
+
+      expect(
+        await po.getNnsStakeNeuronPo().getCreateButtonPo().isDisabled()
+      ).toBe(true);
+      expect(await po.getNnsStakeNeuronPo().getAmountInputPo().hasError()).toBe(
+        false
+      );
+
+      await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(100000000);
+
+      expect(
+        await po.getNnsStakeNeuronPo().getCreateButtonPo().isDisabled()
+      ).toBe(true);
+      expect(await po.getNnsStakeNeuronPo().getAmountInputPo().hasError()).toBe(
+        true
+      );
+      expect(
+        await po.getNnsStakeNeuronPo().getAmountInputPo().getErrorMessage()
+      ).toBe(en.error.insufficient_funds);
     });
 
     it("should move to update dissolve delay after creating a neuron", async () => {


### PR DESCRIPTION
# Motivation

We want to inform users that the amount of ICP they are attempting to stake is invalid. We already do this for staking SNS tokens and for transactions.

Before:

https://github.com/user-attachments/assets/d921509d-e8b1-46c1-8a88-c4e5eb139cb6

After:

https://github.com/user-attachments/assets/ffdfa369-a330-4baf-be64-e20a4289f134


[NNS1-3688](https://dfinity.atlassian.net/browse/NNS1-3688)

# Changes

- Adds front-end validation to the `NnsStakeNeuron` component

# Tests

- Extends tests to verify that error messages are presented when the input is invalid.

# Todos

- [x] Add entry to changelog (if necessary).


[NNS1-3688]: https://dfinity.atlassian.net/browse/NNS1-3688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ