### PR TITLE
refactor(filters): migrate SNS proposal filters to svelte 5

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -13,22 +13,17 @@
     snsFiltersStore,
     type ProjectFiltersStoreData,
   } from "$lib/stores/sns-filters.store";
-  import type { Principal } from "@dfinity/principal";
 
-  let modal: "types" | "status" | undefined = undefined;
+  type Filters = "types" | "status";
+  let modal = $state<Filters | undefined>();
 
-  let rootCanisterId: Principal;
-  $: rootCanisterId = $selectedUniverseIdStore;
-  let filtersStore: ProjectFiltersStoreData | undefined;
-  $: filtersStore = $snsFiltersStore[rootCanisterId.toText()];
+  const rootCanisterId = $derived($selectedUniverseIdStore);
+  const filtersStore = $derived<ProjectFiltersStoreData | undefined>(
+    $snsFiltersStore[rootCanisterId.toText()]
+  );
 
-  const openFilters = (filtersModal: "types" | "status") => {
-    modal = filtersModal;
-  };
-
-  const close = () => {
-    modal = undefined;
-  };
+  const openFilters = (filtersModal: Filters) => (modal = filtersModal);
+  const closeModal = () => (modal = undefined);
 </script>
 
 <TestIdWrapper testId="sns-proposals-filters-component">
@@ -65,7 +60,7 @@
     <SnsFilterTypesModal
       filters={filtersStore?.types}
       {rootCanisterId}
-      on:nnsClose={close}
+      {closeModal}
     />
   {/if}
 
@@ -73,7 +68,7 @@
     <SnsFilterStatusModal
       filters={filtersStore?.decisionStatus}
       {rootCanisterId}
-      on:nnsClose={close}
+      {closeModal}
     />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
@@ -24,9 +24,11 @@ describe("SnsFilterStatusModal", () => {
       checked: false,
     },
   ];
+  const closeModal = vi.fn();
   const props = {
     rootCanisterId: mockPrincipal,
     filters,
+    closeModal,
   };
 
   it("should display modal", () => {
@@ -55,21 +57,19 @@ describe("SnsFilterStatusModal", () => {
     );
   });
 
-  it("should forward close modal event", () =>
-    new Promise<void>((done) => {
-      const { container } = render(SnsFilterStatusModal, {
-        props,
-        events: {
-          nnsClose: () => done(),
-        },
-      });
+  it("should call closeModal function", () => {
+    const { container } = render(SnsFilterStatusModal, {
+      props,
+    });
 
-      const button: HTMLButtonElement | null = container.querySelector(
-        "button:first-of-type"
-      );
+    const button: HTMLButtonElement | null = container.querySelector(
+      "button:first-of-type"
+    );
 
-      button && fireEvent.click(button);
-    }));
+    expect(closeModal).toHaveBeenCalledTimes(0);
+    button && fireEvent.click(button);
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
 
   it("should filter filters", async () => {
     const uncheckedFilters = filters.map((filter) => ({

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
@@ -23,9 +23,12 @@ describe("SnsFilterTypesModal", () => {
       checked: false,
     },
   ];
+
+  const closeModal = vi.fn();
   const props = {
     rootCanisterId: mockPrincipal,
     filters,
+    closeModal,
   };
 
   it("should display modal", () => {
@@ -54,21 +57,19 @@ describe("SnsFilterTypesModal", () => {
     );
   });
 
-  it("should forward close modal event", () =>
-    new Promise<void>((done) => {
-      const { container } = render(SnsFilterTypesModal, {
-        props,
-        events: {
-          nnsClose: () => done(),
-        },
-      });
+  it("should call closeModal function", () => {
+    const { container } = render(SnsFilterTypesModal, {
+      props,
+    });
 
-      const button: HTMLButtonElement | null = container.querySelector(
-        "button:first-of-type"
-      );
+    const button: HTMLButtonElement | null = container.querySelector(
+      "button:first-of-type"
+    );
 
-      button && fireEvent.click(button);
-    }));
+    expect(closeModal).toHaveBeenCalledTimes(0);
+    button && fireEvent.click(button);
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
 
   it("should update selection", async () => {
     const uncheckedFilters = filters.map((filter) => ({


### PR DESCRIPTION
# Motivation

In the scope of [NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666), we want to prepare the `SnsProposalsFilters` to support a new type of filter, the `SnsFilterTopicsModal`. This PR does the preliminary work of updating the components to Svelte 5, so the next PRs can focus on the new functionality rather than refactoring.

# Changes

- Refactors `SnsProposalsFilters` to Svelte 5.
- Refactors `SnsFilterTypesModal` to Svelte 5.
- Refactors `SnsFilterStatusModal` to Svelte 5.

# Tests

- Updated tests to check that cb `closeModal` is being called instead of event being forwarded.
- Tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ