### PR TITLE
feat(proposals): track SNS projects not supporting topic filter

### DIFF
--- a/frontend/src/lib/services/public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/public/sns-proposals.services.ts
@@ -14,7 +14,7 @@ import { queryAndUpdate } from "$lib/services/utils.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsSelectedFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
-import { unsupportedFilterByTopicCanistersStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
+import { unsupportedFilterByTopicSnsesStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import {
   getSnsNeuronState,
@@ -176,11 +176,11 @@ export const loadSnsProposals = async ({
       const includeTopicFiltering = fromNullable(include_topic_filtering);
 
       if (isNullish(includeTopicFiltering)) {
-        unsupportedFilterByTopicCanistersStore.add(rootCanisterId.toText());
+        unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
       } else if (includeTopicFiltering) {
-        unsupportedFilterByTopicCanistersStore.delete(rootCanisterId.toText());
+        unsupportedFilterByTopicSnsesStore.delete(rootCanisterId.toText());
       } else {
-        unsupportedFilterByTopicCanistersStore.add(rootCanisterId.toText());
+        unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
       }
     },
     onError: (err) => {

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "$lib/services/public/sns-proposals.services";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
-import { unsupportedFilterByTopicCanistersStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
+import { unsupportedFilterByTopicSnsesStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
 import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
 import { ALL_SNS_GENERIC_PROPOSAL_TYPES_ID } from "$lib/types/filters";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -238,7 +238,7 @@ describe("sns-proposals services", () => {
           });
 
           expect(
-            unsupportedFilterByTopicCanistersStore.has(mockPrincipal.toText())
+            unsupportedFilterByTopicSnsesStore.has(mockPrincipal.toText())
           ).toBe(true);
         });
 
@@ -256,13 +256,13 @@ describe("sns-proposals services", () => {
           });
 
           expect(
-            unsupportedFilterByTopicCanistersStore.has(mockPrincipal.toText())
+            unsupportedFilterByTopicSnsesStore.has(mockPrincipal.toText())
           ).toBe(true);
         });
 
         it("should remove canister from unsupported list when include_topic_filtering is true", async () => {
           // First add the canister to the unsupported list
-          unsupportedFilterByTopicCanistersStore.add(mockPrincipal.toText());
+          unsupportedFilterByTopicSnsesStore.add(mockPrincipal.toText());
 
           // Set up the API response with true include_topic_filtering
           vi.spyOn(api, "queryProposals").mockResolvedValue({
@@ -277,7 +277,7 @@ describe("sns-proposals services", () => {
           });
 
           expect(
-            unsupportedFilterByTopicCanistersStore.has(mockPrincipal.toText())
+            unsupportedFilterByTopicSnsesStore.has(mockPrincipal.toText())
           ).toBe(false);
         });
       });


### PR DESCRIPTION
# Motivation

Following up on #6740, we want to use the new store to track projects that do not support the new API for listing proposals by topic. This will later be used by the `SnsProposalsFilter` component to determine which filter to display: Topics or Types.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Track projects that do not support the new API in the `unsupportedFilterByTopicCanistersStore` using their rootCanisterId.

# Tests

- Unit tests to cover the new logic in the service.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ