### PR TITLE
fix(docs): update neurons fund documentation link

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -852,7 +852,7 @@
     "max_user_commitment_reached": "Maximum commitment reached",
     "not_eligible_to_participate": "You are not eligible to participate in this swap.",
     "getting_sns_open_ticket": "We're connecting with the SNS swap. This might take more than a minute.",
-    "current_nf_commitment_description": "The Neurons' Fund commitment increases based on direct participation. The exact amount is computed at the end of the swap. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/neurons-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about neurons' fund\" target=\"_blank\">Learn more</a>.",
+    "current_nf_commitment_description": "The Neurons' Fund commitment increases based on direct participation. The exact amount is computed at the end of the swap. <a href=\"https://learn.internetcomputer.org/hc/en-us/articles/34084179554196-Neurons-Fund-NF\" rel=\"noopener noreferrer\" aria-label=\"more info about neurons' fund\" target=\"_blank\">Learn more</a>.",
     "sign_in": "Sign in to participate"
   },
   "sns_sale": {


### PR DESCRIPTION
# Motivation

The current [link](https://internetcomputer.org/docs/current/tokenomics/nns/neurons-fund) to the NF documentation is no longer correct so we want to replace it with a link to the new [learn hub](https://learn.internetcomputer.org/hc/en-us).

More info can be found [here](https://dfinity.slack.com/archives/C039M7YS6F6/p1742986063183969)

# Changes

- Update link 

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary