### PR TITLE
refactor(topics): use derived store for topic list access

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -8,6 +8,7 @@
   import AddPermissionsModal from "$lib/modals/sns/neurons/AddPermissionsModal.svelte";
   import AddSnsHotkeyModal from "$lib/modals/sns/neurons/AddSnsHotkeyModal.svelte";
   import DissolveSnsNeuronModal from "$lib/modals/sns/neurons/DissolveSnsNeuronModal.svelte";
+  import FollowSnsNeuronsByTopicModal from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte";
   import FollowSnsNeuronsModal from "$lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte";
   import IncreaseSnsDissolveDelayModal from "$lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.svelte";
   import SnsActiveDisbursementsModal from "$lib/modals/sns/neurons/SnsActiveDisbursementsModal.svelte";
@@ -15,6 +16,7 @@
   import SnsDisburseMaturityModal from "$lib/modals/sns/neurons/SnsDisburseMaturityModal.svelte";
   import SnsIncreaseStakeNeuronModal from "$lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte";
   import SnsStakeMaturityModal from "$lib/modals/sns/neurons/SnsStakeMaturityModal.svelte";
+  import SnsTopicDefinitionsModal from "$lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte";
   import SplitSnsNeuronModal from "$lib/modals/sns/neurons/SplitSnsNeuronModal.svelte";
   import {
     SELECTED_SNS_NEURON_CONTEXT_KEY,
@@ -39,8 +41,6 @@
     type Token,
   } from "@dfinity/utils";
   import { getContext } from "svelte";
-  import FollowSnsNeuronsByTopicModal from "$lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte";
-  import SnsTopicDefinitionsModal from "$lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte";
 
   // Modal events
 
@@ -133,7 +133,7 @@
   {/if}
 
   {#if type === "sns-topic-definitions" && nonNullish(rootCanisterId)}
-    <SnsTopicDefinitionsModal {rootCanisterId} on:nnsClose={close} />
+    <SnsTopicDefinitionsModal {rootCanisterId} onClose={close} />
   {/if}
 
   {#if type === "stake-maturity" && nonNullish(rootCanisterId) && nonNullish(neuronId)}

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte.spec.ts
@@ -19,13 +19,12 @@ describe("SnsTopicDefinitionsModal", () => {
   const topicName2 = "Application Business Logic";
 
   const renderComponent = ({
-    onNnsClose = () => {},
+    onClose = () => {},
   }: {
-    onNnsClose?: () => void;
+    onClose?: () => void;
   } = {}) => {
     const { container } = render(SnsTopicDefinitionsModal, {
-      props: { rootCanisterId },
-      events: { nnsClose: onNnsClose },
+      props: { rootCanisterId, onClose },
     });
 
     return SnsTopicDefinitionsModalPo.under(
@@ -85,12 +84,12 @@ describe("SnsTopicDefinitionsModal", () => {
   });
 
   it("emits close event", async () => {
-    const onNnsClose = vi.fn();
+    const onClose = vi.fn();
     const po = renderComponent({
-      onNnsClose,
+      onClose,
     });
 
     await po.clickCloseButton();
-    expect(onNnsClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Motivation

We want to apply the same sorting used for the proposals filter #6745 in other parts of the application. This requires that consumers of the list of topics retrieve them from the derived store `createSnsTopicsProjectStore` instead of directly from the topics store.

This PR prepares the component to consume this store, so once the store returns the sorted topics, they will be automatically used. Additionally, it has been migrated to Svelte 5.

[NNS1-3792](https://dfinity.atlassian.net/browse/NNS1-3792)

# Changes

- Replace direct access to `snsTopicsStore` with `createSnsTopicsProjectStore`.  
- Refactor the component to use runes instead of the reactive syntax `$:`.

# Tests

- Tests should pass as before since there were no functional changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3792]: https://dfinity.atlassian.net/browse/NNS1-3792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ