### PR TITLE
feat(sns): handle discontinued project

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -2,7 +2,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
-  import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { abandonedProjectsCanisterId } from "$lib/constants/canister-ids.constants";
   import { AppPath } from "$lib/constants/routes.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { pageStore } from "$lib/derived/page.derived";
@@ -31,7 +31,7 @@
   {/if}
 
   {#each $selectableUniversesStore as universe (universe.canisterId)}
-    {#if universe.canisterId !== CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID}
+    {#if !abandonedProjectsCanisterId.includes(universe.canisterId)}
       <SelectUniverseCard
         {universe}
         {role}

--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -25,3 +25,11 @@ export const TVL_CANISTER_ID: Principal | undefined = nonNullish(
 // This project has been abandoned https://dfinity.slack.com/archives/C039M7YS6F6/p1733302975333649
 export const CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID =
   "ibahq-taaaa-aaaaq-aadna-cai";
+
+// This project has been abandoned https://dfinity.slack.com/archives/C03H6QEPW5D/p1745829568330499
+export const SEERS_ROOT_CANISTER_ID = "u67kc-jyaaa-aaaaq-aabpq-cai";
+
+export const abandonedProjectsCanisterId = [
+  CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
+  SEERS_ROOT_CANISTER_ID,
+];

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -1,4 +1,4 @@
-import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { abandonedProjectsCanisterId } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
 import { nowInSeconds } from "$lib/utils/date.utils";
@@ -28,7 +28,7 @@ const filterCyclesTransferStation = ({
   universeId,
 }: {
   universeId: string;
-}): boolean => CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID !== universeId;
+}): boolean => !abandonedProjectsCanisterId.includes(universeId);
 
 const compareTokensByUsdBalance = createDescendingComparator(
   (token: UserTokenData) => token?.balanceInUsd ?? 0 > 0

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -212,6 +212,43 @@ describe("sns-aggregator store", () => {
       expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (CTS)" });
     });
 
+    it("should override information for SNS with rootCanisterId u67kc-jyaaa-aaaaq-aabpq-cai", () => {
+      const brokenSns = withBrokenSns({
+        sns: {
+          ...mockedSns,
+          meta: {
+            ...mockedSns.meta,
+            name: "---",
+          },
+          icrc1_metadata: [...mockedSns.icrc1_metadata].map(([name, value]) => {
+            if (name === "icrc1:symbol" && "Text" in value) {
+              return [
+                name,
+                {
+                  Text: "---",
+                },
+              ];
+            }
+            return [name, value];
+          }),
+        },
+        rootCanisterId: "u67kc-jyaaa-aaaaq-aabpq-cai",
+      });
+      const data = [brokenSns];
+      snsAggregatorIncludingAbortedProjectsStore.setData(data);
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0].meta.name
+      ).toBe("---");
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data[0]
+          .icrc1_metadata[3][1]
+      ).toEqual({ Text: "---" });
+
+      const result = get(snsAggregatorStore).data[0];
+      expect(result.meta.name).toBe("\u200B--- (formerly SEERS)");
+      expect(result.icrc1_metadata[3][1]).toEqual({ Text: "--- (SEER)" });
+    });
+
     it("should send the CTS SNS to the bottom of the store", () => {
       const data = [brokenSns, ...aggregatorMockSnsesDataDto];
       snsAggregatorIncludingAbortedProjectsStore.setData(data);

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -1,4 +1,7 @@
-import { CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import {
+  CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
+  SEERS_ROOT_CANISTER_ID,
+} from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
@@ -350,14 +353,19 @@ describe("Portfolio utils", () => {
         expect(result).toHaveLength(0);
       });
 
-      it("should filter CTS project", () => {
+      it("should filter abandoned project", () => {
         const mockCTSProject: TableProject = {
           ...mockTableProject,
           stakeInUsd: 1000,
           universeId: CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
         };
+        const mockSeersProject: TableProject = {
+          ...mockTableProject,
+          stakeInUsd: 1000,
+          universeId: SEERS_ROOT_CANISTER_ID,
+        };
 
-        const projects = [mockCTSProject, mockIcpProject];
+        const projects = [mockCTSProject, mockSeersProject, mockIcpProject];
 
         const result = getTopStakedTokens({
           projects,
@@ -366,6 +374,7 @@ describe("Portfolio utils", () => {
 
         expect(result).toHaveLength(1);
         expect(result).not.toContainEqual(mockCTSProject);
+        expect(result).not.toContainEqual(mockSeersProject);
       });
     });
   });


### PR DESCRIPTION
# Motivation

A new SNS has been discontinued. Since we do not yet have a long-term solution for the nns-dapp, we will apply the same approach used for the first project discontinuation.

This PR refactors the existing code to handle a list rather than a single element.

# Changes

- Create a list of discontinued projects.  
- Move these projects to the bottom of the tokens and neurons table.  
- Rename the token or project for better visibility.  

# Tests

- Update tests to check for multiple discontinued projects.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.