### PR TITLE
refactor(sns-topics): Change getTopicInfoBySnsTopicKey arguments

### DIFF
--- a/frontend/src/lib/utils/sns-topics.utils.ts
+++ b/frontend/src/lib/utils/sns-topics.utils.ts
@@ -77,14 +77,12 @@ export const getSnsTopicKeys = (
 
 export const getTopicInfoBySnsTopicKey = ({
   topicKey,
-  listTopics,
+  topics,
 }: {
   topicKey: SnsTopicKey;
-  listTopics: ListTopicsResponseWithUnknown;
+  topics: Array<TopicInfoWithUnknown>;
 }): TopicInfoWithUnknown | undefined =>
-  (fromNullable(listTopics.topics) ?? []).find(
-    (topicInfo) => getSnsTopicInfoKey(topicInfo) === topicKey
-  );
+  topics.find((topicInfo) => getSnsTopicInfoKey(topicInfo) === topicKey);
 
 // Combines native and generic nervous system functions
 export const getAllSnsNSFunctions = (

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -199,7 +199,7 @@ describe("sns-topics utils", () => {
       expect(
         getTopicInfoBySnsTopicKey({
           topicKey: "DaoCommunitySettings",
-          listTopics,
+          topics: [knownTopicInfo, completelyUnknownTopicInfo],
         })
       ).toEqual(knownTopicInfo);
     });
@@ -208,7 +208,7 @@ describe("sns-topics utils", () => {
       expect(
         getTopicInfoBySnsTopicKey({
           topicKey: "DappCanisterManagement",
-          listTopics,
+          topics: [knownTopicInfo, completelyUnknownTopicInfo],
         })
       ).toEqual(undefined);
     });


### PR DESCRIPTION
# Motivation

As part of the transition to **topic-based voting delegation**, this updates the `getTopicInfoBySnsTopicKey` util to accept a simplified argument — just a list of topics.

Although this util isn’t currently used in the UI, it will be used in a new derived store to determine which topic should be displayed on the proposal details page.

[Jira Ticket → NNS1-3677](https://dfinity.atlassian.net/browse/NNS1-3677)  
[Live Demo](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/)

<img width="413" alt="image" src="https://github.com/user-attachments/assets/aa2c4e9f-53a1-48db-aaa1-d35572efc34f" />

# Changes

- Refactoring.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
