### PR TITLE
fix(sns_aggregator_release): Small fixes to make the release smoother

### DIFF
--- a/scripts/nns-dapp/download-ci-wasm
+++ b/scripts/nns-dapp/download-ci-wasm
@@ -32,7 +32,7 @@ ci_build_run_id="$("$SOURCE_DIR/get-ci-build-run" --commit "$COMMIT" --limit "$L
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf $tmp_dir' EXIT
-gh run download "$ci_build_run_id" --dir "$tmp_dir" -n nns-dapp
+gh run download "$ci_build_run_id" --dir "$tmp_dir" -n nns-dapp -n sns_aggregator
 
 mkdir -p "$OUTPUT_DIR"
 dst_wasm_file="$OUTPUT_DIR/$WASM_FILENAME"

--- a/scripts/sns/aggregator/release-template
+++ b/scripts/sns/aggregator/release-template
@@ -62,4 +62,4 @@ sha256sum sns_aggregator.wasm.gz
 EOF
 
 ARG_DID="./release/sns_aggregator_arg.did"
-echo '(record{})' >"$ARG_DID"
+echo '(null : null)' >"$ARG_DID"


### PR DESCRIPTION
# Motivation

I had to debug the scripts and fix these small issues before I could use the ./scripts/sns/aggregator/release-template script.

# Changes

* scripts/nns-dapp/download-ci-wasm now also downloads sns_aggregator.wasm.gz, now just the nns-dapp.
* use the correct init argument during the SNS Aggregator upgrade proposal generation.

# Tests

Tested manually.