### PR TITLE
(sns-topics): Remove "remove" buttons

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicLegacyFollowee.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicLegacyFollowee.svelte
@@ -5,7 +5,7 @@
   type Props = {
     nsFunction: SnsNervousSystemFunction;
     neuronId: SnsNeuronId;
-    onRemoveClick: () => void;
+    onRemoveClick?: () => void;
   };
   const { nsFunction, neuronId, onRemoveClick }: Props = $props();
 </script>

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepDeactivateCatchAll.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepDeactivateCatchAll.svelte
@@ -39,9 +39,6 @@
         <FollowSnsNeuronsByTopicLegacyFollowee
           nsFunction={catchAllFollowing.nsFunction}
           {neuronId}
-          onRemoveClick={() => {
-            // TODO(sns-topics): Make it optional
-          }}
         />
       </li>
     {/each}

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepLegacy.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepLegacy.svelte
@@ -79,9 +79,6 @@
             <FollowSnsNeuronsByTopicLegacyFollowee
               nsFunction={followees.nsFunction}
               {neuronId}
-              onRemoveClick={() => {
-                // TODO: call a callback
-              }}
             />
           </li>
         {/each}


### PR DESCRIPTION
# Motivation

As part of the transition to topic-based voting delegation, legacy tags displayed in the confirmation step should not be removable via the “X” icon.  
This PR removes the remove buttons from legacy followee tags in the `confirm-rewrite-legacy` and `confirm-deactivating-all-non-critical` steps.

# Changes

- Remove `onRemoveClick` params.

# Tests

- Added.
- Verifying manually that these tags have no remove buttons.

| FollowSnsNeuronsByTopicStepLegacy | FollowSnsNeuronsByTopicStepDeactivateCatchAll |
|--------|--------|
| <img width="638" alt="image" src="https://github.com/user-attachments/assets/1908156e-dd9c-4e8f-95a8-2e21bbf158ef" /> | <img width="629" alt="image" src="https://github.com/user-attachments/assets/b6a96be9-076d-49ce-9816-77b38a2d216e" /> | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.