### PR TITLE
chore(scripts): simplify beta release verification steps

### DIFF
--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -154,8 +154,7 @@ Verify the build before approving:
 
 One liner:
 
-git fetch && git checkout "$COMMIT" && (git merge-base --is-ancestor HEAD origin/main && echo OK || echo \"Commit is not on main branch!\") && ./scripts/docker-build && sha256sum \"nns-dapp.wasm.gz\"
-"
+git fetch && git checkout \"$COMMIT\" && (git merge-base --is-ancestor HEAD origin/main && echo OK || echo \"Commit is not on main branch!\") && ./scripts/docker-build && sha256sum \"nns-dapp.wasm.gz\""
 
 dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" request --title "$TITLE" --summary "$SUMMARY" canister install --mode "$INSTALL_MODE" --wasm "$WASM_PATH" "$NNS_DAPP_BETA_CANISTER_ID" --argument "$(cat nns-dapp-arg-beta.did)" --asset-canister "$ASSET_CANISTER_ID"
 

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -150,7 +150,12 @@ Verify the build before approving:
 2. git checkout $COMMIT
 3. git merge-base --is-ancestor HEAD origin/main && echo OK || echo \"Commit is not on main branch!\"
 4. ./scripts/docker-build
-5. sha256sum nns-dapp.wasm.gz"
+5. sha256sum nns-dapp.wasm.gz
+
+One liner:
+
+git fetch && git checkout "$COMMIT" && (git merge-base --is-ancestor HEAD origin/main && echo OK || echo \"Commit is not on main branch!\") && ./scripts/docker-build && sha256sum \"nns-dapp.wasm.gz\"
+"
 
 dfx-orbit --station "$STATION" --identity "$DFX_IDENTITY" request --title "$TITLE" --summary "$SUMMARY" canister install --mode "$INSTALL_MODE" --wasm "$WASM_PATH" "$NNS_DAPP_BETA_CANISTER_ID" --argument "$(cat nns-dapp-arg-beta.did)" --asset-canister "$ASSET_CANISTER_ID"
 


### PR DESCRIPTION
# Motivation

The `scripts/nns-dapp/release-beta` creates an Orbit proposal to release the nns-dapp to Beta. Voters should ideally review the proposal before casting their votes. Currently, the instructions for reviewing the proposal are as follows:
```
1. git fetch
2. git checkout $COMMIT
3. git merge-base --is-ancestor HEAD origin/main && echo OK || echo \"Commit is not on main branch!\"
4. ./scripts/docker-build
5. sha256sum nns-dapp.wasm.gz"
```

This is very helpful for understanding what is happening, but it is a bit cumbersome to operate since one has to copy and paste each line.

# Changes

- Adds a one-liner with instructions to verify the proposal.

# Tests

- Tested locally.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.