### PR TITLE
style(portfolio): optimize total assets card layout 

### DIFF
--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -6,10 +6,19 @@
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
   import { i18n } from "$lib/stores/i18n";
   import { Spinner } from "@dfinity/gix-components";
+  type Props = {
+    usdAmount: number | undefined;
+    hasUnpricedTokens: boolean;
+    isLoading: boolean;
+    isFullWidth: boolean;
+  };
 
-  export let usdAmount: number | undefined;
-  export let hasUnpricedTokens: boolean = false;
-  export let isLoading: boolean = false;
+  const {
+    usdAmount,
+    hasUnpricedTokens = false,
+    isLoading = false,
+    isFullWidth = true,
+  }: Props = $props();
 </script>
 
 <UsdValueHeadless
@@ -22,7 +31,7 @@
   let:hasPricesAndUnpricedTokens
 >
   <Card testId="total-assets-card-component">
-    <div class="wrapper">
+    <div class="wrapper" class:full-width={isFullWidth}>
       <h3>{$i18n.portfolio.total_assets_title}</h3>
       <div class="pricing">
         <div class="totals">
@@ -115,6 +124,15 @@
 
         .secondary-amount {
           color: var(--text-description);
+        }
+      }
+    }
+
+    &.full-width {
+      .pricing {
+        @include media.min-width(large) {
+          flex-direction: row;
+          align-items: flex-end;
         }
       }
     }

--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -31,7 +31,11 @@
   let:hasPricesAndUnpricedTokens
 >
   <Card testId="total-assets-card-component">
-    <div class="wrapper" class:full-width={isFullWidth}>
+    <div
+      class="wrapper"
+      class:full-width={isFullWidth}
+      data-tid="total-assets-card-component-wrapper"
+    >
       <h3>{$i18n.portfolio.total_assets_title}</h3>
       <div class="pricing">
         <div class="totals">

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -163,6 +163,7 @@
         usdAmount={totalUsdAmount}
         hasUnpricedTokens={hasUnpricedTokensOrStake}
         isLoading={isSomethingLoading}
+        isFullWidth={launchpadCards.length === 0}
       />
     {/if}
 

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -152,7 +152,7 @@
   <div
     class="top"
     class:signed-in={$authSignedInStore}
-    class:launchpad={launchpadCards.length > 0}
+    class:launchpad={cards.length > 0}
   >
     {#if !$authSignedInStore}
       <div class="login-card">
@@ -163,7 +163,7 @@
         usdAmount={totalUsdAmount}
         hasUnpricedTokens={hasUnpricedTokensOrStake}
         isLoading={isSomethingLoading}
-        isFullWidth={launchpadCards.length === 0}
+        isFullWidth={cards.length === 0}
       />
     {/if}
 

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -10,15 +10,18 @@ describe("TotalAssetsCard", () => {
     usdAmount,
     hasUnpricedTokens,
     isLoading,
+    isFullWidth,
   }: {
     usdAmount: number;
     hasUnpricedTokens?: boolean;
     isLoading?: boolean;
+    isFullWidth?: boolean;
   }) => {
     const { container } = render(TotalAssetsCard, {
       usdAmount,
       hasUnpricedTokens,
       isLoading,
+      isFullWidth,
     });
     return TotalAssetsCardPo.under(new JestPageObjectElement(container));
   };
@@ -168,5 +171,23 @@ describe("TotalAssetsCard", () => {
     });
 
     expect(await po.hasSpinner()).toEqual(false);
+  });
+
+  it("should apply full-width class when isFullWidth is true", async () => {
+    const isFullWidth = true;
+    const usdAmount = 50;
+    
+    const po = renderComponent({ usdAmount, isFullWidth });
+    
+    expect(await po.hasFullWidthClass()).toBe(true);
+  });
+
+  it("should not apply full-width class when isFullWidth is false", async () => {
+    const isFullWidth = false;
+    const usdAmount = 50;
+    
+    const po = renderComponent({ usdAmount, isFullWidth });
+    
+    expect(await po.hasFullWidthClass()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/TotalAssetsCard.spec.ts
@@ -176,18 +176,18 @@ describe("TotalAssetsCard", () => {
   it("should apply full-width class when isFullWidth is true", async () => {
     const isFullWidth = true;
     const usdAmount = 50;
-    
+
     const po = renderComponent({ usdAmount, isFullWidth });
-    
-    expect(await po.hasFullWidthClass()).toBe(true);
+
+    expect(await po.isFullWidth()).toBe(true);
   });
 
   it("should not apply full-width class when isFullWidth is false", async () => {
     const isFullWidth = false;
     const usdAmount = 50;
-    
+
     const po = renderComponent({ usdAmount, isFullWidth });
-    
-    expect(await po.hasFullWidthClass()).toBe(false);
+
+    expect(await po.isFullWidth()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -204,6 +204,24 @@ describe("Portfolio page", () => {
       expect(await stackedCardsPo.isPresent()).toBe(false);
     });
 
+    it("should show a full width TotalAssetsCard when no stacked cards", async () => {
+      const po = renderPage();
+      const totalAssetsCardPo = po.getTotalAssetsCardPo();
+
+      expect(await totalAssetsCardPo.isPresent()).toBe(true);
+      expect(await totalAssetsCardPo.isFullWidth()).toBe(true);
+    });
+
+    it("should show a not full width TotalAssetsCard when stacked cards is not empty", async () => {
+      const po = renderPage({ openSnsProposals: mockSnsProposals });
+      const totalAssetsCardPo = po.getTotalAssetsCardPo();
+      const stackedCardsPo = po.getStackedCardsPo();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(await totalAssetsCardPo.isPresent()).toBe(true);
+      expect(await totalAssetsCardPo.isFullWidth()).toBe(false);
+    });
+
     it("should display StackedCards when snsProjects is not empty", async () => {
       const po = renderPage({ snsProjects: mockSnsProjects });
       const stackedCardsPo = po.getStackedCardsPo();

--- a/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
@@ -38,6 +38,10 @@ export class TotalAssetsCardPo extends BasePageObject {
     return this.getIcpExchangeRatePo().hasError();
   }
 
+  async hasFullWidthClass(): Promise<boolean> {
+    return this.root.querySelector(".wrapper").hasClass("full-width");
+  }
+
   async waitForLoaded(): Promise<void> {
     await this.waitForAbsent("spinner");
   }

--- a/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TotalAssetsCard.page-object.ts
@@ -38,8 +38,10 @@ export class TotalAssetsCardPo extends BasePageObject {
     return this.getIcpExchangeRatePo().hasError();
   }
 
-  async hasFullWidthClass(): Promise<boolean> {
-    return this.root.querySelector(".wrapper").hasClass("full-width");
+  async isFullWidth(): Promise<boolean> {
+    const wrapper = this.getElement("total-assets-card-component-wrapper");
+    const classes = await wrapper.getClasses();
+    return classes.includes("full-width");
   }
 
   async waitForLoaded(): Promise<void> {


### PR DESCRIPTION
# Motivation

We want to optimize the display of the `TotalAssetsCard` based on the presence of StackedCards. When there are no Cards, we aim to maximize the horizontal space. However, when Cards are present, we want to maximize the vertical space.

[NNS1-3641](https://dfinity.atlassian.net/browse/NNS1-3641)

With `StackedCards`:

<img width="1499" alt="Screenshot 2025-04-14 at 09 23 43" src="https://github.com/user-attachments/assets/d160f091-0d2e-4196-be8c-1bd40bf7c3fd" />

Without `StackedCards`:

<img width="1512" alt="Screenshot 2025-04-14 at 09 24 44" src="https://github.com/user-attachments/assets/2784b468-feba-461d-9cea-f38195d35f8c" />

# Changes

- Add conditional CSS styles when no cards are present.

# Tests

- Adds unit tests to both the `TotalAssetsCard` and the `Portfolio` page based on the presence of SNS cards or not.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3641]: https://dfinity.atlassian.net/browse/NNS1-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ