### PR TITLE
chore(cleanup): remove unused code

### DIFF
--- a/frontend/src/lib/services/public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/public/sns-proposals.services.ts
@@ -4,36 +4,24 @@ import {
   registerVote as registerVoteApi,
 } from "$lib/api/sns-governance.api";
 import { DEFAULT_SNS_PROPOSALS_PAGE_SIZE } from "$lib/constants/sns-proposals.constants";
-import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
-import { sortedSnsUserNeuronsStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
-import {
-  getSnsNeuronIdentity,
-  syncSnsNeurons,
-} from "$lib/services/sns-neurons.services";
+import { getSnsNeuronIdentity } from "$lib/services/sns-neurons.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
-import { authStore } from "$lib/stores/auth.store";
 import { snsSelectedFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { unsupportedFilterByTopicSnsesStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
-import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
-import {
-  getSnsNeuronState,
-  hasPermissionToVote,
-  subaccountToHexString,
-} from "$lib/utils/sns-neuron.utils";
+import { toastsError } from "$lib/stores/toasts.store";
+import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
 import { toExcludeTypeParameter } from "$lib/utils/sns-proposals.utils";
-import { NeuronState } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type {
   SnsListProposalsResponse,
   SnsNervousSystemFunction,
-  SnsNeuron,
   SnsNeuronId,
   SnsProposalData,
   SnsProposalId,
   SnsVote,
 } from "@dfinity/sns";
-import { fromDefinedNullable, fromNullable, isNullish } from "@dfinity/utils";
+import { fromNullable, isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 export const registerVote = async ({
@@ -68,69 +56,6 @@ export const registerVote = async ({
       err,
     });
     return { success: false };
-  }
-};
-
-// TODO(demo): remove after voting implementation
-export const registerVoteDemo = async ({
-  vote,
-  proposal,
-  snsFunctions,
-}: {
-  vote: SnsVote;
-  proposal: SnsProposalData;
-  snsFunctions: SnsNervousSystemFunction[];
-}) => {
-  let registrations = 0;
-
-  const rootCanisterId = get(snsOnlyProjectStore);
-
-  if (isNullish(rootCanisterId)) {
-    throw new Error("no rootCanisterId");
-  }
-
-  const registerNeuronVote = async (neuron: SnsNeuron) => {
-    await registerVote({
-      rootCanisterId,
-      neuronId: fromDefinedNullable(neuron.id),
-      proposalId: fromDefinedNullable(proposal.id),
-      vote,
-    });
-    registrations++;
-  };
-
-  try {
-    await syncSnsNeurons(rootCanisterId);
-
-    const neurons = get(sortedSnsUserNeuronsStore);
-    const votableNeurons = neurons.filter(
-      (neuron) =>
-        getSnsNeuronState(neuron) !== NeuronState.Dissolved &&
-        hasPermissionToVote({ neuron, identity: get(authStore).identity })
-    );
-
-    if (votableNeurons.length === 0) {
-      toastsError({
-        labelKey: `None of ${neurons.length} neurons is allowed to vote`,
-      });
-      return;
-    }
-
-    await Promise.all(votableNeurons.map(registerNeuronVote));
-
-    await loadSnsProposals({
-      rootCanisterId,
-      snsFunctions,
-    });
-
-    toastsSuccess({
-      labelKey: `${registrations} votes were successfully registered`,
-    });
-  } catch (err) {
-    toastsError({
-      labelKey: `There was an error while vote registration. ${registrations} votes registered.`,
-      err,
-    });
   }
 };
 

--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -68,7 +68,6 @@ const loadTypesFilters = ({
   });
 };
 
-// TODO: Set default filters
 export const loadSnsFilters = async ({
   rootCanisterId,
   nsFunctions,


### PR DESCRIPTION
# Motivation

We want to keep our codebase clean by removing unused functions and outdated to-dos.

# Changes

- Removes `registerVoteDemo`, which was added in #1756 and has not been used for a long time.  
- Removes the `TODO` from #4142, as it is no longer applicable since we now define default values for the filters.

# Tests

- Removing the untested code is unnecessary.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.