### PR TITLE
feat(store): add topic filtering support to SNS filters

### DIFF
--- a/frontend/src/lib/types/filters.ts
+++ b/frontend/src/lib/types/filters.ts
@@ -1,3 +1,5 @@
+import type { SnsTopicKey } from "$lib/types/sns";
+
 // artificial proposal type id to filter by all generic SNS types
 export const ALL_SNS_GENERIC_PROPOSAL_TYPES_ID = "all_sns_generic_types";
 
@@ -7,6 +9,12 @@ export type SnsProposalTypeFilterId =
   | typeof ALL_SNS_GENERIC_PROPOSAL_TYPES_ID;
 
 export type NnsProposalFilterCategory = "topics" | "status" | "uncategorized";
+
+export const ALL_SNS_PROPOSALS_WITHOUT_TOPIC =
+  "all_sns_proposals_without_topic" as const;
+export type SnsProposalTopicFilterId =
+  | SnsTopicKey
+  | typeof ALL_SNS_PROPOSALS_WITHOUT_TOPIC;
 
 export type Filter<T> = {
   name: string;


### PR DESCRIPTION
# Motivation

We want to enable users to filter SNS proposals by topic. This filtering will be saved in local storage to enhance the user experience. This PR extends the `sns-filters.store` to support filtering by topic. Follow-up PRs will utilize this new entry in the store to filter proposals and update the store based on user interactions with the new topic filter modal.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Extends `sns-filters.store` with `setTopics ` and `setCheckTopics`.

# Tests

- Adds new tests to cover the latest entries in the store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ