### PR TITLE
Show sns topic definitions

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -25,6 +25,7 @@
   import type { SnsNeuron } from "@dfinity/sns";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { getContext } from "svelte";
+  import { openSnsNeuronModal } from "$lib/utils/modals.utils";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -82,10 +83,17 @@
           <span class="note">
             {$i18n.neuron_detail.following_note}
           </span>
-          <a href="/#" class="link">
+          <button
+            data-tid="sns-topic-definitions-button"
+            class="ghost with-icon sns-topic-definitions-button"
+            on:click={() =>
+              openSnsNeuronModal({
+                type: "sns-topic-definitions",
+              })}
+          >
             <span>{$i18n.neuron_detail.following_link} </span>
             <IconRight />
-          </a>
+          </button>
         {:else}
           <span>
             {$i18n.neuron_detail.following_description_to_be_removed}
@@ -144,14 +152,10 @@
       @include fonts.small(true);
     }
 
-    .link {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      color: var(--button-secondary-color);
+    .sns-topic-definitions-button {
+      padding: var(--padding) 0;
+      color: var(--primary);
       font-weight: var(--font-weight-bold);
-      text-decoration: none;
     }
   }
 </style>

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -504,7 +504,7 @@ describe("SnsNeuronDetail", () => {
       expect(await po.getSnsTopicDefinitionsModalPo().isPresent()).toBe(true);
 
       await po.getSnsTopicDefinitionsModalPo().clickCloseButton();
-      expect(await po.getSnsTopicDefinitionsModalPo().isPresent()).toBe(false);
+      await po.getSnsTopicDefinitionsModalPo().waitForClosed();
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -483,5 +483,28 @@ describe("SnsNeuronDetail", () => {
       expect(await po.getFollowSnsNeuronsModalPo().isPresent()).toBe(false);
       await po.getFollowSnsNeuronsByTopicModalPo().waitForClosed();
     });
+
+    it("should open topic definitions modal", async () => {
+      setSnsProjects([
+        {
+          rootCanisterId,
+          topics: {
+            topics: [],
+            uncategorized_functions: [],
+          },
+        },
+      ]);
+      const po = await renderComponent({
+        neuronId: validNeuronIdAsHexString,
+      });
+
+      expect(await po.getSnsTopicDefinitionsModalPo().isPresent()).toBe(false);
+
+      await po.getFollowingCardPo().getSnsTopicDefinitionsButtonPo().click();
+      expect(await po.getSnsTopicDefinitionsModalPo().isPresent()).toBe(true);
+
+      await po.getSnsTopicDefinitionsModalPo().clickCloseButton();
+      expect(await po.getSnsTopicDefinitionsModalPo().isPresent()).toBe(false);
+    });
   });
 });

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -10,6 +10,7 @@ import { SnsNeuronMaturitySectionPo } from "$tests/page-objects/SnsNeuronMaturit
 import { SnsNeuronPageHeaderPo } from "$tests/page-objects/SnsNeuronPageHeader.page-object";
 import { SnsNeuronPageHeadingPo } from "$tests/page-objects/SnsNeuronPageHeading.page-object";
 import { SnsNeuronVotingPowerSectionPo } from "$tests/page-objects/SnsNeuronVotingPowerSection.page-object";
+import { SnsTopicDefinitionsModalPo } from "$tests/page-objects/SnsTopicDefinitionsModal.page-object";
 import { SummaryPo } from "$tests/page-objects/Summary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -78,6 +79,10 @@ export class SnsNeuronDetailPo extends BasePageObject {
 
   getFollowSnsNeuronsModalPo(): FollowSnsNeuronsModalPo {
     return FollowSnsNeuronsModalPo.under(this.root);
+  }
+
+  getSnsTopicDefinitionsModalPo(): SnsTopicDefinitionsModalPo {
+    return SnsTopicDefinitionsModalPo.under(this.root);
   }
 
   getFollowSnsNeuronsByTopicModalPo(): FollowSnsNeuronsByTopicModalPo {

--- a/frontend/src/tests/page-objects/SnsNeuronFollowingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronFollowingCard.page-object.ts
@@ -23,4 +23,8 @@ export class SnsNeuronFollowingCardPo extends BasePageObject {
   getFollowSnsNeuronsButtonPo(): ButtonPo {
     return this.getButton("sns-follow-neurons-button");
   }
+
+  getSnsTopicDefinitionsButtonPo(): ButtonPo {
+    return this.getButton("sns-topic-definitions-button");
+  }
 }

--- a/frontend/src/tests/page-objects/SnsTopicDefinitionsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsTopicDefinitionsModal.page-object.ts
@@ -1,9 +1,9 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { SnsTopicDefinitionsTopicPo } from "$tests/page-objects/SnsTopicDefinitionsTopic.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsTopicDefinitionsModalPo extends BasePageObject {
+export class SnsTopicDefinitionsModalPo extends ModalPo {
   private static readonly TID = "sns-topic-definitions-modal-component";
 
   static under(element: PageObjectElement): SnsTopicDefinitionsModalPo {


### PR DESCRIPTION
# Motivation

Migrating from following by type to following by topic to improve neuron management.

To help users better understand how SNS topics are structured - specifically, which types belong to which topics - a new modal has been added. Here, we make the "View topic definitions" button open the modal.

# Changes

- Replace the link with the button.
- Open the modal on click.

# Tests

- Added.
- Tested locally.

https://github.com/user-attachments/assets/32fcdbd4-1c9f-40f2-b28d-1e2edd2c6f9e



# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.