### PR TITLE
feat(store): add SNS topic feature support detection

### DIFF
--- a/frontend/src/lib/derived/sns-topics.derived.ts
+++ b/frontend/src/lib/derived/sns-topics.derived.ts
@@ -47,7 +47,7 @@ export const createSnsTopicsProjectStore = (
     }
   );
 
-export const createSnsTopicsProposalsFilteringStore = (
+export const createEnableFilteringBySnsTopicsStore = (
   rootCanisterId: Principal | null | undefined
 ): Readable<boolean> =>
   derived(

--- a/frontend/src/tests/lib/derived/sns-topics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-topics.derived.spec.ts
@@ -1,6 +1,6 @@
 import {
+  createEnableFilteringBySnsTopicsStore,
   createSnsTopicsProjectStore,
-  createSnsTopicsProposalsFilteringStore,
   snsTopicsStore,
 } from "$lib/derived/sns-topics.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
@@ -216,19 +216,19 @@ describe("sns topics store", () => {
     });
 
     it("should return false when rootCanisterId is null", () => {
-      const store = createSnsTopicsProposalsFilteringStore(null);
+      const store = createEnableFilteringBySnsTopicsStore(null);
       expect(get(store)).toBe(false);
     });
 
     it("should return false when rootCanisterId is undefined", () => {
-      const store = createSnsTopicsProposalsFilteringStore(undefined);
+      const store = createEnableFilteringBySnsTopicsStore(undefined);
       expect(get(store)).toBe(false);
     });
 
     it("should return false when ENABLE_SNS_TOPICS is false", () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_SNS_TOPICS", false);
 
-      const store = createSnsTopicsProposalsFilteringStore(mockPrincipal);
+      const store = createEnableFilteringBySnsTopicsStore(mockPrincipal);
       expect(get(store)).toBe(false);
     });
 
@@ -239,19 +239,19 @@ describe("sns topics store", () => {
         },
       ]);
 
-      const store = createSnsTopicsProposalsFilteringStore(mockPrincipal);
+      const store = createEnableFilteringBySnsTopicsStore(mockPrincipal);
       expect(get(store)).toBe(false);
     });
 
     it("should return false when the project is in the unsupportedFilterByTopicSnsesStore", () => {
       unsupportedFilterByTopicSnsesStore.add(mockPrincipal.toText());
 
-      const store = createSnsTopicsProposalsFilteringStore(mockPrincipal);
+      const store = createEnableFilteringBySnsTopicsStore(mockPrincipal);
       expect(get(store)).toBe(false);
     });
 
     it("should return true when all conditions are met", () => {
-      const store = createSnsTopicsProposalsFilteringStore(mockPrincipal);
+      const store = createEnableFilteringBySnsTopicsStore(mockPrincipal);
       expect(get(store)).toBe(true);
     });
   });


### PR DESCRIPTION
# Motivation

For the upcoming "Following by Topic" feature in SNS projects, not all projects currently support topic filtering. Therefore, we want to create a derived store that indicates whether a specific project supports this feature. 

The conditions for a project to support it are:
* The feature flag is enabled.
* The SNS aggregator returns topics for the project.
* The governance canister of the SNS supports filtering by topics.

# Changes

- New derived store

# Tests

- Unit tests for the derived store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.