### PR TITLE
refactor(content): simplify exchange rate source text

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -290,7 +290,7 @@
     "transaction_time_seconds": "Seconds",
     "token_price_error": "ICPSwap API is currently unavailable, token prices cannot be fetched at the moment.",
     "unpriced_tokens_warning": "Value may be inaccurate as some prices could not be fetched.",
-    "token_price_source": "Token prices are in ckUSDC based on data provided by ICPSwap."
+    "token_price_source": "Token prices are based on data provided by ICPSwap."
   },
   "neuron_types": {
     "seed": "Seed",

--- a/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
@@ -176,7 +176,7 @@ describe("WalletPageHeading", () => {
     expect(await po.hasBalanceInUsd()).toBe(true);
     expect(await po.getBalanceInUsd()).toBe("$30.00");
     expect(await po.getTooltipIconPo().getTooltipText()).toBe(
-      "Token prices are in ckUSDC based on data provided by ICPSwap."
+      en.accounts.token_price_source
     );
   });
 

--- a/frontend/src/tests/lib/components/common/HeadingSubtitleWithUsdValue.spec.ts
+++ b/frontend/src/tests/lib/components/common/HeadingSubtitleWithUsdValue.spec.ts
@@ -1,6 +1,7 @@
 import HeadingSubtitleWithUsdValue from "$lib/components/common/HeadingSubtitleWithUsdValue.svelte";
 import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import en from "$tests/mocks/i18n.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { HeadingSubtitleWithUsdValuePo } from "$tests/page-objects/HeadingSubtitleWithUsdValue.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -47,7 +48,7 @@ describe("HeadingSubtitleWithUsdValue", () => {
     expect(await po.hasAmountInUsd()).toBe(true);
     expect(await po.getAmountInUsd()).toBe("$30.00");
     expect(await po.getTooltipIconPo().getTooltipText()).toBe(
-      "Token prices are in ckUSDC based on data provided by ICPSwap."
+      en.accounts.token_price_source
     );
   });
 

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -699,9 +699,7 @@ describe("ProjectsTable", () => {
       ).toBe(false);
       expect(
         await po.getUsdValueBannerPo().getIcpExchangeRatePo().getTooltipText()
-      ).toBe(
-        "1 ICP = $10.00 Token prices are in ckUSDC based on data provided by ICPSwap."
-      );
+      ).toBe(`1 ICP = $10.00 ${en.accounts.token_price_source}`);
     });
 
     it("should ignore tokens with unknown balance in USD when adding up the total", async () => {


### PR DESCRIPTION
# Motivation

We want to simplify the text in the exchange rate tooltip.

# Changes

- Change copy for `token_price_source`

# Tests

- Update tests to check against the translation key.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary