### PR TITLE
fix(sns-topics): Fix close event

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -165,7 +165,7 @@
   {steps}
   bind:currentStep
   bind:this={modal}
-  on:nnsClose
+  on:nnsClose={closeModal}
 >
   <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
 

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -34,16 +34,15 @@
     isNullish,
     nonNullish,
   } from "@dfinity/utils";
-  import { createEventDispatcher } from "svelte";
 
   type Props = {
     rootCanisterId: Principal;
     neuron: SnsNeuron;
+    closeModal: () => void;
     reloadNeuron: () => Promise<void>;
   };
-  const { rootCanisterId, neuron, reloadNeuron }: Props = $props();
+  const { rootCanisterId, neuron, closeModal, reloadNeuron }: Props = $props();
 
-  const dispatch = createEventDispatcher();
   const STEP_TOPICS = "topics";
   const STEP_NEURON = "neurons";
   const steps: WizardSteps = [
@@ -60,7 +59,6 @@
   let modal: WizardModal | undefined = $state();
   const openNextStep = () => modal?.next();
   const openPrevStep = () => modal?.back();
-  const closeModal = () => dispatch("nnsClose");
 
   const listTopics: ListTopicsResponseWithUnknown | undefined = $derived(
     $snsTopicsStore[rootCanisterId.toText()]

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -34,15 +34,16 @@
     isNullish,
     nonNullish,
   } from "@dfinity/utils";
+  import { createEventDispatcher } from "svelte";
 
   type Props = {
     rootCanisterId: Principal;
     neuron: SnsNeuron;
-    closeModal: () => void;
     reloadNeuron: () => Promise<void>;
   };
-  const { rootCanisterId, neuron, closeModal, reloadNeuron }: Props = $props();
+  const { rootCanisterId, neuron, reloadNeuron }: Props = $props();
 
+  const dispatch = createEventDispatcher();
   const STEP_TOPICS = "topics";
   const STEP_NEURON = "neurons";
   const steps: WizardSteps = [
@@ -59,6 +60,7 @@
   let modal: WizardModal | undefined = $state();
   const openNextStep = () => modal?.next();
   const openPrevStep = () => modal?.back();
+  const closeModal = () => dispatch("nnsClose");
 
   const listTopics: ListTopicsResponseWithUnknown | undefined = $derived(
     $snsTopicsStore[rootCanisterId.toText()]

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -127,8 +127,8 @@
     <FollowSnsNeuronsByTopicModal
       {neuron}
       {rootCanisterId}
+      closeModal={close}
       {reloadNeuron}
-      on:nnsClose={close}
     />
   {/if}
 

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -127,8 +127,8 @@
     <FollowSnsNeuronsByTopicModal
       {neuron}
       {rootCanisterId}
-      closeModal={close}
       {reloadNeuron}
+      on:nnsClose={close}
     />
   {/if}
 


### PR DESCRIPTION
# Motivation

As part of the switch to topic-based voting delegation, this PR fixes an issue where the modal could only be opened once due to the modal value in [SnsNeuronModals](https://github.com/dfinity/nns-dapp/blob/950641f6bc5626a0821d29e50f37aac7e5a51693/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte#L48) not being reset. Now it properly resets by calling `closeModal()` callback on `nnsClose` event of the Modal .

[NNS1-3665](https://dfinity.atlassian.net/browse/NNS1-3665)
Demo:  https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

# Changes

- Call `closeModal` on `nnsClose` event.

# Tests

- Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3665]: https://dfinity.atlassian.net/browse/NNS1-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ