### PR TITLE
refactor(utils): migrate to network economics minimum dissolve delay

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -6,6 +6,10 @@
   import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
   import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import {
+    neuronMinimumDissolveDelayToVoteSeconds,
+    startReducingVotingPowerAfterSecondsStore,
+  } from "$lib/derived/network-economics.derived";
   import { authStore } from "$lib/stores/auth.store";
   import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
@@ -19,7 +23,6 @@
   } from "$lib/utils/neuron.utils";
   import type { NeuronInfo } from "@dfinity/nns";
   import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
-  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuron: NeuronInfo;
 
@@ -31,7 +34,10 @@
 
   // The API might return a non-zero voting power even if the neuron can't vote.
   let canVote: boolean;
-  $: canVote = hasEnoughDissolveDelayToVote(neuron);
+  $: canVote = hasEnoughDissolveDelayToVote(
+    neuron,
+    $neuronMinimumDissolveDelayToVoteSeconds
+  );
 
   let neuronTags: NeuronTagData[];
   $: neuronTags = getNeuronTags({

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -47,6 +47,7 @@
     i18n: $i18n,
     startReducingVotingPowerAfterSeconds:
       $startReducingVotingPowerAfterSecondsStore,
+    minimumDissolveDelay: $neuronMinimumDissolveDelayToVoteSeconds,
   });
 </script>
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte
@@ -2,15 +2,20 @@
   import ConfirmFollowingActionButton from "$lib/components/neuron-detail/actions/ConfirmFollowingActionButton.svelte";
   import FollowNeuronsButton from "$lib/components/neuron-detail/actions/FollowNeuronsButton.svelte";
   import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
+  import {
+    clearFollowingAfterSecondsStore,
+    neuronMinimumDissolveDelayToVoteSeconds,
+    startReducingVotingPowerAfterSecondsStore,
+  } from "$lib/derived/network-economics.derived";
   import { i18n } from "$lib/stores/i18n";
   import { secondsToRoundedDuration } from "$lib/utils/date.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
+    hasEnoughDissolveDelayToVote,
     isNeuronFollowingReset,
     isNeuronMissingReward,
-    secondsUntilMissingReward,
     isNeuronMissingRewardsSoon,
-    hasEnoughDissolveDelayToVote,
+    secondsUntilMissingReward,
   } from "$lib/utils/neuron.utils";
   import {
     IconCheckCircleFill,
@@ -19,10 +24,6 @@
   } from "@dfinity/gix-components";
   import { type NeuronInfo } from "@dfinity/nns";
   import { nonNullish, secondsToDuration } from "@dfinity/utils";
-  import {
-    clearFollowingAfterSecondsStore,
-    startReducingVotingPowerAfterSecondsStore,
-  } from "$lib/derived/network-economics.derived";
 
   export let neuron: NeuronInfo;
 
@@ -97,7 +98,7 @@
   };
 </script>
 
-{#if hasEnoughDissolveDelayToVote(neuron) && nonNullish($startReducingVotingPowerAfterSecondsStore) && nonNullish($clearFollowingAfterSecondsStore)}
+{#if hasEnoughDissolveDelayToVote(neuron, $neuronMinimumDissolveDelayToVoteSeconds) && nonNullish($startReducingVotingPowerAfterSecondsStore) && nonNullish($clearFollowingAfterSecondsStore)}
   <CommonItemAction
     testId="nns-neuron-reward-status-action-component"
     tooltipText={replacePlaceholders($i18n.missing_rewards.description, {

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -3,6 +3,7 @@
   import NnsNeuronRewardStatusAction from "$lib/components/neuron-detail/NnsNeuronRewardStatusAction.svelte";
   import NnsNeuronStateItemAction from "$lib/components/neuron-detail/NnsNeuronStateItemAction.svelte";
   import NnsStakeItemAction from "$lib/components/neuron-detail/NnsStakeItemAction.svelte";
+  import { neuronMinimumDissolveDelayToVoteSeconds } from "$lib/derived/network-economics.derived";
   import { ENABLE_PERIODIC_FOLLOWING_CONFIRMATION } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -24,7 +25,10 @@
 
   // The API might return a non-zero voting power even if the neuron can't vote.
   let canVote: boolean;
-  $: canVote = hasEnoughDissolveDelayToVote(neuron);
+  $: canVote = hasEnoughDissolveDelayToVote(
+    neuron,
+    $neuronMinimumDissolveDelayToVoteSeconds
+  );
 
   let isReducedVotingPower = false;
   $: isReducedVotingPower =

--- a/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsLosingRewardsNeuronCard.svelte
@@ -2,6 +2,10 @@
   import Followee from "$lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte";
   import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import {
+    neuronMinimumDissolveDelayToVoteSeconds,
+    startReducingVotingPowerAfterSecondsStore,
+  } from "$lib/derived/network-economics.derived";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import {
@@ -13,7 +17,6 @@
   import { Card, IconRight } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
-  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuron: NeuronInfo;
   export let onClick: (() => void) | undefined;
@@ -29,6 +32,7 @@
     i18n: $i18n,
     startReducingVotingPowerAfterSeconds:
       $startReducingVotingPowerAfterSecondsStore,
+    minimumDissolveDelay: $neuronMinimumDissolveDelayToVoteSeconds,
   });
 
   let followees: FolloweesNeuron[];

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import {
+    neuronMinimumDissolveDelayToVoteSeconds,
+    startReducingVotingPowerAfterSecondsStore,
+  } from "$lib/derived/network-economics.derived";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import { getNeuronTags, type NeuronTagData } from "$lib/utils/neuron.utils";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let neuron: NeuronInfo;
   export let tagName: "p" | "h3" = "p";
@@ -18,6 +21,7 @@
     i18n: $i18n,
     startReducingVotingPowerAfterSeconds:
       $startReducingVotingPowerAfterSecondsStore,
+    minimumDissolveDelay: $neuronMinimumDissolveDelayToVoteSeconds,
   });
 </script>
 

--- a/frontend/src/lib/derived/neurons.derived.ts
+++ b/frontend/src/lib/derived/neurons.derived.ts
@@ -1,4 +1,7 @@
-import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
+import {
+  neuronMinimumDissolveDelayToVoteSeconds,
+  startReducingVotingPowerAfterSecondsStore,
+} from "$lib/derived/network-economics.derived";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   hasEnoughDissolveDelayToVote,
@@ -22,13 +25,16 @@ export const sortedNeuronStore: Readable<NeuronInfo[]> = derived(
 );
 
 export const soonLosingRewardNeuronsStore: Readable<NeuronInfo[]> = derived(
-  definedNeuronsStore,
-  ($definedNeuronsStore) =>
+  [definedNeuronsStore, neuronMinimumDissolveDelayToVoteSeconds],
+  ([$definedNeuronsStore, $neuronMinimumDissolveDelayToVoteSeconds]) =>
     sortNeuronsByVotingPowerRefreshedTimeout(
       $definedNeuronsStore.filter(
         (neuron) =>
           // Neurons that are not able to vote cannot suddenly miss rewards.
-          hasEnoughDissolveDelayToVote(neuron) &&
+          hasEnoughDissolveDelayToVote(
+            neuron,
+            $neuronMinimumDissolveDelayToVoteSeconds
+          ) &&
           isNeuronMissingRewardsSoon({
             neuron,
             startReducingVotingPowerAfterSeconds: get(

--- a/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import Separator from "$lib/components/ui/Separator.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+  import {
+    neuronMinimumDissolveDelayToVoteSeconds,
+    startReducingVotingPowerAfterSecondsStore,
+  } from "$lib/derived/network-economics.derived";
+  import { sortedNeuronStore } from "$lib/derived/neurons.derived";
   import NeuronVisibilityRow from "$lib/modals/neurons/NeuronVisibilityRow.svelte";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
-  import { sortedNeuronStore } from "$lib/derived/neurons.derived";
   import {
     createNeuronVisibilityRowData,
     isNeuronControllableByUser,
@@ -14,7 +18,6 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
-  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   export let defaultSelectedNeuron: NeuronInfo | null = null;
   export let makePublic: boolean;
@@ -129,6 +132,8 @@
                   i18n: $i18n,
                   startReducingVotingPowerAfterSeconds:
                     $startReducingVotingPowerAfterSecondsStore,
+                  minimumDissolveDelay:
+                    $neuronMinimumDissolveDelayToVoteSeconds,
                 })}
                 checked={isNeuronSelected(n)}
                 on:nnsChange={() => handleCheckboxChange(n)}
@@ -158,6 +163,8 @@
                   i18n: $i18n,
                   startReducingVotingPowerAfterSeconds:
                     $startReducingVotingPowerAfterSecondsStore,
+                  minimumDissolveDelay:
+                    $neuronMinimumDissolveDelayToVoteSeconds,
                 })}
                 disabled
               />

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -6,6 +6,10 @@
   import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import {
+    neuronMinimumDissolveDelayToVoteSeconds,
+    startReducingVotingPowerAfterSecondsStore,
+  } from "$lib/derived/network-economics.derived";
   import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
@@ -20,7 +24,6 @@
   import { getTotalStakeInUsd } from "$lib/utils/staking.utils";
   import { IconNeuronsPage, Spinner } from "@dfinity/gix-components";
   import { onMount } from "svelte";
-  import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;
@@ -38,6 +41,7 @@
     icpSwapUsdPrices: $icpSwapUsdPricesStore,
     startReducingVotingPowerAfterSeconds:
       $startReducingVotingPowerAfterSecondsStore,
+    minimumDissolveDelay: $neuronMinimumDissolveDelayToVoteSeconds,
   });
 
   let totalStakeInUsd: number;

--- a/frontend/src/lib/stores/neurons-table-order-sorted-neuron-ids-store.ts
+++ b/frontend/src/lib/stores/neurons-table-order-sorted-neuron-ids-store.ts
@@ -1,6 +1,9 @@
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
-import { startReducingVotingPowerAfterSecondsStore } from "$lib/derived/network-economics.derived";
+import {
+  neuronMinimumDissolveDelayToVoteSeconds,
+  startReducingVotingPowerAfterSecondsStore,
+} from "$lib/derived/network-economics.derived";
 import { definedNeuronsStore } from "$lib/derived/neurons.derived";
 import { authStore } from "$lib/stores/auth.store";
 import { i18n } from "$lib/stores/i18n";
@@ -20,6 +23,7 @@ const tableNeuronsToSortStore = derived(
     definedNeuronsStore,
     icpSwapUsdPricesStore,
     startReducingVotingPowerAfterSecondsStore,
+    neuronMinimumDissolveDelayToVoteSeconds,
   ],
   ([
     $authStore,
@@ -28,6 +32,7 @@ const tableNeuronsToSortStore = derived(
     $definedNeuronsStore,
     $icpSwapUsdPricesStore,
     $startReducingVotingPowerAfterSecondsStore,
+    $neuronMinimumDissolveDelayToVoteSeconds,
   ]) => {
     const tableNeurons = tableNeuronsFromNeuronInfos({
       identity: $authStore.identity,
@@ -37,6 +42,7 @@ const tableNeuronsToSortStore = derived(
       icpSwapUsdPrices: $icpSwapUsdPricesStore,
       startReducingVotingPowerAfterSeconds:
         $startReducingVotingPowerAfterSecondsStore,
+      minimumDissolveDelay: $neuronMinimumDissolveDelayToVoteSeconds,
     });
     return tableNeurons.sort(compareById);
   }

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -15,7 +15,6 @@ import {
   MAX_DISSOLVE_DELAY_BONUS,
   MAX_NEURONS_MERGED,
   MIN_NEURON_STAKE,
-  NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE,
   NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS,
   TOPICS_TO_FOLLOW_NNS,
 } from "$lib/constants/neurons.constants";
@@ -479,12 +478,14 @@ export const getNeuronTags = ({
   accounts,
   i18n,
   startReducingVotingPowerAfterSeconds,
+  minimumDissolveDelay,
 }: {
   neuron: NeuronInfo;
   identity?: Identity | null;
   accounts: IcpAccountsStoreData;
   i18n: I18n;
   startReducingVotingPowerAfterSeconds: bigint | undefined;
+  minimumDissolveDelay: bigint;
 }): NeuronTagData[] => {
   const tags: NeuronTagData[] = [];
 
@@ -493,6 +494,8 @@ export const getNeuronTags = ({
       neuron,
       i18n,
       startReducingVotingPowerAfterSeconds,
+
+      minimumDissolveDelay,
     })
   );
 
@@ -536,10 +539,12 @@ const getNeuronTagsUnrelatedToController = ({
   neuron,
   i18n,
   startReducingVotingPowerAfterSeconds,
+  minimumDissolveDelay,
 }: {
   neuron: NeuronInfo;
   i18n: I18n;
   startReducingVotingPowerAfterSeconds: bigint | undefined;
+  minimumDissolveDelay: bigint;
 }): NeuronTagData[] => {
   const tags: NeuronTagData[] = [];
 
@@ -558,7 +563,7 @@ const getNeuronTagsUnrelatedToController = ({
   // 2. no voting power economics available
   if (
     nonNullish(startReducingVotingPowerAfterSeconds) &&
-    hasEnoughDissolveDelayToVote(neuron) &&
+    hasEnoughDissolveDelayToVote(neuron, minimumDissolveDelay) &&
     get(ENABLE_PERIODIC_FOLLOWING_CONFIRMATION)
   ) {
     if (
@@ -600,6 +605,7 @@ export const createNeuronVisibilityRowData = ({
   accounts,
   i18n,
   startReducingVotingPowerAfterSeconds,
+  minimumDissolveDelay,
 }: {
   neuron: NeuronInfo;
   identity?: Identity | null;
@@ -608,6 +614,7 @@ export const createNeuronVisibilityRowData = ({
   // The function should work w/o voting power economics to not block the visibility functionality.
   // In this case only the "Missing Rewards" tag will be missing.
   startReducingVotingPowerAfterSeconds: bigint | undefined;
+  minimumDissolveDelay: bigint;
 }): NeuronVisibilityRowData => {
   return {
     neuronId: neuron.neuronId.toString(),
@@ -622,6 +629,7 @@ export const createNeuronVisibilityRowData = ({
       neuron,
       i18n,
       startReducingVotingPowerAfterSeconds,
+      minimumDissolveDelay,
     }),
     uncontrolledNeuronDetails: getNeuronVisibilityRowUncontrolledNeuronDetails({
       neuron,
@@ -1402,7 +1410,7 @@ export const isNeuronMissingRewardsSoon = ({
 /**
  * Returns `true` if the neuron's dissolve delay meets the voting requirements
  */
-export const hasEnoughDissolveDelayToVote = ({
-  dissolveDelaySeconds,
-}: NeuronInfo): boolean =>
-  dissolveDelaySeconds >= BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);
+export const hasEnoughDissolveDelayToVote = (
+  { dissolveDelaySeconds }: NeuronInfo,
+  minimumDissolveDelay: bigint
+): boolean => dissolveDelaySeconds >= minimumDissolveDelay;

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -48,6 +48,7 @@ export const tableNeuronsFromNeuronInfos = ({
   icpSwapUsdPrices,
   i18n,
   startReducingVotingPowerAfterSeconds,
+  minimumDissolveDelay,
 }: {
   neuronInfos: NeuronInfo[];
   identity?: Identity | undefined | null;
@@ -55,6 +56,7 @@ export const tableNeuronsFromNeuronInfos = ({
   icpSwapUsdPrices: IcpSwapUsdPricesStoreData;
   i18n: I18n;
   startReducingVotingPowerAfterSeconds: bigint | undefined;
+  minimumDissolveDelay: bigint;
 }): TableNeuron[] => {
   return neuronInfos.map((neuronInfo) => {
     const { neuronId, dissolveDelaySeconds } = neuronInfo;
@@ -94,6 +96,7 @@ export const tableNeuronsFromNeuronInfos = ({
         accounts,
         i18n,
         startReducingVotingPowerAfterSeconds,
+        minimumDissolveDelay,
       }),
       isPublic: isPublicNeuron(neuronInfo),
     };

--- a/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/network-economics.derived.spec.ts
@@ -1,7 +1,6 @@
 import {
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_MONTH,
-  SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
 import {
   clearFollowingAfterSecondsStore,
@@ -57,14 +56,21 @@ describe("network-economics-derived", () => {
         BigInt(SECONDS_IN_HALF_YEAR)
       );
     });
+
     it("should return neuron minimum dissolve delay to vote seconds", () => {
       networkEconomicsStore.setParameters({
-        parameters: mockNetworkEconomics,
+        parameters: {
+          ...mockNetworkEconomics,
+          votingPowerEconomics: {
+            ...mockNetworkEconomics.votingPowerEconomics,
+            neuronMinimumDissolveDelayToVoteSeconds: BigInt(SECONDS_IN_MONTH),
+          },
+        },
         certified: true,
       });
 
       expect(get(neuronMinimumDissolveDelayToVoteSeconds)).toEqual(
-        BigInt(SECONDS_IN_YEAR)
+        BigInt(SECONDS_IN_MONTH)
       );
     });
   });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -117,6 +117,8 @@ import { get } from "svelte/store";
 describe("neuron-utils", () => {
   const enoughDissolveDelayToVote = BigInt(SECONDS_IN_HALF_YEAR);
   const nowSeconds = nowInSeconds();
+  const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
+
   beforeEach(() => {
     vi.useFakeTimers().setSystemTime(nowSeconds * 1000);
     neuronsStore.setNeurons({ neurons: [], certified: true });
@@ -1525,8 +1527,6 @@ describe("neuron-utils", () => {
     const ectTag = {
       text: "Early Contributor Token",
     } as NeuronTagData;
-
-    const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
 
     it("returns 'hotkey' if neuron is controllable by hotkey and Ledger device is not the controller", () => {
       const neuron = {
@@ -3511,7 +3511,6 @@ describe("neuron-utils", () => {
   });
 
   describe("createNeuronVisibilityRowData", () => {
-    const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
     it("should create neuron visibility row data for a public neuron", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
@@ -3971,8 +3970,6 @@ describe("neuron-utils", () => {
     });
 
     describe("hasEnoughDissolveDelayToVote", () => {
-      const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
-
       it("should return true", () => {
         expect(
           hasEnoughDissolveDelayToVote(

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1525,6 +1525,9 @@ describe("neuron-utils", () => {
     const ectTag = {
       text: "Early Contributor Token",
     } as NeuronTagData;
+
+    const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
+
     it("returns 'hotkey' if neuron is controllable by hotkey and Ledger device is not the controller", () => {
       const neuron = {
         ...mockNeuron,
@@ -1541,6 +1544,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([hotkeyTag]);
     });
@@ -1561,6 +1565,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithoutHw,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([hotkeyTag]);
     });
@@ -1581,6 +1586,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([hwTag]);
     });
@@ -1601,6 +1607,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([]);
     });
@@ -1621,6 +1628,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([]);
     });
@@ -1640,6 +1648,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([nfTag]);
     });
@@ -1661,6 +1670,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([nfTag, hotkeyTag]);
     });
@@ -1682,6 +1692,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([nfTag, hwTag]);
     });
@@ -1702,6 +1713,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([seedTag]);
     });
@@ -1722,6 +1734,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([ectTag]);
     });
@@ -1745,6 +1758,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
           startReducingVotingPowerAfterSeconds: undefined,
+          minimumDissolveDelay,
         })
       ).toEqual([seedTag, nfTag, hwTag]);
     });
@@ -1808,6 +1822,7 @@ describe("neuron-utils", () => {
               i18n: en,
               startReducingVotingPowerAfterSeconds:
                 BigInt(SECONDS_IN_HALF_YEAR),
+              minimumDissolveDelay,
             })
           ).toEqual([
             {
@@ -1875,6 +1890,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            minimumDissolveDelay,
           })
         ).toEqual([]);
       });
@@ -1892,6 +1908,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            minimumDissolveDelay,
           })
         ).toEqual([missingRewardsTag]);
       });
@@ -1912,6 +1929,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            minimumDissolveDelay,
           })
         ).toEqual([]);
       });
@@ -1929,6 +1947,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: undefined,
+            minimumDissolveDelay,
           })
         ).toEqual([]);
       });
@@ -1946,6 +1965,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            minimumDissolveDelay,
           })
         ).toEqual([]);
       });
@@ -1963,6 +1983,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            minimumDissolveDelay,
           })
         ).toEqual([missingRewardsSoonTag]);
       });
@@ -1983,6 +2004,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            minimumDissolveDelay,
           })
         ).toEqual([]);
       });
@@ -2000,6 +2022,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: undefined,
+            minimumDissolveDelay,
           })
         ).toEqual([]);
       });
@@ -2017,6 +2040,7 @@ describe("neuron-utils", () => {
             accounts: accountsWithHW,
             i18n: en,
             startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            minimumDissolveDelay,
           })
         ).toEqual([]);
       });
@@ -3487,6 +3511,7 @@ describe("neuron-utils", () => {
   });
 
   describe("createNeuronVisibilityRowData", () => {
+    const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
     it("should create neuron visibility row data for a public neuron", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
@@ -3498,6 +3523,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result).toEqual({
         neuronId: neuron.neuronId.toString(),
@@ -3518,6 +3544,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.tags).toEqual([{ text: "Seed" }]);
     });
@@ -3533,6 +3560,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.tags).toEqual([{ text: "Early Contributor Token" }]);
     });
@@ -3548,6 +3576,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.tags).toEqual([{ text: "Neurons' fund" }]);
     });
@@ -3569,6 +3598,7 @@ describe("neuron-utils", () => {
         },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.uncontrolledNeuronDetails).toEqual({
         type: "hardwareWallet",
@@ -3593,6 +3623,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.uncontrolledNeuronDetails).toEqual({
         type: "hotkey",
@@ -3614,6 +3645,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.uncontrolledNeuronDetails).toBeUndefined();
     });
@@ -3635,6 +3667,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.stake).toEqual(
         TokenAmountV2.fromUlps({
@@ -3665,6 +3698,7 @@ describe("neuron-utils", () => {
         },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.stake).toBeUndefined();
       expect(result.uncontrolledNeuronDetails).toEqual({
@@ -3692,6 +3726,7 @@ describe("neuron-utils", () => {
         accounts: { main: mockMainAccount },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(result.stake).toBeUndefined();
     });
@@ -3936,33 +3971,48 @@ describe("neuron-utils", () => {
     });
 
     describe("hasEnoughDissolveDelayToVote", () => {
+      const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
+
       it("should return true", () => {
         expect(
-          hasEnoughDissolveDelayToVote({
-            ...mockNeuron,
-            dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR),
-          })
+          hasEnoughDissolveDelayToVote(
+            {
+              ...mockNeuron,
+              dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR),
+            },
+            minimumDissolveDelay
+          )
         ).toBe(true);
         expect(
-          hasEnoughDissolveDelayToVote({
-            ...mockNeuron,
-            dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR) * 100n,
-          })
+          hasEnoughDissolveDelayToVote(
+            {
+              ...mockNeuron,
+              dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR) * 100n,
+            },
+            minimumDissolveDelay
+          )
         ).toBe(true);
       });
 
       it("should return false", () => {
         expect(
-          hasEnoughDissolveDelayToVote({
-            ...mockNeuron,
-            dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR - 1),
-          })
+          hasEnoughDissolveDelayToVote(
+            {
+              ...mockNeuron,
+              dissolveDelaySeconds: BigInt(SECONDS_IN_HALF_YEAR - 1),
+            },
+
+            minimumDissolveDelay
+          )
         ).toBe(false);
         expect(
-          hasEnoughDissolveDelayToVote({
-            ...mockNeuron,
-            dissolveDelaySeconds: 0n,
-          })
+          hasEnoughDissolveDelayToVote(
+            {
+              ...mockNeuron,
+              dissolveDelaySeconds: 0n,
+            },
+            minimumDissolveDelay
+          )
         ).toBe(false);
       });
     });

--- a/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
@@ -1,4 +1,5 @@
 import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import {
   compareByDissolveDelay,
@@ -69,6 +70,8 @@ describe("neurons-table.utils", () => {
       isPublic: false,
     };
 
+    const minimumDissolveDelay = BigInt(SECONDS_IN_HALF_YEAR);
+
     const convert = (neuronInfos: NeuronInfo[]) =>
       tableNeuronsFromNeuronInfos({
         neuronInfos,
@@ -79,6 +82,7 @@ describe("neurons-table.utils", () => {
         },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
 
     it("should convert default neuronInfo to tableNeuron", () => {
@@ -246,6 +250,7 @@ describe("neurons-table.utils", () => {
         },
         i18n: en,
         startReducingVotingPowerAfterSeconds: undefined,
+        minimumDissolveDelay,
       });
       expect(tableNeurons).toEqual([
         {

--- a/frontend/src/tests/mocks/network-economics.mock.ts
+++ b/frontend/src/tests/mocks/network-economics.mock.ts
@@ -1,7 +1,6 @@
 import {
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_MONTH,
-  SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
 import type { NetworkEconomics } from "@dfinity/nns";
 
@@ -38,7 +37,7 @@ export const mockNetworkEconomics: NetworkEconomics = {
   },
   votingPowerEconomics: {
     startReducingVotingPowerAfterSeconds: BigInt(SECONDS_IN_HALF_YEAR),
-    neuronMinimumDissolveDelayToVoteSeconds: BigInt(SECONDS_IN_YEAR),
+    neuronMinimumDissolveDelayToVoteSeconds: BigInt(SECONDS_IN_HALF_YEAR),
     clearFollowingAfterSeconds: BigInt(SECONDS_IN_MONTH),
   },
 };


### PR DESCRIPTION
# Motivation

We want to start using the minimum dissolve delay from the API instead of the hardcoded value `NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE`. 

This first PR is a follow-up of #6781 and updates an existing util and all its consumers to use the new store instead of using the local constant.

[NNS1-3762](https://dfinity.atlassian.net/browse/NNS1-3762)

# Changes

- Update `hasEnoughDissolveDelayToVote` to expect the dissolve delay.  
- Update `soonLosingRewardNeuronsStore` to provide the dissolve delay to `hasEnoughDissolveDelayToVote`.  
- Update `getNeuronTagsUnrelatedToController` to provide the dissolve delay to `hasEnoughDissolveDelayToVote`.

# Tests

- Update unit tests to satisfy the new API.
- Change `neuronMinimumDissolveDelayToVoteSeconds` in `mockNetworkEconomics` to replicate the former behavior with the constant.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3762]: https://dfinity.atlassian.net/browse/NNS1-3762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ