### PR TITLE
feat(proposals): initialize default topic filter state

### DIFF
--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -14,6 +14,7 @@ import { get } from "svelte/store";
 const defaultFiltersProjectData = {
   types: [],
   decisionStatus: [],
+  topics: [],
 };
 
 // Load decision status, these are hardcoded based on enum values
@@ -85,6 +86,11 @@ export const loadSnsFilters = async ({
     snsFiltersStore.setTypes({
       rootCanisterId,
       types: defaultFiltersProjectData.types,
+    });
+
+    snsFiltersStore.setTopics({
+      rootCanisterId,
+      topics: defaultFiltersProjectData.topics,
     });
 
     // Do not re-initialise decision status and reward status to not override user selection.

--- a/frontend/src/tests/lib/services/sns-filters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-filters.services.spec.ts
@@ -14,22 +14,49 @@ describe("sns-filters services", () => {
     get(snsFiltersStore)[mockPrincipal.toText()];
 
   describe("loadSnsFilters", () => {
-    it("should load the sns decision status filters store but not Unspecified", async () => {
-      expect(getFiltersStoreData()?.decisionStatus).toBeUndefined();
-      await loadSnsFilters({
-        rootCanisterId: mockPrincipal,
-        nsFunctions: [nativeNervousSystemFunctionMock],
-        snsName: "sns-name",
+    describe("when there is no stored data", () => {
+      it("should initialize the filter store by type with default value", async () => {
+        expect(getFiltersStoreData()).toEqual(undefined);
+
+        await loadSnsFilters({
+          rootCanisterId: mockPrincipal,
+          nsFunctions: [],
+          snsName: "sns-name",
+        });
+
+        expect(getFiltersStoreData().types).toEqual([]);
       });
 
-      expect(getFiltersStoreData().decisionStatus).toHaveLength(
-        enumSize(SnsProposalDecisionStatus) - 1
-      );
-      expect(
-        getFiltersStoreData().decisionStatus.map(({ value }) => value)
-      ).not.toContainEqual(
-        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED
-      );
+      it("should initialize the filter store by topic with default value", async () => {
+        expect(getFiltersStoreData()).toEqual(undefined);
+
+        await loadSnsFilters({
+          rootCanisterId: mockPrincipal,
+          nsFunctions: [],
+          snsName: "sns-name",
+        });
+
+        expect(getFiltersStoreData().topics).toEqual([]);
+      });
+
+      it("should load the sns decision status filters store but not Unspecified", async () => {
+        expect(getFiltersStoreData()).toEqual(undefined);
+
+        await loadSnsFilters({
+          rootCanisterId: mockPrincipal,
+          nsFunctions: [],
+          snsName: "sns-name",
+        });
+
+        expect(getFiltersStoreData().decisionStatus.length).toBe(
+          enumSize(SnsProposalDecisionStatus) - 1
+        );
+        expect(
+          getFiltersStoreData().decisionStatus.map(({ value }) => value)
+        ).not.toContainEqual(
+          SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED
+        );
+      });
     });
 
     it("should not change filters if they are already present", async () => {


### PR DESCRIPTION
# Motivation

We want to track the topics filter for SNS proposals in the same way we track other filters, such as types and status. The store was already updated in #6732. This PR initializes the filter similarly to the `topics` filter, providing a default value when the store lacks any value. A follow-up PR will load the store from local storage, ensuring a better user experience.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Sets the default value for the topics field in the sns `snsFiltersStore` when no filter is defined.

# Tests

- Adds a test for the existing code regarding the default value of the `type` filter.  
- Adds tests for the new `topics` filter.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

Next PR: #6745

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ