### PR TITLE
fix(ui): resolve svelte5 whitespace rendering in exchange rate tooltip

### DIFF
--- a/frontend/src/lib/components/ui/IcpExchangeRate.svelte
+++ b/frontend/src/lib/components/ui/IcpExchangeRate.svelte
@@ -35,8 +35,7 @@
     {:else}
       <div class="mobile-only">
         1 {$i18n.core.icp} = ${icpPriceFormatted}
-      </div>
-      <div>
+      </div><div>
         {$i18n.accounts.token_price_source}
       </div>
     {/if}

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -84,7 +84,7 @@ describe("TotalAssetsCard", () => {
     setIcpPrice(icpPrice);
 
     const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
-    const message = `1 ICP = $10.00 ${en.accounts.token_price_source}`;
+    const message = `1 ICP = $10.00${en.accounts.token_price_source}`;
 
     expect(await po.getIcpExchangeRatePo().getTooltipText()).toEqual(message);
   });

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -699,7 +699,7 @@ describe("ProjectsTable", () => {
       ).toBe(false);
       expect(
         await po.getUsdValueBannerPo().getIcpExchangeRatePo().getTooltipText()
-      ).toBe(`1 ICP = $10.00 ${en.accounts.token_price_source}`);
+      ).toBe(`1 ICP = $10.00${en.accounts.token_price_source}`);
     });
 
     it("should ignore tokens with unknown balance in USD when adding up the total", async () => {

--- a/frontend/src/tests/lib/components/ui/IcpExchangeRate.spec.ts
+++ b/frontend/src/tests/lib/components/ui/IcpExchangeRate.spec.ts
@@ -67,7 +67,7 @@ describe("IcpExchangeRate", () => {
     const hasError = false;
 
     const po = renderComponent({ icpPrice, hasError });
-    const message = `1 ICP = $10.00 ${en.accounts.token_price_source}`;
+    const message = `1 ICP = $10.00${en.accounts.token_price_source}`;
 
     expect(await po.getTooltipText()).toEqual(message);
   });

--- a/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueBanner.spec.ts
@@ -81,7 +81,7 @@ describe("UsdValueBanner", () => {
     setIcpPrice(icpPrice);
 
     const po = renderComponent({ usdAmount, hasUnpricedTokens: false });
-    const message = `1 ICP = $10.00 ${en.accounts.token_price_source}`;
+    const message = `1 ICP = $10.00${en.accounts.token_price_source}`;
 
     expect(await po.getIcpExchangeRatePo().getTooltipText()).toEqual(message);
   });


### PR DESCRIPTION
# Motivation

After the upgrade of Svelte5, the IcpExchangeRate is wrongly rendering when a child is not displayed because of a meadia query.  It seems that Svelte5 preservers newlines as text nodes while v4 was not doing this. 

In this PR, we fix the regression by removing the whiltespace between the elements.

Before:

<img width="842" alt="Screenshot 2025-03-27 at 16 01 33" src="https://github.com/user-attachments/assets/10ce4b47-19de-436e-bc0c-8c6a38be47eb" />

After:

<img width="367" alt="Screenshot 2025-03-27 at 16 01 12" src="https://github.com/user-attachments/assets/f2a7c08e-f936-451d-9395-25cad02730be" />

# Changes

- Remove new line from `TooltipIcon` child.

# Tests

- Updated tests to not expect an empty text node. Note, that we rely on styling to make the two text nodes look the way they look on mobile devices.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.