### PR TITLE
(sns-demo): Adjusting sns-following card content

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -69,9 +69,6 @@
     $ENABLE_SNS_TOPICS &&
     nonNullish(rootCanisterId) &&
     nonNullish($snsTopicsStore[rootCanisterId?.toText()]);
-
-  let hideFollowees: boolean;
-  $: hideFollowees = isFollowByTopic && $ENABLE_SNS_TOPICS;
 </script>
 
 <CardInfo noMargin testId="sns-neuron-following-card-component">
@@ -95,7 +92,7 @@
     </svelte:fragment>
   </KeyValuePairInfo>
 
-  {#if !hideFollowees && followees.length > 0}
+  {#if !isFollowByTopic && followees.length > 0}
     <div class="frame">
       {#each followees as followee}
         <SnsFollowee {followee} />
@@ -103,7 +100,7 @@
     </div>
   {/if}
 
-  {#if $ENABLE_SNS_TOPICS && isFollowByTopic}
+  {#if isFollowByTopic}
     <button
       data-tid="sns-topic-definitions-button"
       class="ghost with-icon sns-topic-definitions-button"

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -69,6 +69,9 @@
     $ENABLE_SNS_TOPICS &&
     nonNullish(rootCanisterId) &&
     nonNullish($snsTopicsStore[rootCanisterId?.toText()]);
+
+  let hideFollowees: boolean;
+  $: hideFollowees = isFollowByTopic && $ENABLE_SNS_TOPICS;
 </script>
 
 <CardInfo noMargin testId="sns-neuron-following-card-component">
@@ -83,17 +86,6 @@
           <span class="note">
             {$i18n.neuron_detail.following_note}
           </span>
-          <button
-            data-tid="sns-topic-definitions-button"
-            class="ghost with-icon sns-topic-definitions-button"
-            on:click={() =>
-              openSnsNeuronModal({
-                type: "sns-topic-definitions",
-              })}
-          >
-            <span>{$i18n.neuron_detail.following_link} </span>
-            <IconRight />
-          </button>
         {:else}
           <span>
             {$i18n.neuron_detail.following_description_to_be_removed}
@@ -103,12 +95,26 @@
     </svelte:fragment>
   </KeyValuePairInfo>
 
-  {#if followees.length > 0}
+  {#if !hideFollowees && followees.length > 0}
     <div class="frame">
       {#each followees as followee}
         <SnsFollowee {followee} />
       {/each}
     </div>
+  {/if}
+
+  {#if $ENABLE_SNS_TOPICS && isFollowByTopic}
+    <button
+      data-tid="sns-topic-definitions-button"
+      class="ghost with-icon sns-topic-definitions-button"
+      on:click={() =>
+        openSnsNeuronModal({
+          type: "sns-topic-definitions",
+        })}
+    >
+      <span>{$i18n.neuron_detail.following_link} </span>
+      <IconRight />
+    </button>
   {/if}
 
   {#if showLoading}
@@ -151,11 +157,11 @@
     .note {
       @include fonts.small(true);
     }
+  }
 
-    .sns-topic-definitions-button {
-      padding: var(--padding) 0;
-      color: var(--primary);
-      font-weight: var(--font-weight-bold);
-    }
+  .sns-topic-definitions-button {
+    padding: var(--padding) 0 var(--padding-2x);
+    color: var(--primary);
+    font-weight: var(--font-weight-bold);
   }
 </style>


### PR DESCRIPTION
# Motivation

As part of the transition to topic-based voting delegation, this PR introduces minor updates to the "Voting Delegation" section to align with the UI design.

- Do not display legacy followings when topics are available.
- Always display the link to topic definitions when topics are available.

| Collapsed | Expanded |
|--------|--------|
| <img width="786" alt="image" src="https://github.com/user-attachments/assets/ad734c2c-a2ef-476a-8205-1c07a54d79f5" /> | <img width="783" alt="image" src="https://github.com/user-attachments/assets/733952ce-8c6e-4b7e-b02b-2946b4c3d583" /> | 

# Changes

- Add the visibility logic for the block elements.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.