### PR TITLE
feat(api): add option to include large proposal fields

### DIFF
--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -22,6 +22,7 @@ export const queryProposals = async ({
   includeRewardStatus = [],
   includeStatus = [],
   certified,
+  omitLargeFields = true,
 }: {
   beforeProposal: ProposalId | undefined;
   identity: Identity;
@@ -29,6 +30,7 @@ export const queryProposals = async ({
   includeRewardStatus?: ProposalRewardStatus[];
   includeStatus?: ProposalStatus[];
   certified: boolean;
+  omitLargeFields?: boolean;
 }): Promise<ProposalInfo[]> => {
   logWithTimestamp(
     `Querying Proposals (${
@@ -57,7 +59,7 @@ export const queryProposals = async ({
       includeAllManageNeuronProposals: false,
       // This flag solves the issue whe the proposal payload being too large.
       // (e.g. IC0504: Error from Canister rrkah-fqaaa-aaaaa-aaaaq-cai: Canister violated contract: ic0.msg_reply_data_append: application payload size (3661753) cannot be larger than 3145728.)
-      omitLargeFields: true,
+      omitLargeFields,
     },
     certified,
   });

--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -57,7 +57,7 @@ export const queryProposals = async ({
       includeRewardStatus,
       includeStatus,
       includeAllManageNeuronProposals: false,
-      // This flag solves the issue whe the proposal payload being too large.
+      // This flag solves the issue when the proposal payload being too large.
       // (e.g. IC0504: Error from Canister rrkah-fqaaa-aaaaa-aaaaq-cai: Canister violated contract: ic0.msg_reply_data_append: application payload size (3661753) cannot be larger than 3145728.)
       omitLargeFields,
     },

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -102,6 +102,31 @@ describe("proposals-api", () => {
         },
       });
     });
+
+    it("should call with no omitLargeFields", async () => {
+      await queryProposals({
+        beforeProposal: mockProposals[mockProposals.length - 1].id,
+        includeTopics: [],
+        includeStatus: defaultIncludeStatus,
+        includeRewardStatus: [ProposalRewardStatus.AcceptVotes],
+        identity: mockIdentity,
+        certified: true,
+        omitLargeFields: false,
+      });
+
+      expect(spyListProposals).toHaveBeenCalledWith({
+        certified: true,
+        request: {
+          beforeProposal: mockProposals[mockProposals.length - 1].id,
+          excludeTopic: [],
+          includeRewardStatus: [ProposalRewardStatus.AcceptVotes],
+          includeStatus: defaultIncludeStatus,
+          includeAllManageNeuronProposals: false,
+          limit: 100,
+          omitLargeFields: false,
+        },
+      });
+    });
   });
 
   describe("load", () => {


### PR DESCRIPTION
# Motivation

For the upcoming SNS proposals on the Portfolio page, we want to display these proposals along with their SNS icons. To achieve this, we need to disable the `omitLargeFields` flag in the request. This flag was introduced in #5187 to address issues with payloads that are too large when using filters on the `/proposals` page. This PR adds a flag to request the entire payload. Since it will be used to fetch proposals related to the topic `SnsAndCommunityFund`, it seems safe.

Note: In the past, issues arose when the payload exceeded approximately 3MB (3145728 bytes). Our current payload is around 60k, which would allow for up to 50 proposals, while the estimate is to have no more than 5 at a time.

# Changes

- Exposes flag in `queryProposals`.

# Tests

- Adds unit test to check that property is part of request payload.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary