### PR TITLE
(sns-topics): getCatchAllSnsLegacyFollowings utility

### DIFF
--- a/frontend/src/lib/utils/sns-topics.utils.ts
+++ b/frontend/src/lib/utils/sns-topics.utils.ts
@@ -216,27 +216,25 @@ export const getLegacyFolloweesByTopics = ({
   );
 };
 
-export const getSnsLegacyFollowingsByNsFunctionId = ({
+// Returns the catch-all SNS followees of the neuron.
+// Because the catch-all is not part of any topic, we need to get it from nsFunctions.
+export const getCatchAllSnsLegacyFollowings = ({
   neuron,
   nsFunctions,
-  nsFunctionId,
 }: {
   neuron: SnsNeuron;
   nsFunctions: SnsNervousSystemFunction[];
-  nsFunctionId: bigint;
 }): SnsLegacyFollowings | undefined => {
+  const CATCH_ALL_ID = 0n;
   const nsFunction = nsFunctions.find(
-    (nsFunction) => nsFunction.id === nsFunctionId
+    (nsFunction) => nsFunction.id === CATCH_ALL_ID
   );
-  const followees = neuron.followees.find(([id]) => id === nsFunctionId)?.[1]
+  const followees = neuron.followees.find(([id]) => id === CATCH_ALL_ID)?.[1]
     ?.followees;
-
-  if (isNullish(nsFunction) || isNullish(followees)) {
-    return undefined;
-  }
-
-  return {
-    nsFunction,
-    followees,
-  };
+  return isNullish(nsFunction) || isNullish(followees)
+    ? undefined
+    : {
+        nsFunction,
+        followees,
+      };
 };

--- a/frontend/src/lib/utils/sns-topics.utils.ts
+++ b/frontend/src/lib/utils/sns-topics.utils.ts
@@ -15,7 +15,12 @@ import type {
   SnsNeuronId,
   SnsTopic,
 } from "@dfinity/sns";
-import { fromDefinedNullable, fromNullable, nonNullish } from "@dfinity/utils";
+import {
+  fromDefinedNullable,
+  fromNullable,
+  isNullish,
+  nonNullish,
+} from "@dfinity/utils";
 
 export const snsTopicToTopicKey = (
   topic: SnsTopic | UnknownTopic
@@ -209,4 +214,29 @@ export const getLegacyFolloweesByTopics = ({
     },
     []
   );
+};
+
+export const getSnsLegacyFollowingsByNsFunctionId = ({
+  neuron,
+  nsFunctions,
+  nsFunctionId,
+}: {
+  neuron: SnsNeuron;
+  nsFunctions: SnsNervousSystemFunction[];
+  nsFunctionId: bigint;
+}): SnsLegacyFollowings | undefined => {
+  const nsFunction = nsFunctions.find(
+    (nsFunction) => nsFunction.id === nsFunctionId
+  );
+  const followees = neuron.followees.find(([id]) => id === nsFunctionId)?.[1]
+    ?.followees;
+
+  if (isNullish(nsFunction) || isNullish(followees)) {
+    return undefined;
+  }
+
+  return {
+    nsFunction,
+    followees,
+  };
 };

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -6,6 +6,7 @@ import type {
 import {
   addSnsNeuronToFollowingsByTopics,
   getAllSnsNSFunctions,
+  getCatchAllSnsLegacyFollowings,
   getLegacyFolloweesByTopics,
   getSnsTopicFollowings,
   getSnsTopicInfoKey,
@@ -604,6 +605,90 @@ describe("sns-topics utils", () => {
           topicInfos: [],
         })
       ).toEqual([]);
+    });
+  });
+
+  describe("getCatchAllSnsLegacyFollowings", () => {
+    const catchAllNativeNsFunctionId = 0n;
+    const catchAllNativeNsFunction: SnsNervousSystemFunction = {
+      ...nativeNsFunction,
+      id: catchAllNativeNsFunctionId,
+    };
+    const nativeNsFunctionId1 = 1n;
+    const nativeNsFunction1: SnsNervousSystemFunction = {
+      ...nativeNsFunction,
+      id: nativeNsFunctionId1,
+    };
+    const nativeNsFunctionId2 = 2n;
+    const nativeNsFunction2: SnsNervousSystemFunction = {
+      ...nativeNsFunction,
+      id: nativeNsFunctionId2,
+    };
+
+    it("returns catch all followings", () => {
+      const testNeuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        followees: [
+          [nativeNsFunctionId1, { followees: [neuronId1] }],
+          [catchAllNativeNsFunctionId, { followees: [neuronId1, neuronId1] }],
+          [nativeNsFunctionId2, { followees: [neuronId2] }],
+        ],
+      };
+
+      expect(
+        getCatchAllSnsLegacyFollowings({
+          neuron: testNeuron,
+          nsFunctions: [
+            catchAllNativeNsFunction,
+            nativeNsFunction1,
+            nativeNsFunction2,
+          ],
+        })
+      ).toEqual([
+        {
+          nsFunction: catchAllNativeNsFunction,
+          followees: [neuronId1, neuronId2],
+        },
+      ]);
+    });
+
+    it("return undefined when no catch-all followees", () => {
+      const testNeuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        followees: [
+          [nativeNsFunctionId1, { followees: [neuronId1] }],
+          [nativeNsFunctionId2, { followees: [neuronId2] }],
+        ],
+      };
+
+      expect(
+        getCatchAllSnsLegacyFollowings({
+          neuron: testNeuron,
+          nsFunctions: [
+            catchAllNativeNsFunction,
+            nativeNsFunction1,
+            nativeNsFunction2,
+          ],
+        })
+      ).toEqual(undefined);
+    });
+
+    it("return undefined when no catch-all ns function", () => {
+      const testNeuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        followees: [
+          [nativeNsFunctionId1, { followees: [neuronId1] }],
+          [catchAllNativeNsFunctionId, { followees: [neuronId1, neuronId1] }],
+          [nativeNsFunctionId2, { followees: [neuronId2] }],
+        ],
+      };
+
+      expect(
+        getCatchAllSnsLegacyFollowings({
+          neuron: testNeuron,
+          nsFunctions: [nativeNsFunction1, nativeNsFunction2],
+        })
+      ).toEqual(undefined);
     });
   });
 });


### PR DESCRIPTION
# Motivation

As part of the transition to **topic-based voting delegation**, this PR introduces a new utility to get the current user's "Catch-all" following.  
It will be used later in the flow to support unfollowing the "Catch-all" legacy followings.

[Jira Ticket → NNS1-3744](https://dfinity.atlassian.net/browse/NNS1-3744)  

https://github.com/user-attachments/assets/297ceff7-c9ab-4278-b075-9560f376fee5

# Changes

- New utility `getCatchAllSnsLegacyFollowings`.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
