### PR TITLE
refactor(modal): migrate filter component to new simplified syntax

### DIFF
--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -9,22 +9,16 @@
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import { Topic } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
-  import { createEventDispatcher, type Snippet } from "svelte";
+  import { createEventDispatcher } from "svelte";
 
   type Props = {
     // `undefined` means the filters are not loaded yet.
     filters: Filter<FiltersData>[] | undefined;
-    visible: boolean;
-    category: undefined | NnsProposalFilterCategory;
-    title: Snippet;
+    visible?: boolean;
+    category?: NnsProposalFilterCategory | undefined;
   };
 
-  const {
-    filters,
-    visible = true,
-    category = undefined,
-    title,
-  }: Props = $props();
+  const { filters, visible = true, category }: Props = $props();
 
   const loading = $derived(isNullish(filters));
 
@@ -34,7 +28,6 @@
     const filter = filters?.find((f) => f.id === id);
     dispatch("nnsChange", { filter });
   };
-
   const close = () => dispatch("nnsClose");
   const filter = () => dispatch("nnsConfirm");
   const selectAll = () => dispatch("nnsSelectAll");
@@ -43,7 +36,7 @@
 
 {#if !loading}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
-    {@render title()}
+    <slot slot="title" name="title" />
 
     <div slot="sub-title" class="toggle-all-wrapper">
       <button
@@ -101,7 +94,7 @@
   </Modal>
 {:else}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
-    {@render title()}
+    <slot slot="title" name="title" />
 
     <div class="spinner-wrapper">
       <Spinner />

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -9,53 +9,54 @@
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import { Topic } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, type Snippet } from "svelte";
 
-  // `undefined` means the filters are not loaded yet.
-  export let filters: Filter<FiltersData>[] | undefined;
-  export let visible = true;
-  export let category: undefined | NnsProposalFilterCategory = undefined;
+  type Props = {
+    // `undefined` means the filters are not loaded yet.
+    filters: Filter<FiltersData>[] | undefined;
+    visible: boolean;
+    category: undefined | NnsProposalFilterCategory;
+    title: Snippet;
+  };
 
-  let loading: boolean;
-  $: loading = isNullish(filters);
+  const {
+    filters,
+    visible = true,
+    category = undefined,
+    title,
+  }: Props = $props();
+
+  const loading = $derived(isNullish(filters));
 
   const dispatch = createEventDispatcher();
-  const close = () => dispatch("nnsClose");
 
   const onChange = (id: string) => {
     const filter = filters?.find((f) => f.id === id);
     dispatch("nnsChange", { filter });
   };
 
-  const filter = () => {
-    dispatch("nnsConfirm");
-  };
-
-  const selectAll = () => {
-    dispatch("nnsSelectAll");
-  };
-
-  const clearSelection = () => {
-    dispatch("nnsClearSelection");
-  };
+  const close = () => dispatch("nnsClose");
+  const filter = () => dispatch("nnsConfirm");
+  const selectAll = () => dispatch("nnsSelectAll");
+  const clearSelection = () => dispatch("nnsClearSelection");
 </script>
 
 {#if !loading}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
-    <slot slot="title" name="title" />
+    {@render title()}
 
     <div slot="sub-title" class="toggle-all-wrapper">
       <button
         class="text"
         data-tid="filter-modal-select-all"
         aria-label={$i18n.core.filter_select_all}
-        on:click={selectAll}>{$i18n.voting.check_all}</button
+        onclick={selectAll}>{$i18n.voting.check_all}</button
       >
       <button
         class="text"
         data-tid="filter-modal-clear"
         aria-label={$i18n.core.filter_clear_all}
-        on:click={clearSelection}>{$i18n.voting.uncheck_all}</button
+        onclick={clearSelection}>{$i18n.voting.uncheck_all}</button
       >
     </div>
 
@@ -83,7 +84,7 @@
         type="button"
         aria-label={$i18n.core.filter_select_all}
         data-tid="close"
-        on:click={close}
+        onclick={close}
       >
         {$i18n.core.cancel}
       </button>
@@ -91,7 +92,7 @@
         class="primary"
         type="button"
         aria-label={$i18n.core.filter_clear_all}
-        on:click={filter}
+        onclick={filter}
         data-tid="apply-filters"
       >
         {$i18n.core.filter}
@@ -100,7 +101,8 @@
   </Modal>
 {:else}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
-    <slot slot="title" name="title" />
+    {@render title()}
+
     <div class="spinner-wrapper">
       <Spinner />
     </div>

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -36,6 +36,7 @@
 
 {#if !loading}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
+    <!-- TODO: To fix once Modal slots are migrated in gix -->
     <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
     <!-- svelte-ignore slot_element_deprecated -->
     <slot slot="title" name="title" />
@@ -96,6 +97,7 @@
   </Modal>
 {:else}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
+    <!-- TODO: To fix once Modal slots are migrated in gix -->
     <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
     <!-- svelte-ignore slot_element_deprecated -->
     <slot slot="title" name="title" />

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -36,6 +36,8 @@
 
 {#if !loading}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
+    <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
+    <!-- svelte-ignore slot_element_deprecated -->
     <slot slot="title" name="title" />
 
     <div slot="sub-title" class="toggle-all-wrapper">
@@ -94,6 +96,8 @@
   </Modal>
 {:else}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
+    <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
+    <!-- svelte-ignore slot_element_deprecated -->
     <slot slot="title" name="title" />
 
     <div class="spinner-wrapper">


### PR DESCRIPTION
# Motivation

Similar to #6730, this PR cleans up and migrates the `FilterModal` component to Svelte 5. This update simplifies the introduction of the new changes required for the proposals filter and the SNS topics filter.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Migrates `FilterModal` to Svelte 5 syntax.

# Tests

- Should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ