### PR TITLE
feat(sns-topics): Deactivate catch-all

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -445,9 +445,11 @@
     "neuron_follow": "Follow Neuron",
     "busy_updating": "Updating neuron followings",
     "busy_removing": "Removing neuron following",
+    "busy_removing_catch_all": "Removing catch-all followings",
     "busy_removing_legacy": "Removing neuron legacy following",
     "success_set_following": "The neuron following was successfully added.",
     "success_removing_legacy": "The neuron legacy following was successfully removed.",
+    "success_removing_catch_all": "The neuron legacy \"Catch-all\" followings successfully removed.",
     "error_neuron_not_exist": "Neuron with id $neuronId does not exist.",
     "error_add_following": "There was an error while adding a followee.",
     "error_remove_following": "There was an error while unfollowing the neuron."

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -427,6 +427,7 @@
     "topic_definitions_title": "Topic Definition List",
     "topics_title": "Delegate Voting",
     "legacy_title": "Change to Topic Following",
+    "deactivate_catch_all_title": "Deactivating Catch-All Following",
     "topics_description": "Delegate your voting by following other neurons to maximize your voting rewards. Your voting is fully delegated only if following is set for every topic. Alternatively, you can vote manually.",
     "topics_critical_label": "Critical topics",
     "topics_critical_tooltip": "Critical topics include proposals that are vital to the management of a given SNS DAO, so they require 67% \"yes\" votes to be adopted. They include treasury management and critical dapp operations.",

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -280,12 +280,11 @@
       functionId: 0n,
     });
 
-    await reloadNeuron();
-
     if (success) {
       toastsSuccess({
         labelKey: "follow_sns_topics.success_removing_catch_all",
       });
+      await reloadNeuron();
       openPrevStep();
     }
 

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -9,6 +9,7 @@
   import {
     getSnsNeuronIdentity,
     removeFollowee,
+    removeNsFunctionFollowees,
     setFollowing,
   } from "$lib/services/sns-neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
@@ -268,7 +269,27 @@
   };
 
   const confirmDeactivateCatchAllFollowee = async () => {
-    // TODO(sns-topics): Implement deactivation of catch-all followee
+    startBusy({
+      initiator: "remove-sns-legacy-followee",
+      labelKey: "follow_sns_topics.busy_removing_legacy",
+    });
+
+    const { success } = await removeNsFunctionFollowees({
+      rootCanisterId,
+      neuron,
+      functionId: 0n,
+    });
+
+    await reloadNeuron();
+
+    if (success) {
+      toastsSuccess({
+        labelKey: "follow_sns_topics.success_removing_legacy",
+      });
+      openPrevStep();
+    }
+
+    stopBusy("remove-sns-legacy-followee");
   };
 </script>
 

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -270,8 +270,8 @@
 
   const confirmDeactivateCatchAllFollowee = async () => {
     startBusy({
-      initiator: "remove-sns-legacy-followee",
-      labelKey: "follow_sns_topics.busy_removing_legacy",
+      initiator: "remove-sns-catch-all-followee",
+      labelKey: "follow_sns_topics.busy_removing_catch_all",
     });
 
     const { success } = await removeNsFunctionFollowees({
@@ -284,12 +284,12 @@
 
     if (success) {
       toastsSuccess({
-        labelKey: "follow_sns_topics.success_removing_legacy",
+        labelKey: "follow_sns_topics.success_removing_catch_all",
       });
       openPrevStep();
     }
 
-    stopBusy("remove-sns-legacy-followee");
+    stopBusy("remove-sns-catch-all-followee");
   };
 </script>
 

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { querySnsNeuron } from "$lib/api/sns-governance.api";
+  import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
   import { snsTopicsStore } from "$lib/derived/sns-topics.derived";
+  import FollowSnsNeuronsByTopicStepDeactivateCatchAll from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepDeactivateCatchAll.svelte";
   import FollowSnsNeuronsByTopicStepLegacy from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepLegacy.svelte";
   import FollowSnsNeuronsByTopicStepNeuron from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepNeuron.svelte";
   import FollowSnsNeuronsByTopicStepTopics from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte";
@@ -12,13 +14,18 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
-  import type { SnsTopicFollowing, SnsTopicKey } from "$lib/types/sns";
+  import type {
+    SnsLegacyFollowings,
+    SnsTopicFollowing,
+    SnsTopicKey,
+  } from "$lib/types/sns";
   import type {
     ListTopicsResponseWithUnknown,
     TopicInfoWithUnknown,
   } from "$lib/types/sns-aggregator";
   import {
     addSnsNeuronToFollowingsByTopics,
+    getCatchAllSnsLegacyFollowings,
     getLegacyFolloweesByTopics,
     getSnsTopicFollowings,
     getSnsTopicInfoKey,
@@ -43,6 +50,7 @@
     isNullish,
     nonNullish,
   } from "@dfinity/utils";
+  import { get } from "svelte/store";
 
   type Props = {
     rootCanisterId: Principal;
@@ -54,6 +62,7 @@
 
   const STEP_TOPICS = "topics";
   const STEP_CONFIRM_OVERRIDE_LEGACY = "legacy";
+  const STEP_CONFIRM_DEACTIVATING_CATCH_ALL = "catch-all";
   const STEP_NEURON = "neurons";
   const steps: WizardSteps = [
     {
@@ -63,6 +72,10 @@
     {
       name: STEP_CONFIRM_OVERRIDE_LEGACY,
       title: $i18n.follow_sns_topics.legacy_title,
+    },
+    {
+      name: STEP_CONFIRM_DEACTIVATING_CATCH_ALL,
+      title: $i18n.follow_sns_topics.deactivate_catch_all_title,
     },
     {
       name: STEP_NEURON,
@@ -83,6 +96,10 @@
       modal?.set(wizardStepIndex({ name: STEP_NEURON, steps }));
     }
   };
+  const openDeactivateCatchAllStep = () =>
+    modal?.set(
+      wizardStepIndex({ name: STEP_CONFIRM_DEACTIVATING_CATCH_ALL, steps })
+    );
   const openPrevStep = () => {
     if (
       currentStep?.name === STEP_NEURON &&
@@ -107,6 +124,16 @@
   );
   let selectedTopics = $state<SnsTopicKey[]>([]);
   let followeeNeuronIdHex = $state<string>("");
+
+  const nsFunctions: SnsNervousSystemFunction[] = $derived(
+    get(createSnsNsFunctionsProjectStore(rootCanisterId)) ?? []
+  );
+  const catchAllLegacyFollowings = $derived<SnsLegacyFollowings | undefined>(
+    getCatchAllSnsLegacyFollowings({
+      neuron,
+      nsFunctions,
+    })
+  );
 
   const selectedTopicsContainLegacyFollowee = $derived<boolean>(
     getLegacyFolloweesByTopics({
@@ -239,6 +266,10 @@
     }
     stopBusy("remove-sns-legacy-followee");
   };
+
+  const confirmDeactivateCatchAllFollowee = async () => {
+    // TODO(sns-topics): Implement deactivation of catch-all followee
+  };
 </script>
 
 <WizardModal
@@ -256,8 +287,10 @@
       {followings}
       {neuron}
       bind:selectedTopics
+      {catchAllLegacyFollowings}
       {closeModal}
       {openNextStep}
+      {openDeactivateCatchAllStep}
       {removeFollowing}
       {removeLegacyFollowing}
     />
@@ -269,6 +302,13 @@
       bind:selectedTopics
       {openPrevStep}
       {openNextStep}
+    />
+  {/if}
+  {#if currentStep?.name === STEP_CONFIRM_DEACTIVATING_CATCH_ALL && nonNullish(catchAllLegacyFollowings)}
+    <FollowSnsNeuronsByTopicStepDeactivateCatchAll
+      {catchAllLegacyFollowings}
+      cancel={openPrevStep}
+      confirm={confirmDeactivateCatchAllFollowee}
     />
   {/if}
   {#if currentStep?.name === STEP_NEURON}

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte
@@ -4,11 +4,15 @@
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import FollowSnsNeuronsByTopicItem from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { SnsTopicFollowing, SnsTopicKey } from "$lib/types/sns";
+  import type {
+    SnsLegacyFollowings,
+    SnsTopicFollowing,
+    SnsTopicKey,
+  } from "$lib/types/sns";
   import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
   import {
-    getLegacyFolloweesByTopics,
     getSnsTopicInfoKey,
+    getLegacyFolloweesByTopics,
     snsTopicToTopicKey,
   } from "$lib/utils/sns-topics.utils";
   import type {
@@ -16,13 +20,14 @@
     SnsNeuron,
     SnsNeuronId,
   } from "@dfinity/sns";
-  import { fromDefinedNullable } from "@dfinity/utils";
+  import { fromDefinedNullable, nonNullish } from "@dfinity/utils";
 
   type Props = {
     neuron: SnsNeuron;
     topicInfos: TopicInfoWithUnknown[];
     selectedTopics: SnsTopicKey[];
     followings: SnsTopicFollowing[];
+    catchAllLegacyFollowings: SnsLegacyFollowings | undefined;
     closeModal: () => void;
     openNextStep: () => void;
     removeFollowing: (args: {
@@ -33,16 +38,19 @@
       nsFunction: SnsNervousSystemFunction;
       followee: SnsNeuronId;
     }) => void;
+    openDeactivateCatchAllStep: () => void;
   };
   let {
     neuron,
     topicInfos,
     selectedTopics = $bindable(),
     followings,
+    catchAllLegacyFollowings,
     closeModal,
     openNextStep,
     removeFollowing,
     removeLegacyFollowing,
+    openDeactivateCatchAllStep,
   }: Props = $props();
 
   const criticalTopicInfos: TopicInfoWithUnknown[] = $derived(
@@ -106,12 +114,21 @@
   </div>
 
   <div class="topic-group" data-tid="non-critical-topic-group">
-    <h5 class="headline description"
-      >{$i18n.follow_sns_topics.topics_non_critical_label}
-      <TooltipIcon
-        >{$i18n.follow_sns_topics.topics_critical_tooltip}</TooltipIcon
-      ></h5
-    >
+    <div class="topic-group-header">
+      <h5 class="headline description"
+        >{$i18n.follow_sns_topics.topics_non_critical_label}
+        <TooltipIcon
+          >{$i18n.follow_sns_topics.topics_critical_tooltip}</TooltipIcon
+        ></h5
+      >
+      {#if nonNullish(catchAllLegacyFollowings)}
+        <button
+          data-tid="deactivate-catch-all-button"
+          class="ghost"
+          onclick={openDeactivateCatchAllStep}>{"Deactivate catch-all"}</button
+        >
+      {/if}
+    </div>
     {#each nonCriticalTopicInfos as topicInfo}
       <FollowSnsNeuronsByTopicItem
         {topicInfo}
@@ -158,6 +175,16 @@
 
     .headline {
       margin: var(--padding) 0;
+    }
+  }
+
+  .topic-group-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    button {
+      color: var(--primary);
     }
   }
 </style>

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -23,6 +23,7 @@ export type BusyStateInitiatorType =
   | "add-followee"
   | "add-followee-by-topic"
   | "remove-followee-by-topic"
+  | "remove-sns-catch-all-followee"
   | "remove-followee"
   | "add-hotkey-neuron"
   | "remove-hotkey-neuron"

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -460,9 +460,11 @@ interface I18nFollow_sns_topics {
   neuron_follow: string;
   busy_updating: string;
   busy_removing: string;
+  busy_removing_catch_all: string;
   busy_removing_legacy: string;
   success_set_following: string;
   success_removing_legacy: string;
+  success_removing_catch_all: string;
   error_neuron_not_exist: string;
   error_add_following: string;
   error_remove_following: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -442,6 +442,7 @@ interface I18nFollow_sns_topics {
   topic_definitions_title: string;
   topics_title: string;
   legacy_title: string;
+  deactivate_catch_all_title: string;
   topics_description: string;
   topics_critical_label: string;
   topics_critical_tooltip: string;

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -749,7 +749,6 @@ describe("FollowSnsNeuronsByTopicModal", () => {
       const deactivateCatchAllStepPo =
         po.getFollowSnsNeuronsByTopicStepDeactivateCatchAllPo();
 
-      // Select a topic
       expect(await topicsStepPo.isPresent()).toEqual(true);
       expect(await deactivateCatchAllStepPo.isPresent()).toEqual(false);
 
@@ -762,6 +761,69 @@ describe("FollowSnsNeuronsByTopicModal", () => {
 
       expect(await topicsStepPo.isPresent()).toEqual(true);
       expect(await deactivateCatchAllStepPo.isPresent()).toEqual(false);
+    });
+
+    it("removes catch-all legacy following", async () => {
+      let resolveSetFollowees;
+      const setFolloweesSpy = vi
+        .spyOn(snsGovernanceApi, "setFollowees")
+        .mockImplementation(
+          () => new Promise((resolve) => (resolveSetFollowees = resolve))
+        );
+      const reloadNeuronSpy = vi.fn();
+      const closeModalSpy = vi.fn();
+      const po = renderComponent({
+        ...defaultProps,
+        neuron: {
+          ...neuron,
+          followees: [
+            [
+              0n,
+              { followees: [legacyFolloweeNeuronId1, legacyFolloweeNeuronId2] },
+            ],
+          ],
+        },
+        reloadNeuron: reloadNeuronSpy,
+        closeModal: closeModalSpy,
+      });
+
+      const topicsStepPo = po.getFollowSnsNeuronsByTopicStepTopicsPo();
+      const deactivateCatchAllStepPo =
+        po.getFollowSnsNeuronsByTopicStepDeactivateCatchAllPo();
+
+      await topicsStepPo.clickDeactivateCatchAllButton();
+      await deactivateCatchAllStepPo.clickConfirmButton();
+
+      expect(get(busyStore)).toEqual([
+        {
+          initiator: "remove-sns-catch-all-followee",
+          text: "Removing catch-all followings",
+        },
+      ]);
+      expect(get(toastsStore)).toEqual([]);
+
+      expect(setFolloweesSpy).toBeCalledTimes(1);
+      expect(setFolloweesSpy).toBeCalledWith({
+        rootCanisterId,
+        identity: mockIdentity,
+        neuronId: fromNullable(neuron.id),
+        functionId: 0n,
+        followees: [],
+      });
+
+      expect(reloadNeuronSpy).toBeCalledTimes(0);
+      resolveSetFollowees();
+      await runResolvedPromises();
+
+      expect(reloadNeuronSpy).toBeCalledTimes(1);
+      expect(closeModalSpy).toBeCalledTimes(0);
+      expect(get(busyStore)).toEqual([]);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: 'The neuron legacy "Catch-all" followings successfully removed.',
+        },
+      ]);
     });
   });
 });

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -729,4 +729,39 @@ describe("FollowSnsNeuronsByTopicModal", () => {
     expect(await legacyStepPo.isPresent()).toEqual(false);
     expect(await neuronStepPo.isPresent()).toEqual(false);
   });
+
+  describe("Deactivate catch-all", () => {
+    it("navigates to the deactivate catch-all", async () => {
+      const po = renderComponent({
+        ...defaultProps,
+        neuron: {
+          ...neuron,
+          followees: [
+            [
+              // catch-all followings
+              0n,
+              { followees: [legacyFolloweeNeuronId1, legacyFolloweeNeuronId2] },
+            ],
+          ],
+        },
+      });
+      const topicsStepPo = po.getFollowSnsNeuronsByTopicStepTopicsPo();
+      const deactivateCatchAllStepPo =
+        po.getFollowSnsNeuronsByTopicStepDeactivateCatchAllPo();
+
+      // Select a topic
+      expect(await topicsStepPo.isPresent()).toEqual(true);
+      expect(await deactivateCatchAllStepPo.isPresent()).toEqual(false);
+
+      await topicsStepPo.clickDeactivateCatchAllButton();
+
+      expect(await topicsStepPo.isPresent()).toEqual(false);
+      expect(await deactivateCatchAllStepPo.isPresent()).toEqual(true);
+
+      await deactivateCatchAllStepPo.clickCancelButton();
+
+      expect(await topicsStepPo.isPresent()).toEqual(true);
+      expect(await deactivateCatchAllStepPo.isPresent()).toEqual(false);
+    });
+  });
 });

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
@@ -1,5 +1,9 @@
 import FollowSnsNeuronsByTopicStepTopics from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte";
-import type { SnsTopicFollowing, SnsTopicKey } from "$lib/types/sns";
+import type {
+  SnsLegacyFollowings,
+  SnsTopicFollowing,
+  SnsTopicKey,
+} from "$lib/types/sns";
 import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
@@ -100,6 +104,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     selectedTopics: SnsTopicKey[];
     topicInfos: TopicInfoWithUnknown[];
     followings: SnsTopicFollowing[];
+    catchAllLegacyFollowings: SnsLegacyFollowings | undefined;
     closeModal: () => void;
     openNextStep: () => void;
     removeFollowing: (args: {
@@ -110,6 +115,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
       nsFunction: SnsNervousSystemFunction;
       followee: SnsNeuronId;
     }) => void;
+    openDeactivateCatchAllStep: () => void;
   }) => {
     const { container } = render(FollowSnsNeuronsByTopicStepTopics, {
       props,
@@ -124,10 +130,12 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     selectedTopics: [],
     topicInfos: [],
     followings: [],
+    catchAllLegacyFollowings: undefined,
     closeModal: vi.fn(),
     openNextStep: vi.fn(),
     removeFollowing: vi.fn(),
     removeLegacyFollowing: vi.fn(),
+    openDeactivateCatchAllStep: vi.fn(),
   };
 
   it("displays critical and non-critical topics", async () => {
@@ -265,6 +273,31 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     expect(closeModal).toBeCalledTimes(1);
     await po.clickNextButton();
     expect(openNextStep).toBeCalledTimes(1);
+  });
+
+  it("displays deactivate catch-all followings when catch-all provided", async () => {
+    const spyOpenDeactivateCatchAllStep = vi.fn();
+    const po = renderComponent({
+      ...defaultProps,
+      catchAllLegacyFollowings: {
+        nsFunction: legacyNsFunction1,
+        followees: [legacyFolloweeNeuronId1],
+      },
+      openDeactivateCatchAllStep: spyOpenDeactivateCatchAllStep,
+    });
+
+    expect(await po.getDeactivateCatchAllButtonPo().isPresent()).toEqual(true);
+    await po.clickDeactivateCatchAllButton();
+    expect(spyOpenDeactivateCatchAllStep).toBeCalledTimes(1);
+  });
+
+  it("doesn't displays deactivate catch-all followings when no catch-all", async () => {
+    const po = renderComponent({
+      ...defaultProps,
+      catchAllLegacyFollowings: undefined,
+    });
+
+    expect(await po.getDeactivateCatchAllButtonPo().isPresent()).toEqual(false);
   });
 
   describe("legacy followees", () => {

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicModal.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicModal.page-object.ts
@@ -1,3 +1,4 @@
+import { FollowSnsNeuronsByTopicStepDeactivateCatchAllPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepDeactivateCatchAll.page-object";
 import { FollowSnsNeuronsByTopicStepLegacyPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepLegacy.page-object";
 import { FollowSnsNeuronsByTopicStepNeuronPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepNeuron.page-object";
 import { FollowSnsNeuronsByTopicStepTopicsPo } from "$tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object";
@@ -29,5 +30,9 @@ export class FollowSnsNeuronsByTopicModalPo extends ModalPo {
 
   getFollowSnsNeuronsByTopicStepNeuronPo(): FollowSnsNeuronsByTopicStepNeuronPo {
     return FollowSnsNeuronsByTopicStepNeuronPo.under(this.root);
+  }
+
+  getFollowSnsNeuronsByTopicStepDeactivateCatchAllPo(): FollowSnsNeuronsByTopicStepDeactivateCatchAllPo {
+    return FollowSnsNeuronsByTopicStepDeactivateCatchAllPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowSnsNeuronsByTopicStepTopics.page-object.ts
@@ -97,6 +97,13 @@ export class FollowSnsNeuronsByTopicStepTopicsPo extends BasePageObject {
     });
   }
 
+  getDeactivateCatchAllButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "deactivate-catch-all-button",
+    });
+  }
+
   async getFollowSnsNeuronsByTopicLegacyFolloweePos(): Promise<
     FollowSnsNeuronsByTopicLegacyFolloweePo[]
   > {
@@ -109,5 +116,9 @@ export class FollowSnsNeuronsByTopicStepTopicsPo extends BasePageObject {
 
   clickCancelButton(): Promise<void> {
     return this.getCancelButtonPo().click();
+  }
+
+  clickDeactivateCatchAllButton(): Promise<void> {
+    return this.getDeactivateCatchAllButtonPo().click();
   }
 }


### PR DESCRIPTION
# Motivation

As part of the transition to **topic-based voting delegation**, this PR adds the call to deactivate Catch-all legacy followings. 

[Jira Ticket → NNS1-3744](https://dfinity.atlassian.net/browse/NNS1-3744)  

https://github.com/user-attachments/assets/6c49d214-04e0-44bb-8a91-e79a2a7a885c

# Changes

- Call remove catch-all on "Confirm" button click;

# Tests

- Added.
- Verified manually that the catch-all are removable now.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
