### PR TITLE
chore(deps): bump ic-js and fix update list_proposals response structure

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.10-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.10-next-2025-04-02.1.tgz",
-      "integrity": "sha512-fN8mMkopRpAYZgDXLrbRO3mciEqotf1lDNKXakYp0D+vOCqVHSzrE+2H0Hrcwqr3H38hfe4FZ43N949cNlHXTA==",
+      "version": "3.1.11-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.11-next-2025-04-15.tgz",
+      "integrity": "sha512-ST08mT2wfdPUFM8cvvXZohnt5ou74uXpYMibUymKlzdQpqkYVhjZJ33x0fsWULOL4d3jvqvn/+JJqs+8X6bWww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "5.0.3-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.3-next-2025-04-02.1.tgz",
-      "integrity": "sha512-hSltor0SLkvlWw8IDLMQQY0mS/3cNe4FeTgAErmDpJM4znl0pmUGby4OPn9t1Fz4zSqwO3wcIGg//u4pglwY4w==",
+      "version": "5.0.4-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.4-next-2025-04-15.tgz",
+      "integrity": "sha512-7ytO/ubQcDp0rTrbvHijEAcVgXvzbVIUvL7PjChnPH+3qP4wzuIN/lu1HhljcRaazGDnvuTa2o12sPngqe9v9A==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "6.0.6-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.6-next-2025-04-02.1.tgz",
-      "integrity": "sha512-eNKYJEaWLYVh0G4lAVMOnrfifvaqMG6pZHOtujxOM4q4Rkd59/9RJdFEpmzFP+Pf9VDklXxfA0ZvzaEFctZICw==",
+      "version": "6.1.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.1.0-next-2025-04-15.tgz",
+      "integrity": "sha512-wwYAFS/BivJq0TPuaIDTb6fciLuUl48B1FMuDWuwqX2PEn7UHr27OAM3Ct92bQ9MaUsqs+f3uY5nzkhqa/tr3g==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -429,9 +429,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.6.11-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.11-next-2025-04-02.1.tgz",
-      "integrity": "sha512-txxmBnovOaIPB93k7agYpYem3UDMBZ48Ni9JMTIEdFIYVvfzNEG0WPIFBAYmJyF2WkA+5As90CMuiArlN+WqkQ==",
+      "version": "2.6.12-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.12-next-2025-04-15.tgz",
+      "integrity": "sha512-+fzhlBfCPs6vB88QGNsYwC34DNMcFAuhWNhf96chojJh/zatyH7y0LIOjJ+MIqGAwl8Aqu/u01G4bK7rmmNNgg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.7.6-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.7.6-next-2025-04-02.1.tgz",
-      "integrity": "sha512-ooa7lEkq3P5WFmnrpH5m2d9RodiaqJkpraaBH0GZOAwdSxCxY9E+y27foOX/3hiSMR9EckyKyPIHHlKsflFI/A==",
+      "version": "2.8.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.8.0-next-2025-04-15.tgz",
+      "integrity": "sha512-kIgtRh2Bpse0UbyaB3XYa08EQQdca34UOMcnKK7xzhNUIr1qsPfM2+B7cUL9n/r8UcXGB/hcBW764OIUxwXAfA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "8.3.2-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.3.2-next-2025-04-02.1.tgz",
-      "integrity": "sha512-aSvZkgOmtdWvtp+an32r/xMbtcbS04jo7EKEMl3A41u33WPuShxztlPicABQkOx1v4jsQf8te4wm7Pvbj/rQ0Q==",
+      "version": "8.4.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.4.0-next-2025-04-15.tgz",
+      "integrity": "sha512-1RJ98FK4HkZuE+1CQTFJyZ3Iw0+GpPOWJl8RgmyZAIpVfpdna2ol+uNLCjWsxACttnpLxH9Qf8P4q6oVNj9pOA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.4.0-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.4.0-next-2025-04-02.1.tgz",
-      "integrity": "sha512-dtX3SWFGMShpfF5FPS1yHkUK2t47fbr9/3aM5RFDsJnFemUQ7C5uZHVAR7bZ4NehXrhY/9lZeE/segLdGV9D0w==",
+      "version": "3.5.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.5.0-next-2025-04-15.tgz",
+      "integrity": "sha512-2i0PyaHSWq6sBSxhwHQXdQQdvSbzFNjiTDE9xFyj001InbJbtWGSinucUp+ow2LJ1zmjeCuJhiLP2YRFm1/9FA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -495,9 +495,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.11.0-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.11.0-next-2025-04-02.1.tgz",
-      "integrity": "sha512-BNxWzXHnm1YaeMqwcUSvwjV7RHg/SYHHRRWoJLtM+t9V1Llv42kujscxc9P194AicbogbORoDiKDpHLyauKY8Q==",
+      "version": "2.12.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.12.0-next-2025-04-15.tgz",
+      "integrity": "sha512-YdJT+gNO4hKL+WPeZcx//HVq3K9g2H3B4+70IUyk3gV443bI6hV4nhXRUWXyjXsuEWmUVgJtTCrnvVJ5SS2+rQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -7194,9 +7194,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "3.1.10-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.10-next-2025-04-02.1.tgz",
-      "integrity": "sha512-fN8mMkopRpAYZgDXLrbRO3mciEqotf1lDNKXakYp0D+vOCqVHSzrE+2H0Hrcwqr3H38hfe4FZ43N949cNlHXTA==",
+      "version": "3.1.11-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.11-next-2025-04-15.tgz",
+      "integrity": "sha512-ST08mT2wfdPUFM8cvvXZohnt5ou74uXpYMibUymKlzdQpqkYVhjZJ33x0fsWULOL4d3jvqvn/+JJqs+8X6bWww==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7204,9 +7204,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "5.0.3-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.3-next-2025-04-02.1.tgz",
-      "integrity": "sha512-hSltor0SLkvlWw8IDLMQQY0mS/3cNe4FeTgAErmDpJM4znl0pmUGby4OPn9t1Fz4zSqwO3wcIGg//u4pglwY4w==",
+      "version": "5.0.4-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.4-next-2025-04-15.tgz",
+      "integrity": "sha512-7ytO/ubQcDp0rTrbvHijEAcVgXvzbVIUvL7PjChnPH+3qP4wzuIN/lu1HhljcRaazGDnvuTa2o12sPngqe9v9A==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7221,9 +7221,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "6.0.6-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.0.6-next-2025-04-02.1.tgz",
-      "integrity": "sha512-eNKYJEaWLYVh0G4lAVMOnrfifvaqMG6pZHOtujxOM4q4Rkd59/9RJdFEpmzFP+Pf9VDklXxfA0ZvzaEFctZICw==",
+      "version": "6.1.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.1.0-next-2025-04-15.tgz",
+      "integrity": "sha512-wwYAFS/BivJq0TPuaIDTb6fciLuUl48B1FMuDWuwqX2PEn7UHr27OAM3Ct92bQ9MaUsqs+f3uY5nzkhqa/tr3g==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7237,21 +7237,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.6.11-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.11-next-2025-04-02.1.tgz",
-      "integrity": "sha512-txxmBnovOaIPB93k7agYpYem3UDMBZ48Ni9JMTIEdFIYVvfzNEG0WPIFBAYmJyF2WkA+5As90CMuiArlN+WqkQ==",
+      "version": "2.6.12-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.12-next-2025-04-15.tgz",
+      "integrity": "sha512-+fzhlBfCPs6vB88QGNsYwC34DNMcFAuhWNhf96chojJh/zatyH7y0LIOjJ+MIqGAwl8Aqu/u01G4bK7rmmNNgg==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.7.6-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.7.6-next-2025-04-02.1.tgz",
-      "integrity": "sha512-ooa7lEkq3P5WFmnrpH5m2d9RodiaqJkpraaBH0GZOAwdSxCxY9E+y27foOX/3hiSMR9EckyKyPIHHlKsflFI/A==",
+      "version": "2.8.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.8.0-next-2025-04-15.tgz",
+      "integrity": "sha512-kIgtRh2Bpse0UbyaB3XYa08EQQdca34UOMcnKK7xzhNUIr1qsPfM2+B7cUL9n/r8UcXGB/hcBW764OIUxwXAfA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "8.3.2-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.3.2-next-2025-04-02.1.tgz",
-      "integrity": "sha512-aSvZkgOmtdWvtp+an32r/xMbtcbS04jo7EKEMl3A41u33WPuShxztlPicABQkOx1v4jsQf8te4wm7Pvbj/rQ0Q==",
+      "version": "8.4.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.4.0-next-2025-04-15.tgz",
+      "integrity": "sha512-1RJ98FK4HkZuE+1CQTFJyZ3Iw0+GpPOWJl8RgmyZAIpVfpdna2ol+uNLCjWsxACttnpLxH9Qf8P4q6oVNj9pOA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7266,17 +7266,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.4.0-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.4.0-next-2025-04-02.1.tgz",
-      "integrity": "sha512-dtX3SWFGMShpfF5FPS1yHkUK2t47fbr9/3aM5RFDsJnFemUQ7C5uZHVAR7bZ4NehXrhY/9lZeE/segLdGV9D0w==",
+      "version": "3.5.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.5.0-next-2025-04-15.tgz",
+      "integrity": "sha512-2i0PyaHSWq6sBSxhwHQXdQQdvSbzFNjiTDE9xFyj001InbJbtWGSinucUp+ow2LJ1zmjeCuJhiLP2YRFm1/9FA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.11.0-next-2025-04-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.11.0-next-2025-04-02.1.tgz",
-      "integrity": "sha512-BNxWzXHnm1YaeMqwcUSvwjV7RHg/SYHHRRWoJLtM+t9V1Llv42kujscxc9P194AicbogbORoDiKDpHLyauKY8Q==",
+      "version": "2.12.0-next-2025-04-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.12.0-next-2025-04-15.tgz",
+      "integrity": "sha512-YdJT+gNO4hKL+WPeZcx//HVq3K9g2H3B4+70IUyk3gV443bI6hV4nhXRUWXyjXsuEWmUVgJtTCrnvVJ5SS2+rQ==",
       "requires": {}
     },
     "@esbuild/aix-ppc64": {

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -117,6 +117,7 @@ const getProposals = (keyParams: KeyParams): SnsListProposalsResponse => {
     proposals.set(key, {
       proposals: [],
       include_ballots_by_caller: [true],
+      include_topic_filtering: [],
     });
   }
   return proposals.get(key);
@@ -302,6 +303,7 @@ async function queryProposals({
     proposals.get(mapKey({ identity, rootCanisterId })) || {
       proposals: [],
       include_ballots_by_caller: [true],
+      include_topic_filtering: [],
     }
   );
 }

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -352,6 +352,7 @@ describe("SnsVotingCard", () => {
       vi.spyOn(api, "queryProposals").mockResolvedValue({
         proposals: [],
         include_ballots_by_caller: [true],
+        include_topic_filtering: [],
       });
     });
 

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -210,6 +210,7 @@ describe("actionable-sns-proposals.services", () => {
         .mockImplementation(async () => ({
           proposals: [],
           include_ballots_by_caller: [true] as [boolean],
+          include_topic_filtering: [],
         }));
       spyConsoleError = silentConsoleErrors();
 
@@ -253,6 +254,7 @@ describe("actionable-sns-proposals.services", () => {
         .mockImplementation(async () => ({
           proposals: [],
           include_ballots_by_caller: [true] as [boolean],
+          include_topic_filtering: [],
         }));
       failedActionableSnsesStore.add(rootCanisterId1.toText());
 

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -54,13 +54,11 @@ describe("sns-proposals services", () => {
     let queryProposalsSpy;
 
     beforeEach(() => {
-      queryProposalsSpy = vi
-        .spyOn(api, "queryProposals")
-        .mockResolvedValue({
-          proposals,
-          include_ballots_by_caller: [true],
-          include_topic_filtering: [],
-        });
+      queryProposalsSpy = vi.spyOn(api, "queryProposals").mockResolvedValue({
+        proposals,
+        include_ballots_by_caller: [true],
+        include_topic_filtering: [],
+      });
     });
 
     describe("not logged in", () => {

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -56,7 +56,11 @@ describe("sns-proposals services", () => {
     beforeEach(() => {
       queryProposalsSpy = vi
         .spyOn(api, "queryProposals")
-        .mockResolvedValue({ proposals, include_ballots_by_caller: [true] });
+        .mockResolvedValue({
+          proposals,
+          include_ballots_by_caller: [true],
+          include_topic_filtering: [],
+        });
     });
 
     describe("not logged in", () => {


### PR DESCRIPTION
# Motivation

In the scope of [NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666), we need to filter proposals by topic. To achieve this, we must upgrade to the latest version of [ic-js](https://github.com/dfinity/ic-js/pull/886). The automatic job #6703 cannot upgrade the ic-js version to the latest because it introduced a new field in the response of `list_proposals`, which needs to be updated in the nns-dapp mock responses.

# Changes

- Checked out #6703 and created a new branch.  
- Updated the response for the `list_proposals` mocks

# Tests

- For now, tests should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ