### PR TITLE
fix(validation): handle non-finite numbers in amount inputs

### DIFF
--- a/frontend/src/lib/components/ui/AmountInputFiatValue.svelte
+++ b/frontend/src/lib/components/ui/AmountInputFiatValue.svelte
@@ -10,10 +10,10 @@
   import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
   import type { Principal } from "@dfinity/principal";
   import {
-      isNullish,
-      nonNullish,
-      TokenAmountV2,
-      type Token,
+    isNullish,
+    nonNullish,
+    TokenAmountV2,
+    type Token,
   } from "@dfinity/utils";
 
   export let amount: number = 0;

--- a/frontend/src/tests/lib/components/ui/AmountInputFiatValue.spec.ts
+++ b/frontend/src/tests/lib/components/ui/AmountInputFiatValue.spec.ts
@@ -37,6 +37,13 @@ describe("AmountInputFiatValue", () => {
     });
 
     expect(await po.getFiatValue()).toBe("$50’000.00");
+
+    const updatedPo = renderComponent({
+      amount: 0.2,
+      token: ICPToken,
+    });
+
+    expect(await updatedPo.getFiatValue()).toBe("$2.00");
   });
 
   it("should not display balance when balance prop is not provided", async () => {
@@ -161,5 +168,22 @@ describe("AmountInputFiatValue", () => {
     });
 
     expect(await updatedPo.getFiatValue()).toBe("$100.00");
+  });
+
+  it("should render a placeholder text if the input(amount) is not valid", async () => {
+    setIcpPrice(10);
+    const po = renderComponent({
+      amount: 5,
+      token: ICPToken,
+    });
+
+    expect(await po.getFiatValue()).toBe("$50.00");
+
+    const updatedPo = renderComponent({
+      amount: Number.POSITIVE_INFINITY,
+      token: ICPToken,
+    });
+
+    expect(await updatedPo.getFiatValue()).toBe("$-/-");
   });
 });


### PR DESCRIPTION
# Motivation

We want to handle invalid user inputs. The input already checks for the numeric type but users can still enter non-finite numbers. In this case we want to show a placeholder text to the user.

https://github.com/user-attachments/assets/cb03fc06-36c2-4d08-8760-d4a76ca23f0b

[NNS1-3671](https://dfinity.atlassian.net/browse/NNS1-3671)

# Changes

- Validate user input and render placeholder for invalid values

# Tests

- Added unit tests to cover invalid inputs

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3671]: https://dfinity.atlassian.net/browse/NNS1-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ