### PR TITLE
refactor(tests): migrate filter modal tests to page object pattern

### DIFF
--- a/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
@@ -2,6 +2,7 @@ import FilterModalTest from "$tests/lib/modals/common/FilterModalTest.svelte";
 import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
+import { Topic } from "@dfinity/nns";
 
 describe("FilterModal", () => {
   const filters = [
@@ -109,5 +110,24 @@ describe("FilterModal", () => {
     await po.clickClearSelectionButton();
 
     expect(nnsClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render a Separator if category is topics and value is SnsAndCommunityFund", async () => {
+    const filters = [
+      {
+        id: "1",
+        name: "test",
+        value: Topic.SnsAndCommunityFund,
+        checked: false,
+      },
+    ];
+
+    const po = renderComponent({
+      filters,
+      category: "topics",
+    });
+    const separator = po.getFilterEntrySeparatorByIdPo(filters[0].id);
+
+    expect(await separator.isPresent()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
+++ b/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
@@ -8,7 +8,22 @@
     filters: Filter<FiltersData>[] | undefined;
   };
 
-  const { title, visible = true, filters }: Props = $props();
+  const defaultFilters = [
+    {
+      id: "1",
+      value: 1,
+      name: "Filter 1",
+      checked: false,
+    },
+    {
+      id: "2",
+      value: 2,
+      name: "Filter 2",
+      checked: true,
+    },
+  ];
+
+  const { title, visible = true, filters = defaultFilters }: Props = $props();
 </script>
 
 <FilterModal on:nnsClose on:nnsConfirm {filters} {visible}

--- a/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
+++ b/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
@@ -8,22 +8,7 @@
     filters: Filter<FiltersData>[] | undefined;
   };
 
-  const defaultFilters = [
-    {
-      id: "1",
-      value: 1,
-      name: "Filter 1",
-      checked: false,
-    },
-    {
-      id: "2",
-      value: 2,
-      name: "Filter 2",
-      checked: true,
-    },
-  ];
-
-  const { title, visible = true, filters = defaultFilters }: Props = $props();
+  const { title, visible = true, filters }: Props = $props();
 </script>
 
 <FilterModal on:nnsClose on:nnsConfirm {filters} {visible}

--- a/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
+++ b/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
   import FilterModal from "$lib/modals/common/FilterModal.svelte";
-  import type { Filter, FiltersData } from "$lib/types/filters";
+  import type {
+    Filter,
+    FiltersData,
+    NnsProposalFilterCategory,
+  } from "$lib/types/filters";
 
   type Props = {
     title: string;
     visible: boolean;
     filters: Filter<FiltersData>[] | undefined;
+    category: undefined | NnsProposalFilterCategory;
   };
 
-  const { title, visible = true, filters }: Props = $props();
+  const { title, visible = true, filters, category }: Props = $props();
 </script>
 
 <FilterModal
@@ -18,5 +23,6 @@
   on:nnsSelectAll
   on:nnsClearSelection
   {filters}
-  {visible}><span slot="title">{title}</span></FilterModal
+  {visible}
+  {category}><span slot="title">{title}</span></FilterModal
 >

--- a/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
+++ b/frontend/src/tests/lib/modals/common/FilterModalTest.svelte
@@ -11,6 +11,12 @@
   const { title, visible = true, filters }: Props = $props();
 </script>
 
-<FilterModal on:nnsClose on:nnsConfirm {filters} {visible}
-  ><span slot="title">{title}</span></FilterModal
+<FilterModal
+  on:nnsClose
+  on:nnsConfirm
+  on:nnsChange
+  on:nnsSelectAll
+  on:nnsClearSelection
+  {filters}
+  {visible}><span slot="title">{title}</span></FilterModal
 >

--- a/frontend/src/tests/page-objects/FilterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/FilterModal.page-object.ts
@@ -39,4 +39,8 @@ export class FilterModalPo extends ModalPo {
   clickCloseButton(): Promise<void> {
     return this.click("close");
   }
+
+  getFilterSpinnerPo(): PageObjectElement {
+    return this.getElement("spinner");
+  }
 }


### PR DESCRIPTION
# Motivation

Follow up on #6730 to migrate tests to utilize the existing page object. This will simplify the addition of more test cases later to cover the changes required for the new SNS filter modal for topics.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Refactors `FilterModal` tests to utilize the existing page object.  
- Extends `FilterModalTest` with the necessary events.

# Tests

- Adds a new test to cover the existence of `Separator` based on props.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ