### PR TITLE
chore(deps): revert gix-components to next version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0.tgz",
-      "integrity": "sha512-8Lkbpw5/dKGF0CcF5DQAjXPJaViGrDZtdNNmaGyXe5I/KuZW0BmoAvqjt3VZTS5AACoTwR9qa1c1clUAyocz6A==",
+      "version": "6.0.0-next-2025-04-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-04-02.1.tgz",
+      "integrity": "sha512-dZ9+nNCoNHDH8fAvZ0d5Il+mJMYfon8VyMwKTDRmg1fMtvtHZWdG6/epNYCJP31zrbbw7OdMYoDMU3sPDEsdFQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.2.4",
@@ -7210,9 +7210,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0.tgz",
-      "integrity": "sha512-8Lkbpw5/dKGF0CcF5DQAjXPJaViGrDZtdNNmaGyXe5I/KuZW0BmoAvqjt3VZTS5AACoTwR9qa1c1clUAyocz6A==",
+      "version": "6.0.0-next-2025-04-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-04-02.1.tgz",
+      "integrity": "sha512-dZ9+nNCoNHDH8fAvZ0d5Il+mJMYfon8VyMwKTDRmg1fMtvtHZWdG6/epNYCJP31zrbbw7OdMYoDMU3sPDEsdFQ==",
       "requires": {
         "dompurify": "^3.2.4",
         "html5-qrcode": "^2.3.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@dfinity/candid": "^2.4.0",
         "@dfinity/ckbtc": "next",
         "@dfinity/cmc": "next",
-        "@dfinity/gix-components": "^6.0.0",
+        "@dfinity/gix-components": "next",
         "@dfinity/ic-management": "next",
         "@dfinity/identity": "^2.1.3",
         "@dfinity/ledger-icp": "next",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,7 +77,7 @@
     "@dfinity/candid": "^2.4.0",
     "@dfinity/ckbtc": "next",
     "@dfinity/cmc": "next",
-    "@dfinity/gix-components": "^6.0.0",
+    "@dfinity/gix-components": "next",
     "@dfinity/ic-management": "next",
     "@dfinity/identity": "^2.1.3",
     "@dfinity/ledger-icp": "next",


### PR DESCRIPTION
# Motivation

#6020 upgraded the nns-dapp to svelte@5. During this process, we directed the project to use a specific version of gix-components to ensure compatibility with the correct version of Svelte. Now that the upgrade is complete, we want to revert to pointing to the next version to easily incorporate the latest changes in gix-components into the project.

# Changes

- Manually change the version in `package.json` to `next`.
- Run `npm i` to update `package-lock.json`.

# Tests

- Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary