### PR TITLE
feat(portfolio): add SNS proposal card data mapper util

### DIFF
--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,6 +1,7 @@
 import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import { formatNumber } from "$lib/utils/format.utils";
 import type { FullProjectCommitmentSplit } from "$lib/utils/projects.utils";
 import {
@@ -17,7 +18,8 @@ import {
   compareTokensIcpFirst,
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
-import { ICPToken } from "@dfinity/utils";
+import type { ProposalId, ProposalInfo } from "@dfinity/nns";
+import { ICPToken, isNullish } from "@dfinity/utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 
@@ -153,4 +155,39 @@ export const getMinCommitmentPercentage = (
       token: ICPToken,
     })
   );
+};
+
+export const mapProposalInfoToCard = (
+  proposalInfo: ProposalInfo
+):
+  | undefined
+  | {
+      durationTillDeadline: bigint;
+      id: ProposalId;
+      title: string | undefined;
+      logo: string | undefined;
+      name: string | undefined;
+    } => {
+  const proposal = proposalInfo?.proposal;
+  const action = proposal?.action;
+
+  if (isNullish(action) || isNullish(proposal)) return undefined;
+  if (!("CreateServiceNervousSystem" in action)) return undefined;
+
+  const title = proposal.title;
+  const { id, deadlineTimestampSeconds } = proposalInfo;
+  const durationTillDeadline = deadlineTimestampSeconds
+    ? deadlineTimestampSeconds - BigInt(nowInSeconds())
+    : 0n;
+  const logo: string | undefined =
+    action.CreateServiceNervousSystem?.logo?.base64Encoding;
+  const name: string | undefined = action.CreateServiceNervousSystem?.name;
+
+  return {
+    durationTillDeadline,
+    logo,
+    name,
+    title,
+    id: id as ProposalId,
+  };
 };


### PR DESCRIPTION
# Motivation

For the upcoming SNS proposals on the Portfolio page, we want to display these proposals in a specific card. The `Proposal` type is quite generic, so we will map it to a `CreateServiceNervousSystem` proposal that the card will consume. Additionally, we can remove the unnecessary fields.

[NNS1-3638](https://dfinity.atlassian.net/browse/NNS1-3638)

# Changes

- Adds a new utility to map the proposal to the card data.

# Tests

- Adds unit tests for the utility functions.
- Manually tested along with other changes in #6590

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3638]: https://dfinity.atlassian.net/browse/NNS1-3638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ