### PR TITLE
refactor: snsTopicKeyToTopic

### DIFF
--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -26,10 +26,10 @@ import type {
   ListTopicsResponseWithUnknown,
   TopicInfoDto,
   TopicInfoWithUnknown,
-  UnknownTopic,
 } from "$lib/types/sns-aggregator";
 import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
+import { snsTopicKeyToTopic } from "$lib/utils/sns-topics.utils";
 import { isPngAsset } from "$lib/utils/utils";
 import type { IcrcTokenMetadataResponse } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
@@ -45,7 +45,6 @@ import type {
   SnsSwapInit,
   SnsVotingRewardsParameters,
 } from "@dfinity/sns";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
 import {
   candidNumberArrayToBigInt,
   isNullish,
@@ -550,28 +549,6 @@ export const convertDtoToSnsSummary = ({
     : undefined;
 };
 
-export const convertDtoToTopic = (topic: string): Topic | UnknownTopic => {
-  switch (topic) {
-    case "DappCanisterManagement":
-      return { DappCanisterManagement: null };
-    case "DaoCommunitySettings":
-      return { DaoCommunitySettings: null };
-    case "ApplicationBusinessLogic":
-      return { ApplicationBusinessLogic: null };
-    case "CriticalDappOperations":
-      return { CriticalDappOperations: null };
-    case "TreasuryAssetManagement":
-      return { TreasuryAssetManagement: null };
-    case "Governance":
-      return { Governance: null };
-    case "SnsFrameworkManagement":
-      return { SnsFrameworkManagement: null };
-  }
-
-  console.error("Unknown topic:", topic);
-  return { UnknownTopic: null };
-};
-
 export const convertDtoTopicInfo = ({
   topic,
   name,
@@ -580,7 +557,7 @@ export const convertDtoTopicInfo = ({
   custom_functions,
   is_critical,
 }: TopicInfoDto): TopicInfoWithUnknown => ({
-  topic: toNullable(convertDtoToTopic(topic)),
+  topic: toNullable(snsTopicKeyToTopic(topic)),
   name: toNullable(name),
   description: toNullable(description),
   native_functions: toNullable(native_functions.map(convertNervousFunction)),

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -6,6 +6,7 @@ import type {
   SnsSummary,
   SnsSummaryMetadata,
   SnsSummarySwap,
+  SnsTopicKey,
 } from "$lib/types/sns";
 import type {
   CachedDefaultFolloweesDto,
@@ -557,7 +558,7 @@ export const convertDtoTopicInfo = ({
   custom_functions,
   is_critical,
 }: TopicInfoDto): TopicInfoWithUnknown => ({
-  topic: toNullable(snsTopicKeyToTopic(topic)),
+  topic: toNullable(snsTopicKeyToTopic(topic as SnsTopicKey)),
   name: toNullable(name),
   description: toNullable(description),
   native_functions: toNullable(native_functions.map(convertNervousFunction)),

--- a/frontend/src/lib/utils/sns-topics.utils.ts
+++ b/frontend/src/lib/utils/sns-topics.utils.ts
@@ -8,7 +8,9 @@ import type { SnsNervousSystemFunction } from "@dfinity/sns";
 import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
 import { fromNullable } from "@dfinity/utils";
 
-export const getSnsTopicKey = (topic: Topic | UnknownTopic): SnsTopicKey => {
+export const snsTopicToTopicKey = (
+  topic: Topic | UnknownTopic
+): SnsTopicKey => {
   // We can't ensure that all the topicKeys are present in this list.
   const topicKeys: SnsTopicKey[] = [
     "DappCanisterManagement",
@@ -29,10 +31,34 @@ export const getSnsTopicKey = (topic: Topic | UnknownTopic): SnsTopicKey => {
   return "UnknownTopic";
 };
 
+export const snsTopicKeyToTopic = (
+  topic: SnsTopicKey
+): Topic | UnknownTopic => {
+  switch (topic) {
+    case "DappCanisterManagement":
+      return { DappCanisterManagement: null };
+    case "DaoCommunitySettings":
+      return { DaoCommunitySettings: null };
+    case "ApplicationBusinessLogic":
+      return { ApplicationBusinessLogic: null };
+    case "CriticalDappOperations":
+      return { CriticalDappOperations: null };
+    case "TreasuryAssetManagement":
+      return { TreasuryAssetManagement: null };
+    case "Governance":
+      return { Governance: null };
+    case "SnsFrameworkManagement":
+      return { SnsFrameworkManagement: null };
+  }
+
+  console.error("Unknown topic:", topic);
+  return { UnknownTopic: null };
+};
+
 export const getSnsTopicInfoKey = (
   topicInfo: TopicInfoWithUnknown
 ): SnsTopicKey =>
-  getSnsTopicKey(fromNullable(topicInfo.topic) as Topic | UnknownTopic);
+  snsTopicToTopicKey(fromNullable(topicInfo.topic) as Topic | UnknownTopic);
 
 // Returns all available SNS topics keys
 export const getSnsTopicKeys = (

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -14,12 +14,12 @@ import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import {
   convertDtoToListTopicsResponse,
   convertDtoToSnsSummary,
-  convertDtoToTopic,
   convertDtoTopicInfo,
   convertIcrc1Metadata,
   convertNervousFunction,
   convertNervousSystemParameters,
 } from "$lib/utils/sns-aggregator-converters.utils";
+import { snsTopicKeyToTopic } from "$lib/utils/sns-topics.utils";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemParameters } from "@dfinity/sns";
@@ -992,31 +992,31 @@ describe("sns aggregator converters utils", () => {
     });
 
     // ic-js type: https://github.com/dfinity/ic-js/blob/1a4d3f02d4cfebf47c199a4fdc376e2f62a84746/packages/sns/candid/sns_governance_test.did#L867C1-L875C3
-    describe("convertDtoToTopic", () => {
+    describe("snsTopicKeyToTopic", () => {
       it("converts aggregator topic to ic-js types", () => {
         const spyOnConsoleError = vi
           .spyOn(console, "error")
           .mockImplementation(() => undefined);
 
-        expect(convertDtoToTopic("DappCanisterManagement")).toEqual({
+        expect(snsTopicKeyToTopic("DappCanisterManagement")).toEqual({
           DappCanisterManagement: null,
         });
-        expect(convertDtoToTopic("DaoCommunitySettings")).toEqual({
+        expect(snsTopicKeyToTopic("DaoCommunitySettings")).toEqual({
           DaoCommunitySettings: null,
         });
-        expect(convertDtoToTopic("ApplicationBusinessLogic")).toEqual({
+        expect(snsTopicKeyToTopic("ApplicationBusinessLogic")).toEqual({
           ApplicationBusinessLogic: null,
         });
-        expect(convertDtoToTopic("CriticalDappOperations")).toEqual({
+        expect(snsTopicKeyToTopic("CriticalDappOperations")).toEqual({
           CriticalDappOperations: null,
         });
-        expect(convertDtoToTopic("TreasuryAssetManagement")).toEqual({
+        expect(snsTopicKeyToTopic("TreasuryAssetManagement")).toEqual({
           TreasuryAssetManagement: null,
         });
-        expect(convertDtoToTopic("Governance")).toEqual({
+        expect(snsTopicKeyToTopic("Governance")).toEqual({
           Governance: null,
         });
-        expect(convertDtoToTopic("SnsFrameworkManagement")).toEqual({
+        expect(snsTopicKeyToTopic("SnsFrameworkManagement")).toEqual({
           SnsFrameworkManagement: null,
         });
 
@@ -1028,7 +1028,7 @@ describe("sns aggregator converters utils", () => {
           .spyOn(console, "error")
           .mockImplementation(() => undefined);
 
-        expect(convertDtoToTopic("An Unknown Topic")).toEqual({
+        expect(snsTopicKeyToTopic("An Unknown Topic")).toEqual({
           UnknownTopic: null,
         });
 

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -19,7 +19,6 @@ import {
   convertNervousFunction,
   convertNervousSystemParameters,
 } from "$lib/utils/sns-aggregator-converters.utils";
-import { snsTopicKeyToTopic } from "$lib/utils/sns-topics.utils";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemParameters } from "@dfinity/sns";
@@ -988,55 +987,6 @@ describe("sns aggregator converters utils", () => {
             DappCanisterManagement: null,
           })
         ).toBe(false);
-      });
-    });
-
-    // ic-js type: https://github.com/dfinity/ic-js/blob/1a4d3f02d4cfebf47c199a4fdc376e2f62a84746/packages/sns/candid/sns_governance_test.did#L867C1-L875C3
-    describe("snsTopicKeyToTopic", () => {
-      it("converts aggregator topic to ic-js types", () => {
-        const spyOnConsoleError = vi
-          .spyOn(console, "error")
-          .mockImplementation(() => undefined);
-
-        expect(snsTopicKeyToTopic("DappCanisterManagement")).toEqual({
-          DappCanisterManagement: null,
-        });
-        expect(snsTopicKeyToTopic("DaoCommunitySettings")).toEqual({
-          DaoCommunitySettings: null,
-        });
-        expect(snsTopicKeyToTopic("ApplicationBusinessLogic")).toEqual({
-          ApplicationBusinessLogic: null,
-        });
-        expect(snsTopicKeyToTopic("CriticalDappOperations")).toEqual({
-          CriticalDappOperations: null,
-        });
-        expect(snsTopicKeyToTopic("TreasuryAssetManagement")).toEqual({
-          TreasuryAssetManagement: null,
-        });
-        expect(snsTopicKeyToTopic("Governance")).toEqual({
-          Governance: null,
-        });
-        expect(snsTopicKeyToTopic("SnsFrameworkManagement")).toEqual({
-          SnsFrameworkManagement: null,
-        });
-
-        expect(spyOnConsoleError).not.toHaveBeenCalled();
-      });
-
-      it("returns UnknownTopic if topic is unknown", () => {
-        const spyOnConsoleError = vi
-          .spyOn(console, "error")
-          .mockImplementation(() => undefined);
-
-        expect(snsTopicKeyToTopic("An Unknown Topic")).toEqual({
-          UnknownTopic: null,
-        });
-
-        expect(spyOnConsoleError).toHaveBeenCalledTimes(1);
-        expect(spyOnConsoleError).toHaveBeenCalledWith(
-          "Unknown topic:",
-          "An Unknown Topic"
-        );
       });
     });
 

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -8,6 +8,7 @@ import {
   getSnsTopicKey,
   getSnsTopicKeys,
   getTopicInfoBySnsTopicKey,
+  snsTopicKeyToTopic,
 } from "$lib/utils/sns-topics.utils";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
@@ -72,6 +73,55 @@ describe("sns-topics utils", () => {
     topics: [[knownTopicInfo, completelyUnknownTopicInfo]],
     uncategorized_functions: [],
   };
+
+  // ic-js type: https://github.com/dfinity/ic-js/blob/1a4d3f02d4cfebf47c199a4fdc376e2f62a84746/packages/sns/candid/sns_governance_test.did#L867C1-L875C3
+  describe("snsTopicKeyToTopic", () => {
+    it("converts aggregator topic to ic-js types", () => {
+      const spyOnConsoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      expect(snsTopicKeyToTopic("DappCanisterManagement")).toEqual({
+        DappCanisterManagement: null,
+      });
+      expect(snsTopicKeyToTopic("DaoCommunitySettings")).toEqual({
+        DaoCommunitySettings: null,
+      });
+      expect(snsTopicKeyToTopic("ApplicationBusinessLogic")).toEqual({
+        ApplicationBusinessLogic: null,
+      });
+      expect(snsTopicKeyToTopic("CriticalDappOperations")).toEqual({
+        CriticalDappOperations: null,
+      });
+      expect(snsTopicKeyToTopic("TreasuryAssetManagement")).toEqual({
+        TreasuryAssetManagement: null,
+      });
+      expect(snsTopicKeyToTopic("Governance")).toEqual({
+        Governance: null,
+      });
+      expect(snsTopicKeyToTopic("SnsFrameworkManagement")).toEqual({
+        SnsFrameworkManagement: null,
+      });
+
+      expect(spyOnConsoleError).not.toHaveBeenCalled();
+    });
+
+    it("returns UnknownTopic if topic is unknown", () => {
+      const spyOnConsoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      expect(snsTopicKeyToTopic("An Unknown Topic")).toEqual({
+        UnknownTopic: null,
+      });
+
+      expect(spyOnConsoleError).toHaveBeenCalledTimes(1);
+      expect(spyOnConsoleError).toHaveBeenCalledWith(
+        "Unknown topic:",
+        "An Unknown Topic"
+      );
+    });
+  });
 
   describe("getSnsTopicKey", () => {
     it("should return topic key", () => {

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -1,3 +1,4 @@
+import type { SnsTopicKey } from "$lib/types/sns";
 import type {
   ListTopicsResponseWithUnknown,
   TopicInfoWithUnknown,
@@ -5,10 +6,10 @@ import type {
 import {
   getAllSnsNSFunctions,
   getSnsTopicInfoKey,
-  getSnsTopicKey,
   getSnsTopicKeys,
   getTopicInfoBySnsTopicKey,
   snsTopicKeyToTopic,
+  snsTopicToTopicKey,
 } from "$lib/utils/sns-topics.utils";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
@@ -111,7 +112,7 @@ describe("sns-topics utils", () => {
         .spyOn(console, "error")
         .mockImplementation(() => undefined);
 
-      expect(snsTopicKeyToTopic("An Unknown Topic")).toEqual({
+      expect(snsTopicKeyToTopic("An Unknown Topic" as SnsTopicKey)).toEqual({
         UnknownTopic: null,
       });
 
@@ -123,32 +124,32 @@ describe("sns-topics utils", () => {
     });
   });
 
-  describe("getSnsTopicKey", () => {
+  describe("snsTopicToTopicKey", () => {
     it("should return topic key", () => {
-      expect(getSnsTopicKey({ DappCanisterManagement: null })).toBe(
+      expect(snsTopicToTopicKey({ DappCanisterManagement: null })).toBe(
         "DappCanisterManagement"
       );
-      expect(getSnsTopicKey({ DaoCommunitySettings: null })).toBe(
+      expect(snsTopicToTopicKey({ DaoCommunitySettings: null })).toBe(
         "DaoCommunitySettings"
       );
-      expect(getSnsTopicKey({ ApplicationBusinessLogic: null })).toBe(
+      expect(snsTopicToTopicKey({ ApplicationBusinessLogic: null })).toBe(
         "ApplicationBusinessLogic"
       );
-      expect(getSnsTopicKey({ CriticalDappOperations: null })).toBe(
+      expect(snsTopicToTopicKey({ CriticalDappOperations: null })).toBe(
         "CriticalDappOperations"
       );
-      expect(getSnsTopicKey({ TreasuryAssetManagement: null })).toBe(
+      expect(snsTopicToTopicKey({ TreasuryAssetManagement: null })).toBe(
         "TreasuryAssetManagement"
       );
-      expect(getSnsTopicKey({ Governance: null })).toBe("Governance");
-      expect(getSnsTopicKey({ SnsFrameworkManagement: null })).toBe(
+      expect(snsTopicToTopicKey({ Governance: null })).toBe("Governance");
+      expect(snsTopicToTopicKey({ SnsFrameworkManagement: null })).toBe(
         "SnsFrameworkManagement"
       );
-      expect(getSnsTopicKey({ UnknownTopic: null })).toBe("UnknownTopic");
+      expect(snsTopicToTopicKey({ UnknownTopic: null })).toBe("UnknownTopic");
     });
 
     it("should return UnknownTopic if topic is unknown", () => {
-      expect(getSnsTopicKey({} as Topic)).toBe("UnknownTopic");
+      expect(snsTopicToTopicKey({} as Topic)).toBe("UnknownTopic");
     });
   });
 


### PR DESCRIPTION
# Motivation

To simplify handling of SNS tokens (e.g., using them as object keys), we transform them from the backend type (e.g. `{ DappCanisterManagement: null }`) into a string (e.g. "DappCanisterManagement").

Initially, the transformation function was added to the aggregator DTO utils, but since it will be widely used for reading/writing topics via the API, it makes sense to move it to the sns-topic utils.

# Changes

- Rename and move dto-utils/`convertDtoToTopic` to sns-topic-utils/`snsTopicKeyToTopic`.
- Rename `getSnsTopicKey` to `snsTopicToTopicKey` to align function names.

# Tests

- Moved.

# Todos

- [ ] Add entry to changelog (if necessary).
!necessary.