### PR TITLE
feat(sns-topics): Display deactivate catch all step

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -427,6 +427,7 @@
     "topic_definitions_title": "Topic Definition List",
     "topics_title": "Delegate Voting",
     "legacy_title": "Change to Topic Following",
+    "deactivate_catch_all_title": "Deactivating Catch-All Following",
     "topics_description": "Delegate your voting by following other neurons to maximize your voting rewards. Your voting is fully delegated only if following is set for every topic. Alternatively, you can vote manually.",
     "topics_critical_label": "Critical topics",
     "topics_critical_tooltip": "Critical topics include proposals that are vital to the management of a given SNS DAO, so they require 67% \"yes\" votes to be adopted. They include treasury management and critical dapp operations.",

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -135,7 +135,7 @@
     })
   );
 
-  const selectedTopicsContainLegacyFollowee = $derived<boolean>(
+  const selectedTopicsContainLegacyFollowee: boolean = $derived(
     getLegacyFolloweesByTopics({
       neuron,
       topicInfos: topicInfos.filter((topicInfo) =>

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -128,7 +128,7 @@
   const nsFunctions: SnsNervousSystemFunction[] = $derived(
     get(createSnsNsFunctionsProjectStore(rootCanisterId)) ?? []
   );
-  const catchAllLegacyFollowings = $derived<SnsLegacyFollowings | undefined>(
+  const catchAllLegacyFollowings: SnsLegacyFollowings | undefined = $derived(
     getCatchAllSnsLegacyFollowings({
       neuron,
       nsFunctions,

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -9,7 +9,6 @@
   import {
     getSnsNeuronIdentity,
     removeFollowee,
-    removeNsFunctionFollowees,
     setFollowing,
   } from "$lib/services/sns-neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
@@ -4,11 +4,15 @@
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import FollowSnsNeuronsByTopicItem from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { SnsTopicFollowing, SnsTopicKey } from "$lib/types/sns";
+  import type {
+    SnsLegacyFollowings,
+    SnsTopicFollowing,
+    SnsTopicKey,
+  } from "$lib/types/sns";
   import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
   import {
-    getLegacyFolloweesByTopics,
     getSnsTopicInfoKey,
+    getLegacyFolloweesByTopics,
     snsTopicToTopicKey,
   } from "$lib/utils/sns-topics.utils";
   import type {
@@ -16,13 +20,14 @@
     SnsNeuron,
     SnsNeuronId,
   } from "@dfinity/sns";
-  import { fromDefinedNullable } from "@dfinity/utils";
+  import { fromDefinedNullable, nonNullish } from "@dfinity/utils";
 
   type Props = {
     neuron: SnsNeuron;
     topicInfos: TopicInfoWithUnknown[];
     selectedTopics: SnsTopicKey[];
     followings: SnsTopicFollowing[];
+    catchAllLegacyFollowings: SnsLegacyFollowings | undefined;
     closeModal: () => void;
     openNextStep: () => void;
     removeFollowing: (args: {
@@ -33,16 +38,19 @@
       nsFunction: SnsNervousSystemFunction;
       followee: SnsNeuronId;
     }) => void;
+    openDeactivateCatchAllStep: () => void;
   };
   let {
     neuron,
     topicInfos,
     selectedTopics = $bindable(),
     followings,
+    catchAllLegacyFollowings,
     closeModal,
     openNextStep,
     removeFollowing,
     removeLegacyFollowing,
+    openDeactivateCatchAllStep,
   }: Props = $props();
 
   const criticalTopicInfos: TopicInfoWithUnknown[] = $derived(
@@ -106,12 +114,21 @@
   </div>
 
   <div class="topic-group" data-tid="non-critical-topic-group">
-    <h5 class="headline description"
-      >{$i18n.follow_sns_topics.topics_non_critical_label}
-      <TooltipIcon
-        >{$i18n.follow_sns_topics.topics_critical_tooltip}</TooltipIcon
-      ></h5
-    >
+    <div class="topic-group-header">
+      <h5 class="headline description"
+        >{$i18n.follow_sns_topics.topics_non_critical_label}
+        <TooltipIcon
+          >{$i18n.follow_sns_topics.topics_critical_tooltip}</TooltipIcon
+        ></h5
+      >
+      {#if nonNullish(catchAllLegacyFollowings)}
+        <button
+          data-tid="deactivate-catch-all-button"
+          class="ghost"
+          onclick={openDeactivateCatchAllStep}>{"Deactivate catch-all"}</button
+        >
+      {/if}
+    </div>
     {#each nonCriticalTopicInfos as topicInfo}
       <FollowSnsNeuronsByTopicItem
         {topicInfo}
@@ -158,6 +175,16 @@
 
     .headline {
       margin: var(--padding) 0;
+    }
+  }
+
+  .topic-group-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    button {
+      color: var(--primary);
     }
   }
 </style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -442,6 +442,7 @@ interface I18nFollow_sns_topics {
   topic_definitions_title: string;
   topics_title: string;
   legacy_title: string;
+  deactivate_catch_all_title: string;
   topics_description: string;
   topics_critical_label: string;
   topics_critical_tooltip: string;

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -729,4 +729,39 @@ describe("FollowSnsNeuronsByTopicModal", () => {
     expect(await legacyStepPo.isPresent()).toEqual(false);
     expect(await neuronStepPo.isPresent()).toEqual(false);
   });
+
+  describe("Deactivate catch-all", () => {
+    it("navigates to the deactivate catch-all", async () => {
+      const po = renderComponent({
+        ...defaultProps,
+        neuron: {
+          ...neuron,
+          followees: [
+            [
+              // catch-all followings
+              0n,
+              { followees: [legacyFolloweeNeuronId1, legacyFolloweeNeuronId2] },
+            ],
+          ],
+        },
+      });
+      const topicsStepPo = po.getFollowSnsNeuronsByTopicStepTopicsPo();
+      const deactivateCatchAllStepPo =
+        po.getFollowSnsNeuronsByTopicStepDeactivateCatchAllPo();
+
+      // Select a topic
+      expect(await topicsStepPo.isPresent()).toEqual(true);
+      expect(await deactivateCatchAllStepPo.isPresent()).toEqual(false);
+
+      await topicsStepPo.clickDeactivateCatchAllButton();
+
+      expect(await topicsStepPo.isPresent()).toEqual(false);
+      expect(await deactivateCatchAllStepPo.isPresent()).toEqual(true);
+
+      await deactivateCatchAllStepPo.clickCancelButton();
+
+      expect(await topicsStepPo.isPresent()).toEqual(true);
+      expect(await deactivateCatchAllStepPo.isPresent()).toEqual(false);
+    });
+  });
 });

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
@@ -1,5 +1,9 @@
 import FollowSnsNeuronsByTopicStepTopics from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte";
-import type { SnsTopicFollowing, SnsTopicKey } from "$lib/types/sns";
+import type {
+  SnsLegacyFollowings,
+  SnsTopicFollowing,
+  SnsTopicKey,
+} from "$lib/types/sns";
 import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
@@ -100,6 +104,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     selectedTopics: SnsTopicKey[];
     topicInfos: TopicInfoWithUnknown[];
     followings: SnsTopicFollowing[];
+    catchAllLegacyFollowings: SnsLegacyFollowings | undefined;
     closeModal: () => void;
     openNextStep: () => void;
     removeFollowing: (args: {
@@ -110,6 +115,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
       nsFunction: SnsNervousSystemFunction;
       followee: SnsNeuronId;
     }) => void;
+    openDeactivateCatchAllStep: () => void;
   }) => {
     const { container } = render(FollowSnsNeuronsByTopicStepTopics, {
       props,
@@ -124,10 +130,12 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     selectedTopics: [],
     topicInfos: [],
     followings: [],
+    catchAllLegacyFollowings: undefined,
     closeModal: vi.fn(),
     openNextStep: vi.fn(),
     removeFollowing: vi.fn(),
     removeLegacyFollowing: vi.fn(),
+    openDeactivateCatchAllStep: vi.fn(),
   };
 
   it("displays critical and non-critical topics", async () => {
@@ -265,6 +273,31 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     expect(closeModal).toBeCalledTimes(1);
     await po.clickNextButton();
     expect(openNextStep).toBeCalledTimes(1);
+  });
+
+  it("displays deactivate catch-all followings when catch-all provided", async () => {
+    const spyOpenDeactivateCatchAllStep = vi.fn();
+    const po = renderComponent({
+      ...defaultProps,
+      catchAllLegacyFollowings: {
+        nsFunction: legacyNsFunction1,
+        followees: [legacyFolloweeNeuronId1],
+      },
+      openDeactivateCatchAllStep: spyOpenDeactivateCatchAllStep,
+    });
+
+    expect(await po.getDeactivateCatchAllButtonPo().isPresent()).toEqual(true);
+    await po.clickDeactivateCatchAllButton();
+    expect(spyOpenDeactivateCatchAllStep).toBeCalledTimes(1);
+  });
+
+  it("doesn't displays deactivate catch-all followings when no catch-all", async () => {
+    const po = renderComponent({
+      ...defaultProps,
+      catchAllLegacyFollowings: undefined,
+    });
+
+    expect(await po.getDeactivateCatchAllButtonPo().isPresent()).toEqual(false);
   });
 
   describe("legacy followees", () => {

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicModal.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicModal.page-object.ts
@@ -1,3 +1,4 @@
+import { FollowSnsNeuronsByTopicStepDeactivateCatchAllPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepDeactivateCatchAll.page-object";
 import { FollowSnsNeuronsByTopicStepLegacyPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepLegacy.page-object";
 import { FollowSnsNeuronsByTopicStepNeuronPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepNeuron.page-object";
 import { FollowSnsNeuronsByTopicStepTopicsPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object";
@@ -29,5 +30,9 @@ export class FollowSnsNeuronsByTopicModalPo extends ModalPo {
 
   getFollowSnsNeuronsByTopicStepNeuronPo(): FollowSnsNeuronsByTopicStepNeuronPo {
     return FollowSnsNeuronsByTopicStepNeuronPo.under(this.root);
+  }
+
+  getFollowSnsNeuronsByTopicStepDeactivateCatchAllPo(): FollowSnsNeuronsByTopicStepDeactivateCatchAllPo {
+    return FollowSnsNeuronsByTopicStepDeactivateCatchAllPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object.ts
@@ -97,6 +97,13 @@ export class FollowSnsNeuronsByTopicStepTopicsPo extends BasePageObject {
     });
   }
 
+  getDeactivateCatchAllButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "deactivate-catch-all-button",
+    });
+  }
+
   async getFollowSnsNeuronsByTopicLegacyFolloweePos(): Promise<
     FollowSnsNeuronsByTopicLegacyFolloweePo[]
   > {
@@ -109,5 +116,9 @@ export class FollowSnsNeuronsByTopicStepTopicsPo extends BasePageObject {
 
   clickCancelButton(): Promise<void> {
     return this.getCancelButtonPo().click();
+  }
+
+  clickDeactivateCatchAllButton(): Promise<void> {
+    return this.getDeactivateCatchAllButtonPo().click();
   }
 }


### PR DESCRIPTION
# Motivation

As part of the transition to **topic-based voting delegation**, this PR adds navigation to and from the "Deactivate Catch-all" step. 

[Jira Ticket → NNS1-3744](https://dfinity.atlassian.net/browse/NNS1-3744)  

https://github.com/user-attachments/assets/acd4be1d-1a37-4416-b709-3674fb4db3d5

# Changes

- Display "Deactivate catch all" button when catchAllLegacyFollowings present.
- Provide navigation to "Deactivate catch all" step and back.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
