### PR TITLE
feat(proposals): load topic filters on application start

### DIFF
--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -1,8 +1,12 @@
+import { createSnsTopicsProjectStore } from "$lib/derived/sns-topics.derived";
 import { i18n } from "$lib/stores/i18n";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
-import type { Filter } from "$lib/types/filters";
+import { type Filter } from "$lib/types/filters";
 import { enumValues } from "$lib/utils/enum.utils";
-import { generateSnsProposalTypesFilterData } from "$lib/utils/sns-proposals.utils";
+import {
+  generateSnsProposalTopicsFilterData,
+  generateSnsProposalTypesFilterData,
+} from "$lib/utils/sns-proposals.utils";
 import type { Principal } from "@dfinity/principal";
 import {
   SnsProposalDecisionStatus,
@@ -100,4 +104,6 @@ export const loadSnsFilters = async ({
   // It's safe to reload types filters as the `loadTypesFilters` respects user selection,
   // and it needs to be reloaded to get nsFunctions update.
   loadTypesFilters({ rootCanisterId, nsFunctions, snsName });
+
+  loadTopicsFilters(rootCanisterId);
 };

--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -73,6 +73,23 @@ const loadTypesFilters = ({
   });
 };
 
+const loadTopicsFilters = (rootCanisterId: Principal) => {
+  const topics = get(createSnsTopicsProjectStore(rootCanisterId));
+  if (isNullish(topics)) return [];
+
+  const currentTopicsFilterData =
+    get(snsFiltersStore)?.[rootCanisterId.toText()]?.topics ?? [];
+  const updatedTopicsFilterData = generateSnsProposalTopicsFilterData({
+    topics,
+    filters: currentTopicsFilterData,
+  });
+
+  snsFiltersStore.setTopics({
+    rootCanisterId,
+    topics: updatedTopicsFilterData,
+  });
+};
+
 export const loadSnsFilters = async ({
   rootCanisterId,
   nsFunctions,

--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -74,14 +74,12 @@ const loadTypesFilters = ({
 };
 
 const loadTopicsFilters = (rootCanisterId: Principal) => {
-  const topics = get(createSnsTopicsProjectStore(rootCanisterId));
-  if (isNullish(topics)) return [];
+  const topics = get(createSnsTopicsProjectStore(rootCanisterId)) ?? [];
+  const filters = get(snsFiltersStore)?.[rootCanisterId.toText()]?.topics ?? [];
 
-  const currentTopicsFilterData =
-    get(snsFiltersStore)?.[rootCanisterId.toText()]?.topics ?? [];
   const updatedTopicsFilterData = generateSnsProposalTopicsFilterData({
     topics,
-    filters: currentTopicsFilterData,
+    filters,
   });
 
   snsFiltersStore.setTopics({

--- a/frontend/src/tests/lib/services/sns-filters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-filters.services.spec.ts
@@ -3,6 +3,8 @@ import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { enumSize } from "$lib/utils/enum.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { nativeNervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
+import { topicInfoDtoMock } from "$tests/mocks/sns-topics.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   SnsProposalDecisionStatus,
   type SnsNervousSystemFunction,
@@ -99,6 +101,48 @@ describe("sns-filters services", () => {
           id: "1",
           name: "Motion",
           value: "1",
+        },
+      ]);
+    });
+
+    it("should update the topics in filters store", async () => {
+      setSnsProjects([
+        {
+          rootCanisterId: mockPrincipal,
+          topics: {
+            topics: [
+              topicInfoDtoMock({
+                topic: "DaoCommunitySettings",
+                name: "Topic1",
+                description: "This is a description",
+                isCritical: false,
+              }),
+            ],
+            uncategorized_functions: [],
+          },
+        },
+      ]);
+      expect(getFiltersStoreData()).toBe(undefined);
+
+      await loadSnsFilters({
+        rootCanisterId: mockPrincipal,
+        nsFunctions: [],
+        snsName: "sns-name",
+      });
+
+      expect(getFiltersStoreData().topics).toEqual([
+        {
+          checked: false,
+          id: "DaoCommunitySettings",
+          isCritical: false,
+          name: "Topic1",
+          value: "DaoCommunitySettings",
+        },
+        {
+          checked: false,
+          id: "all_sns_proposals_without_topic",
+          name: "Proposals without a topic",
+          value: "all_sns_proposals_without_topic",
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/sns-filters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-filters.services.spec.ts
@@ -132,14 +132,14 @@ describe("sns-filters services", () => {
 
       expect(getFiltersStoreData().topics).toEqual([
         {
-          checked: false,
+          checked: true,
           id: "DaoCommunitySettings",
           isCritical: false,
           name: "Topic1",
           value: "DaoCommunitySettings",
         },
         {
-          checked: false,
+          checked: true,
           id: "all_sns_proposals_without_topic",
           name: "Proposals without a topic",
           value: "all_sns_proposals_without_topic",


### PR DESCRIPTION
# Motivation

We want to track the topics filter for SNS proposals just as we track other filters, such as `types` and `status`. This PR utilizes the utility created in #6745 to load the filters when the user loads the application.

[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Load the SNS proposals and filter topics similar to the types.

# Tests

- Add a unit test for loading the topics.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

Prev. PR: #6745

[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ