### PR TITLE
chore(deps): upgrade vite to 6.2.5 to patch security vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,7 @@
         "svelte-preprocess": "^6.0.3",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.24.0",
-        "vite": "^6.2.4",
+        "vite": "^6.2.5",
         "vitest": "^3.1.1",
         "vitest-mock-extended": "^3.0.1"
       },
@@ -6502,9 +6502,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11118,9 +11118,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
     "svelte-preprocess": "^6.0.3",
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.24.0",
-    "vite": "^6.2.4",
+    "vite": "^6.2.5",
     "vitest": "^3.1.1",
     "vitest-mock-extended": "^3.0.1"
   },


### PR DESCRIPTION
# Motivation

Upgrades vite to handle security vulnerability.

[SCAVM-1140](https://dfinity.atlassian.net/browse/SCAVM-1140)

# Changes

- Run `npm run vite@latest`

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[SCAVM-1140]: https://dfinity.atlassian.net/browse/SCAVM-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ