### PR TITLE
refactor(nav): standardize portfolio route to root path

### DIFF
--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -13,7 +13,8 @@ export enum AppPath {
   Settings = "/settings",
   Tokens = "/tokens",
   Reporting = "/reporting",
-  Portfolio = "/portfolio",
+  // We point to the home page to prevent different tracking for both pages
+  Portfolio = "/",
 }
 
 // SvelteKit uses the group defined in src/routes/(app)/ as part of the routeId. It also prefixes it with /.

--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -18,6 +18,7 @@ export const accountsPageOrigin: Readable<AppPath> = derived(
       .reverse()
       .slice(0, 3)
       .find((path) => path === AppPath.Portfolio || path === AppPath.Tokens);
+
     return lastPath ?? AppPath.Tokens;
   }
 );

--- a/frontend/src/lib/utils/page.utils.ts
+++ b/frontend/src/lib/utils/page.utils.ts
@@ -28,10 +28,13 @@ export const pathForRouteId = (routeId: string | null | undefined): AppPath => {
       routeId
     );
 
+  const pathWithoutGroups = routeIdWithoutGroups(routeId);
+  const normalizedPath =
+    pathWithoutGroups === "/"
+      ? pathWithoutGroups
+      : pathWithoutGroups.replace(/\/$/, "");
   const index = Object.values(AppPath).indexOf(
-    routeIdWithoutGroups(routeId)
-      // Remove trailing slash if present
-      .replace(/\/$/, "") as unknown as AppPath
+    normalizedPath as unknown as AppPath
   );
 
   const key = Object.keys(AppPath)[index];

--- a/frontend/src/tests/routes/app/accounts/layout.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/layout.spec.ts
@@ -76,7 +76,7 @@ describe("Accounts layout", () => {
     expect(get(pageStore).path).toEqual(AppPath.Tokens);
   });
 
-  it("back button should navigate to tokens page when coming from Portfolio page", async () => {
+  it("back button should navigate to portfolio page when coming from portfolio page", async () => {
     referrerPathStore.pushPath(AppPath.Portfolio);
     page.mock({
       routeId: AppPath.Accounts,

--- a/frontend/src/tests/routes/app/neurons/layout.spec.ts
+++ b/frontend/src/tests/routes/app/neurons/layout.spec.ts
@@ -42,7 +42,8 @@ describe("Neurons layout", () => {
     expect(get(pageStore).path).toBe(AppPath.Staking);
   });
 
-  it("should navigate back to Portfolio page if previous page was Portfolio page", async () => {
+  it.only("should navigate back to Portfolio page if previous page was Portfolio page", async () => {
+    // overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
     page.mock({
       routeId: AppPath.Neurons,
     });

--- a/frontend/src/tests/routes/app/neurons/layout.spec.ts
+++ b/frontend/src/tests/routes/app/neurons/layout.spec.ts
@@ -42,8 +42,7 @@ describe("Neurons layout", () => {
     expect(get(pageStore).path).toBe(AppPath.Staking);
   });
 
-  it.only("should navigate back to Portfolio page if previous page was Portfolio page", async () => {
-    // overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
+  it("should navigate back to Portfolio page if previous page was Portfolio page", async () => {
     page.mock({
       routeId: AppPath.Neurons,
     });


### PR DESCRIPTION
# Motivation

We don't want to expose the `/portfolio` in the navigation menu of the app to avoid multiple entries for the same page and improve data quality.

# Changes

- Change relative link in the navigation bar from `/portfolio` to `/`.
- Update `pathForRouteId` to recognize `/` as a potential route to be used for the portfolio page.

# Tests

- Update tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.