### PR TITLE
refactor(portfolio): simplify pre-login page layout

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -130,9 +130,6 @@
     component: LaunchProjectCard as unknown as Component,
     props: { summary },
   }));
-
-  let hideTotalAssetsCards = false;
-  $: hideTotalAssetsCards = !$authSignedInStore;
 </script>
 
 <main data-tid="portfolio-page-component">
@@ -141,18 +138,16 @@
     class:signed-in={$authSignedInStore}
     class:launchpad={launchpadCards.length > 0}
   >
-    {#if !hideTotalAssetsCards}
+    {#if !$authSignedInStore}
+      <div class="login-card">
+        <LoginCard />
+      </div>
+    {:else}
       <TotalAssetsCard
         usdAmount={totalUsdAmount}
         hasUnpricedTokens={hasUnpricedTokensOrStake}
         isLoading={isSomethingLoading}
       />
-    {/if}
-
-    {#if !$authSignedInStore}
-      <div class="login-card">
-        <LoginCard />
-      </div>
     {/if}
 
     {#if launchpadCards.length > 0}
@@ -211,15 +206,10 @@
       grid-template-columns: 1fr;
       gap: var(--padding-2x);
 
-      .login-card {
-        order: -1;
-      }
-
       @include media.min-width(large) {
         grid-template-columns: 1fr 2fr;
 
         .login-card {
-          order: 0;
           height: 100%;
         }
 

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -132,7 +132,7 @@
   }));
 
   let hideTotalAssetsCards = false;
-  $: hideTotalAssetsCards = !$authSignedInStore && launchpadCards.length > 0;
+  $: hideTotalAssetsCards = !$authSignedInStore;
 </script>
 
 <main data-tid="portfolio-page-component">
@@ -230,7 +230,7 @@
 
         // Case: not signed in, with no projects
         &:not(.signed-in):not(.launchpad) {
-          grid-template-columns: 1fr 2fr;
+          grid-template-columns: 1fr;
         }
 
         // Case: signed in, no projects

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -131,12 +131,7 @@ describe("Portfolio route", () => {
     const nativeBalances =
       await tokensCardPo.getHeldTokensBalanceInNativeCurrency();
 
-    expect(
-      await portfolioPagePo.getTotalAssetsCardPo().getPrimaryAmount()
-    ).toBe("$-/-");
-    expect(
-      await portfolioPagePo.getTotalAssetsCardPo().getSecondaryAmount()
-    ).toBe("-/- ICP");
+    expect(await portfolioPagePo.getLoginCard().isPresent()).toBe(true);
 
     expect(titles.length).toBe(4);
     expect(titles).toEqual(["Internet Computer", "ckBTC", "ckETH", "ckUSDC"]);

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -132,6 +132,9 @@ describe("Portfolio route", () => {
       await tokensCardPo.getHeldTokensBalanceInNativeCurrency();
 
     expect(await portfolioPagePo.getLoginCard().isPresent()).toBe(true);
+    expect(await portfolioPagePo.getTotalAssetsCardPo().isPresent()).toBe(
+      false
+    );
 
     expect(titles.length).toBe(4);
     expect(titles).toEqual(["Internet Computer", "ckBTC", "ckETH", "ckUSDC"]);


### PR DESCRIPTION
# Motivation

We want to update the portfolio layout for users who are not signed in by hiding the `TotalAssetsCard`. This way, it only displays the `LoginCard` and any SNS cards if there are any swaps or proposals open.

https://github.com/user-attachments/assets/cae929a6-befa-453c-9bd6-2911f6974372

# Changes

- Hide `TotalAssetsCard` when user is not signed in.
- Update size of the `LoginCard` based on the presence of the sns cards.

# Tests

- Update unit tests expectations.

# Todos

- [ ] Add entry to changelog (if necessary).
