### PR TITLE
Neuron step in follow by Sns topics modal

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -428,7 +428,10 @@
     "topics_critical_label": "Critical topics",
     "topics_critical_tooltip": "TBD",
     "topics_non_critical_label": "Non-critical topics",
-    "topics_non_critical_tooltip": "TBD"
+    "topics_non_critical_tooltip": "TBD",
+    "neuron_label": "Neuron to Follow",
+    "neuron_description": "*Developer neurons are not stored in a central place as of now. You can often find them on the <a href=\"https://forum.dfinity.org/\" rel=\"noopener noreferrer\" aria-label=\"DFINITY forum\" target=\"_blank\">DFINITY forum</a> in the founding team’s announcement, or on their <a href=\"https://x.com/home\" rel=\"noopener noreferrer\" aria-label=\"X\" target=\"_blank\">X</a> account. Alternatively, you can review voting power distributions of all neurons on <a href=\"https://snsgeek.app/sns\" rel=\"noopener noreferrer\" aria-label=\"snsgeek\" target=\"_blank\">snsGeek</a>, and select a neuron from their list.",
+    "neuron_follow": "Follow Neuron"
   },
   "missing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import Input from "$lib/components/ui/Input.svelte";
+  import { Html } from "@dfinity/gix-components";
+
+  interface Props {
+    followeeHex: string;
+    openPrevStep: () => void;
+    addFollowing: (followeeHex: string) => void;
+  }
+  let {
+    followeeHex = $bindable(),
+    openPrevStep,
+    addFollowing,
+  }: Props = $props();
+</script>
+
+<form
+  data-tid="follow-sns-neurons-by-topic-step-neuron-component"
+  onsubmit={(event) => {
+    event.preventDefault();
+    addFollowing(followeeHex);
+  }}
+>
+  <Input
+    testId="new-followee-id"
+    inputType="text"
+    autocomplete="off"
+    placeholderLabelKey="new_followee.placeholder"
+    name="new-followee-id"
+    bind:value={followeeHex}
+  >
+    <svelte:fragment slot="label"
+      >{$i18n.follow_sns_topics.neuron_label}</svelte:fragment
+    >
+  </Input>
+
+  <p class="description"
+    ><Html text={$i18n.follow_sns_topics.neuron_description} /></p
+  >
+
+  <div class="toolbar">
+    <button
+      data-tid="back-button"
+      class="secondary"
+      type="button"
+      onclick={openPrevStep}
+    >
+      {$i18n.core.back}
+    </button>
+    <button
+      class="primary"
+      type="submit"
+      data-tid="add-followee-button"
+      disabled={followeeHex.length === 0}
+    >
+      {$i18n.follow_sns_topics.neuron_follow}
+    </button>
+  </div>
+</form>

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte
@@ -3,11 +3,11 @@
   import Input from "$lib/components/ui/Input.svelte";
   import { Html } from "@dfinity/gix-components";
 
-  interface Props {
+  type Props = {
     followeeHex: string;
     openPrevStep: () => void;
     addFollowing: (followeeHex: string) => void;
-  }
+  };
   let {
     followeeHex = $bindable(),
     openPrevStep,
@@ -31,7 +31,8 @@
     bind:value={followeeHex}
   >
     <svelte:fragment slot="label"
-      >{$i18n.follow_sns_topics.neuron_label}</svelte:fragment
+      ><h5 class="label">{$i18n.follow_sns_topics.neuron_label}</h5
+      ></svelte:fragment
     >
   </Input>
 
@@ -58,3 +59,15 @@
     </button>
   </div>
 </form>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .label {
+    margin: 0;
+  }
+
+  .description {
+    @include fonts.small(true);
+  }
+</style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -444,6 +444,9 @@ interface I18nFollow_sns_topics {
   topics_critical_tooltip: string;
   topics_non_critical_label: string;
   topics_non_critical_tooltip: string;
+  neuron_label: string;
+  neuron_description: string;
+  neuron_follow: string;
 }
 
 interface I18nMissing_rewards {

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte.spec.ts
@@ -1,0 +1,76 @@
+import FollowSnsNeuronsByTopicStepNeuron from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte";
+import { FollowSnsNeuronsByTopicStepNeuronPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepNeuron.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { render } from "@testing-library/svelte";
+
+describe("FollowSnsNeuronsByTopicStepNeuron", () => {
+  const renderComponent = (props: {
+    followeeHex: string;
+    openPrevStep: () => void;
+    addFollowing: (followeeHex: string) => void;
+  }) => {
+    const { container } = render(FollowSnsNeuronsByTopicStepNeuron, {
+      props,
+    });
+
+    return FollowSnsNeuronsByTopicStepNeuronPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("binds neuron hex field", async () => {
+    const props = $state({
+      followeeHex: "1234",
+      openPrevStep: vi.fn(),
+      addFollowing: vi.fn(),
+    });
+    const po = renderComponent(props);
+
+    expect(await po.getNeuronIdValue()).toEqual("1234");
+    expect(await po.getConfirmButtonPo().isDisabled()).toBe(false);
+
+    await po.getNeuronIdInputPo().typeText("");
+    expect(props.followeeHex).toEqual("");
+
+    props.followeeHex = "ABC";
+    await runResolvedPromises();
+    expect(await po.getNeuronIdValue()).toEqual("ABC");
+  });
+
+  it("disables confirm button", async () => {
+    const po = renderComponent({
+      followeeHex: "",
+      openPrevStep: vi.fn(),
+      addFollowing: vi.fn(),
+    });
+    expect(await po.getConfirmButtonPo().isDisabled()).toBe(true);
+
+    await po.getNeuronIdInputPo().typeText("1234");
+    expect(await po.getConfirmButtonPo().isDisabled()).toBe(false);
+
+    await po.getNeuronIdInputPo().typeText("");
+    expect(await po.getConfirmButtonPo().isDisabled()).toBe(true);
+  });
+
+  it("calls callbacks", async () => {
+    const props = $state({
+      followeeHex: "1234",
+      openPrevStep: vi.fn(),
+      addFollowing: vi.fn(),
+    });
+    const po = renderComponent(props);
+
+    await po.clickBackButton();
+    expect(props.openPrevStep).toHaveBeenCalledTimes(1);
+
+    await po.clickConfirmButton();
+    expect(props.addFollowing).toHaveBeenCalledTimes(1);
+    expect(props.addFollowing).toHaveBeenCalledWith("1234");
+
+    props.followeeHex = "5678";
+    await po.clickConfirmButton();
+    expect(props.addFollowing).toHaveBeenCalledTimes(2);
+    expect(props.addFollowing).toHaveBeenCalledWith("5678");
+  });
+});

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepNeuron.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepNeuron.page-object.ts
@@ -1,0 +1,50 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { TextInputPo } from "$tests/page-objects/TextInput.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class FollowSnsNeuronsByTopicStepNeuronPo extends BasePageObject {
+  private static readonly TID =
+    "follow-sns-neurons-by-topic-step-neuron-component";
+
+  static under(
+    element: PageObjectElement
+  ): FollowSnsNeuronsByTopicStepNeuronPo {
+    return new FollowSnsNeuronsByTopicStepNeuronPo(
+      element.byTestId(FollowSnsNeuronsByTopicStepNeuronPo.TID)
+    );
+  }
+
+  getNeuronIdInputPo(): TextInputPo {
+    return TextInputPo.under({
+      element: this.root,
+      testId: "new-followee-id",
+    });
+  }
+
+  getNeuronIdValue(): Promise<string> {
+    return this.getNeuronIdInputPo().getValue();
+  }
+
+  getBackButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "back-button",
+    });
+  }
+
+  getConfirmButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "add-followee-button",
+    });
+  }
+
+  clickConfirmButton(): Promise<void> {
+    return this.getConfirmButtonPo().click();
+  }
+
+  clickBackButton(): Promise<void> {
+    return this.getBackButtonPo().click();
+  }
+}


### PR DESCRIPTION
# Motivation

After selecting topics in the [first step](https://github.com/dfinity/nns-dapp/pull/6697), the user needs to enter a neuron ID. This PR adds the component that will be used as the second step in the follow by SNS Topics [modal](https://github.com/dfinity/nns-dapp/pull/6699).

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)
Demo:  https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

<img width="447" alt="image" src="https://github.com/user-attachments/assets/d46f3ddb-4264-4c0f-828a-7f4947fedce0" />

# Changes

- New component.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3665]: https://dfinity.atlassian.net/browse/NNS1-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ