### PR TITLE
feat(services): expose large fields flag for SNS proposals

### DIFF
--- a/frontend/src/lib/services/public/sns.services.ts
+++ b/frontend/src/lib/services/public/sns.services.ts
@@ -51,7 +51,11 @@ export const loadSnsProjects = async (): Promise<void> => {
   }
 };
 
-export const loadProposalsSnsCF = async (): Promise<void> => {
+export const loadProposalsSnsCF = async ({
+  omitLargeFields = true,
+}: {
+  omitLargeFields?: boolean;
+} = {}): Promise<void> => {
   snsProposalsStore.reset();
 
   return queryAndUpdate<ProposalInfo[], unknown>({
@@ -64,6 +68,7 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
         includeTopics: [Topic.SnsAndCommunityFund],
         includeStatus: [ProposalStatus.Open],
         certified,
+        omitLargeFields,
       }),
     onLoad: ({ response: proposals, certified }) =>
       snsProposalsStore.setProposals({

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -30,6 +30,7 @@ describe("Proposals", () => {
       identity: new AnonymousIdentity(),
       includeTopics: [Topic.SnsAndCommunityFund],
       includeStatus: [ProposalStatus.Open],
+      omitLargeFields: true,
     });
   });
 

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -1,5 +1,6 @@
 import { clearSnsAggregatorCache } from "$lib/api-services/sns-aggregator.api-service";
 import * as agent from "$lib/api/agent.api";
+import * as proposalsApi from "$lib/api/proposals.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import {
   clearWrapperCache,
@@ -10,6 +11,7 @@ import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
 import { snsTotalTokenSupplyStore } from "$lib/derived/sns-total-token-supply.derived";
 import {
   getLoadedSnsAggregatorData,
+  loadProposalsSnsCF,
   loadSnsProjects,
 } from "$lib/services/public/sns.services";
 import {
@@ -32,7 +34,7 @@ import {
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
-import type { HttpAgent } from "@dfinity/agent";
+import { AnonymousIdentity, type HttpAgent } from "@dfinity/agent";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 import { mock } from "vitest-mock-extended";
@@ -233,6 +235,45 @@ describe("SNS public services", () => {
       expect(wrappers.has(committedSns2.canister_ids.root_canister_id)).toBe(
         true
       );
+    });
+  });
+
+  describe("loadProposalsSnsCF", () => {
+    let queryProposalsSpy;
+    const baseRequestPayload = {
+      beforeProposal: undefined,
+      identity: new AnonymousIdentity(),
+      includeStatus: [1],
+      includeTopics: [14],
+      certified: false,
+    };
+
+    beforeEach(() => {
+      queryProposalsSpy = vi
+        .spyOn(proposalsApi, "queryProposals")
+        .mockResolvedValue([]);
+    });
+
+    it("should request proposals omiting large fields by default", async () => {
+      await loadProposalsSnsCF();
+
+      expect(queryProposalsSpy).toHaveBeenCalledTimes(1);
+      expect(queryProposalsSpy).toHaveBeenCalledWith({
+        omitLargeFields: true,
+        ...baseRequestPayload,
+      });
+    });
+
+    it("should request proposals not omiting large fields when requested", async () => {
+      await loadProposalsSnsCF({
+        omitLargeFields: false,
+      });
+
+      expect(queryProposalsSpy).toHaveBeenCalledTimes(1);
+      expect(queryProposalsSpy).toHaveBeenCalledWith({
+        omitLargeFields: false,
+        ...baseRequestPayload,
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -254,7 +254,7 @@ describe("SNS public services", () => {
         .mockResolvedValue([]);
     });
 
-    it("should request proposals omiting large fields by default", async () => {
+    it("should request proposals omitting large fields by default", async () => {
       await loadProposalsSnsCF();
 
       expect(queryProposalsSpy).toHaveBeenCalledTimes(1);
@@ -264,7 +264,7 @@ describe("SNS public services", () => {
       });
     });
 
-    it("should request proposals not omiting large fields when requested", async () => {
+    it("should request proposals not omitting large fields when requested", async () => {
       await loadProposalsSnsCF({
         omitLargeFields: false,
       });


### PR DESCRIPTION
# Motivation

For the upcoming SNS proposals on the Portfolio page, we want to display these proposals along with their SNS icons. To achieve this, we need to disable the `omitLargeFields` flag in the request. This PR follows up on the work done in #6647 and exposes the flag in the service.

The service lacked tests, so this PR adds the minimum necessary to ensure that the flag functions as intended while maintaining the previous behavior as the default.

[NNS1-3638](https://dfinity.atlassian.net/browse/NNS1-3638)

# Changes

- Exposes flag in `loadProposalsSnsCF`.

# Tests

- Adds unit test to check that property is properly forwarded to `queryProposals`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3638]: https://dfinity.atlassian.net/browse/NNS1-3638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ