### PR TITLE
test(e2e): fix flaky carousel animations

### DIFF
--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -14,8 +14,12 @@ const VIEWPORT_SIZES = {
 
 test("Visual test Landing Page", async ({ page, browser }) => {
   await page.addInitScript(() => {
-    // @ts-expect-error disable animations based on setInterval for the stackedCards
-    window.setInterval = () => 999;
+    // @ts-expect-error: Overrides setinterval for tests
+    window.setInterval = (_: TimerHandler, timeout: number) => {
+      const noop = () => {};
+      const id = setTimeout(noop, timeout);
+      return id;
+    };
   });
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);

--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -13,6 +13,10 @@ const VIEWPORT_SIZES = {
 } as const;
 
 test("Visual test Landing Page", async ({ page, browser }) => {
+  await page.addInitScript(() => {
+    // @ts-expect-error disable animations based on setInterval for the stackedCards
+    window.setInterval = () => 999;
+  });
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
   const portfolioPo = appPo.getPortfolioPo();


### PR DESCRIPTION
# Motivation

[sns-demo](https://github.com/dfinity/snsdemo/pull/461) recently added a new ongoing swap to help develop features for the Portfolio page. End-to-end tests have become unreliable because we now have multiple cards on the Portfolio page that change every 5 seconds. Additionally, continuous integration can sometimes take longer, resulting in mismatched screenshots.

# Changes

- Overwrite `setInterval` in Portfolio end-to-end tests with a no-op callback.

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.