### PR TITLE
feat(proposals): add SNS topic filtering support store

### DIFF
--- a/frontend/src/lib/stores/sns-unsupported-filter-by-topic.store.ts
+++ b/frontend/src/lib/stores/sns-unsupported-filter-by-topic.store.ts
@@ -6,12 +6,12 @@ export type UnsupportedFilterByTopicCanistersStoreData =
 
 export interface UnsupportedFilterByTopicCanistersStore
   extends Readable<UnsupportedFilterByTopicCanistersStoreData> {
-  add: (canisterId: CanisterIdString) => void;
-  has: (canisterId: CanisterIdString) => boolean;
-  delete: (canisterId: CanisterIdString) => void;
+  add: (rootCanisterId: CanisterIdString) => void;
+  has: (rootCanisterId: CanisterIdString) => boolean;
+  delete: (rootCanisterId: CanisterIdString) => void;
 }
 
-export const initUnsupportedFilterByTopicCanistersStore =
+export const initUnsupportedFilterByTopicSnsesStore =
   (): UnsupportedFilterByTopicCanistersStore => {
     const initialUnsupportedCanisters: Array<CanisterIdString> = [];
 
@@ -22,23 +22,23 @@ export const initUnsupportedFilterByTopicCanistersStore =
 
     return {
       subscribe,
-      add: (canisterId) => {
+      add: (rootCanisterId) => {
         update((canisters) => {
-          if (canisters.includes(canisterId)) return canisters;
-          return [...canisters, canisterId];
+          if (canisters.includes(rootCanisterId)) return canisters;
+          return [...canisters, rootCanisterId];
         });
       },
-      has: (canisterId) => {
+      has: (rootCanisterId) => {
         const canisters = get({ subscribe });
-        return canisters.includes(canisterId);
+        return canisters.includes(rootCanisterId);
       },
-      delete: (canisterId) => {
+      delete: (rootCanisterId) => {
         update((canisters) => {
-          return [...canisters].filter((id) => id !== canisterId);
+          return [...canisters].filter((id) => id !== rootCanisterId);
         });
       },
     };
   };
 
-export const unsupportedFilterByTopicCanistersStore =
-  initUnsupportedFilterByTopicCanistersStore();
+export const unsupportedFilterByTopicSnsesStore =
+  initUnsupportedFilterByTopicSnsesStore();

--- a/frontend/src/lib/stores/sns-unsupported-filter-by-topic.store.ts
+++ b/frontend/src/lib/stores/sns-unsupported-filter-by-topic.store.ts
@@ -1,0 +1,48 @@
+import type { CanisterIdString } from "@dfinity/nns";
+import { writable, type Readable } from "svelte/store";
+
+export type UnsupportedFilterByTopicCanistersStoreData =
+  Array<CanisterIdString>;
+
+export interface UnsupportedFilterByTopicCanistersStore
+  extends Readable<UnsupportedFilterByTopicCanistersStoreData> {
+  add: (canisterId: CanisterIdString) => void;
+  has: (canisterId: CanisterIdString) => boolean;
+  delete: (canisterId: CanisterIdString) => void;
+}
+
+export const initUnsupportedFilterByTopicCanistersStore =
+  (): UnsupportedFilterByTopicCanistersStore => {
+    const initialUnsupportedCanisters: Array<CanisterIdString> = [];
+
+    const { subscribe, update } =
+      writable<UnsupportedFilterByTopicCanistersStoreData>(
+        initialUnsupportedCanisters
+      );
+
+    return {
+      subscribe,
+      add: (canisterId) => {
+        update((canisters) => {
+          if (canisters.includes(canisterId)) return canisters;
+          return [...canisters, canisterId];
+        });
+      },
+      has: (canisterId) => {
+        let result = false;
+        update((canisters) => {
+          result = canisters.includes(canisterId);
+          return canisters;
+        });
+        return result;
+      },
+      delete: (canisterId) => {
+        update((canisters) => {
+          return [...canisters].filter((id) => id !== canisterId);
+        });
+      },
+    };
+  };
+
+export const unsupportedFilterByTopicCanistersStore =
+  initUnsupportedFilterByTopicCanistersStore();

--- a/frontend/src/lib/stores/sns-unsupported-filter-by-topic.store.ts
+++ b/frontend/src/lib/stores/sns-unsupported-filter-by-topic.store.ts
@@ -1,5 +1,5 @@
 import type { CanisterIdString } from "@dfinity/nns";
-import { writable, type Readable } from "svelte/store";
+import { get, writable, type Readable } from "svelte/store";
 
 export type UnsupportedFilterByTopicCanistersStoreData =
   Array<CanisterIdString>;
@@ -29,12 +29,8 @@ export const initUnsupportedFilterByTopicCanistersStore =
         });
       },
       has: (canisterId) => {
-        let result = false;
-        update((canisters) => {
-          result = canisters.includes(canisterId);
-          return canisters;
-        });
-        return result;
+        const canisters = get({ subscribe });
+        return canisters.includes(canisterId);
       },
       delete: (canisterId) => {
         update((canisters) => {

--- a/frontend/src/tests/lib/stores/sns-unsupported-filter-by-topic.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-unsupported-filter-by-topic.store.spec.ts
@@ -1,0 +1,80 @@
+import { unsupportedFilterByTopicCanistersStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
+import { get } from "svelte/store";
+
+describe("unsupportedFilterByTopicCanistersStore", () => {
+  it("should initialize with an empty Set", () => {
+    const store = get(unsupportedFilterByTopicCanistersStore);
+
+    expect(store.length).toBe(0);
+  });
+
+  it("should add canister IDs to the store", () => {
+    const canisterId1 = "aaaaa-aa";
+    const canisterId2 = "bbbbb-bb";
+
+    unsupportedFilterByTopicCanistersStore.add(canisterId1);
+    unsupportedFilterByTopicCanistersStore.add(canisterId2);
+
+    const store = get(unsupportedFilterByTopicCanistersStore);
+
+    expect(store.length).toBe(2);
+    expect(store.includes(canisterId1)).toBe(true);
+    expect(store.includes(canisterId2)).toBe(true);
+  });
+
+  it("should not add duplicate canister IDs", () => {
+    const canisterId = "aaaaa-aa";
+
+    unsupportedFilterByTopicCanistersStore.add(canisterId);
+    unsupportedFilterByTopicCanistersStore.add(canisterId);
+
+    const store = get(unsupportedFilterByTopicCanistersStore);
+
+    expect(store.length).toBe(1);
+    expect(store.includes(canisterId)).toBe(true);
+  });
+
+  it("should check if a canister ID exists in the store", () => {
+    const canisterId = "aaaaa-aa";
+    const nonExistentCanisterId = "bbbbb-bb";
+
+    unsupportedFilterByTopicCanistersStore.add(canisterId);
+
+    const store = get(unsupportedFilterByTopicCanistersStore);
+
+    expect(store.includes(canisterId)).toBe(true);
+    expect(store.includes(nonExistentCanisterId)).toBe(false);
+  });
+
+  it("should remove canister IDs from the store", () => {
+    const canisterId1 = "aaaaa-aa";
+    const canisterId2 = "bbbbb-bb";
+
+    unsupportedFilterByTopicCanistersStore.add(canisterId1);
+    unsupportedFilterByTopicCanistersStore.add(canisterId2);
+
+    let store = get(unsupportedFilterByTopicCanistersStore);
+
+    expect(store.length).toBe(2);
+
+    unsupportedFilterByTopicCanistersStore.delete(canisterId1);
+
+    store = get(unsupportedFilterByTopicCanistersStore);
+    expect(store.length).toBe(1);
+    expect(store.includes(canisterId1)).toBe(false);
+    expect(store.includes(canisterId2)).toBe(true);
+  });
+
+  it("should do nothing when trying to remove a non-existent canister ID", () => {
+    const canisterId = "aaaaa-aa";
+    const nonExistentCanisterId = "bbbbb-bb";
+
+    unsupportedFilterByTopicCanistersStore.add(canisterId);
+    unsupportedFilterByTopicCanistersStore.delete(nonExistentCanisterId);
+
+    const store = get(unsupportedFilterByTopicCanistersStore);
+
+    expect(store.length).toBe(1);
+    expect(store.includes(canisterId)).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/stores/sns-unsupported-filter-by-topic.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-unsupported-filter-by-topic.store.spec.ts
@@ -1,9 +1,9 @@
-import { unsupportedFilterByTopicCanistersStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
+import { unsupportedFilterByTopicSnsesStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
 import { get } from "svelte/store";
 
-describe("unsupportedFilterByTopicCanistersStore", () => {
+describe("unsupportedFilterByTopicSnsesStore", () => {
   it("should initialize with an empty Set", () => {
-    const store = get(unsupportedFilterByTopicCanistersStore);
+    const store = get(unsupportedFilterByTopicSnsesStore);
 
     expect(store.length).toBe(0);
   });
@@ -12,10 +12,10 @@ describe("unsupportedFilterByTopicCanistersStore", () => {
     const canisterId1 = "aaaaa-aa";
     const canisterId2 = "bbbbb-bb";
 
-    unsupportedFilterByTopicCanistersStore.add(canisterId1);
-    unsupportedFilterByTopicCanistersStore.add(canisterId2);
+    unsupportedFilterByTopicSnsesStore.add(canisterId1);
+    unsupportedFilterByTopicSnsesStore.add(canisterId2);
 
-    const store = get(unsupportedFilterByTopicCanistersStore);
+    const store = get(unsupportedFilterByTopicSnsesStore);
 
     expect(store.length).toBe(2);
     expect(store.includes(canisterId1)).toBe(true);
@@ -25,10 +25,10 @@ describe("unsupportedFilterByTopicCanistersStore", () => {
   it("should not add duplicate canister IDs", () => {
     const canisterId = "aaaaa-aa";
 
-    unsupportedFilterByTopicCanistersStore.add(canisterId);
-    unsupportedFilterByTopicCanistersStore.add(canisterId);
+    unsupportedFilterByTopicSnsesStore.add(canisterId);
+    unsupportedFilterByTopicSnsesStore.add(canisterId);
 
-    const store = get(unsupportedFilterByTopicCanistersStore);
+    const store = get(unsupportedFilterByTopicSnsesStore);
 
     expect(store.length).toBe(1);
     expect(store.includes(canisterId)).toBe(true);
@@ -38,9 +38,9 @@ describe("unsupportedFilterByTopicCanistersStore", () => {
     const canisterId = "aaaaa-aa";
     const nonExistentCanisterId = "bbbbb-bb";
 
-    unsupportedFilterByTopicCanistersStore.add(canisterId);
+    unsupportedFilterByTopicSnsesStore.add(canisterId);
 
-    const store = get(unsupportedFilterByTopicCanistersStore);
+    const store = get(unsupportedFilterByTopicSnsesStore);
 
     expect(store.includes(canisterId)).toBe(true);
     expect(store.includes(nonExistentCanisterId)).toBe(false);
@@ -50,16 +50,16 @@ describe("unsupportedFilterByTopicCanistersStore", () => {
     const canisterId1 = "aaaaa-aa";
     const canisterId2 = "bbbbb-bb";
 
-    unsupportedFilterByTopicCanistersStore.add(canisterId1);
-    unsupportedFilterByTopicCanistersStore.add(canisterId2);
+    unsupportedFilterByTopicSnsesStore.add(canisterId1);
+    unsupportedFilterByTopicSnsesStore.add(canisterId2);
 
-    let store = get(unsupportedFilterByTopicCanistersStore);
+    let store = get(unsupportedFilterByTopicSnsesStore);
 
     expect(store.length).toBe(2);
 
-    unsupportedFilterByTopicCanistersStore.delete(canisterId1);
+    unsupportedFilterByTopicSnsesStore.delete(canisterId1);
 
-    store = get(unsupportedFilterByTopicCanistersStore);
+    store = get(unsupportedFilterByTopicSnsesStore);
     expect(store.length).toBe(1);
     expect(store.includes(canisterId1)).toBe(false);
     expect(store.includes(canisterId2)).toBe(true);
@@ -69,10 +69,10 @@ describe("unsupportedFilterByTopicCanistersStore", () => {
     const canisterId = "aaaaa-aa";
     const nonExistentCanisterId = "bbbbb-bb";
 
-    unsupportedFilterByTopicCanistersStore.add(canisterId);
-    unsupportedFilterByTopicCanistersStore.delete(nonExistentCanisterId);
+    unsupportedFilterByTopicSnsesStore.add(canisterId);
+    unsupportedFilterByTopicSnsesStore.delete(nonExistentCanisterId);
 
-    const store = get(unsupportedFilterByTopicCanistersStore);
+    const store = get(unsupportedFilterByTopicSnsesStore);
 
     expect(store.length).toBe(1);
     expect(store.includes(canisterId)).toBe(true);


### PR DESCRIPTION
# Motivation

We want users to filter proposals by topic; however, not all SNS may have upgraded to the latest version, so not all will support this feature. Therefore, the canister added a new field to the [response](https://github.com/dfinity/ic/blob/579b8ba3a31341f354f4ddb3d60ac44548a91bc2/rs/sns/governance/canister/governance.did#L383) that can be used to determine which filter to display to the user: topics or types.

This PR introduces a new store to track those projects that don't support yet this new API.

Note: As of today, most existing projects support the new API. The approach is to track those that do not support it and update the UI accordingly.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- New store to track a list of all sns that don't support the new API.

# Tests

- Unit tests for the new store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ