### PR TITLE
feat(ui): implement Highlight component for one-time announcements

### DIFF
--- a/frontend/src/lib/components/ui/Highlight.svelte
+++ b/frontend/src/lib/components/ui/Highlight.svelte
@@ -104,12 +104,14 @@
     border-radius: var(--border-radius);
     box-shadow: var(--strong-shadow, 8px 8px 16px 0 rgba(0, 0, 0, 0.25));
 
-    background: var(--card-background);
+    background: var(--card-background-tint);
     color: var(--content-color);
 
-    width: 320px;
+    min-width: 320px;
+    width: 90%;
     height: 204px;
 
+    top: calc(var(--header-height) + var(--padding-2x));
     right: auto;
     left: 50%;
     transform: translateX(-50%);
@@ -121,6 +123,7 @@
       bottom: 64px;
       transform: translateX(0);
       left: auto;
+      top: auto;
     }
 
     .highlight-wrapper {

--- a/frontend/src/lib/components/ui/Highlight.svelte
+++ b/frontend/src/lib/components/ui/Highlight.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import {
+    IconCheck,
+    IconClose,
+    IconErrorOutline,
+    IconEyeOpen,
+  } from "@dfinity/gix-components";
+  import type { Component } from "svelte";
+
+  type Props = {
+    level: "info" | "success" | "warn" | "danger";
+    title: string;
+    description: string;
+    link: string;
+  };
+
+  const { level, title, description, link }: Props = $props();
+
+  let isOpen = $state(true);
+
+  const iconMapper: Record<Props["level"], Component> = {
+    ["info"]: IconEyeOpen,
+    ["success"]: IconCheck,
+    ["warn"]: IconErrorOutline,
+    ["danger"]: IconErrorOutline,
+  };
+
+  const Icon = $derived(iconMapper[level]);
+  const close = () => {
+    isOpen = false;
+  };
+</script>
+
+{#if isOpen}
+  <div class="highlight">
+    <div class="highlight-wrapper">
+      <div class="highlight-header">
+        <div class="highlight-icon {level}" aria-hidden="true">
+          <Icon size="24" />
+        </div>
+
+        <button
+          data-tid="close-button"
+          class="close"
+          onclick={close}
+          aria-label={$i18n.core.close}><IconClose /></button
+        >
+      </div>
+
+      <div class="highlight-title">{title}</div>
+      <div class="highlight-content">
+        <p class="highlight-description">{description}</p>
+
+        <a href={link} class="highlight-link">View more</a>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .highlight {
+    box-sizing: border-box;
+
+    position: fixed;
+    z-index: 1000;
+    padding: var(--padding-2x) var(--padding-3x);
+
+    border-radius: var(--border-radius);
+    box-shadow: var(--strong-shadow, 8px 8px 16px 0 rgba(0, 0, 0, 0.25));
+
+    background: var(--card-background);
+
+    width: 320px;
+    height: 204px;
+
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
+
+    @include media.min-width(medium) {
+      width: 423px;
+
+      right: 48px;
+      bottom: 64px;
+      transform: translateX(0);
+      left: auto;
+    }
+
+    .highlight-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-2x);
+
+      .highlight-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        .highlight-icon {
+          border-radius: 50%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 40px;
+          height: 40px;
+
+          &.info {
+            background-color: var(--background);
+            color: var(--background-contrast);
+          }
+
+          &.success {
+            background-color: var(--positive-emphasis-light);
+            color: var(--positive-emphasis);
+          }
+
+          &.warn {
+            background-color: var(--warning-emphasis-light);
+            color: var(--warning-emphasis);
+          }
+
+          &.danger {
+            background-color: var(--negative-emphasis-light);
+            color: var(--negative-emphasis);
+          }
+        }
+      }
+
+      .highlight-title {
+        @include fonts.h5();
+        font-weight: bold;
+      }
+
+      .highlight-content {
+        @include fonts.standard();
+
+        display: flex;
+        flex-direction: column;
+        gap: var(--padding);
+
+        .highlight-link {
+          color: var(--button-secondary-color);
+          font-weight: var(--font-weight-bold);
+          text-decoration: none;
+        }
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -7,7 +7,7 @@ export enum StoreLocalStorageKey {
   JsonRepresentation = "jsonRepresentation",
   HideZeroBalances = "nnsHideZeroBalanceTokens",
   HideZeroNeurons = "nnsHideZeroNeuronProjects",
-  HighlightClosedPrefix = "nnsHighlightClosed-",
+  HighlightDisplay = "nnsHighlightDisplay-",
 }
 
 export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -7,6 +7,7 @@ export enum StoreLocalStorageKey {
   JsonRepresentation = "jsonRepresentation",
   HideZeroBalances = "nnsHideZeroBalanceTokens",
   HideZeroNeurons = "nnsHideZeroNeuronProjects",
+  HighlightClosedPrefix = "nnsHighlightClosed-",
 }
 
 export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -36,7 +36,8 @@
     "collapse_all": "Collapse All",
     "or": "or",
     "add": "Add",
-    "not_applicable": "N/A"
+    "not_applicable": "N/A",
+    "view_more": "View more"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -40,6 +40,7 @@ interface I18nCore {
   or: string;
   add: string;
   not_applicable: string;
+  view_more: string;
 }
 
 interface I18nError {

--- a/frontend/src/tests/lib/components/ui/Highlight.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Highlight.spec.ts
@@ -1,5 +1,3 @@
-// nns-dapp/frontend/src/tests/lib/components/ui/Highlight.spec.ts
-
 import Highlight from "$lib/components/ui/Highlight.svelte";
 import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import { HighlightPo } from "$tests/page-objects/Highlight.page-object";
@@ -16,7 +14,7 @@ describe("Highlight", () => {
   };
 
   const getStorageKey = (id: string) =>
-    `${StoreLocalStorageKey.HighlightClosedPrefix}${id}`;
+    `${StoreLocalStorageKey.HighlightDisplay}${id}`;
 
   const renderComponent = (props = defaultProps) => {
     const { container } = render(Highlight, props);
@@ -24,7 +22,6 @@ describe("Highlight", () => {
   };
 
   beforeEach(() => {
-    // Clear localStorage before each test
     localStorage.clear();
   });
 
@@ -37,19 +34,23 @@ describe("Highlight", () => {
   });
 
   it("should hide the component when the close button is clicked", async () => {
+    vi.useFakeTimers();
+
     const po = renderComponent();
 
     expect(await po.isPresent()).toBe(true);
 
     await po.clickClose();
 
+    vi.advanceTimersByTime(1000);
+
     expect(await po.isPresent()).toBe(false);
 
-    expect(localStorage.getItem(getStorageKey(defaultProps.id))).toBe("true");
+    expect(localStorage.getItem(getStorageKey(defaultProps.id))).toBe("false");
   });
 
-  it("should not render if localStorage indicates it was closed", async () => {
-    localStorage.setItem(getStorageKey(defaultProps.id), "true");
+  it("should not render if localStorage indicates it is closed", async () => {
+    localStorage.setItem(getStorageKey(defaultProps.id), "false");
 
     const po = renderComponent();
 

--- a/frontend/src/tests/lib/components/ui/Highlight.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Highlight.spec.ts
@@ -1,0 +1,76 @@
+// nns-dapp/frontend/src/tests/lib/components/ui/Highlight.spec.ts
+
+import Highlight from "$lib/components/ui/Highlight.svelte";
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
+import { HighlightPo } from "$tests/page-objects/Highlight.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("Highlight", () => {
+  const defaultProps = {
+    id: "test-highlight",
+    level: "info" as const,
+    title: "Test Title",
+    description: "Test Description",
+    link: "https://example.com",
+  };
+
+  const getStorageKey = (id: string) =>
+    `${StoreLocalStorageKey.HighlightClosedPrefix}${id}`;
+
+  const renderComponent = (props = defaultProps) => {
+    const { container } = render(Highlight, props);
+    return HighlightPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear();
+  });
+
+  it("should render by default", async () => {
+    const po = renderComponent();
+
+    expect(await po.isPresent()).toBe(true);
+    expect(await po.getTitle()).toBe(defaultProps.title);
+    expect(await po.getDescription()).toBe(defaultProps.description);
+  });
+
+  it("should hide the component when the close button is clicked", async () => {
+    const po = renderComponent();
+
+    expect(await po.isPresent()).toBe(true);
+
+    await po.clickClose();
+
+    expect(await po.isPresent()).toBe(false);
+
+    expect(localStorage.getItem(getStorageKey(defaultProps.id))).toBe("true");
+  });
+
+  it("should not render if localStorage indicates it was closed", async () => {
+    localStorage.setItem(getStorageKey(defaultProps.id), "true");
+
+    const po = renderComponent();
+
+    expect(await po.isPresent()).toBe(false);
+  });
+
+  it("should render when different id is used even if another highlight was closed", async () => {
+    localStorage.setItem(getStorageKey("other-id"), "true");
+
+    const po = renderComponent();
+
+    expect(await po.isPresent()).toBe(true);
+  });
+
+  it("should not render link when link prop is not provided", async () => {
+    const po = renderComponent({
+      ...defaultProps,
+      link: undefined,
+    });
+
+    expect(await po.isPresent()).toBe(true);
+    expect(await po.hasLink()).toBe(false);
+  });
+});

--- a/frontend/src/tests/page-objects/Highlight.page-object.ts
+++ b/frontend/src/tests/page-objects/Highlight.page-object.ts
@@ -1,0 +1,35 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class HighlightPo extends BasePageObject {
+  private static readonly TID = "highlight-component";
+
+  static under(element: PageObjectElement): HighlightPo {
+    return new HighlightPo(element.byTestId(HighlightPo.TID));
+  }
+
+  getCloseButtonPo(): ButtonPo {
+    return this.getButton("close-button");
+  }
+
+  async getTitle(): Promise<string> {
+    return this.getText("highlight-title");
+  }
+
+  async getDescription(): Promise<string> {
+    return this.getText("highlight-description");
+  }
+
+  async getLinkPo(): Promise<PageObjectElement> {
+    return this.getElement("highlight-link");
+  }
+
+  async hasLink(): Promise<boolean> {
+    return await (await this.getLinkPo()).isPresent();
+  }
+
+  async clickClose(): Promise<void> {
+    await this.getCloseButtonPo().click();
+  }
+}


### PR DESCRIPTION
# Motivation

We want to display special messages to users to notify them of new features in the nns-dapp. These messages should appear only once. After closing them, they should be saved locally on the device and not shown again.

This PR introduces a new component, `Highlight`, designed for this purpose. The logic for when and where to display it will be determined by the component's consumers.

On mobile devices, the component will be displayed at the center top, while on tablet and desktop devices, it will appear at the bottom right.

<img width="1506" alt="Screenshot 2025-04-29 at 16 43 43" src="https://github.com/user-attachments/assets/119683fd-82c8-4d53-bfb0-5dedd88ad319" />

<img width="451" alt="Screenshot 2025-04-29 at 16 43 54" src="https://github.com/user-attachments/assets/a27e0fff-2e03-421d-94de-1ca7b27ac59e" />

<img width="1512" alt="Screenshot 2025-04-29 at 16 44 31" src="https://github.com/user-attachments/assets/433a934c-34f9-40c8-8205-24ccccf4934d" />

<img width="1511" alt="Screenshot 2025-04-29 at 16 45 02" src="https://github.com/user-attachments/assets/f7c1f193-4d6e-43e9-b41e-a005f31ecc2e" />

<img width="1502" alt="Screenshot 2025-04-29 at 16 45 20" src="https://github.com/user-attachments/assets/3f166eab-dd36-45b0-a300-a0d93d6a3e30" />

<img width="1512" alt="Screenshot 2025-04-29 at 16 45 38" src="https://github.com/user-attachments/assets/6b6f9e7c-3ebb-4001-8322-887921ec6c74" />


[NNS1-3749](https://dfinity.atlassian.net/browse/NNS1-3749)

# Changes

- Add a new component, `Highlight`, to display a one-time device message.

# Tests

- Unit tests for the component.
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3749]: https://dfinity.atlassian.net/browse/NNS1-3749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ