### PR TITLE
feat(security): restrict native feature permissions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -31,6 +31,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+* Added Permissions Policy to enhance browser security controls
+
 #### Not Published
 
 ### Operations

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -307,10 +307,15 @@ fn security_headers() -> Vec<HeaderField> {
     vec![
         ("X-Frame-Options".to_string(), "DENY".to_string()),
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
-        ("Strict-Transport-Security".to_string(), "max-age=31536000 ; includeSubDomains".to_string()),
+        (
+            "Strict-Transport-Security".to_string(),
+            "max-age=31536000 ; includeSubDomains".to_string(),
+        ),
         // "Referrer-Policy: no-referrer" would be more strict, but breaks local dev deployment same-origin is still ok from a security perspective
         ("Referrer-Policy".to_string(), "same-origin".to_string()),
-        ("Permissions-Policy".to_string(), "accelerometer=(),\
+        (
+            "Permissions-Policy".to_string(),
+            "accelerometer=(),\
          ambient-light-sensor=(),\
          autoplay=(),\
          battery=(),\
@@ -351,7 +356,8 @@ fn security_headers() -> Vec<HeaderField> {
          web-share=(),\
          window-placement=(),\
          xr-spatial-tracking=()"
-            .to_string()),
+                .to_string(),
+        ),
     ]
 }
 

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -307,13 +307,51 @@ fn security_headers() -> Vec<HeaderField> {
     vec![
         ("X-Frame-Options".to_string(), "DENY".to_string()),
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
-        (
-            "Strict-Transport-Security".to_string(),
-            "max-age=31536000 ; includeSubDomains".to_string(),
-        ),
-        // "Referrer-Policy: no-referrer" would be more strict, but breaks local dev deployment
-        // same-origin is still ok from a security perspective
+        ("Strict-Transport-Security".to_string(), "max-age=31536000 ; includeSubDomains".to_string()),
+        // "Referrer-Policy: no-referrer" would be more strict, but breaks local dev deployment same-origin is still ok from a security perspective
         ("Referrer-Policy".to_string(), "same-origin".to_string()),
+        ("Permissions-Policy".to_string(), "accelerometer=(),\
+         ambient-light-sensor=(),\
+         autoplay=(),\
+         battery=(),\
+         camera=(self),\
+         clipboard-read=(self),\
+         clipboard-write=(self),\
+         conversion-measurement=(),\
+         cross-origin-isolated=(),\
+         display-capture=(),\
+         document-domain=(),\
+         encrypted-media=(),\
+         execution-while-not-rendered=(),\
+         execution-while-out-of-viewport=(),\
+         focus-without-user-activation=(),\
+         fullscreen=(),\
+         gamepad=(),\
+         geolocation=(),\
+         gyroscope=(),\
+         hid=(),\
+         idle-detection=(),\
+         interest-cohort=(),\
+         keyboard-map=(),\
+         magnetometer=(),\
+         microphone=(),\
+         midi=(),\
+         navigation-override=(),\
+         payment=(),\
+         picture-in-picture=(),\
+         publickey-credentials-get=(),\
+         screen-wake-lock=(),\
+         serial=(),\
+         speaker-selection=(),\
+         sync-script=(),\
+         sync-xhr=(),\
+         trust-token-redemption=(),\
+         usb=(),\
+         vertical-scroll=(),\
+         web-share=(),\
+         window-placement=(),\
+         xr-spatial-tracking=()"
+            .to_string()),
     ]
 }
 


### PR DESCRIPTION
# Motivation

The Security Team has recommended introducing a Permissions Policy for the application to explicitly enable the necessary native features.

This is inspired by the [II configuration](https://github.com/dfinity/internet-identity/blob/39633b45d3aad1f0d3c92f90809b60fd35906625/src/internet_identity/src/http.rs#L93) but is configured for the nns-dapp.

The required permissions are:
-  Camera: for QR code flow.
-  Clipboard: for read and write access.

Note: Some features are not yet supported by major browsers, so we are receiving warnings.

[SECFIND-226](https://dfinity.atlassian.net/browse/SECFIND-226)

# Changes

- Add a list of permissions to `security_headers`

# Tests

- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).


[SECFIND-226]: https://dfinity.atlassian.net/browse/SECFIND-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ