### PR TITLE
style(format): trim trailing zeros in transfer fee display

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -41,11 +41,7 @@
   </p>
 
   <p class="value">
-    <AmountDisplay
-      amount={transactionFee}
-      singleLine
-      detailed="height_decimals"
-    />
+    <AmountDisplay amount={transactionFee} singleLine />
     <span class="usd-value" data-tid="transaction-form-fee-usd-value">
       {usdValueDisplay}
     </span>

--- a/frontend/src/tests/lib/components/transaction/TransactionFormFee.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionFormFee.spec.ts
@@ -20,8 +20,7 @@ describe("TransactionFormFee", () => {
     });
     const po = renderComponent({ transactionFee });
 
-    // TODO(yhabib): Fix the implementation to not show so many decimals
-    expect(await po.getAmountDisplayPo().getText()).toBe("0.10000000 ICP");
+    expect(await po.getAmountDisplayPo().getText()).toBe("0.10 ICP");
   });
 
   it("should display the USD value without 'less than' sign when above or equal to $0.01", async () => {

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -425,7 +425,7 @@ describe("Staking", () => {
           .getTransactionFormFeePo()
           .getAmountDisplayPo()
           .getAmount()
-      ).toBe("0.00123000");
+      ).toBe("0.00123");
 
       await modal.getTransactionFormPo().enterAmount(1);
       expect(await modal.getTransactionFormPo().isContinueButtonEnabled()).toBe(


### PR DESCRIPTION
# Motivation

We want to hide extra zeros from the transaction transfer fee, as they do not provide any value to the users. The number of zeros being hidden depends on the token and its decimal part.

Before:

<img width="698" alt="Screenshot 2025-03-23 at 14 00 34" src="https://github.com/user-attachments/assets/8a40c9ff-3527-4c82-b0c6-4575d533305b" />

After:

<img width="719" alt="Screenshot 2025-03-23 at 14 00 50" src="https://github.com/user-attachments/assets/a3b16330-1196-4166-a492-2e95d28a7ce8" />

[NNS1-3705](https://dfinity.atlassian.net/browse/NNS1-3705)

# Changes

- Hide extra decimal zeros from transfer fee

# Tests

- Update the unit tests to reflect the new expectations for the transfer fee.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3705]: https://dfinity.atlassian.net/browse/NNS1-3705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ