### PR TITLE
Sns topics/already following error

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -453,7 +453,8 @@
     "success_removing_catch_all": "Legacy \"Catch-All\" followings were successfully removed.",
     "error_neuron_not_exist": "Neuron with ID $neuronId does not exist.",
     "error_add_following": "There was an error while adding a followee.",
-    "error_remove_following": "There was an error while unfollowing the neuron."
+    "error_remove_following": "There was an error while unfollowing the neuron.",
+    "error_already_following": "A voting delegation for the selected topic(s) and the entered neuron ID has already been set."
   },
   "missing_rewards": {
     "description": "ICP neurons that are inactive for $period start missing voting rewards. To avoid missing rewards, vote manually, edit, or confirm your following.",

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -182,14 +182,24 @@
       return;
     }
 
+    const followingsToSet = addSnsNeuronToFollowingsByTopics({
+      topics: selectedTopics,
+      neuronId: followeeNeuronId,
+      followings,
+    });
+
+    if (followingsToSet.length === 0) {
+      stopBusy("add-followee-by-topic");
+      toastsError({
+        labelKey: "follow_sns_topics.error_already_following",
+      });
+      return;
+    }
+
     const { success, error } = await setFollowing({
       rootCanisterId,
       neuronId: fromDefinedNullable(neuron.id),
-      followings: addSnsNeuronToFollowingsByTopics({
-        topics: selectedTopics,
-        neuronId: followeeNeuronId,
-        followings,
-      }),
+      followings: followingsToSet,
     });
 
     if (success) {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -469,6 +469,7 @@ interface I18nFollow_sns_topics {
   error_neuron_not_exist: string;
   error_add_following: string;
   error_remove_following: string;
+  error_already_following: string;
 }
 
 interface I18nMissing_rewards {


### PR DESCRIPTION
# Motivation

This PR improves the user experience when attempting to add a voting delegation that has already been set.

Previously, if a delegation already existed for the selected topic(s) and the entered neuron ID, the user encountered a confusing error message:  
**"There was an error while adding a followee. topic_following must contain at least one element."**

This PR handles that case explicitly and displays a more descriptive message:  
**"A voting delegation for the selected topic(s) and the entered neuron ID has already been set."**

# Changes

- Catch and display already-following error.

# Tests

- Added.
- Verified locally that it works.

https://github.com/user-attachments/assets/26d4658b-d224-44e6-b0cf-9bddf4ac4638

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.