### PR TITLE
fix(sns-topics): Hide remove button from the legacy followee tag

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.svelte
@@ -19,6 +19,7 @@
   import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
   import FollowSnsNeuronsByTopicLegacyFollowee from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicLegacyFollowee.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import { ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID } from "$lib/constants/sns-proposals.constants";
 
   type Props = {
     topicInfo: TopicInfoWithUnknown;
@@ -149,12 +150,15 @@
                   <FollowSnsNeuronsByTopicLegacyFollowee
                     nsFunction={followees.nsFunction}
                     {neuronId}
-                    onRemoveClick={() => {
-                      removeLegacyFollowing({
-                        nsFunction: followees.nsFunction,
-                        followee: neuronId,
-                      });
-                    }}
+                    onRemoveClick={followees.nsFunction.id ===
+                    ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID
+                      ? undefined
+                      : () => {
+                          removeLegacyFollowing({
+                            nsFunction: followees.nsFunction,
+                            followee: neuronId,
+                          });
+                        }}
                   />
                 </li>
               {/each}

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
@@ -330,11 +330,30 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
       await po.getTopicItemPoByName(topicName2)
     ).getFollowSnsNeuronsByTopicLegacyFolloweePos();
     expect(topic2FolloweePos.length).toEqual(3);
+    const topic2LegacyFolloweePos = await (
+      await po.getTopicItemPoByName(topicName2)
+    ).getFollowSnsNeuronsByTopicLegacyFolloweePos();
+
     expect(
       await (
         await po.getTopicItemPoByName(topicName2)
       ).getLegacyFolloweeNsFunctionNames()
     ).toEqual(["Catch-all", "Catch-all", legacyNsFunction2Name]);
+
+    // Only "Catch-all" should not have remove button
+    for (const po of topic2LegacyFolloweePos) {
+      const nsFunctionName = await po.getNsFunctionName();
+      const hasRemoveButton = await po
+        .getFollowSnsNeuronsByTopicFolloweePo()
+        .hasRemoveButton();
+
+      if (nsFunctionName === "Catch-all") {
+        expect(hasRemoveButton).toEqual(false);
+      } else {
+        expect(hasRemoveButton).toEqual(true);
+      }
+    }
+
     expect(
       await (
         await po.getTopicItemPoByName(topicName2)
@@ -342,7 +361,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     ).toEqual(["01020304", "05060708", "01020304"]);
   });
 
-  it("displays deactivate catch-all followings when catch-all provided", async () => {
+  it("displays deactivate catch-all followings button when catch-all provided", async () => {
     const spyOpenDeactivateCatchAllStep = vi.fn();
     const po = renderComponent({
       ...defaultProps,


### PR DESCRIPTION
# Motivation

Currently, there is a way to skip the confirmation step for the "Catch-all" legacy following by clicking the **X icon** on the "Catch-all" following tag instead of using the **"Deactivate catch-all"** button. This is not the desired flow.

[NNS1-3791](https://dfinity.atlassian.net/browse/NNS1-3791).

![image](https://github.com/user-attachments/assets/8867d890-69de-48ac-b6de-48b6a3ee722d)

# Changes

- Removed the ability to delete the "Catch-all" legacy following using the X icon on its tag, in order to enforce the confirmation step.

# Tests

- Added.
- Verified locally that the button is not being rendered.

<img width="564" alt="image" src="https://github.com/user-attachments/assets/af4013e6-ab8b-451a-b48a-541b05076a46" />

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3791]: https://dfinity.atlassian.net/browse/NNS1-3791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ