### PR TITLE
chore: bump agent-js to 2.4.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.109",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@dfinity/agent": "^2.3.0",
+        "@dfinity/agent": "^2.4.0",
         "@dfinity/auth-client": "^2.3.0",
         "@dfinity/candid": "^2.3.0",
         "@dfinity/ckbtc": "next",
@@ -316,9 +316,10 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
-      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.0.tgz",
+      "integrity": "sha512-9ez+lgQr09jUonYUw1NRxPG81yGVillKp0hp79WQ3o/XDn6wbDq/YcMh3/62z8PpGJRLyt2+FlE3pxoGlzWHbw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -328,8 +329,8 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/candid": "^2.4.0",
+        "@dfinity/principal": "^2.4.0"
       }
     },
     "node_modules/@dfinity/auth-client": {
@@ -346,11 +347,12 @@
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
-      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.0.tgz",
+      "integrity": "sha512-ZVuBIFlWOZOvEZaLtBKE2666rab32XSdHo1BtzdDy36NMvQbRXkZRbIEd7xoZXRud2wK7pk5cNsZULnXghAORg==",
+      "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/principal": "^2.4.0"
       }
     },
     "node_modules/@dfinity/ckbtc": {
@@ -466,9 +468,10 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
-      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.0.tgz",
+      "integrity": "sha512-gBKCyxrPYKdqHVk/Qh9cfxN0Hnt4BvRYVo5KgNEAOKyoySCIPO39xlcfE6JJzWtLqEftQLMbeSMrLrTHDdMZ5w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.1"
       }
@@ -7161,9 +7164,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
-      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.0.tgz",
+      "integrity": "sha512-9ez+lgQr09jUonYUw1NRxPG81yGVillKp0hp79WQ3o/XDn6wbDq/YcMh3/62z8PpGJRLyt2+FlE3pxoGlzWHbw==",
       "requires": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -7182,9 +7185,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
-      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.0.tgz",
+      "integrity": "sha512-ZVuBIFlWOZOvEZaLtBKE2666rab32XSdHo1BtzdDy36NMvQbRXkZRbIEd7xoZXRud2wK7pk5cNsZULnXghAORg==",
       "requires": {}
     },
     "@dfinity/ckbtc": {
@@ -7252,9 +7255,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
-      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.0.tgz",
+      "integrity": "sha512-gBKCyxrPYKdqHVk/Qh9cfxN0Hnt4BvRYVo5KgNEAOKyoySCIPO39xlcfE6JJzWtLqEftQLMbeSMrLrTHDdMZ5w==",
       "requires": {
         "@noble/hashes": "^1.3.1"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@dfinity/agent": "^2.3.0",
+    "@dfinity/agent": "^2.4.0",
     "@dfinity/auth-client": "^2.3.0",
     "@dfinity/candid": "^2.3.0",
     "@dfinity/ckbtc": "next",


### PR DESCRIPTION
# Motivation

1. Keep our dependencies up to date.
2. A bug in [agent-js](https://github.com/dfinity/agent-js/pull/981) that caused issues decoding variants from candid

# Changes

1. Ran `npm i @dfinity/agent@latest`.

# Tests

1. Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary