### PR TITLE
sns topics: Topic item component

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import {
+    Checkbox,
+    Collapsible,
+    IconErrorOutline,
+    IconExpandMore,
+  } from "@dfinity/gix-components";
+  import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
+  import { fromDefinedNullable } from "@dfinity/utils";
+  import type { SnsTopicKey } from "$lib/types/sns";
+  import { getSnsTopicInfoKey } from "$lib/utils/sns-topics.utils";
+
+  export let topicInfo: TopicInfoWithUnknown;
+  export let checked: boolean = false;
+  export let onNnsChange: (args: {
+    topicKey: SnsTopicKey;
+    checked: boolean;
+  }) => void;
+
+  let topicKey: SnsTopicKey;
+  $: topicKey = getSnsTopicInfoKey(topicInfo);
+  let name: string;
+  $: name = fromDefinedNullable(topicInfo.name);
+  let description: string;
+  $: description = fromDefinedNullable(topicInfo.description);
+
+  const onChange = () => {
+    // Checkbox doesn't support two-way binding
+    checked = !checked;
+    onNnsChange({ topicKey, checked });
+  };
+
+  let toggleContent: () => void;
+  let expanded: boolean;
+</script>
+
+<div class="topic-item" data-tid="follow-sns-neurons-by-topic-item-component">
+  <Collapsible
+    testId="topic-collapsible"
+    expandButton={false}
+    externalToggle={true}
+    bind:toggleContent
+    bind:expanded
+    wrapHeight
+  >
+    <div slot="header" class="header" class:expanded>
+      <Checkbox
+        inputId={topicKey}
+        text="block"
+        {checked}
+        on:nnsChange={onChange}
+        preventDefault
+        stopPropagation
+        --checkbox-label-order="1"
+        --checkbox-padding="var(--padding) 0"
+      >
+        <span data-tid="topic-name">{name}</span>
+      </Checkbox>
+
+      <!-- TODO: display following status -->
+      <div class="icon" data-tid="topic-following-status">
+        <IconErrorOutline />
+      </div>
+
+      <button
+        data-tid="expand-button"
+        class="expand-button"
+        class:expanded
+        on:click|stopPropagation={toggleContent}
+      >
+        <IconExpandMore />
+      </button>
+    </div>
+    <div class="expandable-content">
+      <p class="description" data-tid="topic-description">
+        {description}
+      </p>
+    </div>
+  </Collapsible>
+</div>
+
+<style lang="scss">
+  .header {
+    display: grid;
+    grid-template-columns: auto min-content min-content;
+    gap: var(--padding);
+    align-items: center;
+
+    // stretching to the full Collapsible header width
+    flex: 1 1 100%;
+  }
+
+  .expand-button {
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary);
+
+    transition: transform ease-out var(--animation-time-normal);
+    &.expanded {
+      transform: rotate(-180deg);
+    }
+  }
+
+  .expandable-content {
+    // Aligning with the checkbox label
+    margin-left: calc(20px + var(--padding));
+
+    .description {
+      margin: 0 0 var(--padding-3x);
+    }
+  }
+</style>

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
@@ -32,6 +32,9 @@
 
   let toggleContent: () => void;
   let expanded: boolean;
+
+  // TODO(sns-topics): Add "stopPropagation" prop to the gix/Checkbox component
+  // to avoid collapsable toggling
 </script>
 
 <div class="topic-item" data-tid="follow-sns-neurons-by-topic-item-component">
@@ -50,7 +53,6 @@
         {checked}
         on:nnsChange={onChange}
         preventDefault
-        stopPropagation
         --checkbox-label-order="1"
         --checkbox-padding="var(--padding) 0"
       >

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
@@ -68,7 +68,7 @@
         data-tid="expand-button"
         class="expand-button"
         class:expanded
-        on:click|stopPropagation={toggleContent}
+        on:click={toggleContent}
       >
         <IconExpandMore />
       </button>

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
@@ -29,7 +29,7 @@ describe("FollowSnsNeuronsByTopicItem", () => {
   const renderComponent = (props: {
     topicInfo: TopicInfoWithUnknown;
     checked: boolean;
-    onNnsChange?: () => void;
+    onNnsChange: () => void;
   }) => {
     const { container } = render(FollowSnsNeuronsByTopicItem, {
       props,

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
@@ -1,0 +1,82 @@
+import FollowSnsNeuronsByTopicItem from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte";
+import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
+import { FollowSnsNeuronsByTopicItemPo } from "$tests/page-objects/FollowSnsNeuronsByTopicItem.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import type { SnsNervousSystemFunction } from "@dfinity/sns";
+
+describe("FollowSnsNeuronsByTopicItem", () => {
+  const nativeNsFunction: SnsNervousSystemFunction = {
+    id: 1n,
+    name: "Native Function",
+    description: ["Description 1"],
+    function_type: [{ NativeNervousSystemFunction: {} }],
+  };
+  const topicKey = "DaoCommunitySettings";
+  const topicInfo: TopicInfoWithUnknown = {
+    native_functions: [[nativeNsFunction]],
+    topic: [
+      {
+        [topicKey]: null,
+      },
+    ],
+    is_critical: [true],
+    name: ["Known topic name"],
+    description: ["Known topic description"],
+    custom_functions: [[]],
+  };
+
+  const renderComponent = (props: {
+    topicInfo: TopicInfoWithUnknown;
+    checked: boolean;
+    onNnsChange?: () => void;
+  }) => {
+    const { container } = render(FollowSnsNeuronsByTopicItem, {
+      props,
+    });
+
+    return FollowSnsNeuronsByTopicItemPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+  const defaultProps = {
+    topicInfo,
+    checked: false,
+    onNnsChange: vi.fn(),
+  };
+
+  it("should expand and collapse", async () => {
+    const po = renderComponent({
+      ...defaultProps,
+    });
+
+    expect(await po.getCollapsiblePo().isExpanded()).toBe(false);
+    await po.clickExpandButton();
+    expect(await po.getCollapsiblePo().isExpanded()).toBe(true);
+    await po.clickExpandButton();
+    expect(await po.getCollapsiblePo().isExpanded()).toBe(false);
+  });
+
+  it("should dispatch on nnsChange on check", async () => {
+    const onNnsChange = vi.fn();
+    const po = renderComponent({
+      ...defaultProps,
+      onNnsChange,
+    });
+
+    expect(await po.getCheckboxPo().isChecked()).toBe(false);
+
+    await po.getCheckboxPo().click();
+    expect(await po.getCheckboxPo().isChecked()).toBe(true);
+    expect(onNnsChange).toBeCalledTimes(1);
+    expect(onNnsChange).toBeCalledWith({
+      checked: true,
+      topicKey,
+    });
+
+    await po.getCheckboxPo().click();
+    expect(await po.getCheckboxPo().isChecked()).toBe(false);
+    expect(onNnsChange).toBeCalledTimes(2);
+    expect(onNnsChange).toBeCalledWith({ checked: false, topicKey });
+  });
+});

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicItem.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicItem.page-object.ts
@@ -1,0 +1,53 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
+import { CollapsiblePo } from "$tests/page-objects/Collapsible.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class FollowSnsNeuronsByTopicItemPo extends BasePageObject {
+  private static readonly TID = "follow-sns-neurons-by-topic-item-component";
+
+  static under(element: PageObjectElement): FollowSnsNeuronsByTopicItemPo {
+    return new FollowSnsNeuronsByTopicItemPo(
+      element.byTestId(FollowSnsNeuronsByTopicItemPo.TID)
+    );
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<FollowSnsNeuronsByTopicItemPo[]> {
+    return (await element.allByTestId(FollowSnsNeuronsByTopicItemPo.TID)).map(
+      (element) => FollowSnsNeuronsByTopicItemPo.under(element)
+    );
+  }
+
+  getCollapsiblePo(): CollapsiblePo {
+    return CollapsiblePo.under({
+      element: this.root,
+      testId: "topic-collapsible",
+    });
+  }
+
+  getExpandButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "expand-button",
+    });
+  }
+
+  clickExpandButton(): Promise<void> {
+    return this.getExpandButtonPo().click();
+  }
+
+  getCheckboxPo(): CheckboxPo {
+    return CheckboxPo.under({ element: this.root });
+  }
+
+  getTopicName(): Promise<string> {
+    return this.root.byTestId("topic-name").getText();
+  }
+
+  getTopicDescription(): Promise<string> {
+    return this.root.byTestId("topic-description").getText();
+  }
+}


### PR DESCRIPTION
# Motivation

Migrating from following by type to following by topic to improve neuron management.

In the new “Follow” modal, all topics will be displayed with the ability to select them for following in the next step.
This PR adds the component that will be used in the topic list. The full component structure can be found in the draft pr - https://github.com/dfinity/nns-dapp/pull/6610.

Currently **DEMO NOT WORKING** because of the missing aggregator update.
[Demo](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/neuron/?u=7tjcv-pp777-77776-qaaaa-cai&neuron=a12652a79755ee2158248250b9038a35a87adbd53674d789b318bf024e1d2989)
1. `__featureFlags.ENABLE_SNS_TOPICS.overrideWith(true)`
2. Click `Follow Neurons` button on the sns neuron detail page.


https://github.com/user-attachments/assets/1de40535-f9d2-43c5-b87b-07c5add8ef5c


# Changes

- New FollowSnsNeuronsByTopicItem component

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
