### PR TITLE
(sns-topics): Display sns topic info on proposal page

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { Html, KeyValuePairInfo } from "@dfinity/gix-components";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let label: string;
   export let testId: string;
@@ -13,6 +14,8 @@
   <span class="value" slot="value" data-tid={`${testId}-value`}>{value}</span>
 
   <svelte:fragment slot="info">
-    <Html text={description ?? $i18n.proposal_detail.no_more_info} />
+    <TestIdWrapper testId="info">
+      <Html text={description ?? $i18n.proposal_detail.no_more_info} />
+    </TestIdWrapper>
   </svelte:fragment>
 </KeyValuePairInfo>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -6,11 +6,13 @@
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import type { SnsProposalDataMap } from "$lib/utils/sns-proposals.utils";
   import type { SnsNeuronId } from "@dfinity/sns";
-  import { nonNullish } from "@dfinity/utils";
+  import { fromNullable, nonNullish } from "@dfinity/utils";
+  import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
 
   export let proposalDataMap: SnsProposalDataMap;
 
   let type: string | undefined;
+  let topicInfo: TopicInfoWithUnknown | undefined;
   let typeDescription: string | undefined;
   let statusString: string;
   let statusDescription: string | undefined;
@@ -24,6 +26,7 @@
 
   $: ({
     type,
+    topicInfo,
     typeDescription,
     statusString,
     statusDescription,
@@ -35,6 +38,11 @@
     failed_timestamp_seconds,
     proposer,
   } = proposalDataMap);
+
+  let topicName: string | undefined;
+  $: topicName = fromNullable(topicInfo?.name ?? []);
+  let topicDescription: string | undefined;
+  $: topicDescription = fromNullable(topicInfo?.description ?? []);
 </script>
 
 <TestIdWrapper testId="proposal-system-info-details-component">
@@ -49,6 +57,15 @@
         testId="proposal-system-info-type"
         value={type}
         description={typeDescription}
+      />
+    {/if}
+
+    {#if nonNullish(topicName) && nonNullish(topicDescription)}
+      <ProposalSystemInfoEntry
+        label={$i18n.proposal_detail.topic_prefix}
+        testId="proposal-system-info-topic"
+        value={topicName}
+        description={topicDescription}
       />
     {/if}
 

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -13,7 +13,11 @@ import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { SnsProposalDecisionStatus, type SnsProposalData } from "@dfinity/sns";
+import {
+  SnsProposalDecisionStatus,
+  type SnsProposalData,
+  type SnsTopic,
+} from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -49,23 +53,20 @@ describe("ProposalSystemInfoSection", () => {
   });
 
   describe("open proposal", () => {
+    const testTopic: SnsTopic = { Governance: null };
     const openProposal = {
       ...createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
         proposalId: 2n,
       }),
       action: testNervousFunctionId,
-      topic: [{ Governance: null }],
+      topic: [testTopic],
     } as SnsProposalData;
     const topicName = "Topic name";
     const topicDescription = "Topic description";
     const testTopicInfo: TopicInfoWithUnknown = {
       native_functions: [[nervousFunction]],
-      topic: [
-        {
-          Governance: null,
-        },
-      ],
+      topic: [testTopic],
       is_critical: [false],
       name: [topicName],
       description: [topicDescription],
@@ -116,7 +117,13 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should render topic data", async () => {
-      const po = await renderComponent(props);
+      const po = await renderComponent({
+        proposalDataMap: mapProposalInfo({
+          proposalData: { ...openProposal, topic: [testTopic] },
+          nsFunctions: [nervousFunction],
+          topics: [testTopicInfo],
+        }),
+      });
 
       expect(await po.getTopicKeyValuePairPo().isPresent()).toBe(true);
       expect((await po.getTopicKeyValuePairPo().getValueText()).trim()).toBe(
@@ -280,7 +287,7 @@ describe("ProposalSystemInfoSection", () => {
       );
     });
 
-    it("should render fialed timestamp", async () => {
+    it("should render failed timestamp", async () => {
       const po = await renderComponent(props);
 
       expect(await po.getFailedText()).toBe(

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -1,5 +1,6 @@
 import ProposalSystemInfoSection from "$lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte";
 import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
+import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
 import { secondsToDateTime } from "$lib/utils/date.utils";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
@@ -12,7 +13,7 @@ import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { SnsProposalDecisionStatus, type SnsProposalData } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -54,6 +55,21 @@ describe("ProposalSystemInfoSection", () => {
         proposalId: 2n,
       }),
       action: testNervousFunctionId,
+      topic: [{ Governance: null }],
+    } as SnsProposalData;
+    const topicName = "Topic name";
+    const topicDescription = "Topic description";
+    const testTopicInfo: TopicInfoWithUnknown = {
+      native_functions: [[nervousFunction]],
+      topic: [
+        {
+          Governance: null,
+        },
+      ],
+      is_critical: [false],
+      name: [topicName],
+      description: [topicDescription],
+      custom_functions: [],
     };
     const {
       rewardStatusString,
@@ -97,6 +113,42 @@ describe("ProposalSystemInfoSection", () => {
       const po = await renderComponent(props);
 
       expect(await po.getTypeText()).toBe(testNervousFunctionName);
+    });
+
+    it("should render topic data", async () => {
+      const po = await renderComponent(props);
+
+      expect(await po.getTopicKeyValuePairPo().isPresent()).toBe(true);
+      expect((await po.getTopicKeyValuePairPo().getValueText()).trim()).toBe(
+        topicName
+      );
+      expect((await po.getTopicKeyValuePairPo().getInfoText()).trim()).toBe(
+        topicDescription
+      );
+    });
+
+    it("should not render topic data when no topic in proposal", async () => {
+      const po = await renderComponent({
+        proposalDataMap: mapProposalInfo({
+          proposalData: { ...openProposal, topic: undefined },
+          nsFunctions: [nervousFunction],
+          topics: [testTopicInfo],
+        }),
+      });
+
+      expect(await po.getTopicKeyValuePairPo().isPresent()).toBe(false);
+    });
+
+    it("should not render topic data when no topic infos are available", async () => {
+      const po = await renderComponent({
+        proposalDataMap: mapProposalInfo({
+          proposalData: openProposal,
+          nsFunctions: [nervousFunction],
+          topics: [],
+        }),
+      });
+
+      expect(await po.getTopicKeyValuePairPo().isPresent()).toBe(false);
     });
 
     it("should render open status", async () => {

--- a/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
@@ -19,4 +19,8 @@ export class KeyValuePairPo extends BasePageObject {
   getValueText(): Promise<string | null> {
     return this.root.querySelector("dd").getText();
   }
+
+  getInfoText(): Promise<string | null> {
+    return this.getText("info");
+  }
 }

--- a/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
@@ -27,6 +27,13 @@ export class SnsProposalSystemInfoSectionPo extends BasePageObject {
     )?.trim();
   }
 
+  getTopicKeyValuePairPo(): KeyValuePairPo {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-topic",
+    });
+  }
+
   async getDecisionStatusText(): Promise<string> {
     return (
       await KeyValuePairPo.under({


### PR DESCRIPTION
# Motivation

As part of the transition to **topic-based voting delegation**, this PR adds topic information to the proposal page.

[Jira Ticket → NNS1-3677](https://dfinity.atlassian.net/browse/NNS1-3677)  
[Live Demo](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/)

<img width="462" alt="image" src="https://github.com/user-attachments/assets/f0b0dd99-e47f-4b25-ab25-b40778b1d60a" />

# Changes

- Display topic info on the page.

# Tests

- Update KeyValuePair PO to getInfoText.
- Verify that the topic is rendered.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
