### PR TITLE
chore(deps): bump typescript to 5.5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,7 @@
         "svelte": "^5.28.2",
         "svelte-check": "^4.1.6",
         "svelte-preprocess": "^6.0.3",
-        "typescript": "^5.2.2",
+        "typescript": "^5.5",
         "typescript-eslint": "^8.24.0",
         "vite": "^6.3.3",
         "vitest": "^3.1.2",
@@ -6459,10 +6459,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11173,9 +11174,9 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
     "typescript-eslint": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "svelte": "^5.28.2",
     "svelte-check": "^4.1.6",
     "svelte-preprocess": "^6.0.3",
-    "typescript": "^5.2.2",
+    "typescript": "^5.5",
     "typescript-eslint": "^8.24.0",
     "vite": "^6.3.3",
     "vitest": "^3.1.2",

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -47,5 +47,5 @@ export const icrcTokensUniversesStore: Readable<Universe[]> = derived(
       .map((canisters: IcrcCanisters) =>
         convertIcrcCanistersToUniverse({ canisters, tokensData })
       )
-      .filter((universe) => nonNullish(universe))
+      .filter(nonNullish)
 );

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -47,5 +47,5 @@ export const icrcTokensUniversesStore: Readable<Universe[]> = derived(
       .map((canisters: IcrcCanisters) =>
         convertIcrcCanistersToUniverse({ canisters, tokensData })
       )
-      .filter((universe): universe is Universe => nonNullish(universe))
+      .filter((universe) => nonNullish(universe))
 );

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -52,7 +52,6 @@ import {
   SnsProposalRewardStatus,
   type SnsPercentage,
 } from "@dfinity/sns";
-import type { Topic } from "@dfinity/sns/dist/candid/sns_governance";
 import {
   fromDefinedNullable,
   fromNullable,
@@ -493,16 +492,13 @@ export const toExcludeTypeParameter = ({
 export const toIncludeTopicsParameter = (
   topicsFilter: Filter<SnsProposalTopicFilterId>[]
 ) => {
-  return (
-    topicsFilter
-      .map(({ value }) => {
-        if (value === ALL_SNS_PROPOSALS_WITHOUT_TOPIC) return null;
-        const topic = snsTopicKeyToTopic(value);
-        return isUnknownTopic(topic) ? undefined : topic;
-      })
-      // TODO: Remove type assertion once TS is upgraded to 5.5
-      .filter((topic): topic is Topic | null => topic !== undefined)
-  );
+  return topicsFilter
+    .map(({ value }) => {
+      if (value === ALL_SNS_PROPOSALS_WITHOUT_TOPIC) return null;
+      const topic = snsTopicKeyToTopic(value);
+      return isUnknownTopic(topic) ? undefined : topic;
+    })
+    .filter((topic) => topic !== undefined);
 };
 
 // Generate new "types" filter data, but preserve the checked state of the current filter state


### PR DESCRIPTION
# Motivation

We want to upgrade TypeScript to at least version `5.5`, as it introduced significant improvements to [inferred type predicates](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#inferred-type-predicates).

Note: We cannot upgrade to the latest version yet because TypeScript ESLint is lagging behind.

# Changes

- Bump TS to 5.5  
-  Remove a few instances of filter-type assertions that are no longer required.

# Tests

- Pipeline should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.