### PR TITLE
feat(portfolio): integrate SNS proposal cards into stacked cards on the portfolio page

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -2,6 +2,7 @@
   import HeldTokensCard from "$lib/components/portfolio/HeldTokensCard.svelte";
   import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
   import LoginCard from "$lib/components/portfolio/LoginCard.svelte";
+  import NewSnsProposalCard from "$lib/components/portfolio/NewSnsProposalCard.svelte";
   import NoHeldTokensCard from "$lib/components/portfolio/NoHeldTokensCard.svelte";
   import NoStakedTokensCard from "$lib/components/portfolio/NoStakedTokensCard.svelte";
   import SkeletonTokensCard from "$lib/components/portfolio/SkeletonTokensCard.svelte";
@@ -22,12 +23,14 @@
   import { comparesByDecentralizationSaleOpenTimestampDesc } from "$lib/utils/projects.utils";
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
   import { getTotalBalanceInUsd } from "$lib/utils/token.utils";
+  import type { ProposalInfo } from "@dfinity/nns";
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
   import type { Component } from "svelte";
 
   export let userTokens: UserToken[] = [];
   export let tableProjects: TableProject[];
   export let snsProjects: SnsFullProject[];
+  export let openSnsProposals: ProposalInfo[] = [];
 
   let totalTokensBalanceInUsd: number;
   $: totalTokensBalanceInUsd = getTotalBalanceInUsd(userTokens);
@@ -130,6 +133,16 @@
     component: LaunchProjectCard as unknown as Component,
     props: { summary },
   }));
+
+  let openProposalCards: CardItem[];
+  $: openProposalCards = openSnsProposals.map((proposalInfo) => ({
+    // TODO: Svelte v5 migration - fix type
+    component: NewSnsProposalCard as unknown as Component,
+    props: { proposalInfo },
+  }));
+
+  let cards: CardItem[] = [];
+  $: cards = [...launchpadCards, ...openProposalCards];
 </script>
 
 <main data-tid="portfolio-page-component">
@@ -150,8 +163,8 @@
       />
     {/if}
 
-    {#if launchpadCards.length > 0}
-      <StackedCards cards={launchpadCards} />
+    {#if cards.length > 0}
+      <StackedCards {cards} />
     {/if}
   </div>
 

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -22,6 +22,7 @@ import {
 import { PortfolioPagePo } from "$tests/page-objects/PortfolioPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
+import type { ProposalInfo } from "@dfinity/nns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
@@ -30,16 +31,19 @@ describe("Portfolio page", () => {
     userTokens = [],
     tableProjects = [],
     snsProjects = [],
+    openSnsProposals = [],
   }: {
     userTokens?: UserToken[];
     tableProjects?: TableProject[];
     snsProjects?: SnsFullProject[];
+    openSnsProposals?: ProposalInfo[];
   } = {}) => {
     const { container } = render(Portfolio, {
       props: {
         userTokens,
         tableProjects,
         snsProjects,
+        openSnsProposals,
       },
     });
 
@@ -136,14 +140,45 @@ describe("Portfolio page", () => {
     });
   });
 
-  describe("OpenLaunches", () => {
+  describe("StackedCards", () => {
     const mockSnsProjects: SnsFullProject[] = [
       mockSnsFullProject,
       { ...mockSnsFullProject, rootCanisterId: principal(2) },
     ];
 
+    const mockSnsProposals = [
+      {
+        proposal: {
+          title: "Proposal to create new SNS",
+          summary: "",
+          url: "url",
+          action: {
+            CreateServiceNervousSystem: {
+              name: "TestDAO",
+              governanceParameters: {},
+              fallbackControllerPrincipalIds: [],
+              logo: {},
+              url: "url",
+              ledgerParameters: {},
+              description: "",
+              dappCanisters: [],
+              swapParameters: {},
+              initialTokenDistribution: {},
+            },
+          },
+        },
+      },
+    ] as ProposalInfo[];
+
     beforeEach(() => {
       resetIdentity();
+    });
+
+    it("should not display StackedCards if no snsProjects nor proposals for new sns", async () => {
+      const po = renderPage();
+      const stackedCardsPo = po.getStackedCardsPo();
+
+      expect(await stackedCardsPo.isPresent()).toBe(false);
     });
 
     it("should display StackedCards when snsProjects is not empty", async () => {
@@ -155,11 +190,46 @@ describe("Portfolio page", () => {
       expect(cardWrappers.length).toBe(2);
     });
 
-    it("should not display StackedCards when snsProjects is empty", async () => {
-      const po = renderPage();
+    it("should display StackedCards when openSnsProposals is not empty", async () => {
+      const po = renderPage({ openSnsProposals: mockSnsProposals });
       const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
 
-      expect(await stackedCardsPo.isPresent()).toBe(false);
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(1);
+    });
+
+    it("should show all cards when snsProjects and openSnsProposals are not empty", async () => {
+      const po = renderPage({
+        snsProjects: mockSnsProjects,
+        openSnsProposals: mockSnsProposals,
+      });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(3);
+    });
+
+    it("should show first on going swaps and then proposals", async () => {
+      const po = renderPage({
+        snsProjects: mockSnsProjects.slice(0, 1),
+        openSnsProposals: mockSnsProposals,
+      });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+      const dotsPo = await stackedCardsPo.getDots();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(2);
+
+      let activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("Tetris");
+
+      await dotsPo[1].click();
+
+      activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("TestDAO");
     });
 
     it("should hide TotalAssetsCard when not signed in and there are sns projects", async () => {

--- a/frontend/src/tests/page-objects/BasePortfolioCard.page-object.ts
+++ b/frontend/src/tests/page-objects/BasePortfolioCard.page-object.ts
@@ -1,0 +1,5 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+
+export abstract class BasePortfolioCardPo extends BasePageObject {
+  abstract getTitle(): Promise<string>;
+}

--- a/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/LaunchProjectCard.page-object.ts
@@ -1,9 +1,9 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { BasePortfolioCardPo } from "$tests/page-objects/BasePortfolioCard.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class LaunchProjectCardPo extends BasePageObject {
+export class LaunchProjectCardPo extends BasePortfolioCardPo {
   private static readonly TID = "launch-project-card";
 
   static under(element: PageObjectElement): LaunchProjectCardPo {

--- a/frontend/src/tests/page-objects/NewSnsProposalCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NewSnsProposalCard.page-object.ts
@@ -1,8 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { BasePortfolioCardPo } from "$tests/page-objects/BasePortfolioCard.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NewSnsProposalCardPo extends BasePageObject {
+export class NewSnsProposalCardPo extends BasePortfolioCardPo {
   private static readonly TID = "new-sns-proposal-card";
 
   static under(element: PageObjectElement): NewSnsProposalCardPo {

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -1,4 +1,7 @@
+import type { BasePortfolioCardPo } from "$tests/page-objects/BasePortfolioCard.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { LaunchProjectCardPo } from "$tests/page-objects/LaunchProjectCard.page-object";
+import { NewSnsProposalCardPo } from "$tests/page-objects/NewSnsProposalCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -67,5 +70,19 @@ export class StackedCardsPo extends BasePageObject {
       }
     }
     return -1;
+  }
+
+  async getActiveCardPo(): Promise<BasePortfolioCardPo> {
+    const activeIndex = await this.getActiveCardIndex();
+    const cardWrappers = await this.getCardWrappers();
+    let activeCard: BasePortfolioCardPo;
+
+    activeCard = LaunchProjectCardPo.under(cardWrappers[activeIndex].root);
+    if (await activeCard.isPresent()) return activeCard;
+
+    activeCard = NewSnsProposalCardPo.under(cardWrappers[activeIndex].root);
+    if (await activeCard.isPresent()) return activeCard;
+
+    return null;
   }
 }


### PR DESCRIPTION
# Motivation

Following up on #6663, we want to display the SNS proposals for creating a new SNS on the Portfolio page. This PR utilizes the new card component, `NewSnsProposalCard`, to showcase all the open SNS proposals provided through the props.

It sorts them into two groups: ongoing swaps and open proposals. Each group is then sorted by the duration until the deadline.

[NNS1-3637](https://dfinity.atlassian.net/browse/NNS1-3637)

# Changes

- Compose list of cards for the `StackedCards` component, prioritizing ongoing swaps over NNS proposals for new SNSs.

# Tests

- Unit tests for the new component.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3637]: https://dfinity.atlassian.net/browse/NNS1-3637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ