### PR TITLE
feat(navigation): implement dynamic back navigation for Proposal page

### DIFF
--- a/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
@@ -3,22 +3,9 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
-  import { AppPath } from "$lib/constants/routes.constants";
-  import { proposalsPathStore } from "$lib/derived/paths.derived";
-  import { referrerPathStore } from "$lib/stores/routes.store";
+  import { proposalsPageOrigin } from "$lib/derived/routes.derived";
 
-  const back = async (): Promise<void> => {
-    const lastReferrer = $referrerPathStore.at(-1);
-    // This is a hack to jump back to the specific project page (because of the query params)
-    if (lastReferrer === AppPath.Project) {
-      history.back();
-      return;
-    }
-
-    goto(
-      lastReferrer === AppPath.Launchpad ? lastReferrer : $proposalsPathStore
-    );
-  };
+  const back = async () => goto($proposalsPageOrigin);
 </script>
 
 <LayoutNavGuard>

--- a/frontend/src/tests/routes/app/proposals/layout.spec.ts
+++ b/frontend/src/tests/routes/app/proposals/layout.spec.ts
@@ -1,14 +1,15 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
+import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import Layout from "$routes/(app)/(u)/(detail)/proposal/+layout.svelte";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-describe("Layout", () => {
-  it("should go back to the proposal page", async () => {
+describe("Proposal Layout", () => {
+  it("should go back to the proposal page if coming from proposals page", async () => {
     page.mock({
       data: {
         universe: OWN_CANISTER_ID_TEXT,
@@ -69,5 +70,49 @@ describe("Layout", () => {
       const { universe } = get(pageStore);
       return expect(universe).toEqual(mockCanisterId.toText());
     });
+  });
+
+  it("should go back to the Launchpad page if coming from the Launchpad page", async () => {
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+      },
+      routeId: AppPath.Proposal,
+    });
+    referrerPathStore.pushPath(AppPath.Launchpad);
+
+    const { queryByTestId } = render(Layout);
+
+    const { path } = get(pageStore);
+    expect(path).toEqual(AppPath.Proposal);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+
+    expect(get(pageStore).path).toEqual(AppPath.Launchpad);
+  });
+
+  it("should go back to the Portfolio page if coming from the Portfolio page", async () => {
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+      },
+      routeId: AppPath.Proposal,
+    });
+    referrerPathStore.pushPath(AppPath.Portfolio);
+
+    const { queryByTestId } = render(Layout);
+
+    const { path } = get(pageStore);
+    expect(path).toEqual(AppPath.Proposal);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+
+    expect(get(pageStore).path).toEqual(AppPath.Portfolio);
   });
 });


### PR DESCRIPTION
# Motivation

This PR follows up on #6632 by utilizing the new derive store to redirect the user to the correct page after clicking the back button on the layout.

[NNS1-3638](https://dfinity.atlassian.net/browse/NNS1-3638)

# Changes

- Implement back navigation in Proposal page layout.

# Tests

- Added unit test

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary


[NNS1-3638]: https://dfinity.atlassian.net/browse/NNS1-3638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ