### PR TITLE
feat(sns-topics): Validate neuron ID

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -437,7 +437,8 @@
     "neuron_description": "*Developer neurons are not stored in a central place as of now. You can often find them on the <a href=\"https://forum.dfinity.org/\" rel=\"noopener noreferrer\" aria-label=\"DFINITY forum\" target=\"_blank\">DFINITY forum</a> in the founding team’s announcement, or on their <a href=\"https://x.com/home\" rel=\"noopener noreferrer\" aria-label=\"X\" target=\"_blank\">X</a> account. Alternatively, you can review voting power distributions of all neurons on <a href=\"https://snsgeek.app/sns\" rel=\"noopener noreferrer\" aria-label=\"snsgeek\" target=\"_blank\">snsGeek</a>, and select a neuron from their list.",
     "neuron_follow": "Follow Neuron",
     "busy_updating": "Updating neuron followings",
-    "success_set_following": "The neuron following was successfully added."
+    "success_set_following": "The neuron following was successfully added.",
+    "error_neuron_not_exist": "Neuron with id $neuronId does not exist."
   },
   "missing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -31,6 +31,7 @@
     arrayOfNumberToUint8Array,
     fromDefinedNullable,
     isNullish,
+    nonNullish,
   } from "@dfinity/utils";
 
   type Props = {
@@ -73,14 +74,13 @@
   // Validate the followee neuron id by fetching it.
   const validateNeuronId = async (neuronId: SnsNeuronId) => {
     try {
-      const identity = await getSnsNeuronIdentity();
-      return (
-        (await querySnsNeuron({
-          identity,
+      return nonNullish(
+        await querySnsNeuron({
+          identity: await getSnsNeuronIdentity(),
           rootCanisterId,
           neuronId,
           certified: false,
-        })) !== undefined
+        })
       );
     } catch (_) {
       return false;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -453,6 +453,7 @@ interface I18nFollow_sns_topics {
   neuron_follow: string;
   busy_updating: string;
   success_set_following: string;
+  error_neuron_not_exist: string;
 }
 
 interface I18nMissing_rewards {

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -325,7 +325,7 @@ describe("FollowSnsNeuronsByTopicModal", () => {
   });
 
   it("handles provided invalid neuron id", async () => {
-    const newFolloweeNeuronIdHex = "040506";
+    const invalidFolloweeNeuronIdHex = "040506";
     let rejectQuerySnsNeuron;
     vi.spyOn(snsGovernanceApi, "querySnsNeuron").mockImplementation(
       () => new Promise((_, reject) => (rejectQuerySnsNeuron = reject))
@@ -345,7 +345,9 @@ describe("FollowSnsNeuronsByTopicModal", () => {
     await topicsStepPo.clickTopicItemByName(criticalTopicName2);
     await topicsStepPo.clickNextButton();
     const neuronStepPo = await po.getFollowSnsNeuronsByTopicStepNeuronPo();
-    await neuronStepPo.getNeuronIdInputPo().typeText(newFolloweeNeuronIdHex);
+    await neuronStepPo
+      .getNeuronIdInputPo()
+      .typeText(invalidFolloweeNeuronIdHex);
 
     expect(get(busyStore)).toEqual([]);
     expect(get(toastsStore)).toEqual([]);

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -175,6 +175,12 @@ describe("FollowSnsNeuronsByTopicModal", () => {
     const newFolloweeNeuronId: SnsNeuronId = {
       id: arrayOfNumberToUint8Array([4, 5, 6]),
     };
+    let resolveQuerySnsNeuron;
+    const querySnsNeuronSpy = vi
+      .spyOn(snsGovernanceApi, "querySnsNeuron")
+      .mockImplementation(
+        () => new Promise((resolve) => (resolveQuerySnsNeuron = resolve))
+      );
     let resolveSetFollowing;
     const setFollowingSpy = vi
       .spyOn(snsGovernanceApi, "setFollowing")
@@ -217,6 +223,19 @@ describe("FollowSnsNeuronsByTopicModal", () => {
       },
     ]);
     expect(get(toastsStore)).toEqual([]);
+
+    // Neuron id validation request
+    expect(querySnsNeuronSpy).toBeCalledTimes(1);
+    expect(querySnsNeuronSpy).toBeCalledWith({
+      identity: mockIdentity,
+      rootCanisterId,
+      certified: false,
+      neuronId: newFolloweeNeuronId,
+    });
+    expect(setFollowingSpy).toBeCalledTimes(0);
+
+    resolveQuerySnsNeuron(neuron);
+    await runResolvedPromises();
 
     // Set following request
     expect(setFollowingSpy).toBeCalledTimes(1);
@@ -303,5 +322,56 @@ describe("FollowSnsNeuronsByTopicModal", () => {
         text: "There was an error while adding a followee. Test Error",
       },
     ]);
+  });
+
+  it("handles provided invalid neuron id", async () => {
+    const newFolloweeNeuronIdHex = "040506";
+    let rejectQuerySnsNeuron;
+    vi.spyOn(snsGovernanceApi, "querySnsNeuron").mockImplementation(
+      () => new Promise((_, reject) => (rejectQuerySnsNeuron = reject))
+    );
+    const setFollowingSpy = vi
+      .spyOn(snsGovernanceApi, "setFollowing")
+      .mockResolvedValue();
+    const reloadNeuronSpy = vi.fn();
+    const closeModalSpy = vi.fn();
+    const po = renderComponent({
+      ...defaultProps,
+      reloadNeuron: reloadNeuronSpy,
+      closeModal: closeModalSpy,
+    });
+
+    const topicsStepPo = await po.getFollowSnsNeuronsByTopicStepTopicsPo();
+    await topicsStepPo.clickTopicItemByName(criticalTopicName2);
+    await topicsStepPo.clickNextButton();
+    const neuronStepPo = await po.getFollowSnsNeuronsByTopicStepNeuronPo();
+    await neuronStepPo.getNeuronIdInputPo().typeText(newFolloweeNeuronIdHex);
+
+    expect(get(busyStore)).toEqual([]);
+    expect(get(toastsStore)).toEqual([]);
+    await neuronStepPo.clickConfirmButton();
+
+    expect(get(busyStore)).toEqual([
+      {
+        initiator: "add-followee-by-topic",
+        text: "Updating neuron followings",
+      },
+    ]);
+    expect(get(toastsStore)).toEqual([]);
+
+    rejectQuerySnsNeuron();
+    await runResolvedPromises();
+
+    expect(get(busyStore)).toEqual([]);
+    expect(get(toastsStore)).toMatchObject([
+      {
+        level: "error",
+        text: "Neuron with id 040506 does not exist.",
+      },
+    ]);
+
+    expect(setFollowingSpy).toBeCalledTimes(0);
+    expect(reloadNeuronSpy).toBeCalledTimes(0);
+    expect(closeModalSpy).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
# Motivation

As we’re switching from type-based to topic-based voting delegation, this adds a check to ensure that the user-entered neuron ID exists. The same approach is currently used for the NS-function based followings https://github.com/dfinity/nns-dapp/blob/8385e6a7130d9f5118362f85c9b61a551b2cb39b/frontend/src/lib/services/sns-neurons.services.ts#L613

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)
Demo:  https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

# Changes

- Calls querySnsNeuron before updating the following, to ensure the neuron exists.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3665]: https://dfinity.atlassian.net/browse/NNS1-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ