### PR TITLE
feat(portfolio): sort SNS proposals by deadline

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -17,6 +17,7 @@
   import type { TableProject } from "$lib/types/staking";
   import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
   import {
+    compareProposalInfoByDeadlineTimestampSeconds,
     getTopHeldTokens,
     getTopStakedTokens,
   } from "$lib/utils/portfolio.utils";
@@ -135,11 +136,13 @@
   }));
 
   let openProposalCards: CardItem[];
-  $: openProposalCards = openSnsProposals.map((proposalInfo) => ({
-    // TODO: Svelte v5 migration - fix type
-    component: NewSnsProposalCard as unknown as Component,
-    props: { proposalInfo },
-  }));
+  $: openProposalCards = openSnsProposals
+    .sort(compareProposalInfoByDeadlineTimestampSeconds)
+    .map((proposalInfo) => ({
+      // TODO: Svelte v5 migration - fix type
+      component: NewSnsProposalCard as unknown as Component,
+      props: { proposalInfo },
+    }));
 
   let cards: CardItem[] = [];
   $: cards = [...launchpadCards, ...openProposalCards];

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -5,6 +5,7 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import { formatNumber } from "$lib/utils/format.utils";
 import type { FullProjectCommitmentSplit } from "$lib/utils/projects.utils";
 import {
+  createAscendingComparator,
   createDescendingComparator,
   mergeComparators,
 } from "$lib/utils/sort.utils";
@@ -191,3 +192,8 @@ export const mapProposalInfoToCard = (
     id: id as ProposalId,
   };
 };
+
+export const compareProposalInfoByDeadlineTimestampSeconds =
+  createAscendingComparator(
+    (proposal: ProposalInfo) => proposal.deadlineTimestampSeconds
+  );

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -154,7 +154,7 @@ describe("Portfolio page", () => {
           url: "url",
           action: {
             CreateServiceNervousSystem: {
-              name: "TestDAO",
+              name: "TestDAO1",
               governanceParameters: {},
               fallbackControllerPrincipalIds: [],
               logo: {},
@@ -167,6 +167,29 @@ describe("Portfolio page", () => {
             },
           },
         },
+        deadlineTimestampSeconds: 168_0000_000n,
+      },
+      {
+        proposal: {
+          title: "Proposal to create new SNS",
+          summary: "",
+          url: "url",
+          action: {
+            CreateServiceNervousSystem: {
+              name: "TestDAO2",
+              governanceParameters: {},
+              fallbackControllerPrincipalIds: [],
+              logo: {},
+              url: "url",
+              ledgerParameters: {},
+              description: "",
+              dappCanisters: [],
+              swapParameters: {},
+              initialTokenDistribution: {},
+            },
+          },
+        },
+        deadlineTimestampSeconds: 68_0000_000n,
       },
     ] as ProposalInfo[];
 
@@ -196,7 +219,25 @@ describe("Portfolio page", () => {
       const cardWrappers = await stackedCardsPo.getCardWrappers();
 
       expect(await stackedCardsPo.isPresent()).toBe(true);
-      expect(cardWrappers.length).toBe(1);
+      expect(cardWrappers.length).toBe(2);
+    });
+
+    it("should sort openSnsProposal", async () => {
+      const po = renderPage({ openSnsProposals: mockSnsProposals });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+      const dotsPo = await stackedCardsPo.getDots();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(2);
+
+      let activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("TestDAO2");
+
+      await dotsPo[1].click();
+
+      activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("TestDAO1");
     });
 
     it("should show all cards when snsProjects and openSnsProposals are not empty", async () => {
@@ -208,13 +249,13 @@ describe("Portfolio page", () => {
       const cardWrappers = await stackedCardsPo.getCardWrappers();
 
       expect(await stackedCardsPo.isPresent()).toBe(true);
-      expect(cardWrappers.length).toBe(3);
+      expect(cardWrappers.length).toBe(4);
     });
 
     it("should show first on going swaps and then proposals", async () => {
       const po = renderPage({
         snsProjects: mockSnsProjects.slice(0, 1),
-        openSnsProposals: mockSnsProposals,
+        openSnsProposals: mockSnsProposals.slice(0, 1),
       });
       const stackedCardsPo = po.getStackedCardsPo();
       const cardWrappers = await stackedCardsPo.getCardWrappers();
@@ -229,7 +270,7 @@ describe("Portfolio page", () => {
       await dotsPo[1].click();
 
       activeCard = await stackedCardsPo.getActiveCardPo();
-      expect(await activeCard.getTitle()).toBe("TestDAO");
+      expect(await activeCard.getTitle()).toBe("TestDAO1");
     });
 
     it("should hide TotalAssetsCard when not signed in and there are sns projects", async () => {

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -167,7 +167,7 @@ describe("Portfolio page", () => {
             },
           },
         },
-        deadlineTimestampSeconds: 168_0000_000n,
+        deadlineTimestampSeconds: 168_000_000n,
       },
       {
         proposal: {
@@ -189,7 +189,7 @@ describe("Portfolio page", () => {
             },
           },
         },
-        deadlineTimestampSeconds: 68_0000_000n,
+        deadlineTimestampSeconds: 68_000_000n,
       },
     ] as ProposalInfo[];
 


### PR DESCRIPTION
# Motivation

We want to display upcoming projects on the portfolio page. Specifically, we aim to show a card for open proposals to create a new SNS. These cards have to be sorted by `deadlineTimestampSeconds`.

[NNS1-3638](https://dfinity.atlassian.net/browse/NNS1-3638)

# Changes

- Sorts proposals in ascending order by `deadlineTimestampSeconds`.

# Tests

- Adds tests to verify that proposals are sorted in the `StackedCards`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3638]: https://dfinity.atlassian.net/browse/NNS1-3638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ