### PR TITLE
refactor(tests): exposes more from FilterModal in FilterModalTest

### DIFF
--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -1,22 +1,16 @@
 <script lang="ts">
+  import Separator from "$lib/components/ui/Separator.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type {
     Filter,
+    FiltersData,
     NnsProposalFilterCategory,
-    SnsProposalTypeFilterId,
   } from "$lib/types/filters";
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
-  import { Topic, type ProposalStatus } from "@dfinity/nns";
-  import type { SnsProposalDecisionStatus } from "@dfinity/sns";
+  import { Topic } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
-  import Separator from "$lib/components/ui/Separator.svelte";
 
-  type FiltersData =
-    | SnsProposalTypeFilterId
-    | Topic
-    | ProposalStatus
-    | SnsProposalDecisionStatus;
   // `undefined` means the filters are not loaded yet.
   export let filters: Filter<FiltersData>[] | undefined;
   export let visible = true;

--- a/frontend/src/lib/types/filters.ts
+++ b/frontend/src/lib/types/filters.ts
@@ -1,3 +1,4 @@
+import type { SnsTopicKey } from "$lib/types/sns";
 import type { ProposalStatus, Topic } from "@dfinity/nns";
 import type { SnsProposalDecisionStatus } from "@dfinity/sns";
 

--- a/frontend/src/lib/types/filters.ts
+++ b/frontend/src/lib/types/filters.ts
@@ -1,4 +1,5 @@
-import type { SnsTopicKey } from "$lib/types/sns";
+import type { ProposalStatus, Topic } from "@dfinity/nns";
+import type { SnsProposalDecisionStatus } from "@dfinity/sns";
 
 // artificial proposal type id to filter by all generic SNS types
 export const ALL_SNS_GENERIC_PROPOSAL_TYPES_ID = "all_sns_generic_types";
@@ -22,3 +23,9 @@ export type Filter<T> = {
   id: string;
   checked: boolean;
 };
+
+export type FiltersData =
+  | SnsProposalTypeFilterId
+  | Topic
+  | ProposalStatus
+  | SnsProposalDecisionStatus;

--- a/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
+++ b/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
@@ -8,22 +8,7 @@
     filters: Filter<FiltersData>[] | undefined;
   };
 
-  const defaultFilters = [
-    {
-      id: "1",
-      value: 1,
-      name: "Filter 1",
-      checked: false,
-    },
-    {
-      id: "2",
-      value: 2,
-      name: "Filter 2",
-      checked: true,
-    },
-  ];
-
-  const { title, visible = true, filters = defaultFilters }: Props = $props();
+  const { title, visible = true, filters }: Props = $props();
 </script>
 
 <FilterModal on:nnsClose on:nnsConfirm {filters} {visible}

--- a/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
+++ b/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import FilterModal from "$lib/modals/common/FilterModal.svelte";
+  import type { Filter, FiltersData } from "$lib/types/filters";
 
-  export let title: string;
+  type Props = {
+    title: string;
+    visible: boolean;
+    filters: Filter<FiltersData>[] | undefined;
+  };
 
-  const filters = [
+  const defaultFilters = [
     {
       id: "1",
       value: 1,
@@ -17,8 +22,10 @@
       checked: true,
     },
   ];
+
+  const { title, visible = true, filters = defaultFilters }: Props = $props();
 </script>
 
-<FilterModal on:nnsClose on:nnsConfirm {filters}
+<FilterModal on:nnsClose on:nnsConfirm {filters} {visible}
   ><span slot="title">{title}</span></FilterModal
 >


### PR DESCRIPTION
# Motivation

The `FilterModalTest` is a utility component used to test the `FilterModal` component. To migrate the latter to utilize the existing `FilterModal.page-object`, we first need to enhance this utility component. Additionally, this PR refactors it to make use of Svelte 5.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Refactors `FilterModalTest` to Svelte 5.
-  Moves types to a central location for use by both `FilterModal` and `FilterModalTest`.

# Tests

- Tests should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ