### PR TITLE
feat(portfolio): add SNS creation proposal card

### DIFF
--- a/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
+++ b/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
@@ -107,13 +107,13 @@
     gap: var(--padding-2x);
     padding: var(--padding-2x);
     /* Required to give space to the StackedCards dots */
-    padding-bottom: 34px;
+    padding-bottom: var(--card-stacked-dots-space);
 
     @include media.min-width(medium) {
       padding: var(--padding-3x);
 
       /* Required to give space to the StackedCards dots */
-      padding-bottom: 34px;
+      padding-bottom: var(--card-stacked-dots-space);
     }
 
     .header {

--- a/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
+++ b/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import Card from "$lib/components/portfolio/Card.svelte";
+  import VotesResult from "$lib/components/portfolio/VotesResult.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import { pageStore } from "$lib/derived/page.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import { buildProposalUrl } from "$lib/utils/navigation.utils";
+  import { mapProposalInfoToCard } from "$lib/utils/portfolio.utils";
+  import {
+    IconClockNoFill,
+    IconRight,
+    IconVote,
+    Tag,
+  } from "@dfinity/gix-components";
+  import type { ProposalInfo } from "@dfinity/nns";
+  import { nonNullish, secondsToDuration } from "@dfinity/utils";
+
+  type Props = {
+    proposalInfo: ProposalInfo;
+  };
+  const { proposalInfo }: Props = $props();
+
+  const proposal = $derived(mapProposalInfoToCard(proposalInfo));
+  const universe = $derived($pageStore.universe);
+  const href = $derived(
+    nonNullish(proposal)
+      ? buildProposalUrl({
+          universe,
+          proposalId: proposal.id,
+          actionable: false,
+        })
+      : "#"
+  );
+</script>
+
+{#if nonNullish(proposal)}
+  <Card testId="launch-project-card">
+    <div class="wrapper">
+      <div class="header">
+        <div class="title-wrapper">
+          <div>
+            {#if nonNullish(proposal?.logo) && nonNullish(proposal?.name)}
+              <Logo src={proposal?.logo} alt={proposal?.name} size="medium" />
+            {/if}
+          </div>
+          <h5 data-tid="project-name">{proposal.name}</h5>
+        </div>
+        <Tag size="medium">
+          <span>{$i18n.portfolio.project_status_proposal}</span>
+          <IconVote size="14px" />
+        </Tag>
+      </div>
+
+      <div class="content">
+        <div class="description-wrapper">
+          <h3 class="title" data-tid="proposal-title"
+            >{$i18n.portfolio.open_proposal_card_title}</h3
+          >
+          <p class="description" data-tid="proposal-description"
+            >{proposal.title}</p
+          >
+        </div>
+        <VotesResult
+          yes={Number(proposalInfo.latestTally?.yes)}
+          no={Number(proposalInfo.latestTally?.no)}
+          total={Number(proposalInfo.latestTally?.total)}
+        />
+      </div>
+      <div class="footer">
+        <div class="time-remaining">
+          <span class="icon">
+            <IconClockNoFill size="20px" />
+          </span>
+
+          <span data-tid="time-remaining">
+            {secondsToDuration({
+              seconds: proposal.durationTillDeadline,
+              i18n: $i18n.time,
+            })}
+          </span>
+        </div>
+        <a
+          {href}
+          class="link"
+          aria-label={$i18n.portfolio.open_proposal_card_link}
+          data-tid="proposal-link"
+        >
+          <span class="text">{$i18n.portfolio.open_proposal_card_link} </span>
+          <IconRight />
+        </a>
+      </div>
+    </div>
+  </Card>
+{/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    height: 100%;
+    background-color: var(--card-background-tint);
+    min-height: 240px;
+
+    gap: var(--padding-2x);
+    padding: var(--padding-2x);
+    /* Required to give space to the StackedCards dots */
+    padding-bottom: 34px;
+
+    @include media.min-width(medium) {
+      padding: var(--padding-3x);
+
+      /* Required to give space to the StackedCards dots */
+      padding-bottom: 34px;
+    }
+
+    .header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      gap: var(--padding-0_5x);
+
+      .title-wrapper {
+        display: flex;
+        align-items: center;
+        gap: var(--padding);
+
+        h5 {
+          margin: 0;
+          padding: 0;
+          @include text.truncate;
+        }
+      }
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-2x);
+      height: 124px;
+
+      .description-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: var(--padding-0_5x);
+
+        h3 {
+          margin: 0;
+          padding: 0;
+        }
+
+        .description {
+          margin: 0;
+          padding: 0;
+          color: var(--color-text-secondary);
+          max-width: 95%;
+
+          @include text.truncate;
+        }
+      }
+    }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .time-remaining {
+        display: flex;
+        align-items: center;
+        gap: var(--padding);
+
+        .icon {
+          display: flex;
+          color: var(--text-description);
+        }
+      }
+
+      .link {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        color: var(--button-secondary-color);
+        font-weight: var(--font-weight-bold);
+        text-decoration: none;
+
+        width: 35px;
+        height: 35px;
+        border: solid var(--button-border-size) var(--primary);
+        border-radius: 50%;
+        box-sizing: border-box;
+
+        @include media.min-width(medium) {
+          width: auto;
+          height: auto;
+          border: none;
+        }
+
+        .text {
+          display: none;
+          @include media.min-width(medium) {
+            display: inline;
+          }
+        }
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
+++ b/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
@@ -54,7 +54,7 @@
       <div class="content">
         <div class="description-wrapper">
           <h3 class="title" data-tid="proposal-title"
-            >{$i18n.portfolio.open_proposal_card_title}</h3
+            >{$i18n.portfolio.new_sns_proposal_card_title}</h3
           >
           <p class="description" data-tid="proposal-description"
             >{proposal.title}</p
@@ -82,10 +82,12 @@
         <a
           {href}
           class="link"
-          aria-label={$i18n.portfolio.open_proposal_card_link}
+          aria-label={$i18n.portfolio.new_sns_proposal_card_link}
           data-tid="proposal-link"
         >
-          <span class="text">{$i18n.portfolio.open_proposal_card_link} </span>
+          <span class="text"
+            >{$i18n.portfolio.new_sns_proposal_card_link}
+          </span>
           <IconRight />
         </a>
       </div>

--- a/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
+++ b/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
@@ -34,7 +34,7 @@
 </script>
 
 {#if nonNullish(proposal)}
-  <Card testId="launch-project-card">
+  <Card testId="new-sns-proposal-card">
     <div class="wrapper">
       <div class="header">
         <div class="title-wrapper">
@@ -53,12 +53,8 @@
 
       <div class="content">
         <div class="description-wrapper">
-          <h3 class="title" data-tid="proposal-title"
-            >{$i18n.portfolio.new_sns_proposal_card_title}</h3
-          >
-          <p class="description" data-tid="proposal-description"
-            >{proposal.title}</p
-          >
+          <h3 class="title">{$i18n.portfolio.new_sns_proposal_card_title}</h3>
+          <p class="description" data-tid="proposal-title">{proposal.title}</p>
         </div>
         <VotesResult
           yes={Number(proposalInfo.latestTally?.yes)}

--- a/frontend/src/lib/components/portfolio/VotesResult.svelte
+++ b/frontend/src/lib/components/portfolio/VotesResult.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { formatPercentage } from "$lib/utils/format.utils";
+
+  type Props = {
+    yes: number;
+    no: number;
+    total: number;
+  };
+
+  const { yes, no, total }: Props = $props();
+
+  const yesProportion: number = $derived(total ? yes / total : 0);
+  const noProportion: number = $derived(total ? no / total : 0);
+</script>
+
+<div class="votes-info">
+  <div class="yes yes-percent">
+    <span class="caption">{$i18n.portfolio.new_sns_proposal_card_adopt}</span>
+    <span class="percentage" data-tid="adopt-percentage"
+      >{formatPercentage(yesProportion, {
+        minFraction: 2,
+        maxFraction: 2,
+      })}</span
+    >
+  </div>
+  <div class="no no-percent">
+    <span class="caption">{$i18n.portfolio.new_sns_proposal_card_reject}</span>
+    <span class="percentage" data-tid="reject-percentage"
+      >{formatPercentage(noProportion)}</span
+    >
+  </div>
+  <div class="progressbar-container">
+    <div
+      class="progressbar"
+      role="progressbar"
+      data-tid="votes-progressbar"
+      aria-label={$i18n.proposal_detail__vote.vote_progress}
+      aria-valuenow={yes}
+      aria-valuemin={0}
+      aria-valuemax={total}
+    >
+      <div class="yes" style={`width: ${yesProportion * 100}%`}></div>
+      <div class="no" style={`width: ${noProportion * 100}%`}></div>
+    </div>
+    <div class="center-marker" aria-hidden="true"></div>
+  </div>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .votes-info {
+    display: grid;
+    margin: var(--padding-2) 0;
+
+    grid-template-areas:
+      "yes-percent no-percent"
+      "progressbar progressbar";
+    grid-template-columns: 1fr 1fr;
+
+    row-gap: var(--padding-0_5x);
+
+    .yes-percent {
+      grid-area: yes-percent;
+      display: flex;
+      flex-direction: column;
+      align-items: start;
+    }
+    .no-percent {
+      grid-area: no-percent;
+      display: flex;
+      flex-direction: column;
+      align-items: end;
+    }
+
+    .progressbar-container {
+      grid-area: progressbar;
+      position: relative;
+    }
+
+    .percentage {
+      @include fonts.h2(true);
+    }
+
+    .caption {
+      @include fonts.small;
+    }
+
+    .yes .percentage {
+      color: var(--positive-emphasis);
+    }
+    .no .percentage {
+      color: var(--negative-emphasis);
+    }
+  }
+
+  .progressbar-container .majority {
+    position: absolute;
+    background: var(--card-background);
+    width: calc(var(--padding) / 4);
+    height: var(--padding-1_5x);
+
+    .majority-icon {
+      position: absolute;
+      top: calc(-1 * var(--padding-1_5x));
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
+
+  .progressbar {
+    display: flex;
+    justify-content: space-between;
+    height: var(--padding);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    background: var(--elements-divider);
+
+    .yes {
+      background: var(--positive-emphasis);
+      transition: width ease-out var(--animation-time-normal);
+    }
+    .no {
+      background: var(--negative-emphasis);
+      transition: width ease-out var(--animation-time-normal);
+    }
+  }
+
+  .center-marker {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 3px;
+    height: var(--padding);
+    background-color: var(--card-background);
+    transform: translateX(-50%);
+    z-index: 1;
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/VotesResult.svelte
+++ b/frontend/src/lib/components/portfolio/VotesResult.svelte
@@ -75,11 +75,6 @@
       align-items: end;
     }
 
-    .progressbar-container {
-      grid-area: progressbar;
-      position: relative;
-    }
-
     .percentage {
       @include fonts.h2(true);
     }
@@ -91,51 +86,43 @@
     .yes .percentage {
       color: var(--positive-emphasis);
     }
+
     .no .percentage {
       color: var(--negative-emphasis);
     }
   }
 
-  .progressbar-container .majority {
-    position: absolute;
-    background: var(--card-background);
-    width: calc(var(--padding) / 4);
-    height: var(--padding-1_5x);
+  .progressbar-container {
+    grid-area: progressbar;
+    position: relative;
 
-    .majority-icon {
+    .progressbar {
+      display: flex;
+      justify-content: space-between;
+      height: var(--padding);
+      border-radius: var(--border-radius);
+      overflow: hidden;
+      background: var(--elements-divider);
+
+      .yes {
+        background: var(--positive-emphasis);
+        transition: width ease-out var(--animation-time-normal);
+      }
+      .no {
+        background: var(--negative-emphasis);
+        transition: width ease-out var(--animation-time-normal);
+      }
+    }
+
+    .center-marker {
       position: absolute;
-      top: calc(-1 * var(--padding-1_5x));
+      top: 0;
       left: 50%;
+      width: 3px;
+      height: var(--padding);
+      background-color: var(--card-background);
       transform: translateX(-50%);
+      z-index: 1;
     }
-  }
-
-  .progressbar {
-    display: flex;
-    justify-content: space-between;
-    height: var(--padding);
-    border-radius: var(--border-radius);
-    overflow: hidden;
-    background: var(--elements-divider);
-
-    .yes {
-      background: var(--positive-emphasis);
-      transition: width ease-out var(--animation-time-normal);
-    }
-    .no {
-      background: var(--negative-emphasis);
-      transition: width ease-out var(--animation-time-normal);
-    }
-  }
-
-  .center-marker {
-    position: absolute;
-    top: 0;
-    left: 50%;
-    width: 3px;
-    height: var(--padding);
-    background-color: var(--card-background);
-    transform: translateX(-50%);
-    z-index: 1;
   }
 </style>

--- a/frontend/src/lib/components/portfolio/VotesResult.svelte
+++ b/frontend/src/lib/components/portfolio/VotesResult.svelte
@@ -27,7 +27,10 @@
   <div class="no no-percent">
     <span class="caption">{$i18n.portfolio.new_sns_proposal_card_reject}</span>
     <span class="percentage" data-tid="reject-percentage"
-      >{formatPercentage(noProportion)}</span
+      >{formatPercentage(noProportion, {
+        minFraction: 2,
+        maxFraction: 2,
+      })}</span
     >
   </div>
   <div class="progressbar-container">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1212,12 +1212,17 @@
     "staked_tokens_card_info_row": "Earn voting rewards by staking your tokens in neurons and participating in the Internet Computer’s onchain governance",
     "total_assets_title": "Total Holdings",
     "project_status_open": "Ongoing",
+    "project_status_proposal": "Open",
     "open_project_card_title": "COMMITMENT",
     "open_project_current_commitment": "ICP raised",
     "open_project_card_min_icp": "Min ICP",
     "open_project_card_max_icp": "Max ICP",
     "open_project_card_nf": "Neurons' Fund",
     "open_project_card_link": "View",
-    "open_project_card_neuron_fund_tooltip": "The Neurons' Fund (NF) is an NNS controlled treasury, designed to support the development of the SNS ecosystem. Decisions on the allocation of NF resources are collectively made by the NNS."
+    "open_project_card_neuron_fund_tooltip": "The Neurons' Fund (NF) is an NNS controlled treasury, designed to support the development of the SNS ecosystem. Decisions on the allocation of NF resources are collectively made by the NNS.",
+    "new_sns_proposal_card_title": "Create New SNS",
+    "new_sns_proposal_card_link": "Vote",
+    "new_sns_proposal_card_adopt": "Adopt",
+    "new_sns_proposal_card_reject": "Reject"
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1279,6 +1279,7 @@ interface I18nPortfolio {
   staked_tokens_card_info_row: string;
   total_assets_title: string;
   project_status_open: string;
+  project_status_proposal: string;
   open_project_card_title: string;
   open_project_current_commitment: string;
   open_project_card_min_icp: string;
@@ -1286,6 +1287,10 @@ interface I18nPortfolio {
   open_project_card_nf: string;
   open_project_card_link: string;
   open_project_card_neuron_fund_tooltip: string;
+  new_sns_proposal_card_title: string;
+  new_sns_proposal_card_link: string;
+  new_sns_proposal_card_adopt: string;
+  new_sns_proposal_card_reject: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,6 +1,7 @@
 import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import { formatNumber } from "$lib/utils/format.utils";
 import type { FullProjectCommitmentSplit } from "$lib/utils/projects.utils";
 import {
@@ -17,7 +18,8 @@ import {
   compareTokensIcpFirst,
 } from "$lib/utils/tokens-table.utils";
 import { isUserTokenData } from "$lib/utils/user-token.utils";
-import { ICPToken } from "@dfinity/utils";
+import type { ProposalId, ProposalInfo } from "@dfinity/nns";
+import { ICPToken, isNullish } from "@dfinity/utils";
 
 const MAX_NUMBER_OF_ITEMS = 4;
 
@@ -153,4 +155,39 @@ export const getMinCommitmentPercentage = (
       token: ICPToken,
     })
   );
+};
+
+export const mapProposalInfoToCard = (
+  proposalInfo: ProposalInfo
+):
+  | undefined
+  | {
+      durationTillDeadline: bigint;
+      id: ProposalId;
+      title: string | undefined;
+      logo: string | undefined;
+      name: string | undefined;
+    } => {
+  const proposal = proposalInfo?.proposal;
+  const action = proposal?.action;
+
+  if (isNullish(action) || isNullish(proposal)) return undefined;
+  if (!("CreateServiceNervousSystem" in action)) return undefined;
+
+  const title = proposal.title;
+  const { id, deadlineTimestampSeconds } = proposalInfo;
+  const durationTillDeadline = deadlineTimestampSeconds
+    ? deadlineTimestampSeconds - BigInt(nowInSeconds())
+    : 0n;
+  const logo: string | undefined =
+    action.CreateServiceNervousSystem?.logo?.base64Encoding;
+  const name: string | undefined = action.CreateServiceNervousSystem?.name;
+
+  return {
+    durationTillDeadline,
+    logo,
+    name,
+    title,
+    id: id as ProposalId,
+  };
 };

--- a/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
@@ -50,7 +50,7 @@ describe("NewSnsProposalCard", () => {
     ).CreateServiceNervousSystem.name;
     const expectedProposalTitle = mockProposal.proposal.title;
 
-    expect(await po.getProjectName()).toBe(expectedProjectName);
+    expect(await po.getTitle()).toBe(expectedProjectName);
     expect(await po.getProposalTitle()).toBe(expectedProposalTitle);
   });
 

--- a/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
@@ -58,15 +58,15 @@ describe("NewSnsProposalCard", () => {
     const po = renderComponent({
       ...mockProposal,
       latestTally: {
-        yes: 100000n,
-        no: 100000n,
-        total: 200000n,
+        yes: 100_000_000n,
+        no: 200_000_000n,
+        total: 300_000_000n,
         timestampSeconds: 10000000n,
       },
     });
 
-    expect(await po.getAdoptPercentage()).toBe("50.00%");
-    expect(await po.getRejectPercentage()).toBe("50.00%");
+    expect(await po.getAdoptPercentage()).toBe("33.33%");
+    expect(await po.getRejectPercentage()).toBe("66.67%");
   });
 
   it("should display time remaining until deadline", async () => {

--- a/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
@@ -1,0 +1,99 @@
+import NewSnsProposalCard from "$lib/components/portfolio/NewSnsProposalCard.svelte";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { NewSnsProposalCardPo } from "$tests/page-objects/NewSnsProposalCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  type CreateServiceNervousSystem,
+  type ProposalInfo,
+} from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+
+describe("NewSnsProposalCard", () => {
+  const mockProposal = {
+    proposal: {
+      title: "Proposal to create new SNS",
+      summary: "",
+      url: "url",
+      action: {
+        CreateServiceNervousSystem: {
+          name: "TestDAO",
+          governanceParameters: {},
+          fallbackControllerPrincipalIds: [],
+          logo: {},
+          url: "url",
+          ledgerParameters: {},
+          description: "",
+          dappCanisters: [],
+          swapParameters: {},
+          initialTokenDistribution: {},
+        },
+      },
+    },
+  } as ProposalInfo;
+
+  const renderComponent = (proposalInfo: ProposalInfo) => {
+    const { container } = render(NewSnsProposalCard, {
+      props: {
+        proposalInfo,
+      },
+    });
+
+    return NewSnsProposalCardPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should display project name and description", async () => {
+    const po = renderComponent(mockProposal);
+    const expectedProjectName = (
+      mockProposal.proposal.action as {
+        CreateServiceNervousSystem: CreateServiceNervousSystem;
+      }
+    ).CreateServiceNervousSystem.name;
+    const expectedProposalTitle = mockProposal.proposal.title;
+
+    expect(await po.getProjectName()).toBe(expectedProjectName);
+    expect(await po.getProposalTitle()).toBe(expectedProposalTitle);
+  });
+
+  it("should display percengate of yes/no", async () => {
+    const po = renderComponent({
+      ...mockProposal,
+      latestTally: {
+        yes: 100000n,
+        no: 100000n,
+        total: 200000n,
+        timestampSeconds: 10000000n,
+      },
+    });
+
+    expect(await po.getAdoptPercentage()).toBe("50.00%");
+    expect(await po.getRejectPercentage()).toBe("50.00%");
+  });
+
+  it("should display time remaining until deadline", async () => {
+    const mockDate = new Date("2025-03-11T00:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+
+    const oneDayLater = new Date(mockDate.getTime() + 24 * 60 * 60 * 1000);
+    const deadlineTimestampSeconds = BigInt(
+      Math.floor(oneDayLater.getTime() / 1000)
+    );
+
+    const po = renderComponent({
+      ...mockProposal,
+      deadlineTimestampSeconds,
+    });
+
+    expect(await po.getTimeRemaining()).toEqual("1 day");
+  });
+
+  it("should have proper link to project page", async () => {
+    const po = renderComponent({
+      ...mockProposal,
+      id: 1n,
+    });
+    const expectedHref = `/proposal/?u=${OWN_CANISTER_ID_TEXT}&proposal=1`;
+
+    expect(await po.getLinkPo().getHref()).toBe(expectedHref);
+  });
+});

--- a/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/NewSnsProposalCard.spec.ts
@@ -54,7 +54,7 @@ describe("NewSnsProposalCard", () => {
     expect(await po.getProposalTitle()).toBe(expectedProposalTitle);
   });
 
-  it("should display percengate of yes/no", async () => {
+  it("should display percentage of yes/no", async () => {
     const po = renderComponent({
       ...mockProposal,
       latestTally: {

--- a/frontend/src/tests/page-objects/NewSnsProposalCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NewSnsProposalCard.page-object.ts
@@ -1,0 +1,38 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NewSnsProposalCardPo extends BasePageObject {
+  private static readonly TID = "new-sns-proposal-card";
+
+  static under(element: PageObjectElement): NewSnsProposalCardPo {
+    return new NewSnsProposalCardPo(element.byTestId(NewSnsProposalCardPo.TID));
+  }
+
+  getProjectName(): Promise<string> {
+    return this.getText("project-name");
+  }
+
+  getProposalTitle(): Promise<string> {
+    return this.getText("proposal-title");
+  }
+
+  getAdoptPercentage(): Promise<string> {
+    return this.getText("adopt-percentage");
+  }
+
+  getRejectPercentage(): Promise<string> {
+    return this.getText("reject-percentage");
+  }
+
+  getTimeRemaining(): Promise<string> {
+    return this.getText("time-remaining");
+  }
+
+  getLinkPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "proposal-link",
+    });
+  }
+}

--- a/frontend/src/tests/page-objects/NewSnsProposalCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NewSnsProposalCard.page-object.ts
@@ -9,7 +9,7 @@ export class NewSnsProposalCardPo extends BasePageObject {
     return new NewSnsProposalCardPo(element.byTestId(NewSnsProposalCardPo.TID));
   }
 
-  getProjectName(): Promise<string> {
+  getTitle(): Promise<string> {
     return this.getText("project-name");
   }
 


### PR DESCRIPTION
# Motivation

We want to display NSN proposals for creating an SNS directly on the Portfolio page. A new card will be used to present this information, showing basic details about the proposal and the current voting status.

This initial PR creates the new component, which will later be utilized by the Portfolio page.

[NNS1-3637](https://dfinity.atlassian.net/browse/NNS1-3637)

Note: The differences in the remaining time copy are intentional to ensure consistency between the Portfolio cards.

Design reference:

<img width="410" alt="Screenshot 2025-04-04 at 16 31 19" src="https://github.com/user-attachments/assets/fd16296f-ba94-42bd-a79d-3420835639b4" />

Screenshots:

<img width="565" alt="Screenshot 2025-04-04 at 16 34 34" src="https://github.com/user-attachments/assets/8f47f459-82de-42a0-87aa-003b746c25e9" />

<img width="549" alt="Screenshot 2025-04-04 at 16 33 42" src="https://github.com/user-attachments/assets/f517411f-16e8-4a15-aa83-b8db20798f7e" />

# Changes

- New components `VotesResult` and `NewSnsProposalCard`
- New copy for the component

# Tests

- New unit tests and page object for the new component.
- Tested in [devenv]() with other changes

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3637]: https://dfinity.atlassian.net/browse/NNS1-3637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ