### PR TITLE
refactor(sns-topics): Move setFollowing error handling to component

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -439,7 +439,9 @@
     "busy_updating": "Updating neuron followings",
     "busy_removing": "Removing neuron following",
     "success_set_following": "The neuron following was successfully added.",
-    "error_neuron_not_exist": "Neuron with id $neuronId does not exist."
+    "error_neuron_not_exist": "Neuron with id $neuronId does not exist.",
+    "error_add_following": "There was an error while adding a followee.",
+    "error_remove_following": "There was an error while unfollowing the neuron."
   },
   "missing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -109,7 +109,7 @@
       return;
     }
 
-    const { success } = await setFollowing({
+    const { success, error } = await setFollowing({
       rootCanisterId,
       neuronId: fromDefinedNullable(neuron.id),
       followings: addSnsNeuronToFollowingsByTopics({
@@ -125,6 +125,11 @@
       });
       await reloadNeuron();
       closeModal();
+    } else {
+      toastsError({
+        labelKey: "follow_sns_topics.error_add_following",
+        err: error,
+      });
     }
 
     stopBusy("add-followee-by-topic");
@@ -142,7 +147,7 @@
       labelKey: "follow_sns_topics.busy_removing",
     });
 
-    const { success } = await setFollowing({
+    const { success, error } = await setFollowing({
       rootCanisterId,
       neuronId: fromDefinedNullable(neuron.id),
       followings: removeSnsNeuronFromFollowingsByTopics({
@@ -154,6 +159,11 @@
 
     if (success) {
       await reloadNeuron();
+    } else {
+      toastsError({
+        labelKey: "follow_sns_topics.error_remove_following",
+        err: error,
+      });
     }
 
     stopBusy("remove-followee-by-topic");

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -659,7 +659,7 @@ export const setFollowing = async ({
   rootCanisterId: Principal;
   neuronId: SnsNeuronId;
   followings: SnsTopicFollowing[];
-}): Promise<{ success: boolean }> => {
+}): Promise<{ success: boolean; error?: unknown }> => {
   const identity = await getSnsNeuronIdentity();
 
   try {
@@ -676,12 +676,7 @@ export const setFollowing = async ({
 
     return { success: true };
   } catch (error: unknown) {
-    // TODO(sns-topics): Move error handling to the component layer.
-    toastsError({
-      labelKey: "error__sns.sns_add_followee",
-      err: error,
-    });
-    return { success: false };
+    return { success: false, error };
   }
 };
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -455,6 +455,8 @@ interface I18nFollow_sns_topics {
   busy_removing: string;
   success_set_following: string;
   error_neuron_not_exist: string;
+  error_add_following: string;
+  error_remove_following: string;
 }
 
 interface I18nMissing_rewards {

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -485,7 +485,7 @@ describe("FollowSnsNeuronsByTopicModal", () => {
     expect(get(toastsStore)).toMatchObject([
       {
         level: "error",
-        text: "There was an error while adding a followee. Test Error",
+        text: "There was an error while unfollowing the neuron. Test Error",
       },
     ]);
     expect(spyConsoleError).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -928,9 +928,6 @@ describe("sns-neurons-services", () => {
     });
 
     it("should return success:false on error", async () => {
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => undefined);
       const testError = new Error("Test Error");
       const setFollowingSpy = vi
         .spyOn(governanceApi, "setFollowing")
@@ -945,8 +942,6 @@ describe("sns-neurons-services", () => {
       expect(setFollowingSpy).toBeCalledTimes(1);
       expect(success).toBe(false);
       expect(error).toBe(testError);
-      expect(consoleErrorSpy).toBeCalledTimes(1);
-      expect(consoleErrorSpy).toBeCalledWith(testError);
     });
   });
 

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -858,44 +858,45 @@ describe("sns-neurons-services", () => {
   });
 
   describe("setFollowing ", () => {
+    const followee1: SnsNeuronId = {
+      id: arrayOfNumberToUint8Array([1, 2, 3]),
+    };
+    const followee2: SnsNeuronId = {
+      id: arrayOfNumberToUint8Array([1, 2, 4]),
+    };
+    const rootCanisterId = mockPrincipal;
+    const following1: SnsTopicFollowing = {
+      topic: "DappCanisterManagement",
+      followees: [
+        {
+          neuronId: { id: followee1.id },
+        },
+        {
+          neuronId: { id: followee2.id },
+          alias: "followee2",
+        },
+      ],
+    };
+    const following2: SnsTopicFollowing = {
+      topic: "CriticalDappOperations",
+      followees: [
+        {
+          neuronId: { id: followee1.id },
+        },
+      ],
+    };
+
     it("should call sns api setFollowing", async () => {
-      const followee1: SnsNeuronId = {
-        id: arrayOfNumberToUint8Array([1, 2, 3]),
-      };
-      const followee2: SnsNeuronId = {
-        id: arrayOfNumberToUint8Array([1, 2, 4]),
-      };
-      const rootCanisterId = mockPrincipal;
       const setFollowingSpy = vi
         .spyOn(governanceApi, "setFollowing")
         .mockImplementation(() => Promise.resolve());
-      const following1: SnsTopicFollowing = {
-        topic: "DappCanisterManagement",
-        followees: [
-          {
-            neuronId: { id: followee1.id },
-          },
-          {
-            neuronId: { id: followee2.id },
-            alias: "followee2",
-          },
-        ],
-      };
-      const following2: SnsTopicFollowing = {
-        topic: "CriticalDappOperations",
-        followees: [
-          {
-            neuronId: { id: followee1.id },
-          },
-        ],
-      };
-
-      await setFollowing({
+      const { success } = await setFollowing({
         rootCanisterId,
         neuronId: neuron.id[0],
         followings: [following1, following2],
       });
 
+      expect(success).toBe(true);
       expect(setFollowingSpy).toBeCalledTimes(1);
       expect(setFollowingSpy).toBeCalledWith({
         neuronId: fromNullable(neuron.id),
@@ -924,6 +925,28 @@ describe("sns-neurons-services", () => {
           },
         ],
       });
+    });
+
+    it("should return success:false on error", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const testError = new Error("Test Error");
+      const setFollowingSpy = vi
+        .spyOn(governanceApi, "setFollowing")
+        .mockImplementation(() => Promise.reject(testError));
+
+      const { success, error } = await setFollowing({
+        rootCanisterId,
+        neuronId: neuron.id[0],
+        followings: [following1, following2],
+      });
+
+      expect(setFollowingSpy).toBeCalledTimes(1);
+      expect(success).toBe(false);
+      expect(error).toBe(testError);
+      expect(consoleErrorSpy).toBeCalledTimes(1);
+      expect(consoleErrorSpy).toBeCalledWith(testError);
     });
   });
 


### PR DESCRIPTION
# Motivation

As part of the switch to topic-based voting delegation, we move error handling from the setFollowing service to the component. This allows us to show different error messages when users add or remove followings, instead of the same one.

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)
Demo:  https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

# Changes

- Added new error texts to have them inside the feature labels block.
- Moved the error handling.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.


[NNS1-3665]: https://dfinity.atlassian.net/browse/NNS1-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ