### PR TITLE
build: bump vite (CVE-2025-31486)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "@playwright/test": "^1.49.1",
         "@rollup/plugin-inject": "^5.0.5",
         "@sveltejs/adapter-static": "^3.0.8",
-        "@sveltejs/kit": "^2.20.2",
+        "@sveltejs/kit": "^2.20.4",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/svelte": "^5.2.7",
@@ -63,7 +63,7 @@
         "svelte-preprocess": "^6.0.3",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.24.0",
-        "vite": "^6.2.4",
+        "vite": "^6.2.5",
         "vitest": "^3.1.1",
         "vitest-mock-extended": "^3.0.1"
       },
@@ -1811,9 +1811,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.2.tgz",
-      "integrity": "sha512-Dv8TOAZC9vyfcAB9TMsvUEJsRbklRTeNfcYBPaeH6KnABJ99i3CvCB2eNx8fiiliIqe+9GIchBg4RodRH5p1BQ==",
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.4.tgz",
+      "integrity": "sha512-B3Y1mb1Qjt57zXLVch5tfqsK/ebHe6uYTcFSnGFNwRpId3+fplLgQK6Z2zhDVBezSsPuhDq6Pry+9PA88ocN6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6502,9 +6502,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8020,9 +8020,9 @@
       "requires": {}
     },
     "@sveltejs/kit": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.2.tgz",
-      "integrity": "sha512-Dv8TOAZC9vyfcAB9TMsvUEJsRbklRTeNfcYBPaeH6KnABJ99i3CvCB2eNx8fiiliIqe+9GIchBg4RodRH5p1BQ==",
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.4.tgz",
+      "integrity": "sha512-B3Y1mb1Qjt57zXLVch5tfqsK/ebHe6uYTcFSnGFNwRpId3+fplLgQK6Z2zhDVBezSsPuhDq6Pry+9PA88ocN6Q==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.6.0",
@@ -11118,9 +11118,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "@playwright/test": "^1.49.1",
     "@rollup/plugin-inject": "^5.0.5",
     "@sveltejs/adapter-static": "^3.0.8",
-    "@sveltejs/kit": "^2.20.2",
+    "@sveltejs/kit": "^2.20.4",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.2.7",
@@ -66,7 +66,7 @@
     "svelte-preprocess": "^6.0.3",
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.24.0",
-    "vite": "^6.2.4",
+    "vite": "^6.2.5",
     "vitest": "^3.1.1",
     "vitest-mock-extended": "^3.0.1"
   },


### PR DESCRIPTION
# Motivation

Another week, anoter security issue in vite. Similarly to latest incidents (https://github.com/dfinity/gix-components/pull/610 and https://github.com/dfinity/gix-components/pull/614), we are not affected but, for the state of the art, let's bump vite to resolve [CVE-2025-31486](https://github.com/advisories/GHSA-xcj6-pq6g-qj4x).

# Changes

- Bump vite v6.2.5
- Bumo related dev dependencies
