### PR TITLE
Cleanup SnsTopic types

### DIFF
--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -11,9 +11,9 @@ import type {
   SnsNeuronId,
   SnsNeuronPermissionType,
   SnsProposalId,
+  SnsTopic,
   SnsVote,
 } from "@dfinity/sns";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
 
 export const querySnsNeurons = async ({
   identity,
@@ -427,7 +427,7 @@ export const setFollowing = async ({
   rootCanisterId: Principal;
   identity: Identity;
   topicFollowing: Array<{
-    topic: Topic;
+    topic: SnsTopic;
     followees: Array<{
       neuronId: SnsNeuronId;
       alias?: string;

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -1,8 +1,5 @@
 import type { IcrcMetadataResponseEntries } from "@dfinity/ledger-icrc";
-import type {
-  ListTopicsResponse,
-  TopicInfo,
-} from "@dfinity/sns/dist/candid/sns_governance";
+import type { SnsListTopicsResponse, SnsTopicInfo } from "@dfinity/sns";
 
 type CanisterIds = {
   root_canister_id: string;
@@ -244,12 +241,12 @@ export const isUnknownTopic = (
 ): topic is UnknownTopic => "UnknownTopic" in topic;
 
 // Same as TopicInfo but with the topic field being either a Topic or UnknownTopic
-export interface TopicInfoWithUnknown extends Omit<TopicInfo, "topic"> {
+export interface TopicInfoWithUnknown extends Omit<SnsTopicInfo, "topic"> {
   topic: [] | [Topic | UnknownTopic];
 }
 
 export interface ListTopicsResponseWithUnknown
-  extends Omit<ListTopicsResponse, "topics"> {
+  extends Omit<SnsListTopicsResponse, "topics"> {
   topics: [] | [Array<TopicInfoWithUnknown>];
 }
 

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -5,14 +5,15 @@ import type { Principal } from "@dfinity/principal";
 import type {
   CfParticipant,
   SnsGetLifecycleResponse,
+  SnsNeuronId,
   SnsNeuronRecipe,
   SnsParams,
   SnsSwapBuyerState,
   SnsSwapDerivedState,
   SnsSwapInit,
   SnsSwapTicket,
+  SnsTopic,
 } from "@dfinity/sns";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
 import type { FinalizeSwapResponse } from "@dfinity/sns/dist/candid/sns_swap";
 
 export type RootCanisterId = Principal;
@@ -109,5 +110,5 @@ export interface SnsTicket {
 
 // "DappCanisterManagement" | "DaoCommunitySettings" | ...
 export type SnsTopicKey = keyof {
-  [K in Topic | UnknownTopic as keyof K]: true;
+  [K in SnsTopic | UnknownTopic as keyof K]: true;
 };

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -5,7 +5,6 @@ import type { Principal } from "@dfinity/principal";
 import type {
   CfParticipant,
   SnsGetLifecycleResponse,
-  SnsNeuronId,
   SnsNeuronRecipe,
   SnsParams,
   SnsSwapBuyerState,

--- a/frontend/src/lib/utils/sns-topics.utils.ts
+++ b/frontend/src/lib/utils/sns-topics.utils.ts
@@ -4,12 +4,11 @@ import type {
   TopicInfoWithUnknown,
   UnknownTopic,
 } from "$lib/types/sns-aggregator";
-import type { SnsNervousSystemFunction } from "@dfinity/sns";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
+import type { SnsNervousSystemFunction, SnsTopic } from "@dfinity/sns";
 import { fromNullable } from "@dfinity/utils";
 
 export const snsTopicToTopicKey = (
-  topic: Topic | UnknownTopic
+  topic: SnsTopic | UnknownTopic
 ): SnsTopicKey => {
   // We can't ensure that all the topicKeys are present in this list.
   const topicKeys: SnsTopicKey[] = [
@@ -33,7 +32,7 @@ export const snsTopicToTopicKey = (
 
 export const snsTopicKeyToTopic = (
   topic: SnsTopicKey
-): Topic | UnknownTopic => {
+): SnsTopic | UnknownTopic => {
   switch (topic) {
     case "DappCanisterManagement":
       return { DappCanisterManagement: null };
@@ -58,7 +57,7 @@ export const snsTopicKeyToTopic = (
 export const getSnsTopicInfoKey = (
   topicInfo: TopicInfoWithUnknown
 ): SnsTopicKey =>
-  snsTopicToTopicKey(fromNullable(topicInfo.topic) as Topic | UnknownTopic);
+  snsTopicToTopicKey(fromNullable(topicInfo.topic) as SnsTopic | UnknownTopic);
 
 // Returns all available SNS topics keys
 export const getSnsTopicKeys = (

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -21,8 +21,7 @@ import {
 } from "$lib/utils/sns-aggregator-converters.utils";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { Principal } from "@dfinity/principal";
-import type { SnsNervousSystemParameters } from "@dfinity/sns";
-import type { TopicInfo } from "@dfinity/sns/dist/candid/sns_governance";
+import type { SnsNervousSystemParameters, SnsTopicInfo } from "@dfinity/sns";
 
 describe("sns aggregator converters utils", () => {
   describe("convertDtoData", () => {
@@ -992,7 +991,7 @@ describe("sns aggregator converters utils", () => {
 
     describe("convertDtoTopicInfo", () => {
       it("converts aggregator topic info to ic-js types", () => {
-        const expectedTopicInfo: TopicInfo = {
+        const expectedTopicInfo: SnsTopicInfo = {
           native_functions: [
             [
               {

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -12,8 +12,7 @@ import {
   snsTopicToTopicKey,
 } from "$lib/utils/sns-topics.utils";
 import { Principal } from "@dfinity/principal";
-import type { SnsNervousSystemFunction } from "@dfinity/sns";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
+import type { SnsNervousSystemFunction, SnsTopic } from "@dfinity/sns";
 
 describe("sns-topics utils", () => {
   const canisterIdString = "aaaaa-aa";
@@ -63,7 +62,7 @@ describe("sns-topics utils", () => {
     topic: [
       {
         CompletelyUnknownTopic: null,
-      } as unknown as Topic,
+      } as unknown as SnsTopic,
     ],
     is_critical: [true],
     name: ["Unknown topic name"],
@@ -149,7 +148,7 @@ describe("sns-topics utils", () => {
     });
 
     it("should return UnknownTopic if topic is unknown", () => {
-      expect(snsTopicToTopicKey({} as Topic)).toBe("UnknownTopic");
+      expect(snsTopicToTopicKey({} as SnsTopic)).toBe("UnknownTopic");
     });
   });
 

--- a/frontend/src/tests/mocks/sns-topics.mock.ts
+++ b/frontend/src/tests/mocks/sns-topics.mock.ts
@@ -2,10 +2,10 @@ import type {
   CachedNervousFunctionDto,
   TopicInfoDto,
 } from "$lib/types/sns-aggregator";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
+import type { SnsTopic } from "@dfinity/sns";
 
 export const topicTypeMock = "DaoCommunitySettings";
-export const topicMock: Topic = {
+export const topicMock: SnsTopic = {
   [topicTypeMock]: null,
 };
 


### PR DESCRIPTION
# Motivation

Followed up on the [ic-js PR](https://github.com/dfinity/ic-js/pull/882), using the cleaner way to import types from `@dfinity/sns`.

# Changes

- Change SNS topics related type sources.

# Tests

- Should pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.