### PR TITLE
chore(ci): update golden data for small-tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -344,7 +344,7 @@ jobs:
           Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
           Transaction fee:      1000
           Minimum neuron stake: 10000
-          Proposal fee:         15000")
+          Proposal fee:         15000\'")
   checks-pass:
     needs:
       - formatting


### PR DESCRIPTION
# Motivation

Currently, the `small-tests` action fails on CI because of outdated [golden data](https://github.com/dfinity/nns-dapp/actions/runs/14105089474/job/39509734186?pr=6632)

# Changes

- Update the value.

# Tests

- All checks should be green.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.