### PR TITLE
chore(deps): update rust to 1.86.0

### DIFF
--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -281,7 +281,7 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
         return Some("application/octet-stream");
     }
 
-    request_path.split('.').last().and_then(|suffix| match suffix {
+    request_path.split('.').next_back().and_then(|suffix| match suffix {
         "css" => Some("text/css"),
         "html" => Some("text/html"),
         "xml" => Some("application/xml"),

--- a/rs/backend/src/tvl.rs
+++ b/rs/backend/src/tvl.rs
@@ -141,26 +141,24 @@ pub async fn update_exchange_rate() {
 
 pub async fn update_locked_icp_e8s() {
     let metrics_result = governance::get_metrics().await;
-    with_state_mut(|s| {
-        match metrics_result {
-            Ok(Ok(metrics)) => {
-                s.tvl_state.total_locked_icp_e8s = metrics.total_locked_e8s;
-                ic_cdk::println!("Updated total_locked_icp_e8s for TVL to {}", metrics.total_locked_e8s);
-            }
-            Ok(Err(err)) => {
-                ic_cdk::println!(
-                    "Keeping total_locked_icp_e8s for TVL at {} because of response error: {}",
-                    s.tvl_state.total_locked_icp_e8s,
-                    err
-                );
-            }
-            Err(err) => {
-                ic_cdk::println!(
-                    "Keeping total_locked_icp_e8s for TVL at {} because of call error: {}",
-                    s.tvl_state.total_locked_icp_e8s,
-                    err
-                );
-            }
+    with_state_mut(|s| match metrics_result {
+        Ok(Ok(metrics)) => {
+            s.tvl_state.total_locked_icp_e8s = metrics.total_locked_e8s;
+            ic_cdk::println!("Updated total_locked_icp_e8s for TVL to {}", metrics.total_locked_e8s);
+        }
+        Ok(Err(err)) => {
+            ic_cdk::println!(
+                "Keeping total_locked_icp_e8s for TVL at {} because of response error: {}",
+                s.tvl_state.total_locked_icp_e8s,
+                err
+            );
+        }
+        Err(err) => {
+            ic_cdk::println!(
+                "Keeping total_locked_icp_e8s for TVL at {} because of call error: {}",
+                s.tvl_state.total_locked_icp_e8s,
+                err
+            );
         }
     });
 }

--- a/rs/backend/src/tvl.rs
+++ b/rs/backend/src/tvl.rs
@@ -161,7 +161,7 @@ pub async fn update_locked_icp_e8s() {
                     err
                 );
             }
-        };
+        }
     });
 }
 

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -129,7 +129,7 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
     if request_path.ends_with('/') {
         return Some("text/html");
     }
-    request_path.split('.').last().and_then(|suffix| match suffix {
+    request_path.split('.').next_back().and_then(|suffix| match suffix {
         "css" => Some("text/css"),
         "html" => Some("text/html"),
         "xml" => Some("application/xml"),
@@ -210,7 +210,7 @@ pub fn insert_asset<S: Into<String> + Clone>(path: S, asset: Asset) {
         let path = path.into();
 
         let index = "index.html";
-        if path.split('/').last() == Some(index) {
+        if path.split('/').next_back() == Some(index) {
             // Add the directory, with trailing slash, as an alternative path.
             // Note: Without the trailing slash the location of "." is the parent, so breaks resource links.
             let prefix_len = path.len() - index.len();

--- a/rs/sns_aggregator/src/fast_scheduler.rs
+++ b/rs/sns_aggregator/src/fast_scheduler.rs
@@ -118,13 +118,13 @@ impl FastScheduler {
                         Err(err) => crate::state::log(format!(
                             "Failed to get derived state; derived state is NOT updated: {err:?}"
                         )),
-                    };
+                    }
                     match swap_state_maybe {
                         Ok(swap_state) => entry.swap_state = swap_state,
                         Err(err) => {
                             crate::state::log(format!("Failed to get swap state; swap state is NOT updated: {err:?}"));
                         }
-                    };
+                    }
                     match lifecycle_maybe {
                         Ok(lifecycle) => entry.lifecycle = Some(lifecycle),
                         Err(err) => crate::state::log(format!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.85.1"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

There is a new version of Rust. The automatic job #6661 fails due to some Clippy errors. This PR addresses the changes from #6661 and fixes those errors.

# Changes

- Fork #6661 into this branch.
- Fix errors

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.