### PR TITLE
feat(proposals): add SNS proposal topic filter modal

### DIFF
--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -11,7 +11,7 @@
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import { Topic } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, type Snippet } from "svelte";
 
   type Props = {
     // `undefined` means the filters are not loaded yet.

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -11,7 +11,7 @@
   import { Checkbox, Modal, Spinner } from "@dfinity/gix-components";
   import { Topic } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
-  import { createEventDispatcher, type Snippet } from "svelte";
+  import { createEventDispatcher } from "svelte";
 
   type Props = {
     // `undefined` means the filters are not loaded yet.

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -105,6 +105,14 @@
           {#if displaySeparator(category, filters, index)}
             <Separator testId={`separator-${id}`} spacing="medium" />
           {/if}
+
+          {#if hasSnsCriticalTopicsSeparator(category, index, filters, isCritical)}
+            <Separator testId={`separator-${id}`} spacing="medium" />
+          {/if}
+
+          {#if hasSnsProposalsWithoutTopicSeparator(category, index, filters)}
+            <Separator testId={`separator-${id}`} spacing="medium" />
+          {/if}
         {/each}
       </div>
     {:else}

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -105,14 +105,6 @@
           {#if displaySeparator(category, filters, index)}
             <Separator testId={`separator-${id}`} spacing="medium" />
           {/if}
-
-          {#if hasSnsCriticalTopicsSeparator(category, index, filters, isCritical)}
-            <Separator testId={`separator-${id}`} spacing="medium" />
-          {/if}
-
-          {#if hasSnsProposalsWithoutTopicSeparator(category, index, filters)}
-            <Separator testId={`separator-${id}`} spacing="medium" />
-          {/if}
         {/each}
       </div>
     {:else}

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterTopicsModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterTopicsModal.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import FilterModal from "$lib/modals/common/FilterModal.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { snsFiltersStore } from "$lib/stores/sns-filters.store";
+  import type { Filter, SnsProposalTopicFilterId } from "$lib/types/filters";
+  import type { Principal } from "@dfinity/principal";
+
+  type Props = {
+    rootCanisterId: Principal;
+    filters: Filter<SnsProposalTopicFilterId>[] | undefined;
+    closeModal: () => void;
+  };
+
+  const { rootCanisterId, filters = [], closeModal }: Props = $props();
+
+  const filtersValues = $derived<Filter<SnsProposalTopicFilterId>[]>(
+    filters.map((filter) => ({
+      ...filter,
+      checked: selectedFilters.includes(filter.value),
+    }))
+  );
+  let selectedFilters = $derived<SnsProposalTopicFilterId[]>(
+    filters.filter((item) => item.checked).map(({ value }) => value)
+  );
+
+  const filter = () => {
+    snsFiltersStore.setCheckTopics({
+      checkedTopics: selectedFilters,
+      rootCanisterId,
+    });
+    closeModal();
+  };
+
+  const onChange = ({
+    detail: { filter },
+  }: CustomEvent<{
+    filter: Filter<SnsProposalTopicFilterId> | undefined;
+  }>) => {
+    if (filter === undefined) return;
+    selectedFilters = [
+      ...selectedFilters.filter((status) => status !== filter?.value),
+      // Toggle the checked value
+      ...(filter.checked ? [] : [filter.value]),
+    ];
+  };
+  const clear = () => (selectedFilters = []);
+  const selectAll = () => (selectedFilters = filters.map(({ value }) => value));
+</script>
+
+<FilterModal
+  on:nnsClose={closeModal}
+  on:nnsConfirm={filter}
+  on:nnsChange={onChange}
+  on:nnsSelectAll={selectAll}
+  on:nnsClearSelection={clear}
+  filters={filtersValues}
+  category="topics"
+>
+  <span slot="title">{$i18n.voting.topics}</span>
+</FilterModal>

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTopicsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTopicsModal.spec.ts
@@ -198,7 +198,7 @@ describe("SnsFilterTopicsModal", () => {
     await po.clickConfirmButton();
 
     const topics = get(snsFiltersStore)[mockPrincipal.toText()]?.topics;
-    expect(topics.filter(({ checked }) => checked).length).toEqual(2);
+    expect(topics.filter(({ checked }) => checked).length).toEqual(0);
 
     expect(closeModal).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTopicsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTopicsModal.spec.ts
@@ -1,0 +1,205 @@
+import SnsFilterTopicsModal from "$lib/modals/sns/proposals/SnsFilterTopicsModal.svelte";
+import { snsFiltersStore } from "$lib/stores/sns-filters.store";
+import type { Filter, SnsProposalTopicFilterId } from "$lib/types/filters";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import { get } from "svelte/store";
+
+describe("SnsFilterTopicsModal", () => {
+  const renderComponent = (props = {}) => {
+    const { container } = render(SnsFilterTopicsModal, {
+      props,
+    });
+    return FilterModalPo.under(new JestPageObjectElement(container));
+  };
+
+  const filters: Filter<SnsProposalTopicFilterId>[] = [
+    {
+      id: "1",
+      name: "ApplicationBusinessLogic",
+      value: "ApplicationBusinessLogic",
+      checked: false,
+    },
+    {
+      id: "2",
+      name: "CriticalDappOperations",
+      value: "CriticalDappOperations",
+      checked: false,
+    },
+  ];
+
+  it("should display modal", async () => {
+    const po = renderComponent({
+      rootCanisterId: mockPrincipal,
+      filters,
+    });
+
+    expect(await po.isPresent()).toBe(true);
+  });
+
+  it("should render title", async () => {
+    const po = renderComponent({
+      rootCanisterId: mockPrincipal,
+      filters,
+    });
+
+    expect(await po.getModalTitle()).toBe("Topics");
+  });
+
+  it("should render checkboxes", async () => {
+    const po = renderComponent({ filters });
+    const checkboxes = await po.getFilterEntryPos();
+    const labels = (
+      await Promise.all(checkboxes.map((checkbox) => checkbox.getText()))
+    ).map((s) => s.trim());
+
+    expect(checkboxes.length).toBe(filters.length);
+    expect(labels).toEqual([
+      "ApplicationBusinessLogic",
+      "CriticalDappOperations",
+    ]);
+  });
+
+  it("should call closeModal function", async () => {
+    const closeModal = vi.fn();
+    const po = renderComponent({
+      rootCanisterId: mockPrincipal,
+      filters,
+      closeModal,
+    });
+
+    expect(await po.isPresent()).toBe(true);
+    expect(closeModal).toHaveBeenCalledTimes(0);
+
+    await po.clickCloseButton();
+
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("should update filter selection and close modal", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+
+    snsFiltersStore.setTopics({
+      rootCanisterId: mockPrincipal,
+      topics: uncheckedFilters,
+    });
+
+    const closeModal = vi.fn();
+
+    const po = renderComponent({
+      rootCanisterId: mockPrincipal,
+      filters,
+      closeModal,
+    });
+    const checkboxes = await po.getFilterEntryPos();
+
+    const firstCheckbox = checkboxes[0];
+    expect(await firstCheckbox.isChecked()).toBe(false);
+
+    await firstCheckbox.toggle();
+    expect(await firstCheckbox.isChecked()).toBe(true);
+
+    const secondCheckbox = checkboxes[1];
+    expect(await secondCheckbox.isChecked()).toBe(false);
+
+    await secondCheckbox.toggle();
+    expect(await secondCheckbox.isChecked()).toBe(true);
+
+    expect(closeModal).toHaveBeenCalledTimes(0);
+
+    await po.clickConfirmButton();
+
+    const topics = get(snsFiltersStore)[mockPrincipal.toText()]?.topics;
+    expect(topics.filter(({ checked }) => checked).length).toEqual(2);
+
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("should select all filters and close modal", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+
+    snsFiltersStore.setTopics({
+      rootCanisterId: mockPrincipal,
+      topics: uncheckedFilters,
+    });
+
+    const closeModal = vi.fn();
+
+    const po = renderComponent({
+      rootCanisterId: mockPrincipal,
+      filters,
+      closeModal,
+    });
+    const checkboxes = await po.getFilterEntryPos();
+
+    for (const checkbox of checkboxes) {
+      expect(await checkbox.isChecked()).toBe(false);
+    }
+
+    await po.clickSelectAllButton();
+
+    for (const checkbox of checkboxes) {
+      expect(await checkbox.isChecked()).toBe(true);
+    }
+
+    expect(closeModal).toHaveBeenCalledTimes(0);
+
+    await po.clickConfirmButton();
+
+    const topics = get(snsFiltersStore)[mockPrincipal.toText()]?.topics;
+    expect(topics.filter(({ checked }) => checked).length).toEqual(2);
+
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("should clear all filters and close modal", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: true,
+    }));
+
+    snsFiltersStore.setTopics({
+      rootCanisterId: mockPrincipal,
+      topics: uncheckedFilters,
+    });
+
+    const closeModal = vi.fn();
+
+    const po = renderComponent({
+      rootCanisterId: mockPrincipal,
+      filters: filters.map((filter) => ({
+        ...filter,
+        checked: true,
+      })),
+      closeModal,
+    });
+    const checkboxes = await po.getFilterEntryPos();
+
+    for (const checkbox of checkboxes) {
+      expect(await checkbox.isChecked()).toBe(true);
+    }
+
+    await po.clickClearSelectionButton();
+
+    for (const checkbox of checkboxes) {
+      expect(await checkbox.isChecked()).toBe(false);
+    }
+
+    expect(closeModal).toHaveBeenCalledTimes(0);
+
+    await po.clickConfirmButton();
+
+    const topics = get(snsFiltersStore)[mockPrincipal.toText()]?.topics;
+    expect(topics.filter(({ checked }) => checked).length).toEqual(2);
+
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Motivation

We want users to be able to filter proposals by topic. This PR introduces a new modal component similar to `SnsFilterStatusModal` and `SnsFilterTypesModal`. It uses the `FilterModal` component to display a list of topics, enabling users to select which ones they want to filter out.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- New modal to filter proposals by topic.

# Tests

- Unit tests for the new component

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ