### PR TITLE
fix(ui): remove duplicate source text in transaction form

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionFromAccount.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFromAccount.svelte
@@ -43,9 +43,7 @@
         {/if}
       </svelte:fragment>
     </KeyValuePair>
-  {/if}
-
-  {#if canSelectSource}
+  {:else if canSelectSource}
     <span class="label">{$i18n.accounts.source}</span>
   {:else}
     <span class="label account-name"


### PR DESCRIPTION
# Motivation

In #6606, we moved the account balance below the input field when the appropriate component was used. To do this, we had to hide the original balance from the header. However, there was a bug in the condition that caused the string `Source` to be displayed twice. This PR addresses the issue.

Before:

<img width="726" alt="Screenshot 2025-03-28 at 15 33 53" src="https://github.com/user-attachments/assets/d3e684e5-9be1-463f-90b6-015894c7fd3e" />

After:

<img width="1007" alt="Screenshot 2025-03-28 at 15 33 35" src="https://github.com/user-attachments/assets/50dd34af-500f-4fc3-8220-e990e00e679e" />

# Changes

- Fix the condition to display the text within the `TransactionFromAccount` component.

# Tests

- Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary