### PR TITLE
Sns topic utils

### DIFF
--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -5,6 +5,7 @@ import type { Principal } from "@dfinity/principal";
 import type {
   CfParticipant,
   SnsGetLifecycleResponse,
+  SnsNeuronId,
   SnsNeuronRecipe,
   SnsParams,
   SnsSwapBuyerState,
@@ -110,4 +111,14 @@ export interface SnsTicket {
 // "DappCanisterManagement" | "DaoCommunitySettings" | ...
 export type SnsTopicKey = keyof {
   [K in SnsTopic | UnknownTopic as keyof K]: true;
+};
+
+export type SnsTopicFollowee = {
+  neuronId: SnsNeuronId;
+  alias?: string;
+};
+
+export type SnsTopicFollowing = {
+  topic: SnsTopicKey;
+  followees: Array<SnsTopicFollowee>;
 };

--- a/frontend/src/lib/utils/sns-topics.utils.ts
+++ b/frontend/src/lib/utils/sns-topics.utils.ts
@@ -105,7 +105,7 @@ export const getSnsTopicFollowings = (
   }));
 };
 
-export const isSnsNeuronsAlreadyFollowing = ({
+export const isSnsNeuronsFollowing = ({
   followings,
   neuronId,
   topicKey,
@@ -142,7 +142,7 @@ export const addSnsNeuronToFollowingsByTopics = ({
     // Filter out topics that are already followed by the neuron to avoid duplications.
     .filter(
       (topicKey) =>
-        !isSnsNeuronsAlreadyFollowing({
+        !isSnsNeuronsFollowing({
           followings,
           neuronId,
           topicKey,

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -4,17 +4,28 @@ import type {
   TopicInfoWithUnknown,
 } from "$lib/types/sns-aggregator";
 import {
+  addSnsNeuronToFollowingsByTopics,
   getAllSnsNSFunctions,
+  getSnsTopicFollowings,
   getSnsTopicInfoKey,
   getSnsTopicKeys,
   getTopicInfoBySnsTopicKey,
+  isSnsNeuronsAlreadyFollowing,
+  removeSnsNeuronFromFollowingsByTopics,
   snsTopicKeyToTopic,
   snsTopicToTopicKey,
 } from "$lib/utils/sns-topics.utils";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction, SnsTopic } from "@dfinity/sns";
 
 describe("sns-topics utils", () => {
+  const neuronId1 = {
+    id: Uint8Array.from([1, 2, 3]),
+  };
+  const neuronId2 = {
+    id: Uint8Array.from([4, 5, 6]),
+  };
   const canisterIdString = "aaaaa-aa";
   const canisterId = Principal.fromText(canisterIdString);
   const method = "method";
@@ -198,6 +209,308 @@ describe("sns-topics utils", () => {
       expect(getAllSnsNSFunctions(knownTopicInfo)).toEqual([
         nativeNsFunction,
         genericNsFunction,
+      ]);
+    });
+  });
+
+  describe("getSnsTopicFollowings", () => {
+    it("should return empty map if the topic_followees is not available/supported", () => {
+      expect(
+        getSnsTopicFollowings(
+          createMockSnsNeuron({
+            topicFollowees: {},
+          })
+        )
+      ).toEqual([]);
+      expect(
+        getSnsTopicFollowings({
+          ...createMockSnsNeuron({}),
+        })
+      ).toEqual([]);
+    });
+
+    it("should return a followee list", () => {
+      expect(
+        getSnsTopicFollowings(
+          createMockSnsNeuron({
+            topicFollowees: {
+              DappCanisterManagement: [
+                {
+                  neuronId: neuronId1,
+                },
+              ],
+              DaoCommunitySettings: [
+                {
+                  neuronId: neuronId1,
+                },
+                {
+                  neuronId: neuronId2,
+                },
+              ],
+            },
+          })
+        )
+      ).toEqual([
+        {
+          topic: "DappCanisterManagement",
+          followees: [{ neuronId: neuronId1 }],
+        },
+        {
+          topic: "DaoCommunitySettings",
+          followees: [
+            { neuronId: neuronId1 },
+            {
+              neuronId: neuronId2,
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("insertIntoTopicFollowingMap", () => {
+    it("should return empty list if the topic_followees is not available/supported", () => {
+      expect(
+        getSnsTopicFollowings(
+          createMockSnsNeuron({
+            topicFollowees: {},
+          })
+        )
+      ).toEqual([]);
+
+      expect(
+        getSnsTopicFollowings({
+          ...createMockSnsNeuron({}),
+          topic_followees: undefined,
+        })
+      ).toEqual([]);
+    });
+
+    it("should return following list", () => {
+      expect(
+        getSnsTopicFollowings(
+          createMockSnsNeuron({
+            topicFollowees: {
+              DappCanisterManagement: [
+                {
+                  neuronId: neuronId1,
+                },
+              ],
+              DaoCommunitySettings: [
+                {
+                  neuronId: neuronId1,
+                },
+                {
+                  neuronId: neuronId2,
+                },
+              ],
+            },
+          })
+        )
+      ).toEqual([
+        {
+          topic: "DappCanisterManagement",
+          followees: [{ neuronId: neuronId1 }],
+        },
+        {
+          topic: "DaoCommunitySettings",
+          followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+        },
+      ]);
+    });
+  });
+
+  describe("isSnsNeuronsAlreadyFollowing", () => {
+    it("should return true", () => {
+      expect(
+        isSnsNeuronsAlreadyFollowing({
+          followings: [
+            {
+              topic: "CriticalDappOperations",
+              followees: [{ neuronId: neuronId1 }],
+            },
+            {
+              topic: "DappCanisterManagement",
+              followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+            },
+          ],
+          topicKey: "DappCanisterManagement",
+          neuronId: neuronId2,
+        })
+      ).toEqual(true);
+    });
+
+    it("should return false", () => {
+      expect(
+        isSnsNeuronsAlreadyFollowing({
+          followings: [
+            {
+              topic: "CriticalDappOperations",
+              followees: [{ neuronId: neuronId1 }],
+            },
+            {
+              topic: "DappCanisterManagement",
+              followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+            },
+          ],
+          topicKey: "CriticalDappOperations",
+          neuronId: neuronId2,
+        })
+      ).toEqual(false);
+
+      expect(
+        isSnsNeuronsAlreadyFollowing({
+          followings: [
+            {
+              topic: "DappCanisterManagement",
+              followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+            },
+          ],
+          topicKey: "CriticalDappOperations",
+          neuronId: neuronId2,
+        })
+      ).toEqual(false);
+
+      expect(
+        isSnsNeuronsAlreadyFollowing({
+          followings: [],
+          topicKey: "CriticalDappOperations",
+          neuronId: neuronId2,
+        })
+      ).toEqual(false);
+    });
+  });
+
+  describe("addSnsNeuronToFollowingsByTopics", () => {
+    it("Should insert neuron ID into existing topics", () => {
+      expect(
+        addSnsNeuronToFollowingsByTopics({
+          followings: [
+            {
+              topic: "CriticalDappOperations",
+              followees: [{ neuronId: neuronId1 }],
+            },
+            {
+              topic: "DappCanisterManagement",
+              followees: [{ neuronId: neuronId1 }],
+            },
+          ],
+          topics: ["DappCanisterManagement", "CriticalDappOperations"],
+          neuronId: neuronId2,
+        })
+      ).toEqual([
+        {
+          topic: "DappCanisterManagement",
+          followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+        },
+        {
+          topic: "CriticalDappOperations",
+          followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+        },
+      ]);
+    });
+
+    it("should insert neuron ID into non-existing topics", () => {
+      expect(
+        addSnsNeuronToFollowingsByTopics({
+          followings: [
+            {
+              topic: "CriticalDappOperations",
+              followees: [{ neuronId: neuronId1 }],
+            },
+          ],
+          topics: ["DappCanisterManagement", "CriticalDappOperations"],
+          neuronId: neuronId2,
+        })
+      ).toEqual([
+        {
+          topic: "DappCanisterManagement",
+          followees: [{ neuronId: neuronId2 }],
+        },
+        {
+          topic: "CriticalDappOperations",
+          followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+        },
+      ]);
+    });
+  });
+
+  describe("removeSnsNeuronFromFollowingsByTopics", () => {
+    it("Should remove neuron ID", () => {
+      expect(
+        removeSnsNeuronFromFollowingsByTopics({
+          followings: [
+            {
+              topic: "CriticalDappOperations",
+              followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+            },
+            {
+              topic: "DappCanisterManagement",
+              followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+            },
+          ],
+          topics: ["DappCanisterManagement", "CriticalDappOperations"],
+          neuronId: neuronId2,
+        })
+      ).toEqual([
+        {
+          topic: "CriticalDappOperations",
+          followees: [{ neuronId: neuronId1 }],
+        },
+        {
+          topic: "DappCanisterManagement",
+          followees: [{ neuronId: neuronId1 }],
+        },
+      ]);
+
+      expect(
+        removeSnsNeuronFromFollowingsByTopics({
+          followings: [
+            {
+              topic: "CriticalDappOperations",
+              followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+            },
+            {
+              topic: "DappCanisterManagement",
+              followees: [{ neuronId: neuronId2 }],
+            },
+          ],
+          topics: ["CriticalDappOperations"],
+          neuronId: neuronId2,
+        })
+      ).toEqual([
+        {
+          topic: "CriticalDappOperations",
+          followees: [{ neuronId: neuronId1 }],
+        },
+      ]);
+    });
+
+    it("should not exclude empty followees", () => {
+      expect(
+        removeSnsNeuronFromFollowingsByTopics({
+          followings: [
+            {
+              topic: "CriticalDappOperations",
+              followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
+            },
+            {
+              topic: "DappCanisterManagement",
+              followees: [{ neuronId: neuronId1 }],
+            },
+          ],
+          topics: ["DappCanisterManagement", "CriticalDappOperations"],
+          neuronId: neuronId1,
+        })
+      ).toEqual([
+        {
+          topic: "CriticalDappOperations",
+          followees: [{ neuronId: neuronId2 }],
+        },
+        {
+          topic: "DappCanisterManagement",
+          followees: [],
+        },
       ]);
     });
   });

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -330,7 +330,7 @@ describe("sns-topics utils", () => {
   });
 
   describe("addSnsNeuronToFollowingsByTopics", () => {
-    it("Should insert neuron ID into existing topics", () => {
+    it("should insert neuron ID into existing topics", () => {
       expect(
         addSnsNeuronToFollowingsByTopics({
           followings: [

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -269,7 +269,7 @@ describe("sns-topics utils", () => {
   });
 
   describe("isSnsNeuronsFollowing", () => {
-    it("should return true", () => {
+    it("returns true when the specified neuron ID is listed as a followee for the given topic", () => {
       expect(
         isSnsNeuronsFollowing({
           followings: [
@@ -288,7 +288,7 @@ describe("sns-topics utils", () => {
       ).toEqual(true);
     });
 
-    it("should return false", () => {
+    it("returns false when the specified neuron ID is not listed as a followee for the given topic", () => {
       expect(
         isSnsNeuronsFollowing({
           followings: [

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -268,58 +268,6 @@ describe("sns-topics utils", () => {
     });
   });
 
-  describe("insertIntoTopicFollowingMap", () => {
-    it("should return empty list if the topic_followees is not available/supported", () => {
-      expect(
-        getSnsTopicFollowings(
-          createMockSnsNeuron({
-            topicFollowees: {},
-          })
-        )
-      ).toEqual([]);
-
-      expect(
-        getSnsTopicFollowings({
-          ...createMockSnsNeuron({}),
-          topic_followees: undefined,
-        })
-      ).toEqual([]);
-    });
-
-    it("should return following list", () => {
-      expect(
-        getSnsTopicFollowings(
-          createMockSnsNeuron({
-            topicFollowees: {
-              DappCanisterManagement: [
-                {
-                  neuronId: neuronId1,
-                },
-              ],
-              DaoCommunitySettings: [
-                {
-                  neuronId: neuronId1,
-                },
-                {
-                  neuronId: neuronId2,
-                },
-              ],
-            },
-          })
-        )
-      ).toEqual([
-        {
-          topic: "DappCanisterManagement",
-          followees: [{ neuronId: neuronId1 }],
-        },
-        {
-          topic: "DaoCommunitySettings",
-          followees: [{ neuronId: neuronId1 }, { neuronId: neuronId2 }],
-        },
-      ]);
-    });
-  });
-
   describe("isSnsNeuronsFollowing", () => {
     it("should return true", () => {
       expect(

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -10,7 +10,7 @@ import {
   getSnsTopicInfoKey,
   getSnsTopicKeys,
   getTopicInfoBySnsTopicKey,
-  isSnsNeuronsAlreadyFollowing,
+  isSnsNeuronsFollowing,
   removeSnsNeuronFromFollowingsByTopics,
   snsTopicKeyToTopic,
   snsTopicToTopicKey,
@@ -320,10 +320,10 @@ describe("sns-topics utils", () => {
     });
   });
 
-  describe("isSnsNeuronsAlreadyFollowing", () => {
+  describe("isSnsNeuronsFollowing", () => {
     it("should return true", () => {
       expect(
-        isSnsNeuronsAlreadyFollowing({
+        isSnsNeuronsFollowing({
           followings: [
             {
               topic: "CriticalDappOperations",
@@ -342,7 +342,7 @@ describe("sns-topics utils", () => {
 
     it("should return false", () => {
       expect(
-        isSnsNeuronsAlreadyFollowing({
+        isSnsNeuronsFollowing({
           followings: [
             {
               topic: "CriticalDappOperations",
@@ -359,7 +359,7 @@ describe("sns-topics utils", () => {
       ).toEqual(false);
 
       expect(
-        isSnsNeuronsAlreadyFollowing({
+        isSnsNeuronsFollowing({
           followings: [
             {
               topic: "DappCanisterManagement",
@@ -372,7 +372,7 @@ describe("sns-topics utils", () => {
       ).toEqual(false);
 
       expect(
-        isSnsNeuronsAlreadyFollowing({
+        isSnsNeuronsFollowing({
           followings: [],
           topicKey: "CriticalDappOperations",
           neuronId: neuronId2,

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -384,7 +384,7 @@ describe("sns-topics utils", () => {
   });
 
   describe("removeSnsNeuronFromFollowingsByTopics", () => {
-    it("Should remove neuron ID", () => {
+    it("should remove neuron ID", () => {
       expect(
         removeSnsNeuronFromFollowingsByTopics({
           followings: [

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -103,7 +103,6 @@ export const createMockSnsNeuron = ({
     maturity_e8s_equivalent: maturity,
     cached_neuron_stake_e8s: stake,
     created_timestamp_seconds: createdTimestampSeconds,
-    topic_followees: [],
     staked_maturity_e8s_equivalent: [stakedMaturity],
     auto_stake_maturity: [],
     aging_since_timestamp_seconds: ageSinceTimestampSeconds,


### PR DESCRIPTION
# Motivation

Adds utility functions needed to support setting followings by topic. Their usage can be found in [this draft PR](https://github.com/dfinity/nns-dapp/pull/6610/files).

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)

# Changes

- getSnsTopicFollowings
- isSnsNeuronsAlreadyFollowing
- addSnsNeuronToFollowingsByTopics
- removeSnsNeuronFromFollowingsByTopics

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3665]: https://dfinity.atlassian.net/browse/NNS1-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ