### PR TITLE
fix(deps): update tar-fs to patch security vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6206,9 +6206,10 @@
       "dev": true
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -10921,9 +10922,9 @@
       "dev": true
     },
     "tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",


### PR DESCRIPTION
# Motivation

As mentioned [here](https://dfinity.slack.com/archives/C01S03NBM7S/p1743493126160569)
> There is a vulnerability in an npm lib used in hw wallet cli and nns dapp. It affects tar-fs and allows link following / path traversal if a maliciously crafted tar file is extracted. I assigned low risk because IIUC we don't extract malicious tar files.

[SCAVM-1127](https://dfinity.atlassian.net/browse/SCAVM-1127)

# Changes

- Run `npm audit` to validate the vulnerability.
- Run `npm audit fix` to upgrade the version of the dependency.

# Tests

- Pipeline should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[SCAVM-1127]: https://dfinity.atlassian.net/browse/SCAVM-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ