### PR TITLE
fix(ui): add followee button visibility after addition

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -70,3 +70,4 @@ Changelog
 changelog
 geolocation
 USD
+followee

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- "Add Followee" button is not fully visible after adding a followee
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -2,6 +2,7 @@
   // Tested in EditFollowNeurons.spec.ts
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
+  import Separator from "$lib/components/ui/Separator.svelte";
   import NewFolloweeModal from "$lib/modals/neurons/NewFolloweeModal.svelte";
   import { removeFollowee } from "$lib/services/neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
@@ -14,7 +15,6 @@
   } from "$lib/utils/neuron.utils";
   import { IconClose, Value } from "@dfinity/gix-components";
   import { Topic, type NeuronId, type NeuronInfo } from "@dfinity/nns";
-  import Separator from "$lib/components/ui/Separator.svelte";
 
   export let topic: Topic;
   export let neuron: NeuronInfo;
@@ -65,12 +65,13 @@
 
 <TestIdWrapper testId="follow-nns-topic-section-component">
   <FollowTopicSection
-    on:nnsOpen={openNewFolloweeModal}
     id={String(topic)}
     count={followees.length}
+    {openNewFolloweeModal}
   >
     <svelte:fragment slot="title">{title}</svelte:fragment>
     <svelte:fragment slot="subtitle">{subtitle}</svelte:fragment>
+
     <ul>
       {#each followees as followee (followee.neuronId)}
         <li data-tid="current-followee-item">

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -13,12 +13,12 @@
   let testId = $state(defaultTestId);
 
   $effect(() => {
-    count;
+    if (count === 0) return;
     testId = "";
 
     setTimeout(() => {
       testId = defaultTestId;
-    });
+    }, 0);
   });
 </script>
 

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -25,12 +25,16 @@
 <article data-tid={`follow-topic-${id}-section`}>
   <Collapsible {id} iconSize="medium" {testId}>
     <div class="wrapper" slot="header">
+      <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
+      <!-- svelte-ignore slot_element_deprecated -->
       <span class="value" data-tid="topic-title"><slot name="title" /></span>
       <span class="badge" data-tid={`topic-${id}-followees-badge`}>
         {count}
       </span>
     </div>
     <div class="content" data-tid="follow-topic-section-current">
+      <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
+      <!-- svelte-ignore slot_element_deprecated -->
       <p class="subtitle description"><slot name="subtitle" /></p>
 
       {#if count > 0}
@@ -43,6 +47,8 @@
       {/if}
 
       <div class="followees-wrapper">
+        <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
+        <!-- svelte-ignore slot_element_deprecated -->
         <slot />
       </div>
       <div class="button-wrapper">

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -1,19 +1,29 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { Collapsible } from "@dfinity/gix-components";
-  import { createEventDispatcher } from "svelte";
 
-  export let id: string;
-  export let count: number;
-
-  const dispatcher = createEventDispatcher();
-  const open = () => {
-    dispatcher("nnsOpen");
+  type Props = {
+    id: string;
+    count: number;
+    openNewFolloweeModal: () => void;
   };
+
+  const { id, count, openNewFolloweeModal }: Props = $props();
+  const defaultTestId = "collapsible";
+  let testId = $state(defaultTestId);
+
+  $effect(() => {
+    count;
+    testId = "";
+
+    setTimeout(() => {
+      testId = defaultTestId;
+    });
+  });
 </script>
 
 <article data-tid={`follow-topic-${id}-section`}>
-  <Collapsible {id} iconSize="medium" testId="collapsible">
+  <Collapsible {id} iconSize="medium" {testId}>
     <div class="wrapper" slot="header">
       <span class="value" data-tid="topic-title"><slot name="title" /></span>
       <span class="badge" data-tid={`topic-${id}-followees-badge`}>
@@ -39,7 +49,7 @@
         <button
           class="primary"
           data-tid="open-new-followee-modal"
-          on:click={open}>{$i18n.follow_neurons.add}</button
+          onclick={openNewFolloweeModal}>{$i18n.follow_neurons.add}</button
         >
       </div>
     </div>

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -59,9 +59,9 @@
 
 <TestIdWrapper testId="follow-sns-topic-section-component">
   <FollowTopicSection
-    on:nnsOpen={openModal}
     count={followees.length}
     id={nsFunction.id.toString()}
+    openNewFolloweeModal={openModal}
   >
     <svelte:fragment slot="title">{nsFunction.name}</svelte:fragment>
     <svelte:fragment slot="subtitle"

--- a/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
@@ -7,6 +7,7 @@ import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { EditFollowNeuronsPo } from "$tests/page-objects/EditFollowNeurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
@@ -97,6 +98,9 @@ describe("EditFollowNeurons", () => {
 
   it("displays the followees of the user in specific topic", async () => {
     const po = renderComponent();
+
+    await runResolvedPromises();
+
     const topicSectionPo = await po.getFollowTopicSectionPo(Topic.ExchangeRate);
     expect(await topicSectionPo.getCollapsiblePo().isExpanded()).toBe(false);
     await topicSectionPo.getCollapsiblePo().expand();

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
@@ -1,7 +1,7 @@
 import FollowTopicsSection from "$lib/components/neurons/FollowTopicSection.svelte";
 import FollowTopicsSectionTest from "$tests/lib/components/neurons/FollowTopicSectionTest.svelte";
 import { render } from "$tests/utils/svelte.test-utils";
-import { fireEvent, waitFor } from "@testing-library/svelte";
+import { fireEvent } from "@testing-library/svelte";
 
 describe("FollowTopicsSection", () => {
   const title = "title";
@@ -38,16 +38,14 @@ describe("FollowTopicsSection", () => {
       props: {
         id: "3",
         count: 4,
-      },
-      events: {
-        nnsOpen: openSpy,
+        openNewFolloweeModal: openSpy,
       },
     });
 
     const button = queryByTestId("open-new-followee-modal");
     button && fireEvent.click(button);
 
-    await waitFor(() => expect(openSpy).toBeCalled());
+    expect(openSpy).toBeCalled();
   });
 
   it("should not render currently following label ", () => {


### PR DESCRIPTION
# Motivation

We have an issue with the "Add Followee" button, which becomes partially hidden after adding a followee (#6715).

This problem relates to how Svelte calculates dynamic spaces for our `Collapsible` component.  As this flow will be change in a near future to to use topic following similar to how the SNS governance is handled, the propose solution is to force `Collapsible` to re-calculate its height by updating one prop.

Before:

https://github.com/user-attachments/assets/e7a5d55c-56d6-41de-981c-e9a54d0c67ce

After:

https://github.com/user-attachments/assets/1d12ed49-3f3a-4494-ae45-925ab5f59d69

Closes #6715.

# Changes

- Temporarily change a prop to retrigger the height calculation.
- Refactor to Svelte 5.

# Tests

- Update unit tests
- Tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network)

# Todos

- [ ] Add entry to changelog (if necessary).
