### PR TITLE
feat(sns-topics): Remove sns topic following

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -437,6 +437,7 @@
     "neuron_description": "*Developer neurons are not stored in a central place as of now. You can often find them on the <a href=\"https://forum.dfinity.org/\" rel=\"noopener noreferrer\" aria-label=\"DFINITY forum\" target=\"_blank\">DFINITY forum</a> in the founding team’s announcement, or on their <a href=\"https://x.com/home\" rel=\"noopener noreferrer\" aria-label=\"X\" target=\"_blank\">X</a> account. Alternatively, you can review voting power distributions of all neurons on <a href=\"https://snsgeek.app/sns\" rel=\"noopener noreferrer\" aria-label=\"snsgeek\" target=\"_blank\">snsGeek</a>, and select a neuron from their list.",
     "neuron_follow": "Follow Neuron",
     "busy_updating": "Updating neuron followings",
+    "busy_removing": "Removing neuron following",
     "success_set_following": "The neuron following was successfully added."
   },
   "missing_rewards": {

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -14,6 +14,7 @@
   import {
     addSnsNeuronToFollowingsByTopics,
     getSnsTopicFollowings,
+    removeSnsNeuronFromFollowingsByTopics,
   } from "$lib/utils/sns-topics.utils";
   import { hexStringToBytes } from "$lib/utils/utils";
   import {
@@ -104,8 +105,26 @@
     topicKey: SnsTopicKey;
     neuronId: SnsNeuronId;
   }) => {
-    console.error("TBD removeFollowing", topicKey, neuronId);
-    await reloadNeuron();
+    startBusy({
+      initiator: "remove-followee-by-topic",
+      labelKey: "follow_sns_topics.busy_removing",
+    });
+
+    const { success } = await setFollowing({
+      rootCanisterId,
+      neuronId: fromDefinedNullable(neuron.id),
+      followings: removeSnsNeuronFromFollowingsByTopics({
+        followings,
+        topics: [topicKey],
+        neuronId,
+      }),
+    });
+
+    if (success) {
+      await reloadNeuron();
+    }
+
+    stopBusy("remove-followee-by-topic");
   };
 </script>
 

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -676,6 +676,7 @@ export const setFollowing = async ({
 
     return { success: true };
   } catch (error: unknown) {
+    // TODO(sns-topics): Move error handling to the component layer.
     toastsError({
       labelKey: "error__sns.sns_add_followee",
       err: error,

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -22,6 +22,7 @@ export type BusyStateInitiatorType =
   | "dissolve-action"
   | "add-followee"
   | "add-followee-by-topic"
+  | "remove-followee-by-topic"
   | "remove-followee"
   | "add-hotkey-neuron"
   | "remove-hotkey-neuron"

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -452,6 +452,7 @@ interface I18nFollow_sns_topics {
   neuron_description: string;
   neuron_follow: string;
   busy_updating: string;
+  busy_removing: string;
   success_set_following: string;
 }
 


### PR DESCRIPTION
# Motivation

As we’re switching from type-based to topic-based voting delegation, here we use the setFollowing API to remove user’s topic-based following directly from the topic description section.

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)
Demo:  https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

<img src="https://github.com/user-attachments/assets/c2a809f8-a9f0-4755-b4e7-d9f6048ff5fa" width="40%">

# Changes

- Add new busy screen initiator.
- Call setFollowing to remove the following.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.


[NNS1-3665]: https://dfinity.atlassian.net/browse/NNS1-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ