### PR TITLE
feat(proposals): integrate sns topic filtering button and modal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+- Topic-based filtering for SNS proposals
+
 #### Changed
 
 #### Deprecated

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -31,7 +31,7 @@
   const enableFilteringBySnsTopicsStore = $derived(
     createEnableFilteringBySnsTopicsStore(rootCanisterId)
   );
-  const isFilterByTopicVisible = $derived(enableFilteringBySnsTopicsStore);
+  const isFilterByTopicVisible = $derived($enableFilteringBySnsTopicsStore);
 </script>
 
 <TestIdWrapper testId="sns-proposals-filters-component">

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -34,7 +34,7 @@
 
   const topics = $derived(get(createSnsTopicsProjectStore(rootCanisterId)));
   const isTopicFilteringUnsupported = $derived(
-    unsupportedFilterByTopicSnsesStore.has(rootCanisterId.toText())
+    $unsupportedFilterByTopicSnsesStore.includes(rootCanisterId.toText())
   );
   const isFilterByTopicVisible = $derived(
     $ENABLE_SNS_TOPICS && nonNullish(topics) && !isTopicFilteringUnsupported

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -6,19 +6,15 @@
   import { actionableProposalsActiveStore } from "$lib/derived/actionable-proposals.derived";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
-  import { createSnsTopicsProjectStore } from "$lib/derived/sns-topics.derived";
+  import { createEnableFilteringBySnsTopicsStore } from "$lib/derived/sns-topics.derived";
   import SnsFilterStatusModal from "$lib/modals/sns/proposals/SnsFilterStatusModal.svelte";
   import SnsFilterTopicsModal from "$lib/modals/sns/proposals/SnsFilterTopicsModal.svelte";
   import SnsFilterTypesModal from "$lib/modals/sns/proposals/SnsFilterTypesModal.svelte";
-  import { ENABLE_SNS_TOPICS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import {
     snsFiltersStore,
     type ProjectFiltersStoreData,
   } from "$lib/stores/sns-filters.store";
-  import { unsupportedFilterByTopicSnsesStore } from "$lib/stores/sns-unsupported-filter-by-topic.store";
-  import { nonNullish } from "@dfinity/utils";
-  import { get } from "svelte/store";
 
   type Filters = "types" | "status" | "topics";
 
@@ -32,13 +28,10 @@
   const openFilters = (filtersModal: Filters) => (modal = filtersModal);
   const closeModal = () => (modal = undefined);
 
-  const topics = $derived(get(createSnsTopicsProjectStore(rootCanisterId)));
-  const isTopicFilteringUnsupported = $derived(
-    $unsupportedFilterByTopicSnsesStore.includes(rootCanisterId.toText())
+  const enableFilteringBySnsTopicsStore = $derived(
+    createEnableFilteringBySnsTopicsStore(rootCanisterId)
   );
-  const isFilterByTopicVisible = $derived(
-    $ENABLE_SNS_TOPICS && nonNullish(topics) && !isTopicFilteringUnsupported
-  );
+  const isFilterByTopicVisible = $derived(enableFilteringBySnsTopicsStore);
 </script>
 
 <TestIdWrapper testId="sns-proposals-filters-component">

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -131,7 +131,7 @@ describe("SnsProposalsFilters", () => {
     });
   });
 
-  describe.only("filter by topics is on", () => {
+  describe("filter by topics is on", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_SNS_TOPICS", true);
 

--- a/frontend/src/tests/page-objects/SnsProposalFilters.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalFilters.page-object.ts
@@ -11,28 +11,36 @@ export class SnsProposalFiltersPo extends BasePageObject {
     return new SnsProposalFiltersPo(element.byTestId(SnsProposalFiltersPo.TID));
   }
 
-  getFilterByTypesButton(): ButtonPo {
+  getFilterByTypesButtonPo(): ButtonPo {
     return this.getButton("filters-by-types");
   }
 
-  getFilterByRewardsButton(): ButtonPo {
+  getFilterByRewardsButtonPo(): ButtonPo {
     return this.getButton("filters-by-rewards");
   }
 
-  getFilterByStatusButton(): ButtonPo {
+  getFilterByStatusButtonPo(): ButtonPo {
     return this.getButton("filters-by-status");
   }
 
+  getFilterByTopicsButtonPo(): ButtonPo {
+    return this.getButton("filters-by-topics");
+  }
+
   clickFiltersByTypesButton(): Promise<void> {
-    return this.getFilterByTypesButton().click();
+    return this.getFilterByTypesButtonPo().click();
   }
 
   clickFiltersByRewardsButton(): Promise<void> {
-    return this.getFilterByRewardsButton().click();
+    return this.getFilterByRewardsButtonPo().click();
   }
 
   clickFiltersByStatusButton(): Promise<void> {
-    return this.getFilterByStatusButton().click();
+    return this.getFilterByStatusButtonPo().click();
+  }
+
+  clickFiltersByTopicButton(): Promise<void> {
+    return this.getFilterByTopicsButtonPo().click();
   }
 
   getFilterModalPo(): FilterModalPo {


### PR DESCRIPTION
# Motivation

We want users to filter proposals for a specific project by topic. To achieve this, a new button will appear on the proposals page, displaying a modal with all available topics for filtering.

This button will be visible only if:
-  The feature flag is enabled
-  The SNS aggregator returns topics for the specific project
-  The SNS Governance canister supports listing proposals by topic

https://github.com/user-attachments/assets/ceab85d5-13ec-48fe-b82d-e999ca82b851


[NNS1-3666](https://dfinity.atlassian.net/browse/NNS1-3666)

# Changes

- Conditionally render button to open topics modal.
- Show `SnsFilterTopicsModal` if topics modal button was clicked.

# Tests

- Added tests to check that appropriate buttons is displayed.
- Rename some methods returning page-objects to be consistent.

# Todos

- [ ] Add entry to changelog (if necessary).


[NNS1-3666]: https://dfinity.atlassian.net/browse/NNS1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ