### PR TITLE
feat(navigation): add contextual back navigation for proposals

### DIFF
--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -84,7 +84,7 @@ export const projectPageOrigin = derived(referrerPathStore, (paths) => {
  *
  * Returns proposalsPath as default if no matching page is found.
  */
-export const snsProposalsPageOrigin = derived(
+export const proposalsPageOrigin = derived(
   [referrerPathStore, proposalsPathStore],
   ([paths, proposalsPath]) => {
     const lastPath = paths.at(-1);

--- a/frontend/src/lib/derived/routes.derived.ts
+++ b/frontend/src/lib/derived/routes.derived.ts
@@ -1,5 +1,8 @@
 import { AppPath } from "$lib/constants/routes.constants";
-import { accountsPathStore } from "$lib/derived/paths.derived";
+import {
+  accountsPathStore,
+  proposalsPathStore,
+} from "$lib/derived/paths.derived";
 import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { derived, type Readable } from "svelte/store";
@@ -72,3 +75,22 @@ export const projectPageOrigin = derived(referrerPathStore, (paths) => {
 
   return AppPath.Launchpad;
 });
+
+/**
+ * Derives the origin page (Portfolio, Launchpad or Proposals) to return from SNS Proposals page.
+ * Looks at last entry to handle navigation flows:
+ * Portfolio -> NNS Proposal for a new SNS -> (back) -> Portfolio
+ * Launchpad -> NNS Proposal for a new SNS -> (back) -> Launchpad
+ *
+ * Returns proposalsPath as default if no matching page is found.
+ */
+export const snsProposalsPageOrigin = derived(
+  [referrerPathStore, proposalsPathStore],
+  ([paths, proposalsPath]) => {
+    const lastPath = paths.at(-1);
+    if (lastPath === AppPath.Portfolio) return lastPath;
+    if (lastPath === AppPath.Launchpad) return lastPath;
+
+    return proposalsPath;
+  }
+);

--- a/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
@@ -3,22 +3,9 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
-  import { AppPath } from "$lib/constants/routes.constants";
-  import { proposalsPathStore } from "$lib/derived/paths.derived";
-  import { referrerPathStore } from "$lib/stores/routes.store";
+  import { proposalsPageOrigin } from "$lib/derived/routes.derived";
 
-  const back = async (): Promise<void> => {
-    const lastReferrer = $referrerPathStore.at(-1);
-    // This is a hack to jump back to the specific project page (because of the query params)
-    if (lastReferrer === AppPath.Project) {
-      history.back();
-      return;
-    }
-
-    goto(
-      lastReferrer === AppPath.Launchpad ? lastReferrer : $proposalsPathStore
-    );
-  };
+  const back = async () => goto($proposalsPageOrigin);
 </script>
 
 <LayoutNavGuard>

--- a/frontend/src/tests/lib/derived/routes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/routes.derived.spec.ts
@@ -1,9 +1,11 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath, UNIVERSE_PARAM } from "$lib/constants/routes.constants";
+import { proposalsPathStore } from "$lib/derived/paths.derived";
 import {
   accountsPageOrigin,
   neuronsPageOrigin,
   projectPageOrigin,
+  snsProposalsPageOrigin,
   walletPageOrigin,
 } from "$lib/derived/routes.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
@@ -116,6 +118,41 @@ describe("routes.derived", () => {
       referrerPathStore.pushPath(AppPath.Settings);
 
       expect(get(projectPageOrigin)).toBe(AppPath.Launchpad);
+    });
+  });
+
+  describe("snsProposalsPageOrigin.derived", () => {
+    it("should return Portfolio when it was the last page visited", () => {
+      referrerPathStore.pushPath(AppPath.Portfolio);
+
+      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Portfolio);
+    });
+
+    it("should return Launchpad when it was the last page visited", () => {
+      referrerPathStore.pushPath(AppPath.Launchpad);
+
+      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Launchpad);
+    });
+
+    it("should return to proposalsPath as default when no matching page was found", () => {
+      referrerPathStore.pushPath(AppPath.Settings);
+
+      const expectedProposalsPath = get(proposalsPathStore);
+      expect(get(snsProposalsPageOrigin)).toBe(expectedProposalsPath);
+    });
+
+    it("should prioritize Portfolio over other paths", () => {
+      referrerPathStore.pushPath(AppPath.Launchpad);
+      referrerPathStore.pushPath(AppPath.Portfolio);
+
+      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Portfolio);
+    });
+
+    it("should prioritize Launchpad when Portfolio wasn't visited", () => {
+      referrerPathStore.pushPath(AppPath.Settings);
+      referrerPathStore.pushPath(AppPath.Launchpad);
+
+      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Launchpad);
     });
   });
 });

--- a/frontend/src/tests/lib/derived/routes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/routes.derived.spec.ts
@@ -5,7 +5,7 @@ import {
   accountsPageOrigin,
   neuronsPageOrigin,
   projectPageOrigin,
-  snsProposalsPageOrigin,
+  proposalsPageOrigin,
   walletPageOrigin,
 } from "$lib/derived/routes.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
@@ -121,38 +121,38 @@ describe("routes.derived", () => {
     });
   });
 
-  describe("snsProposalsPageOrigin.derived", () => {
+  describe("proposalsPageOrigin.derived", () => {
     it("should return Portfolio when it was the last page visited", () => {
       referrerPathStore.pushPath(AppPath.Portfolio);
 
-      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Portfolio);
+      expect(get(proposalsPageOrigin)).toBe(AppPath.Portfolio);
     });
 
     it("should return Launchpad when it was the last page visited", () => {
       referrerPathStore.pushPath(AppPath.Launchpad);
 
-      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Launchpad);
+      expect(get(proposalsPageOrigin)).toBe(AppPath.Launchpad);
     });
 
     it("should return to proposalsPath as default when no matching page was found", () => {
       referrerPathStore.pushPath(AppPath.Settings);
 
       const expectedProposalsPath = get(proposalsPathStore);
-      expect(get(snsProposalsPageOrigin)).toBe(expectedProposalsPath);
+      expect(get(proposalsPageOrigin)).toBe(expectedProposalsPath);
     });
 
     it("should prioritize Portfolio over other paths", () => {
       referrerPathStore.pushPath(AppPath.Launchpad);
       referrerPathStore.pushPath(AppPath.Portfolio);
 
-      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Portfolio);
+      expect(get(proposalsPageOrigin)).toBe(AppPath.Portfolio);
     });
 
     it("should prioritize Launchpad when Portfolio wasn't visited", () => {
       referrerPathStore.pushPath(AppPath.Settings);
       referrerPathStore.pushPath(AppPath.Launchpad);
 
-      expect(get(snsProposalsPageOrigin)).toBe(AppPath.Launchpad);
+      expect(get(proposalsPageOrigin)).toBe(AppPath.Launchpad);
     });
   });
 });

--- a/frontend/src/tests/routes/app/proposals/layout.spec.ts
+++ b/frontend/src/tests/routes/app/proposals/layout.spec.ts
@@ -1,14 +1,15 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
+import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import Layout from "$routes/(app)/(u)/(detail)/proposal/+layout.svelte";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-describe("Layout", () => {
-  it("should go back to the proposal page", async () => {
+describe("Proposal Layout", () => {
+  it("should go back to the proposal page if coming from proposals page", async () => {
     page.mock({
       data: {
         universe: OWN_CANISTER_ID_TEXT,
@@ -69,5 +70,49 @@ describe("Layout", () => {
       const { universe } = get(pageStore);
       return expect(universe).toEqual(mockCanisterId.toText());
     });
+  });
+
+  it("should go back to the Launchpad page if coming from the Launchpad page", async () => {
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+      },
+      routeId: AppPath.Proposal,
+    });
+    referrerPathStore.pushPath(AppPath.Launchpad);
+
+    const { queryByTestId } = render(Layout);
+
+    const { path } = get(pageStore);
+    expect(path).toEqual(AppPath.Proposal);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+
+    expect(get(pageStore).path).toEqual(AppPath.Launchpad);
+  });
+
+  it("should go back to the Portfolio page if coming from the Portfolio page", async () => {
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+      },
+      routeId: AppPath.Proposal,
+    });
+    referrerPathStore.pushPath(AppPath.Portfolio);
+
+    const { queryByTestId } = render(Layout);
+
+    const { path } = get(pageStore);
+    expect(path).toEqual(AppPath.Proposal);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+
+    expect(get(pageStore).path).toEqual(AppPath.Portfolio);
   });
 });


### PR DESCRIPTION
# Motivation

The Proposal page includes a back button in its layout. Currently, there are two ways to access this page:  
-  From the Proposals page for all proposals.  
-  From the Launchpad page to create a new SNS proposal.  

We will introduce a third option when the Portfolio page displays the Proposal cards. We aim to implement a mechanism similar to #6543 to determine the appropriate navigation based on how the user accessed the page.  

A follow-up PR will utilize this new store from the route's layout.

[NNS1-3638](https://dfinity.atlassian.net/browse/NNS1-3638)

# Changes

- A new derived store will define the navigation path back from the Proposal page.

# Tests

Add unit tests for the new derived store.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary.

[NNS1-3638]: https://dfinity.atlassian.net/browse/NNS1-3638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ