### PR TITLE
Svelte v5 test fix 3

### DIFF
--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -45,6 +45,7 @@ describe("ProjectsTable", () => {
   };
 
   beforeEach(() => {
+    vi.useFakeTimers();
     resetIdentity();
 
     page.mock({
@@ -821,7 +822,7 @@ describe("ProjectsTable", () => {
       expect(await po.getBackdropPo().isPresent()).toBe(true);
 
       await po.getBackdropPo().click();
-      await runResolvedPromises();
+      vi.advanceTimersByTime(500);
 
       expect(await po.getHideZeroNeuronsTogglePo().isPresent()).toBe(false);
       expect(await po.getBackdropPo().isPresent()).toBe(false);
@@ -849,7 +850,7 @@ describe("ProjectsTable", () => {
 
       await po.getSettingsButtonPo().click();
       await po.getHideZeroNeuronsTogglePo().getTogglePo().toggle();
-      await runResolvedPromises();
+      vi.advanceTimersByTime(500);
 
       rowPos = await po.getProjectsTableRowPos();
       expect(rowPos.length).toBe(0);

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -420,7 +420,11 @@ describe("ResponsiveTable", () => {
     ];
 
     const rows = await po.getRows();
+    const rowStyles = await rows[0].getCellStyles();
     expect(rows).toHaveLength(3);
-    expect(await rows[0].getCellStyles()).toEqual(expectedStyles);
+    for (let i = 0; i < rowStyles.length; i++) {
+      // Remove whitespace between semicolons to make the comparison easier.
+      expect(rowStyles[i].replace(/;\s/g, ";")).toEqual(expectedStyles[i]);
+    }
   });
 });

--- a/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -6,6 +6,7 @@ import { addSubAccount } from "$lib/services/icp-accounts.services";
 import en from "$tests/mocks/i18n.mock";
 import { MockLedgerIdentity } from "$tests/mocks/ledger.identity.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
@@ -203,6 +204,8 @@ describe("AddAccountModal", () => {
     const renderResult = await renderModal({ component: AddAccountModal });
 
     await shouldNavigateSubaccountStep(renderResult);
+    // Wait for the step content to be fully rendered
+    await runResolvedPromises();
 
     const { getByTestId, getByText } = renderResult;
     await goBack({


### PR DESCRIPTION
# Motivation

We want to stay up-to-date with the tooling for best practices and security reasons ([see related PR](https://github.com/dfinity/nns-dapp/pull/6020)).

Some tests broke after the upgrade, so this PR updates them to ensure they pass with the new setup.

# Changes

- **ProjectsTable.spec.ts** – `runResolvedPromises` is no longer sufficient, likely due to animations. Using `advanceTimersByTime(500+)` resolves the issue.
- **ResponsiveTable.spec.ts** – After the upgrade, CSS expressions in the `style` attribute may include extra spaces, especially in manually composed styles. Adjusted the test to handle this.
- **AddAccountModal.spec.ts** – Added a wait to ensure the content is rendered before assertions run.

# Tests

- Yes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.