### PR TITLE
Replace Modal with Wizard component

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -425,10 +425,12 @@
   "follow_sns_topics": {
     "topic_definitions_description": "Proposal types are grouped into topics, unique for each SNS. You can review the topic definitions for this SNS here.",
     "topic_definitions_title": "Topic Definition List",
+    "topics_title": "Delegate Voting",
     "topics_critical_label": "Critical topics",
     "topics_critical_tooltip": "TBD",
     "topics_non_critical_label": "Non-critical topics",
-    "topics_non_critical_tooltip": "TBD"
+    "topics_non_critical_tooltip": "TBD",
+    "neuron_title": "Enter Neuron to Follow"
   },
   "missing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -1,31 +1,44 @@
 <script lang="ts">
-  import Separator from "$lib/components/ui/Separator.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { Modal } from "@dfinity/gix-components";
+  import {
+    WizardModal,
+    type WizardStep,
+    type WizardSteps,
+  } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
 
   const dispatcher = createEventDispatcher();
 
   const close = () => dispatcher("nnsClose");
+  const STEP_TOPICS = "topics";
+  const STEP_NEURON = "neurons";
+  const steps: WizardSteps = [
+    {
+      name: STEP_TOPICS,
+      title: $i18n.follow_sns_topics.topics_title,
+    },
+    {
+      name: STEP_NEURON,
+      title: $i18n.follow_sns_topics.neuron_title,
+    },
+  ];
+  let currentStep: WizardStep | undefined = $state();
+  let modal: WizardModal | undefined = $state();
 </script>
 
-<Modal
-  on:nnsClose
+<WizardModal
   testId="follow-sns-neurons-by-topic-modal"
-  --modal-content-overflow-y="scroll"
+  {steps}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
 >
-  <svelte:fragment slot="title"
-    >{$i18n.neurons.follow_neurons_screen}</svelte:fragment
-  >
-  <p class="description">{$i18n.follow_neurons.description}</p>
+  <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
 
-  <Separator spacing="medium" />
-
-  TBD
-
-  <div class="toolbar">
-    <button data-tid="close-button" class="secondary" on:click={close}>
-      {$i18n.core.close}
-    </button>
-  </div>
-</Modal>
+  {#if currentStep?.name === STEP_TOPICS}
+    TBD FollowSnsNeuronsByTopicStepTopics
+  {/if}
+  {#if currentStep?.name === STEP_NEURON}
+    TBD FollowSnsNeuronsByTopicStepNeuron
+  {/if}
+</WizardModal>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -440,6 +440,7 @@ interface I18nNeurons {
 interface I18nFollow_sns_topics {
   topic_definitions_description: string;
   topic_definitions_title: string;
+  topics_title: string;
   topics_critical_label: string;
   topics_critical_tooltip: string;
   topics_non_critical_label: string;


### PR DESCRIPTION
# Motivation

Since following a neuron by topic involves multiple steps, we’re replacing the Modal with WizardModal (with initial 2 steps) to match other flows in the dapp.

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)
Demo:  https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

# Changes

- Replace Modal with WizardModal component.

# Tests

-Will be added when we replace placeholders with actual components.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.