### PR TITLE
(sns-topics): Remove NSfunction followees service

### DIFF
--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -746,6 +746,36 @@ export const removeFollowee = async ({
   }
 };
 
+export const removeNsFunctionFollowees = async ({
+  neuron,
+  functionId,
+  rootCanisterId,
+}: {
+  neuron: SnsNeuron;
+  functionId: bigint;
+  rootCanisterId: Principal;
+}): Promise<{ success: boolean }> => {
+  const identity = await getSnsNeuronIdentity();
+
+  try {
+    await setFollowees({
+      rootCanisterId,
+      identity,
+      neuronId: fromDefinedNullable(neuron.id),
+      functionId,
+      followees: [],
+    });
+
+    return { success: true };
+  } catch (error: unknown) {
+    toastsError({
+      labelKey: "error__sns.sns_remove_followee",
+      err: error,
+    });
+    return { success: false };
+  }
+};
+
 export const stakeMaturity = async ({
   neuronId,
   rootCanisterId,

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1031,6 +1031,45 @@ describe("sns-neurons-services", () => {
     });
   });
 
+  describe("removeNsFunctionFollowees ", () => {
+    let setFolloweesSpy;
+
+    const followee1: SnsNeuronId = {
+      id: arrayOfNumberToUint8Array([1, 2, 3]),
+    };
+    const followee2: SnsNeuronId = {
+      id: arrayOfNumberToUint8Array([1, 2, 4]),
+    };
+    const rootCanisterId = mockPrincipal;
+    const functionId = 0n;
+
+    beforeEach(() => {
+      setFolloweesSpy = vi
+        .spyOn(governanceApi, "setFollowees")
+        .mockImplementation(() => Promise.resolve());
+    });
+
+    it("should call sns api setFollowees with empty followee list to remove them all", async () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        followees: [[functionId, { followees: [followee1, followee2] }]],
+      };
+      await services.removeNsFunctionFollowees({
+        rootCanisterId,
+        neuron,
+        functionId,
+      });
+
+      expect(setFolloweesSpy).toBeCalledWith({
+        neuronId: fromNullable(neuron.id),
+        identity: mockIdentity,
+        rootCanisterId,
+        followees: [],
+        functionId,
+      });
+    });
+  });
+
   describe("stakeMaturity", () => {
     it("should call api.stakeMaturity", async () => {
       const neuronId = mockSnsNeuron.id[0] as SnsNeuronId;


### PR DESCRIPTION
# Motivation

As part of the transition to **topic-based voting delegation**, this PR adds a new service `removeNsFunctionFollowees` to remove all followings for a specified NS function.  
It will be used later to handle unfollowing the "Catch-all" function.

[Jira Ticket → NNS1-3744](https://dfinity.atlassian.net/browse/NNS1-3744)  

https://github.com/user-attachments/assets/297ceff7-c9ab-4278-b075-9560f376fee5

# Changes

- Add new service `removeNsFunctionFollowees `.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
