### PR TITLE
feat(sns-topics): Fix checkbox selection

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
@@ -81,7 +81,6 @@
         text="block"
         {checked}
         on:nnsChange={onChange}
-        preventDefault
         --checkbox-label-order="1"
         --checkbox-padding="var(--padding) 0"
       >


### PR DESCRIPTION
# Motivation

Due to `preventDefault`, clicking on the visual part of the checkbox in the topic item component didn’t update its visible state.

# Changes

- Remove preventDefault property.

# Tests

- Tested manually.

**Before**

https://github.com/user-attachments/assets/45d2a11e-bce8-42c0-b2d0-76681cc1a3c7

**After**

https://github.com/user-attachments/assets/ad67d05f-e6de-4479-b565-8a6c6177d116

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.