### PR TITLE
Topics step in follow by Sns topics modal

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -425,10 +425,12 @@
   "follow_sns_topics": {
     "topic_definitions_description": "Proposal types are grouped into topics, unique for each SNS. You can review the topic definitions for this SNS here.",
     "topic_definitions_title": "Topic Definition List",
+    "topics_description": "Delegate your voting by following other neurons to maximize your voting rewards. Your voting is fully delegated only if following is set for every topic. Alternatively, you can vote manually.",
     "topics_critical_label": "Critical topics",
-    "topics_critical_tooltip": "TBD",
+    "topics_critical_tooltip": "Critical topics include proposals that are vital to the management of a given SNS DAO, so they require 67% \"yes\" votes to be adopted. They include treasury management and critical dapp operations.",
     "topics_non_critical_label": "Non-critical topics",
-    "topics_non_critical_tooltip": "TBD"
+    "topics_non_critical_tooltip": "Non-critical topics include proposals that manage the day-to-day operations of a given SNS DAO, including code upgrades or SNS parameter management.",
+    "topics_following": "CURRENTLY FOLLOWING"
   },
   "missing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -430,8 +430,7 @@
     "topics_critical_tooltip": "Critical topics include proposals that are vital to the management of a given SNS DAO, so they require 67% \"yes\" votes to be adopted. They include treasury management and critical dapp operations.",
     "topics_non_critical_label": "Non-critical topics",
     "topics_non_critical_tooltip": "Non-critical topics include proposals that manage the day-to-day operations of a given SNS DAO, including code upgrades or SNS parameter management.",
-    "topics_following": "CURRENTLY FOLLOWING"
-    "topics_non_critical_tooltip": "TBD",
+    "topics_following": "CURRENTLY FOLLOWING",
     "neuron_label": "Neuron to Follow",
     "neuron_description": "*Developer neurons are not stored in a central place as of now. You can often find them on the <a href=\"https://forum.dfinity.org/\" rel=\"noopener noreferrer\" aria-label=\"DFINITY forum\" target=\"_blank\">DFINITY forum</a> in the founding team’s announcement, or on their <a href=\"https://x.com/home\" rel=\"noopener noreferrer\" aria-label=\"X\" target=\"_blank\">X</a> account. Alternatively, you can review voting power distributions of all neurons on <a href=\"https://snsgeek.app/sns\" rel=\"noopener noreferrer\" aria-label=\"snsgeek\" target=\"_blank\">snsGeek</a>, and select a neuron from their list.",
     "neuron_follow": "Follow Neuron"

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicFollowee.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicFollowee.svelte
@@ -3,15 +3,15 @@
   import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
   import Hash from "$lib/components/ui/Hash.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { SnsTopicFollowee } from "$lib/types/sns";
+  import type { SnsNeuronId } from "@dfinity/sns";
 
   type Props = {
-    followee: SnsTopicFollowee;
+    neuronId: SnsNeuronId;
     onRemoveClick: () => void;
   };
-  const { followee, onRemoveClick }: Props = $props();
+  const { neuronId, onRemoveClick }: Props = $props();
 
-  let neuronIdHex = $derived(subaccountToHexString(followee.neuronId.id));
+  let neuronIdHex = $derived(subaccountToHexString(neuronId.id));
 </script>
 
 <div

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
@@ -48,7 +48,7 @@
 
   let toggleContent: () => void = $state(() => {});
   let expanded: boolean = $state(false);
-  let isFollowingByTopic = $derived(followees.length > 0);
+  const isFollowingByTopic = $derived(followees.length > 0);
 
   // TODO(sns-topics): Add "stopPropagation" prop to the gix/Checkbox component
   // to avoid collapsable toggling

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
@@ -2,6 +2,7 @@
   import {
     Checkbox,
     Collapsible,
+    IconCheckCircleFill,
     IconErrorOutline,
     IconExpandMore,
   } from "@dfinity/gix-components";
@@ -12,13 +13,14 @@
   import type { SnsNeuronId } from "@dfinity/sns";
   import FollowSnsNeuronsByTopicFollowee from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicFollowee.svelte";
   import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
+  import { i18n } from "$lib/stores/i18n";
 
   type Props = {
     topicInfo: TopicInfoWithUnknown;
     followees: SnsTopicFollowee[];
     checked: boolean;
     onNnsChange: (args: { topicKey: SnsTopicKey; checked: boolean }) => void;
-    onNnsRemove: (args: {
+    removeFollowing: (args: {
       topicKey: SnsTopicKey;
       neuronId: SnsNeuronId;
     }) => void;
@@ -29,7 +31,7 @@
     followees,
     checked = false,
     onNnsChange,
-    onNnsRemove,
+    removeFollowing,
   }: Props = $props();
 
   let topicKey: SnsTopicKey = $derived(getSnsTopicInfoKey(topicInfo));
@@ -46,6 +48,7 @@
 
   let toggleContent: () => void = $state(() => {});
   let expanded: boolean = $state(false);
+  let isFollowingByTopic = $derived(followees.length > 0);
 
   // TODO(sns-topics): Add "stopPropagation" prop to the gix/Checkbox component
   // to avoid collapsable toggling
@@ -73,9 +76,16 @@
         <span data-tid="topic-name">{name}</span>
       </Checkbox>
 
-      <!-- TODO: display following status -->
-      <div class="icon" data-tid="topic-following-status">
-        <IconErrorOutline />
+      <div
+        class="icon"
+        data-tid="topic-following-status"
+        class:isFollowingByTopic
+      >
+        {#if isFollowingByTopic}
+          <IconCheckCircleFill />
+        {:else}
+          <IconErrorOutline />
+        {/if}
       </div>
 
       <button
@@ -94,14 +104,16 @@
 
       <div class="followees">
         {#if followees.length > 0}
-          <h5 class="headline description"> Followees</h5>
+          <h5 class="followee-header"
+            >{$i18n.follow_sns_topics.topics_following}</h5
+          >
           <ul class="followee-list">
             {#each followees as followee (subaccountToHexString(followee.neuronId.id))}
               <li
                 ><FollowSnsNeuronsByTopicFollowee
-                  {followee}
+                  neuronId={followee.neuronId}
                   onRemoveClick={() => {
-                    onNnsRemove({
+                    removeFollowing({
                       topicKey,
                       neuronId: followee.neuronId,
                     });
@@ -117,6 +129,8 @@
 </div>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
   .header {
     display: grid;
     grid-template-columns: auto min-content min-content;
@@ -143,9 +157,29 @@
   .expandable-content {
     // Aligning with the checkbox label
     margin-left: calc(20px + var(--padding));
+  }
 
-    .description {
-      margin: 0 0 var(--padding-3x);
+  .followee-header {
+    margin-top: var(--padding-3x);
+    color: var(--description-color);
+  }
+
+  .followee-list {
+    padding: 0;
+    list-style-type: none;
+
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--padding);
+  }
+
+  .icon {
+    display: flex;
+    align-items: center;
+    color: var(--tertiary);
+
+    &.isFollowingByTopic {
+      color: var(--positive-emphasis);
     }
   }
 

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import Separator from "$lib/components/ui/Separator.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
+  import FollowSnsNeuronsByTopicItem from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte";
+  import { fromDefinedNullable } from "@dfinity/utils";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import type { SnsTopicFollowing, SnsTopicKey } from "$lib/types/sns";
+  import {
+    getSnsTopicInfoKey,
+    snsTopicToTopicKey,
+  } from "$lib/utils/sns-topics.utils";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import type { SnsNeuronId } from "@dfinity/sns";
+
+  type Props = {
+    topicInfos: TopicInfoWithUnknown[];
+    selectedTopics: SnsTopicKey[];
+    followings: SnsTopicFollowing[];
+    closeModal: () => void;
+    openNextStep: () => void;
+    removeFollowing: (args: {
+      topicKey: SnsTopicKey;
+      neuronId: SnsNeuronId;
+    }) => void;
+  };
+  let {
+    topicInfos,
+    selectedTopics = $bindable(),
+    followings,
+    closeModal,
+    openNextStep,
+    removeFollowing,
+  }: Props = $props();
+
+  let criticalTopicInfos: TopicInfoWithUnknown[] = $derived(
+    topicInfos.filter((topicInfo) => fromDefinedNullable(topicInfo.is_critical))
+  );
+  let nonCriticalTopicInfos: TopicInfoWithUnknown[] = $derived(
+    topicInfos.filter(
+      (topicInfo) => !fromDefinedNullable(topicInfo.is_critical)
+    )
+  );
+
+  const onTopicSelectionChange = ({
+    topicKey,
+    checked,
+  }: {
+    topicKey: SnsTopicKey;
+    checked: boolean;
+  }) => {
+    if (checked) {
+      selectedTopics = [...selectedTopics, topicKey];
+    } else {
+      selectedTopics = selectedTopics.filter((key) => key !== topicKey);
+    }
+  };
+  const isTopicInfoSelected = (topicInfo: TopicInfoWithUnknown) =>
+    selectedTopics.includes(getSnsTopicInfoKey(topicInfo));
+  const getTopicFollowees = (topicInfo: TopicInfoWithUnknown) =>
+    followings.find(
+      (following) =>
+        snsTopicToTopicKey(fromDefinedNullable(topicInfo.topic)) ===
+        following.topic
+    )?.followees ?? [];
+</script>
+
+<TestIdWrapper testId="follow-sns-neurons-by-topic-step-topics-component">
+  <p class="description">{$i18n.follow_sns_topics.topics_description}</p>
+
+  <Separator spacing="medium" />
+
+  <div class="topic-group" data-tid="critical-topic-group">
+    <h5 class="headline description"
+      >{$i18n.follow_sns_topics.topics_critical_label}
+      <TooltipIcon
+        >{$i18n.follow_sns_topics.topics_critical_tooltip}</TooltipIcon
+      ></h5
+    >
+    {#each criticalTopicInfos as topicInfo}
+      <FollowSnsNeuronsByTopicItem
+        {topicInfo}
+        followees={getTopicFollowees(topicInfo)}
+        checked={isTopicInfoSelected(topicInfo)}
+        onNnsChange={onTopicSelectionChange}
+        {removeFollowing}
+      />
+    {/each}
+  </div>
+
+  <div class="topic-group" data-tid="non-critical-topic-group">
+    <h5 class="headline description"
+      >{$i18n.follow_sns_topics.topics_non_critical_label}
+      <TooltipIcon
+        >{$i18n.follow_sns_topics.topics_critical_tooltip}</TooltipIcon
+      ></h5
+    >
+    {#each nonCriticalTopicInfos as topicInfo}
+      <FollowSnsNeuronsByTopicItem
+        {topicInfo}
+        followees={getTopicFollowees(topicInfo)}
+        checked={isTopicInfoSelected(topicInfo)}
+        onNnsChange={onTopicSelectionChange}
+        {removeFollowing}
+      />
+    {/each}
+  </div>
+
+  <div class="toolbar">
+    <button
+      class="secondary"
+      type="button"
+      data-tid="cancel-button"
+      onclick={closeModal}
+    >
+      {$i18n.core.cancel}
+    </button>
+
+    <button
+      data-tid="next-button"
+      class="primary"
+      disabled={selectedTopics.length === 0}
+      onclick={openNextStep}
+    >
+      {$i18n.core.next}
+    </button>
+  </div>
+</TestIdWrapper>
+
+<style lang="scss">
+  .topic-group {
+    margin-bottom: var(--padding-3x);
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+
+    .headline {
+      margin: var(--padding) 0;
+    }
+  }
+</style>

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
@@ -36,7 +36,7 @@
   let criticalTopicInfos: TopicInfoWithUnknown[] = $derived(
     topicInfos.filter((topicInfo) => fromDefinedNullable(topicInfo.is_critical))
   );
-  let nonCriticalTopicInfos: TopicInfoWithUnknown[] = $derived(
+  const nonCriticalTopicInfos: TopicInfoWithUnknown[] = $derived(
     topicInfos.filter(
       (topicInfo) => !fromDefinedNullable(topicInfo.is_critical)
     )

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
@@ -33,7 +33,7 @@
     removeFollowing,
   }: Props = $props();
 
-  let criticalTopicInfos: TopicInfoWithUnknown[] = $derived(
+  const criticalTopicInfos: TopicInfoWithUnknown[] = $derived(
     topicInfos.filter((topicInfo) => fromDefinedNullable(topicInfo.is_critical))
   );
   const nonCriticalTopicInfos: TopicInfoWithUnknown[] = $derived(

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -440,10 +440,12 @@ interface I18nNeurons {
 interface I18nFollow_sns_topics {
   topic_definitions_description: string;
   topic_definitions_title: string;
+  topics_description: string;
   topics_critical_label: string;
   topics_critical_tooltip: string;
   topics_non_critical_label: string;
   topics_non_critical_tooltip: string;
+  topics_following: string;
 }
 
 interface I18nMissing_rewards {

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
@@ -34,7 +34,7 @@ describe("FollowSnsNeuronsByTopicItem", () => {
     checked: boolean;
     followees: SnsTopicFollowee[];
     onNnsChange: () => void;
-    onNnsRemove: () => void;
+    removeFollowing: () => void;
   }) => {
     const { container } = render(FollowSnsNeuronsByTopicItem, {
       props,
@@ -49,7 +49,7 @@ describe("FollowSnsNeuronsByTopicItem", () => {
     followees: [],
     checked: false,
     onNnsChange: vi.fn(),
-    onNnsRemove: vi.fn(),
+    removeFollowing: vi.fn(),
   };
 
   it("should expand and collapse", async () => {
@@ -104,7 +104,7 @@ describe("FollowSnsNeuronsByTopicItem", () => {
   });
 
   it("triggers onRemove", async () => {
-    const onNnsRemove = vi.fn();
+    const removeFollowing = vi.fn();
     const po = renderComponent({
       ...defaultProps,
       followees: [
@@ -115,21 +115,21 @@ describe("FollowSnsNeuronsByTopicItem", () => {
           neuronId: neuronId2,
         },
       ],
-      onNnsRemove,
+      removeFollowing,
     });
 
     const followeePos = await po.getFolloweesPo();
 
     await followeePos[0].clickRemoveButton();
-    expect(onNnsRemove).toBeCalledTimes(1);
-    expect(onNnsRemove).toBeCalledWith({
+    expect(removeFollowing).toBeCalledTimes(1);
+    expect(removeFollowing).toBeCalledWith({
       neuronId: neuronId1,
       topicKey,
     });
 
     await followeePos[1].clickRemoveButton();
-    expect(onNnsRemove).toBeCalledTimes(2);
-    expect(onNnsRemove).toBeCalledWith({
+    expect(removeFollowing).toBeCalledTimes(2);
+    expect(removeFollowing).toBeCalledWith({
       neuronId: neuronId2,
       topicKey,
     });

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
@@ -1,0 +1,235 @@
+import FollowSnsNeuronsByTopicStepTopics from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte";
+import type { SnsTopicFollowing, SnsTopicKey } from "$lib/types/sns";
+import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
+import { FollowSnsNeuronsByTopicStepTopicsPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuronId } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("FollowSnsNeuronsByTopicStepTopics", () => {
+  const criticalTopicKey1: SnsTopicKey = "CriticalDappOperations";
+  const criticalTopicName1 = "Critical Dapp Operations";
+  const criticalTopicDescription1 = "Critical topic description 1";
+  const criticalTopicInfo1: TopicInfoWithUnknown = {
+    native_functions: [[]],
+    topic: [
+      {
+        [criticalTopicKey1]: null,
+      },
+    ],
+    is_critical: [true],
+    name: [criticalTopicName1],
+    description: [criticalTopicDescription1],
+    custom_functions: [[]],
+  };
+  const criticalTopicKey2: SnsTopicKey = "TreasuryAssetManagement";
+  const criticalTopicName2 = "Treasury Asset Management";
+  const criticalTopicDescription2 = "Critical topic description 2";
+  const criticalTopicInfo2: TopicInfoWithUnknown = {
+    native_functions: [[]],
+    topic: [
+      {
+        [criticalTopicKey2]: null,
+      },
+    ],
+    is_critical: [true],
+    name: [criticalTopicName2],
+    description: [criticalTopicDescription2],
+    custom_functions: [[]],
+  };
+  const topicKey1: SnsTopicKey = "DaoCommunitySettings";
+  const topicName1 = "Dao Community Settings";
+  const topicDescription1 = "Topic description 1";
+  const topicInfo1: TopicInfoWithUnknown = {
+    native_functions: [[]],
+    topic: [
+      {
+        [topicKey1]: null,
+      },
+    ],
+    is_critical: [false],
+    name: [topicName1],
+    description: [topicDescription1],
+    custom_functions: [[]],
+  };
+  const topicKey2: SnsTopicKey = "ApplicationBusinessLogic";
+  const topicName2 = "Application Business Logic";
+  const topicDescription2 = "Topic description 2";
+  const topicInfo2: TopicInfoWithUnknown = {
+    native_functions: [[]],
+    topic: [
+      {
+        [topicKey2]: null,
+      },
+    ],
+    is_critical: [false],
+    name: [topicName2],
+    description: [topicDescription2],
+    custom_functions: [[]],
+  };
+
+  const renderComponent = (props: {
+    selectedTopics: SnsTopicKey[];
+    topicInfos: TopicInfoWithUnknown[];
+    followings: SnsTopicFollowing[];
+    closeModal: () => void;
+    openNextStep: () => void;
+    removeFollowing: (args: {
+      topicKey: SnsTopicKey;
+      neuronId: SnsNeuronId;
+    }) => void;
+  }) => {
+    const { container } = render(FollowSnsNeuronsByTopicStepTopics, {
+      props,
+    });
+
+    return FollowSnsNeuronsByTopicStepTopicsPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+  const defaultProps = {
+    selectedTopics: [],
+    topicInfos: [],
+    followings: [],
+    closeModal: vi.fn(),
+    openNextStep: vi.fn(),
+    removeFollowing: vi.fn(),
+  };
+
+  it("displays critical and non-critical topics", async () => {
+    const po = renderComponent({
+      ...defaultProps,
+      topicInfos: [
+        criticalTopicInfo1,
+        topicInfo1,
+        criticalTopicInfo2,
+        topicInfo2,
+      ],
+    });
+
+    expect(await po.getCriticalTopicItemNames()).toEqual([
+      criticalTopicName1,
+      criticalTopicName2,
+    ]);
+    expect(await po.getNonCriticalTopicItemNames()).toEqual([
+      topicName1,
+      topicName2,
+    ]);
+    expect(await po.getCriticalTopicItemDescriptions()).toEqual([
+      criticalTopicDescription1,
+      criticalTopicDescription2,
+    ]);
+    expect(await po.getNonCriticalTopicItemDescriptions()).toEqual([
+      topicDescription1,
+      topicDescription2,
+    ]);
+  });
+
+  it("displays status icon", async () => {
+    const testFollowee = {
+      neuronId: {
+        id: Uint8Array.from([0, 1, 2]),
+      },
+    };
+    const po = renderComponent({
+      ...defaultProps,
+      topicInfos: [
+        criticalTopicInfo1,
+        topicInfo1,
+        criticalTopicInfo2,
+        topicInfo2,
+      ],
+      followings: [
+        {
+          topic: criticalTopicKey1,
+          followees: [testFollowee],
+        },
+        {
+          topic: topicKey1,
+          followees: [testFollowee],
+        },
+      ],
+    });
+
+    expect(
+      await (
+        await po.getTopicItemPoByName(criticalTopicName1)
+      ).hasFollowingStatusIcon()
+    ).toEqual(true);
+    expect(
+      await (
+        await po.getTopicItemPoByName(criticalTopicName2)
+      ).hasFollowingStatusIcon()
+    ).toEqual(false);
+    expect(
+      await (await po.getTopicItemPoByName(topicName1)).hasFollowingStatusIcon()
+    ).toEqual(true);
+    expect(
+      await (await po.getTopicItemPoByName(topicName2)).hasFollowingStatusIcon()
+    ).toEqual(false);
+  });
+
+  it("binds topic selection", async () => {
+    const props = $state({
+      ...defaultProps,
+      topicInfos: [
+        criticalTopicInfo1,
+        criticalTopicInfo2,
+        topicInfo1,
+        topicInfo2,
+      ],
+      selectedTopics: [topicKey1, criticalTopicKey1],
+    });
+    const po = renderComponent(props);
+
+    expect(await po.getTopicSelectionByName(criticalTopicName1)).toEqual(true);
+    expect(await po.getTopicSelectionByName(criticalTopicName2)).toEqual(false);
+    expect(await po.getTopicSelectionByName(topicName1)).toEqual(true);
+    expect(await po.getTopicSelectionByName(topicName2)).toEqual(false);
+    expect([...props.selectedTopics].sort()).toEqual(
+      [criticalTopicKey1, topicKey1].sort()
+    );
+
+    await po.clickTopicItemByName(criticalTopicName1);
+    expect(await po.getTopicSelectionByName(criticalTopicName1)).toEqual(false);
+    expect(await po.getTopicSelectionByName(criticalTopicName2)).toEqual(false);
+    expect(await po.getTopicSelectionByName(topicName1)).toEqual(true);
+    expect(await po.getTopicSelectionByName(topicName2)).toEqual(false);
+    expect([...props.selectedTopics]).toEqual([topicKey1]);
+
+    await po.clickTopicItemByName(criticalTopicName2);
+    expect(await po.getTopicSelectionByName(criticalTopicName1)).toEqual(false);
+    expect(await po.getTopicSelectionByName(criticalTopicName2)).toEqual(true);
+    expect(await po.getTopicSelectionByName(topicName1)).toEqual(true);
+    expect(await po.getTopicSelectionByName(topicName2)).toEqual(false);
+    expect([...props.selectedTopics].sort()).toEqual(
+      [criticalTopicKey2, topicKey1].sort()
+    );
+
+    await po.clickTopicItemByName(topicName2);
+    expect(await po.getTopicSelectionByName(criticalTopicName1)).toEqual(false);
+    expect(await po.getTopicSelectionByName(criticalTopicName2)).toEqual(true);
+    expect(await po.getTopicSelectionByName(topicName1)).toEqual(true);
+    expect(await po.getTopicSelectionByName(topicName2)).toEqual(true);
+    expect([...props.selectedTopics].sort()).toEqual(
+      [criticalTopicKey2, topicKey1, topicKey2].sort()
+    );
+  });
+
+  it("calls callbacks", async () => {
+    const closeModal = vi.fn();
+    const openNextStep = vi.fn();
+    const po = renderComponent({
+      ...defaultProps,
+      closeModal,
+      openNextStep,
+    });
+
+    expect(await po.getCancelButtonPo().isPresent()).toBe(true);
+    expect(await po.getNextButtonPo().isPresent()).toBe(true);
+    await po.clickCancelButton();
+    expect(closeModal).toBeCalledTimes(1);
+    await po.clickNextButton();
+    expect(openNextStep).toBeCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicFollowee.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicFollowee.page-object.ts
@@ -17,7 +17,7 @@ export class FollowSnsNeuronsByTopicFolloweePo extends BasePageObject {
   ): Promise<FollowSnsNeuronsByTopicFolloweePo[]> {
     return (
       await element.allByTestId(FollowSnsNeuronsByTopicFolloweePo.TID)
-    ).map((element) => FollowSnsNeuronsByTopicFolloweePo.under(element));
+    ).map((element) => new FollowSnsNeuronsByTopicFolloweePo(element));
   }
 
   getNeuronHashPo(): HashPo {

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicItem.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicItem.page-object.ts
@@ -18,7 +18,7 @@ export class FollowSnsNeuronsByTopicItemPo extends BasePageObject {
     element: PageObjectElement
   ): Promise<FollowSnsNeuronsByTopicItemPo[]> {
     return (await element.allByTestId(FollowSnsNeuronsByTopicItemPo.TID)).map(
-      (element) => FollowSnsNeuronsByTopicItemPo.under(element)
+      (element) => new FollowSnsNeuronsByTopicItemPo(element)
     );
   }
 
@@ -45,15 +45,25 @@ export class FollowSnsNeuronsByTopicItemPo extends BasePageObject {
   }
 
   getTopicName(): Promise<string> {
-    return this.root.byTestId("topic-name").getText();
+    return this.getText("topic-name");
   }
 
   getTopicDescription(): Promise<string> {
-    return this.root.byTestId("topic-description").getText();
+    return this.getText("topic-description");
+  }
+
+  getStatusIcon(): PageObjectElement {
+    return this.getElement("topic-following-status");
   }
 
   getFolloweesPo(): Promise<FollowSnsNeuronsByTopicFolloweePo[]> {
     return FollowSnsNeuronsByTopicFolloweePo.allUnder(this.root);
+  }
+
+  async hasFollowingStatusIcon(): Promise<boolean> {
+    return (await this.getStatusIcon().getClasses()).includes(
+      "isFollowingByTopic"
+    );
   }
 
   async getFolloweesNeuronIds(): Promise<string[]> {

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object.ts
@@ -1,0 +1,106 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { FollowSnsNeuronsByTopicFolloweePo } from "$tests/page-objects/FollowSnsNeuronsByTopicFollowee.page-object";
+import { FollowSnsNeuronsByTopicItemPo } from "$tests/page-objects/FollowSnsNeuronsByTopicItem.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class FollowSnsNeuronsByTopicStepTopicsPo extends BasePageObject {
+  private static readonly TID =
+    "follow-sns-neurons-by-topic-step-topics-component";
+
+  static under(
+    element: PageObjectElement
+  ): FollowSnsNeuronsByTopicStepTopicsPo {
+    return new FollowSnsNeuronsByTopicStepTopicsPo(
+      element.byTestId(FollowSnsNeuronsByTopicStepTopicsPo.TID)
+    );
+  }
+
+  getCriticalFollowSnsNeuronsByTopicItemPos(): Promise<
+    FollowSnsNeuronsByTopicItemPo[]
+  > {
+    const groupElementPo = this.getElement("critical-topic-group");
+    return FollowSnsNeuronsByTopicItemPo.allUnder(groupElementPo);
+  }
+
+  getNonCriticalFollowSnsNeuronsByTopicItemPos(): Promise<
+    FollowSnsNeuronsByTopicItemPo[]
+  > {
+    const groupElementPo = this.root.byTestId("non-critical-topic-group");
+    return FollowSnsNeuronsByTopicItemPo.allUnder(groupElementPo);
+  }
+
+  async getCriticalTopicItemNames(): Promise<string[]> {
+    const itemPos = await this.getCriticalFollowSnsNeuronsByTopicItemPos();
+    return Promise.all(itemPos.map((itemPo) => itemPo.getTopicName()));
+  }
+
+  async getNonCriticalTopicItemNames(): Promise<string[]> {
+    const itemPos = await this.getNonCriticalFollowSnsNeuronsByTopicItemPos();
+    return Promise.all(itemPos.map((itemPo) => itemPo.getTopicName()));
+  }
+
+  async getCriticalTopicItemDescriptions(): Promise<string[]> {
+    const itemPos = await this.getCriticalFollowSnsNeuronsByTopicItemPos();
+    return Promise.all(itemPos.map((itemPo) => itemPo.getTopicDescription()));
+  }
+
+  async getNonCriticalTopicItemDescriptions(): Promise<string[]> {
+    const itemPos = await this.getNonCriticalFollowSnsNeuronsByTopicItemPos();
+    return Promise.all(itemPos.map((itemPo) => itemPo.getTopicDescription()));
+  }
+
+  async getTopicItemPoByName(
+    topicName: string
+  ): Promise<FollowSnsNeuronsByTopicItemPo> {
+    const itemPos = [
+      ...(await this.getCriticalFollowSnsNeuronsByTopicItemPos()),
+      ...(await this.getNonCriticalFollowSnsNeuronsByTopicItemPos()),
+    ];
+    for (const itemPo of itemPos) {
+      const name = await itemPo.getTopicName();
+      if (name === topicName) {
+        return itemPo;
+      }
+    }
+    throw new Error(`Topic with name ${topicName} not found`);
+  }
+
+  async clickTopicItemByName(topicName: string): Promise<void> {
+    return (await this.getTopicItemPoByName(topicName)).getCheckboxPo().click();
+  }
+
+  async getTopicSelectionByName(topicName: string): Promise<boolean> {
+    return (await this.getTopicItemPoByName(topicName))
+      .getCheckboxPo()
+      .isChecked();
+  }
+
+  async getTopicFolloweePos(
+    topicName: string
+  ): Promise<FollowSnsNeuronsByTopicFolloweePo[]> {
+    return (await this.getTopicItemPoByName(topicName)).getFolloweesPo();
+  }
+
+  getCancelButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "cancel-button",
+    });
+  }
+
+  getNextButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "next-button",
+    });
+  }
+
+  clickNextButton(): Promise<void> {
+    return this.getNextButtonPo().click();
+  }
+
+  clickCancelButton(): Promise<void> {
+    return this.getCancelButtonPo().click();
+  }
+}


### PR DESCRIPTION
# Motivation

Adds the first step component to the "Follow SNS Neurons by Topic" modal, showing topics to follow and current follow state.

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)

Demo:  https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

<img width="459" alt="image" src="https://github.com/user-attachments/assets/9e0fdfda-6082-4c5a-a702-01105e2fb394" />

# Changes

- Rename TopicFollowee props and callbacks to better align with other components.
- New component FollowSnsNeuronsByTopicStepTopics

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3665]: https://dfinity.atlassian.net/browse/NNS1-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ