### PR TITLE
feat(proposals): add sorted topic filter list util

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -520,7 +520,8 @@
     "nns_actionable_proposal_tooltip": "You can still vote on $count NNS proposals.",
     "sns_actionable_proposal_tooltip": "You can still vote on $count $snsName proposals.",
     "total_actionable_proposal_tooltip": "You can still vote on $count proposals.",
-    "is_actionable_status_badge_tooltip": "You can still vote on this proposal."
+    "is_actionable_status_badge_tooltip": "You can still vote on this proposal.",
+    "all_sns_proposals_without_topic": "Proposals without a topic"
   },
   "actionable_proposals_sign_in": {
     "title": "You are not signed in.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -543,6 +543,7 @@ interface I18nVoting {
   sns_actionable_proposal_tooltip: string;
   total_actionable_proposal_tooltip: string;
   is_actionable_status_badge_tooltip: string;
+  all_sns_proposals_without_topic: string;
 }
 
 interface I18nActionable_proposals_sign_in {

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -552,6 +552,10 @@ export const generateSnsProposalTopicsFilterData = ({
 }): Filter<SnsProposalTopicFilterId>[] => {
   if (topics.length === 0) return [];
 
+  // TODO: Extract and reuse
+  const getCheckedState = (filterId: string) =>
+    filters.find(({ id }) => id === filterId)?.checked !== false;
+
   const i18nKeys = get(i18n);
 
   const existingFilters: Filter<SnsProposalTopicFilterId>[] = topics
@@ -566,7 +570,7 @@ export const generateSnsProposalTopicsFilterData = ({
       value: topic,
       name,
       isCritical,
-      checked: filters.find(({ id }) => id === topic)?.checked ?? false,
+      checked: getCheckedState(topic),
     }))
     // sorts filters with critical topics first, then alphabetically within each group
     .sort((a, b) => {
@@ -579,9 +583,7 @@ export const generateSnsProposalTopicsFilterData = ({
     id: ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
     value: ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
     name: i18nKeys.voting.all_sns_proposals_without_topic,
-    checked:
-      filters.find(({ id }) => id === ALL_SNS_PROPOSALS_WITHOUT_TOPIC)
-        ?.checked ?? false,
+    checked: getCheckedState(ALL_SNS_PROPOSALS_WITHOUT_TOPIC),
   };
   return [...existingFilters, allSnsProposalsWithoutTopicFilter];
 };

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -904,7 +904,7 @@ describe("sns-proposals utils", () => {
           id: ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
           value: ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
           name: "All proposals without topic",
-          checked: true,
+          checked: false,
         },
       ];
 
@@ -919,13 +919,13 @@ describe("sns-proposals utils", () => {
       );
 
       expect(governanceFilter?.checked).toBe(true);
-      expect(withoutTopicFilter?.checked).toBe(true);
+      expect(withoutTopicFilter?.checked).toBe(false);
 
-      // DaoCommunitySettings was not in the existing filters, so should be unchecked
+      // DaoCommunitySettings was not in the existing filters, so it should be checked
       const daoSettingsFilter = result.find(
         ({ id }) => id === "DaoCommunitySettings"
       );
-      expect(daoSettingsFilter?.checked).toBe(false);
+      expect(daoSettingsFilter?.checked).toBe(true);
     });
 
     it("should sort topics with critical topics first, then alphabetically", () => {
@@ -975,7 +975,7 @@ describe("sns-proposals utils", () => {
       expect(result[4].id).toBe(ALL_SNS_PROPOSALS_WITHOUT_TOPIC);
     });
 
-    it("should handle topics with all properties properly", () => {
+    it("should show all proposals when default setupt of filters", () => {
       const topics: TopicInfoWithUnknown[] = [
         {
           ...topicInfoMock,
@@ -995,14 +995,14 @@ describe("sns-proposals utils", () => {
         value: "Governance",
         name: "Test Topic",
         isCritical: true,
-        checked: false,
+        checked: true,
       });
 
       expect(result[1]).toEqual({
         id: "all_sns_proposals_without_topic",
         name: "Proposals without a topic",
         value: "all_sns_proposals_without_topic",
-        checked: false,
+        checked: true,
       });
     });
   });

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -1,11 +1,20 @@
 import { ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID } from "$lib/constants/sns-proposals.constants";
-import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
-import { ALL_SNS_GENERIC_PROPOSAL_TYPES_ID } from "$lib/types/filters";
+import type {
+  Filter,
+  SnsProposalTopicFilterId,
+  SnsProposalTypeFilterId,
+} from "$lib/types/filters";
+import {
+  ALL_SNS_GENERIC_PROPOSAL_TYPES_ID,
+  ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
+} from "$lib/types/filters";
+import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { enumValues } from "$lib/utils/enum.utils";
 import {
   ballotVotingPower,
   fromPercentageBasisPoints,
+  generateSnsProposalTopicsFilterData,
   generateSnsProposalTypesFilterData,
   getUniversalProposalStatus,
   isAccepted,
@@ -58,6 +67,7 @@ describe("sns-proposals utils", () => {
     total: 30n,
     timestamp_seconds: 1n,
   };
+
   describe("isAccepted", () => {
     it("should return true if the proposal is accepted", () => {
       const proposal: SnsProposalData = {
@@ -835,6 +845,164 @@ describe("sns-proposals utils", () => {
             snsName: "test_sns",
           })
         ).toStrictEqual(result);
+      });
+    });
+  });
+
+  describe("generateSnsProposalTopicsFilterData", () => {
+    it("should return an empty array if there are no topics", () => {
+      const result = generateSnsProposalTopicsFilterData({
+        topics: [],
+        filters: [],
+      });
+
+      expect(result.length).toBe(0);
+    });
+
+    it("should filter out topics with null topic field", () => {
+      const topicsWithNull: TopicInfoWithUnknown[] = [
+        {
+          ...topicInfoMock,
+          topic: null,
+        },
+        {
+          ...topicInfoMock,
+          topic: [{ Governance: null }],
+        },
+      ];
+
+      const result = generateSnsProposalTopicsFilterData({
+        topics: topicsWithNull,
+        filters: [],
+      });
+
+      expect(result.length).toBe(2);
+      expect(result[0].id).toBe("Governance");
+      expect(result[1].id).toBe(ALL_SNS_PROPOSALS_WITHOUT_TOPIC);
+    });
+
+    it("should preserve checked state from existing filters", () => {
+      const topics: TopicInfoWithUnknown[] = [
+        {
+          ...topicInfoMock,
+          topic: [{ Governance: null }],
+        },
+        {
+          ...topicInfoMock,
+          topic: [{ DaoCommunitySettings: null }],
+        },
+      ];
+
+      const existingFilters: Filter<SnsProposalTopicFilterId>[] = [
+        {
+          id: "Governance",
+          value: "Governance",
+          name: "Governance Topic",
+          checked: true,
+        },
+        {
+          id: ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
+          value: ALL_SNS_PROPOSALS_WITHOUT_TOPIC,
+          name: "All proposals without topic",
+          checked: true,
+        },
+      ];
+
+      const result = generateSnsProposalTopicsFilterData({
+        topics,
+        filters: existingFilters,
+      });
+
+      const governanceFilter = result.find(({ id }) => id === "Governance");
+      const withoutTopicFilter = result.find(
+        ({ id }) => id === ALL_SNS_PROPOSALS_WITHOUT_TOPIC
+      );
+
+      expect(governanceFilter?.checked).toBe(true);
+      expect(withoutTopicFilter?.checked).toBe(true);
+
+      // DaoCommunitySettings was not in the existing filters, so should be unchecked
+      const daoSettingsFilter = result.find(
+        ({ id }) => id === "DaoCommunitySettings"
+      );
+      expect(daoSettingsFilter?.checked).toBe(false);
+    });
+
+    it("should sort topics with critical topics first, then alphabetically", () => {
+      const topics: TopicInfoWithUnknown[] = [
+        {
+          ...topicInfoMock,
+          name: ["Z Topic"],
+          topic: [{ Governance: null }],
+          is_critical: [false],
+        },
+        {
+          ...topicInfoMock,
+          name: ["B Topic"],
+          topic: [{ DaoCommunitySettings: null }],
+          is_critical: [true],
+        },
+        {
+          ...topicInfoMock,
+          name: ["A Topic"],
+          topic: [{ ApplicationBusinessLogic: null }],
+          is_critical: [false],
+        },
+        {
+          ...topicInfoMock,
+          name: ["C Topic"],
+          topic: [{ CriticalDappOperations: null }],
+          is_critical: [true],
+        },
+      ];
+
+      const result = generateSnsProposalTopicsFilterData({
+        topics,
+        filters: [],
+      });
+
+      // Should have 4 topic filters + the 'without topic' filter
+      expect(result.length).toBe(5);
+
+      // Critical topics should come first alphabetically
+      expect(result[0].id).toBe("DaoCommunitySettings");
+      expect(result[1].id).toBe("CriticalDappOperations");
+
+      // Then non-critical topics alphabetically
+      expect(result[2].id).toBe("ApplicationBusinessLogic");
+      expect(result[3].id).toBe("Governance");
+
+      expect(result[4].id).toBe(ALL_SNS_PROPOSALS_WITHOUT_TOPIC);
+    });
+
+    it("should handle topics with all properties properly", () => {
+      const topics: TopicInfoWithUnknown[] = [
+        {
+          ...topicInfoMock,
+          name: ["Test Topic"],
+          topic: [{ Governance: null }],
+          is_critical: [true],
+        },
+      ];
+
+      const result = generateSnsProposalTopicsFilterData({
+        topics,
+        filters: [],
+      });
+
+      expect(result[0]).toEqual({
+        id: "Governance",
+        value: "Governance",
+        name: "Test Topic",
+        isCritical: true,
+        checked: false,
+      });
+
+      expect(result[1]).toEqual({
+        id: "all_sns_proposals_without_topic",
+        name: "Proposals without a topic",
+        value: "all_sns_proposals_without_topic",
+        checked: false,
       });
     });
   });


### PR DESCRIPTION
# Motivation

We want to track the topics filter for SNS proposals in the same way we track other filters, such as types and status. 

This PR creates a new utility to generate a list of filters based on existing topics and persisted filters. The filters are sorted according to the following logic:

-  First, critical topics are sorted alphabetically.
-  Second, non-critical topics are sorted alphabetically.
-  Lastly, a special filter shows all proposals without a topic.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- New utility to create a list of filters from topics and saved filters. If there are no topics, the filter list will be empty.

# Tests

- Unit tests for this new util.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

Prev. PR: #6744 | Next PR: #6746

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ