### PR TITLE
refactor(validation): adds inline error message for neuron split modal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Move the balance or maximum amount from the transaction address to the amount inputs below.
 * Replaces the toaster error with an input error message for the split neuron modal flow.
 
 #### Deprecated

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,9 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Move the balance or maximum amount from the transaction address to the amount inputs below.
+* Replaces the toaster error with an input error message for the split neuron modal flow.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -39,20 +39,20 @@
         });
 
   let validForm: boolean;
-  $: validForm = isValidInputAmount({ amount, max });
+  $: validForm = isValidInputAmount(amount, max);
 
   const onMax = () => (amount = max);
 
   const dispatcher = createEventDispatcher();
   const close = () => dispatcher("nnsClose");
   const split = async () => {
-    // TS is not smart enought to understand that `validForm` also covers `amount === undefined`
-    if (!validForm || amount === undefined) {
+    if (!isValidInputAmount(amount, max)) {
       toastsError({
         labelKey: "error.amount_not_valid",
       });
       return;
     }
+
     const hwControlled = isNeuronControlledByHardwareWallet({
       neuron,
       accounts: $icpAccountsStore,

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -14,9 +14,14 @@
     neuronStake,
   } from "$lib/utils/neuron.utils";
   import { ulpsToNumber } from "$lib/utils/token.utils";
-  import { Modal, busy } from "@dfinity/gix-components";
+  import { busy, Modal } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+  import {
+    ICPToken,
+    isNullish,
+    TokenAmount,
+    TokenAmountV2,
+  } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   export let neuron: NeuronInfo;
@@ -42,7 +47,8 @@
   $: validForm = isValidInputAmount(amount, max);
 
   let errorMessage: string | undefined;
-  $: errorMessage = validForm ? undefined : $i18n.error.amount_not_valid;
+  $: errorMessage =
+    isNullish(amount) || validForm ? undefined : $i18n.error.amount_not_valid;
 
   const onMax = () => (amount = max);
 

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -7,7 +7,7 @@
   import { splitNeuron } from "$lib/services/neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
+  import { toastsSuccess } from "$lib/stores/toasts.store";
   import {
     isNeuronControlledByHardwareWallet,
     isValidInputAmount,
@@ -41,17 +41,15 @@
   let validForm: boolean;
   $: validForm = isValidInputAmount(amount, max);
 
+  let errorMessage: string | undefined;
+  $: errorMessage = validForm ? undefined : $i18n.error.amount_not_valid;
+
   const onMax = () => (amount = max);
 
   const dispatcher = createEventDispatcher();
   const close = () => dispatcher("nnsClose");
   const split = async () => {
-    if (!isValidInputAmount(amount, max)) {
-      toastsError({
-        labelKey: "error.amount_not_valid",
-      });
-      return;
-    }
+    if (!isValidInputAmount(amount, max)) return;
 
     const hwControlled = isNeuronControlledByHardwareWallet({
       neuron,
@@ -82,7 +80,13 @@
   >
   <div class="wrapper" data-tid="split-neuron-modal">
     <CurrentBalance {balance} />
-    <AmountInput bind:amount on:nnsMax={onMax} {max} token={ICPToken} />
+    <AmountInput
+      bind:amount
+      on:nnsMax={onMax}
+      token={ICPToken}
+      {max}
+      {errorMessage}
+    />
     <TransactionFormFee
       transactionFee={TokenAmount.fromE8s({
         amount: BigInt($mainTransactionFeeE8sStore),

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -50,7 +50,7 @@
         Number(E8S_PER_ICP);
 
   let validForm: boolean;
-  $: validForm = isValidInputAmount({ amount, max });
+  $: validForm = isValidInputAmount(amount, max);
 
   const onMax = () => (amount = max);
 
@@ -58,8 +58,7 @@
   const close = () => dispatcher("nnsClose");
 
   const split = async () => {
-    // TS is not smart enough to understand that `validForm` also covers `amount === undefined`
-    if (!validForm || amount === undefined) {
+    if (!isValidInputAmount(amount, max)) {
       toastsError({
         labelKey: "error.amount_not_valid",
       });

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -6,7 +6,7 @@
   import { splitNeuron } from "$lib/services/sns-neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
+  import { toastsSuccess } from "$lib/stores/toasts.store";
   import { isValidInputAmount } from "$lib/utils/neuron.utils";
   import { getSnsNeuronStake } from "$lib/utils/sns-neuron.utils";
   import { busy, Modal } from "@dfinity/gix-components";
@@ -52,18 +52,16 @@
   let validForm: boolean;
   $: validForm = isValidInputAmount(amount, max);
 
+  let errorMessage: string | undefined;
+  $: errorMessage = validForm ? undefined : $i18n.error.amount_not_valid;
+
   const onMax = () => (amount = max);
 
   const dispatcher = createEventDispatcher();
   const close = () => dispatcher("nnsClose");
 
   const split = async () => {
-    if (!isValidInputAmount(amount, max)) {
-      toastsError({
-        labelKey: "error.amount_not_valid",
-      });
-      return;
-    }
+    if (!isValidInputAmount(amount, max)) return;
 
     startBusy({ initiator: "split-sns-neuron" });
 
@@ -94,7 +92,7 @@
   >
   <div class="wrapper" data-tid="split-neuron-modal">
     <CurrentBalance {balance} />
-    <AmountInput bind:amount on:nnsMax={onMax} {max} {token} />
+    <AmountInput bind:amount on:nnsMax={onMax} {max} {token} {errorMessage} />
     <TransactionFormFee
       transactionFee={TokenAmount.fromE8s({
         amount: transactionFee,

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -15,6 +15,7 @@
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import {
     fromDefinedNullable,
+    isNullish,
     TokenAmount,
     TokenAmountV2,
     type Token,
@@ -53,7 +54,8 @@
   $: validForm = isValidInputAmount(amount, max);
 
   let errorMessage: string | undefined;
-  $: errorMessage = validForm ? undefined : $i18n.error.amount_not_valid;
+  $: errorMessage =
+    isNullish(amount) || validForm ? undefined : $i18n.error.amount_not_valid;
 
   const onMax = () => (amount = max);
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -752,14 +752,6 @@ export const isValidInputAmount = (
   max: number
 ): amount is number => amount !== undefined && amount > 0 && amount <= max;
 
-// export const isValidInputAmount = (params: {
-//   amount?: number;
-//   max: number;
-// }): params is { amount: number; max: number } =>
-//   params.amount !== undefined &&
-//   params.amount > 0 &&
-//   params.amount <= params.max;
-
 export const isEnoughToStakeNeuron = ({
   stakeE8s,
   feeE8s = 0n,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -747,13 +747,18 @@ export const ballotsWithDefinedProposal = ({
     ({ proposalId }: BallotInfo) => proposalId !== undefined
   );
 
-export const isValidInputAmount = ({
-  amount,
-  max,
-}: {
-  amount?: number;
-  max: number;
-}): boolean => amount !== undefined && amount > 0 && amount <= max;
+export const isValidInputAmount = (
+  amount: number | undefined,
+  max: number
+): amount is number => amount !== undefined && amount > 0 && amount <= max;
+
+// export const isValidInputAmount = (params: {
+//   amount?: number;
+//   max: number;
+// }): params is { amount: number; max: number } =>
+//   params.amount !== undefined &&
+//   params.amount > 0 &&
+//   params.amount <= params.max;
 
 export const isEnoughToStakeNeuron = ({
   stakeE8s,

--- a/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
@@ -43,7 +43,14 @@ describe("SplitNeuronModal", () => {
     expect(splitButton?.getAttribute("disabled")).not.toBeNull();
   });
 
-  it("should have disabled button if value is 0", async () => {
+  it("should not display error message by default", async () => {
+    const { queryByTestId } = await renderSplitNeuronModal(mockNeuron);
+
+    const errorMessage = queryByTestId("input-error-message");
+    expect(errorMessage).toBeNull();
+  });
+
+  it("should have disabled button and error message if value is 0", async () => {
     const { queryByTestId } = await renderSplitNeuronModal(mockNeuron);
 
     const inputElement = queryByTestId("input-ui-element");
@@ -54,6 +61,9 @@ describe("SplitNeuronModal", () => {
 
     const splitButton = queryByTestId("split-neuron-button");
     expect(splitButton?.getAttribute("disabled")).not.toBeNull();
+
+    const errorMessage = queryByTestId("input-error-message");
+    expect(errorMessage).not.toBeNull();
   });
 
   it("should start busy screen with message if controlled by HW", async () => {
@@ -102,6 +112,9 @@ describe("SplitNeuronModal", () => {
     expect(splitButton).not.toBeNull();
     expect(splitButton?.getAttribute("disabled")).toBeNull();
 
+    const errorMessage = queryByTestId("input-error-message");
+    expect(errorMessage).toBeNull();
+
     splitButton && (await fireEvent.click(splitButton));
 
     expect(splitNeuron).toHaveBeenCalled();
@@ -109,5 +122,31 @@ describe("SplitNeuronModal", () => {
     expect(startBusySpy).toHaveBeenCalledWith({
       initiator: "split-neuron",
     });
+  });
+
+  it("should have disabled button and error message if value is bigger than max", async () => {
+    const value = 10;
+    const mockNeuronWithSmallerStake = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        cachedNeuronStake: 1n,
+      },
+    };
+    const { queryByTestId } = await renderSplitNeuronModal(
+      mockNeuronWithSmallerStake
+    );
+
+    const inputElement = queryByTestId("input-ui-element");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, { target: { value } }));
+
+    const splitButton = queryByTestId("split-neuron-button");
+    expect(splitButton?.getAttribute("disabled")).not.toBeNull();
+
+    const errorMessage = queryByTestId("input-error-message");
+    expect(errorMessage).not.toBeNull();
   });
 });

--- a/frontend/src/tests/lib/modals/sns/neurons/SplitSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SplitSnsNeuronModal.spec.ts
@@ -65,7 +65,7 @@ describe("SplitSnsNeuronModal", () => {
     expect(errorMessage).not.toBeNull();
   });
 
-  it("should have not disabled button and no error message if value is valid", async () => {
+  it("should enable button and display no error message when input is valid", async () => {
     const value = 10;
     const stake = 10_000_000_000n;
     const { queryByTestId } = await renderSplitNeuronModal(stake);

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1249,15 +1249,24 @@ describe("neuron-utils", () => {
 
   describe("isValidInputAmount", () => {
     it("return false if amount is undefined", () => {
-      expect(isValidInputAmount({ amount: undefined, max: 10 })).toBe(false);
+      const amount = undefined;
+      const max = 10;
+
+      expect(isValidInputAmount(amount, max)).toBe(false);
     });
 
     it("return true if amount is lower than max", () => {
-      expect(isValidInputAmount({ amount: 3, max: 10 })).toBe(true);
+      const amount = 3;
+      const max = 10;
+
+      expect(isValidInputAmount(amount, max)).toBe(true);
     });
 
     it("return false if amount is higher than max", () => {
-      expect(isValidInputAmount({ amount: 40, max: 10 })).toBe(false);
+      const amount = 40;
+      const max = 10;
+
+      expect(isValidInputAmount(amount, max)).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Motivation

Similar to #6602, we want to implement client validation to check whether the value provided by the user for splitting a neuron is valid. If it is not valid, we will display a message below the input field instead of using a toast message.

In this PR, we address both flows: NNS and SNS for splitting neurons.

Before:

https://github.com/user-attachments/assets/756f468c-a134-462e-91da-8161642d8eae

After:

https://github.com/user-attachments/assets/291ae9e7-13d7-4eea-9ea8-f2da0796e6f6

[NNS1-3690](https://dfinity.atlassian.net/browse/NNS1-3690)

# Changes

- Refactor `isValidInputForm` from a utility function to a type predicate. This change helps TypeScript recognize that `amount` is defined when `isValidInputForm` returns true.  
- Move the validation to the `split` closure for better clarity.  
- Remove the toaster message, as it was unnecessary; the button was disabled when `isValidInputForm` was false.  Additionally, it wasn't cover by tests.
- Reuse the toaster message as an input error message.

# Tests

- Refactor `isValidInputForm` to ensure compatibility with the new function signature.  
- Add a test to verify that the error message is displayed correctly.

# Todos

- [x] Add entry to changelog (if necessary).

[NNS1-3690]: https://dfinity.atlassian.net/browse/NNS1-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ