### PR TITLE
i18n(sns-topics): Add tutorial link

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -59,7 +59,7 @@
     level="info"
     title={$i18n.highlight.topics_feature_title}
     description={$i18n.highlight.topics_feature_description}
-    link="https://internetcomputer.org/docs/building-apps/governing-apps/nns/using-the-nns-dapp/sns-topic-following"
+    link="https://internetcomputer.org/docs/building-apps/governing-apps/nns/using-the-nns-dapp/nns-dapp-sns-topic-following"
     id="topics-feature"
   />
 {/if}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -59,7 +59,7 @@
     level="info"
     title={$i18n.highlight.topics_feature_title}
     description={$i18n.highlight.topics_feature_description}
-    link="#"
+    link="https://internetcomputer.org/docs/building-apps/governing-apps/nns/using-the-nns-dapp/sns-topic-following"
     id="topics-feature"
   />
 {/if}


### PR DESCRIPTION
# Motivation

The Highlight component was [integrated](https://github.com/dfinity/nns-dapp/pull/6766) without the tutorial link to avoid blocking progress. This PR adds the missing URL.

# Changes

- Add tutorial link.

# Tests

- Verified locally that the link works. It currently leads to a blank page, as the tutorial hasn’t been published yet.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.