### PR TITLE
feat(proposals): add conditional separators to FilterModal

### DIFF
--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -38,39 +38,37 @@
   const clearSelection = () => dispatch("nnsClearSelection");
 
   /**
-   * Determines if a separator should be shown after critical topics.
-   * Returns true when:
-   * - We're in the "topics" category
-   * - Current filter is critical
-   * - Not the last filter in the list
-   * - Next filter is not critical
-   * This creates a visual separation between critical and non-critical topics.
+   * Determines whether to display a separator after a filter item in a list.
+   *
+   * @param category - The current filter category
+   * @param filters - The array of all filters
+   * @param index - The index of the current filter being evaluated
+   * @returns True if a separator should be displayed after this filter, false otherwise
    */
-  const hasSnsCriticalTopicsSeparator = (
+  const displaySeparator = (
     category: Props["category"],
-    index: number,
     filters: Filter<FiltersData>[],
-    isCritical: boolean = false
-  ) =>
-    category === "topics" &&
-    isCritical &&
-    index < filters.length - 1 &&
-    !filters[index + 1].isCritical;
+    index: number
+  ) => {
+    // Only show separators if "topics" category
+    if (category !== "topics") return false;
 
-  /**
-   * Determines if a separator should be shown before the "All SNS proposals without topic" filter.
-   * Returns true when:
-   * - We're in the "topics" category
-   * - The next filter is the special "All SNS proposals without topic" filter
-   * This visually separates the special filter from regular topic filters.
-   */
-  const hasSnsProposalsWithoutTopicSeparator = (
-    category: Props["category"],
-    index: number,
-    filters: Filter<FiltersData>[]
-  ) =>
-    category === "topics" &&
-    filters?.[index + 1]?.value === ALL_SNS_PROPOSALS_WITHOUT_TOPIC;
+    const currentEntry = filters[index];
+
+    // Always show separator after SNS and Community Fund topic
+    if (currentEntry.value === Topic.SnsAndCommunityFund) return true;
+
+    const nextEntry = filters[index + 1];
+    if (isNullish(nextEntry)) return false;
+
+    // Show separator between critical and non-critical topics
+    if (currentEntry.isCritical && !nextEntry.isCritical) return true;
+
+    // Show separator before the "All SNS proposals without topic" special filter
+    if (nextEntry.value === ALL_SNS_PROPOSALS_WITHOUT_TOPIC) return true;
+
+    return false;
+  };
 </script>
 
 {#if !loading}
@@ -97,22 +95,14 @@
 
     {#if filters}
       <div class="filters">
-        {#each filters as { id, name, checked, value, isCritical }, index (id)}
+        {#each filters as { id, name, checked }, index (id)}
           <Checkbox
             testId={`filter-modal-option-${id}`}
             inputId={id}
             {checked}
             on:nnsChange={() => onChange(id)}>{name}</Checkbox
           >
-          {#if category === "topics" && value === Topic.SnsAndCommunityFund}
-            <Separator testId={`separator-${id}`} spacing="medium" />
-          {/if}
-
-          {#if hasSnsCriticalTopicsSeparator(category, index, filters, isCritical)}
-            <Separator testId={`separator-${id}`} spacing="medium" />
-          {/if}
-
-          {#if hasSnsProposalsWithoutTopicSeparator(category, index, filters)}
+          {#if displaySeparator(category, filters, index)}
             <Separator testId={`separator-${id}`} spacing="medium" />
           {/if}
         {/each}

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -9,7 +9,7 @@
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import { Topic } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
-  import { createEventDispatcher, type Snippet } from "svelte";
+  import { createEventDispatcher } from "svelte";
 
   type Props = {
     // `undefined` means the filters are not loaded yet.

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -9,7 +9,7 @@
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import { Topic } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, type Snippet } from "svelte";
 
   type Props = {
     // `undefined` means the filters are not loaded yet.

--- a/frontend/src/lib/types/filters.ts
+++ b/frontend/src/lib/types/filters.ts
@@ -11,7 +11,9 @@ export type SnsProposalTypeFilterId =
   | typeof ALL_SNS_GENERIC_PROPOSAL_TYPES_ID;
 
 export type NnsProposalFilterCategory = "topics" | "status" | "uncategorized";
+export type SnsProposalFilterCategory = "topics" | "types";
 
+// artificial proposal type id to filter by SNSs without topics
 export const ALL_SNS_PROPOSALS_WITHOUT_TOPIC =
   "all_sns_proposals_without_topic" as const;
 export type SnsProposalTopicFilterId =
@@ -23,6 +25,7 @@ export type Filter<T> = {
   value: T;
   id: string;
   checked: boolean;
+  isCritical?: boolean;
 };
 
 export type FiltersData =

--- a/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
@@ -1,3 +1,4 @@
+import { ALL_SNS_PROPOSALS_WITHOUT_TOPIC } from "$lib/types/filters";
 import FilterModalTest from "$tests/lib/modals/common/FilterModalTest.svelte";
 import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -115,10 +116,66 @@ describe("FilterModal", () => {
   it("should render a Separator if category is topics and value is SnsAndCommunityFund", async () => {
     const filters = [
       {
-        id: "1",
+        id: "topic",
         name: "test",
         value: Topic.SnsAndCommunityFund,
         checked: false,
+      },
+    ];
+
+    const po = renderComponent({
+      filters,
+      category: "topics",
+    });
+    const separator = po.getFilterEntrySeparatorByIdPo(filters[0].id);
+
+    expect(await separator.isPresent()).toBe(true);
+  });
+
+  it("should render a Separator if category is topics and there are critical and non-critical topics", async () => {
+    const filters = [
+      {
+        id: "critical-topic",
+        name: "test",
+        value: "CRITICAL_TOPIC",
+        checked: false,
+        isCritical: true,
+      },
+
+      {
+        id: "non-critical-topic",
+        name: "test",
+        value: "NON_CRITICAL_TOPIC",
+        checked: false,
+        isCritical: false,
+      },
+    ];
+
+    const po = renderComponent({
+      filters,
+      category: "topics",
+    });
+    const separator = po.getFilterEntrySeparatorByIdPo(filters[0].id);
+
+    expect(await separator.isPresent()).toBe(true);
+  });
+
+  it("should render a Separator if category is topics and the next entry is the special filter to show proposals without a topic", async () => {
+    const filters = [
+      {
+        id: "last-known-topic",
+        name: "test",
+        value: "TOPIC",
+        checked: false,
+        isCritical: true,
+      },
+
+      {
+        id: "special-topic-filter",
+        name: "test",
+        value: ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
+        checked: false,
+        isCritical: false,
       },
     ];
 


### PR DESCRIPTION
# Motivation

The new filter for SNS proposals by topic needs to display separators between the options:  
-  Between critical topics and non-critical topics.
-  Between non-critical topics and the custom filter for proposals without a topic.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Extends `FIlterModal` to display additional separators based on conditions.

# Tests

- Adds unit tests to check the logic for the separators.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ