### PR TITLE
feat(store): add minimum dissolve delay from network economics

### DIFF
--- a/frontend/src/lib/derived/network-economics.derived.ts
+++ b/frontend/src/lib/derived/network-economics.derived.ts
@@ -1,3 +1,4 @@
+import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";
 import { derived, type Readable } from "svelte/store";
 
@@ -18,11 +19,11 @@ export const clearFollowingAfterSecondsStore: Readable<bigint | undefined> =
         ?.clearFollowingAfterSeconds
   );
 
-export const neuronMinimumDissolveDelayToVoteSeconds: Readable<
-  bigint | undefined
-> = derived(
-  networkEconomicsStore,
-  ($networkEconomicsStore) =>
-    $networkEconomicsStore.parameters?.votingPowerEconomics
-      ?.neuronMinimumDissolveDelayToVoteSeconds
-);
+export const neuronMinimumDissolveDelayToVoteSeconds: Readable<bigint> =
+  derived(
+    networkEconomicsStore,
+    ($networkEconomicsStore) =>
+      $networkEconomicsStore.parameters?.votingPowerEconomics
+        ?.neuronMinimumDissolveDelayToVoteSeconds ??
+      BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE)
+  );

--- a/frontend/src/lib/derived/network-economics.derived.ts
+++ b/frontend/src/lib/derived/network-economics.derived.ts
@@ -17,3 +17,12 @@ export const clearFollowingAfterSecondsStore: Readable<bigint | undefined> =
       $networkEconomicsStore.parameters?.votingPowerEconomics
         ?.clearFollowingAfterSeconds
   );
+
+export const neuronMinimumDissolveDelayToVoteSeconds: Readable<
+  bigint | undefined
+> = derived(
+  networkEconomicsStore,
+  ($networkEconomicsStore) =>
+    $networkEconomicsStore.parameters?.votingPowerEconomics
+      ?.neuronMinimumDissolveDelayToVoteSeconds
+);

--- a/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "$lib/constants/constants";
 import {
   clearFollowingAfterSecondsStore,
+  neuronMinimumDissolveDelayToVoteSeconds,
   startReducingVotingPowerAfterSecondsStore,
 } from "$lib/derived/network-economics.derived";
 import { networkEconomicsStore } from "$lib/stores/network-economics.store";

--- a/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
@@ -24,7 +24,7 @@ describe("network-economics-derived", () => {
     );
   });
 
-  it("should return start reducing voting power", () => {
+  it("should return clear following", () => {
     expect(get(clearFollowingAfterSecondsStore)).toEqual(undefined);
 
     networkEconomicsStore.setParameters({
@@ -34,6 +34,19 @@ describe("network-economics-derived", () => {
 
     expect(get(clearFollowingAfterSecondsStore)).toEqual(
       BigInt(SECONDS_IN_MONTH)
+    );
+  });
+
+  it("should return neuron minimum dissolve delay to vote seconds", () => {
+    expect(get(neuronMinimumDissolveDelayToVoteSeconds)).toEqual(undefined);
+
+    networkEconomicsStore.setParameters({
+      parameters: mockNetworkEconomics,
+      certified: true,
+    });
+
+    expect(get(neuronMinimumDissolveDelayToVoteSeconds)).toEqual(
+      BigInt(SECONDS_IN_YEAR)
     );
   });
 });

--- a/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
@@ -1,6 +1,7 @@
 import {
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_MONTH,
+  SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
 import {
   clearFollowingAfterSecondsStore,
@@ -38,16 +39,33 @@ describe("network-economics-derived", () => {
     );
   });
 
-  it("should return neuron minimum dissolve delay to vote seconds", () => {
-    expect(get(neuronMinimumDissolveDelayToVoteSeconds)).toEqual(undefined);
+  describe("neuronMinimumDissolveDelayToVoteSeconds", () => {
+    it("should return default 6M if value is not provided by the API", () => {
+      networkEconomicsStore.setParameters({
+        parameters: {
+          ...mockNetworkEconomics,
 
-    networkEconomicsStore.setParameters({
-      parameters: mockNetworkEconomics,
-      certified: true,
+          votingPowerEconomics: {
+            ...mockNetworkEconomics.votingPowerEconomics,
+            neuronMinimumDissolveDelayToVoteSeconds: undefined,
+          },
+        },
+        certified: true,
+      });
+
+      expect(get(neuronMinimumDissolveDelayToVoteSeconds)).toEqual(
+        BigInt(SECONDS_IN_HALF_YEAR)
+      );
     });
+    it("should return neuron minimum dissolve delay to vote seconds", () => {
+      networkEconomicsStore.setParameters({
+        parameters: mockNetworkEconomics,
+        certified: true,
+      });
 
-    expect(get(neuronMinimumDissolveDelayToVoteSeconds)).toEqual(
-      BigInt(SECONDS_IN_YEAR)
-    );
+      expect(get(neuronMinimumDissolveDelayToVoteSeconds)).toEqual(
+        BigInt(SECONDS_IN_YEAR)
+      );
+    });
   });
 });


### PR DESCRIPTION
# Motivation

We want to start using the minimum dissolve delay from the API instead of the hardcoded value `NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE`. This change is necessary because the value may change in the near future, and we want the application to respond accordingly.

This first PR introduces a store that retrieves this value from the network economics API.

It defaults to the existing value while the API defines it: [thread](https://dfinity.slack.com/archives/C039M7YS6F6/p1746198021862419?thread_ts=1746197917.500179&cid=C039M7YS6F6).

[NNS1-3762](https://dfinity.atlassian.net/browse/NNS1-3762)

# Changes

- Derived store to expose the `neuronMinimumDissolveDelayToVoteSeconds` value.

# Tests

- Adds unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3762]: https://dfinity.atlassian.net/browse/NNS1-3762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ