### PR TITLE
Set following service

### DIFF
--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -5,14 +5,15 @@ import type { Principal } from "@dfinity/principal";
 import type {
   CfParticipant,
   SnsGetLifecycleResponse,
+  SnsNeuronId,
   SnsNeuronRecipe,
   SnsParams,
   SnsSwapBuyerState,
   SnsSwapDerivedState,
   SnsSwapInit,
   SnsSwapTicket,
+  SnsTopic,
 } from "@dfinity/sns";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
 import type { FinalizeSwapResponse } from "@dfinity/sns/dist/candid/sns_swap";
 
 export type RootCanisterId = Principal;
@@ -109,5 +110,15 @@ export interface SnsTicket {
 
 // "DappCanisterManagement" | "DaoCommunitySettings" | ...
 export type SnsTopicKey = keyof {
-  [K in Topic | UnknownTopic as keyof K]: true;
+  [K in SnsTopic | UnknownTopic as keyof K]: true;
+};
+
+export type SnsTopicFollowee = {
+  neuronId: SnsNeuronId;
+  alias?: string;
+};
+
+export type SnsTopicFollowing = {
+  topic: SnsTopicKey;
+  followees: Array<SnsTopicFollowee>;
 };


### PR DESCRIPTION
# Motivation

Followed up on the [setFollowing](https://github.com/dfinity/nns-dapp/pull/6646) API PR — this adds the service to set following by topics.

# Changes

- New related to sns-topics types.
- New setFollowing service.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.