### PR TITLE
feat(topics): implement topic priority sorting in store

### DIFF
--- a/frontend/src/lib/derived/sns-topics.derived.ts
+++ b/frontend/src/lib/derived/sns-topics.derived.ts
@@ -51,7 +51,7 @@ export const createSnsTopicsProjectStore = (
       const topics = fromNullable(topicResponse.topics);
       if (isNullish(topics)) return undefined;
 
-      // sorts filters with critical topics first, then alphabetically within each group
+      // sorts topics with critical topics first, then alphabetically within each group
       return topics.sort((a, b) => {
         const isACritical = fromDefinedNullable(a.is_critical);
         const isBCritical = fromDefinedNullable(b.is_critical);

--- a/frontend/src/lib/derived/sns-topics.derived.ts
+++ b/frontend/src/lib/derived/sns-topics.derived.ts
@@ -8,7 +8,12 @@ import type {
 } from "$lib/types/sns-aggregator";
 import { convertDtoToListTopicsResponse } from "$lib/utils/sns-aggregator-converters.utils";
 import type { Principal } from "@dfinity/principal";
-import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
+import {
+  fromDefinedNullable,
+  fromNullable,
+  isNullish,
+  nonNullish,
+} from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
 export interface SnsParametersStore {
@@ -41,9 +46,24 @@ export const createSnsTopicsProjectStore = (
       }
 
       const topicResponse = $snsTopicStore[rootCanisterIdText];
-      return nonNullish(topicResponse)
-        ? fromNullable(topicResponse.topics)
-        : undefined;
+      if (isNullish(topicResponse)) return undefined;
+
+      const topics = fromNullable(topicResponse.topics);
+      if (isNullish(topics)) return undefined;
+
+      // sorts filters with critical topics first, then alphabetically within each group
+      return topics.sort((a, b) => {
+        const isACritical = fromDefinedNullable(a.is_critical);
+        const isBCritical = fromDefinedNullable(b.is_critical);
+
+        if (isACritical && !isBCritical) return -1;
+        if (!isACritical && isBCritical) return 1;
+
+        const nameOfA = fromDefinedNullable(a.name);
+        const nameOfB = fromDefinedNullable(b.name);
+
+        return nameOfA.localeCompare(nameOfB);
+      });
     }
   );
 

--- a/frontend/src/tests/lib/derived/sns-topics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-topics.derived.spec.ts
@@ -192,6 +192,44 @@ describe("sns topics store", () => {
       const store = createSnsTopicsProjectStore(principal(123));
       expect(get(store)).toEqual(undefined);
     });
+
+    it("should sort topics by criticallity and then alphabetically", () => {
+      const topicInfoDto1 = topicInfoDtoMock({
+        topic: "Governance",
+        name: "Topic2",
+        description: "This is a description 2",
+        isCritical: false,
+      });
+
+      const topicInfoDto2 = topicInfoDtoMock({
+        topic: "DaoCommunitySettings",
+        name: "Topic1",
+        description: "This is a description",
+      });
+
+      const topicInfoDto3 = topicInfoDtoMock({
+        topic: "TreasuryAssetManagement",
+        name: "Topic1",
+        description: "This is a description",
+        isCritical: true,
+      });
+      setSnsProjects([
+        {
+          rootCanisterId: mockPrincipal,
+          topics: {
+            topics: [topicInfoDto1, topicInfoDto2, topicInfoDto3],
+            uncategorized_functions: [],
+          },
+        },
+      ]);
+
+      const store = createSnsTopicsProjectStore(mockPrincipal);
+      expect(get(store)).toEqual([
+        convertDtoTopicInfo(topicInfoDto3),
+        convertDtoTopicInfo(topicInfoDto2),
+        convertDtoTopicInfo(topicInfoDto1),
+      ]);
+    });
   });
 
   describe("createSnsTopicsProposalsFilteringStore", () => {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte.spec.ts
@@ -1,5 +1,4 @@
 import SnsTopicDefinitionsModal from "$lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte";
-import type { SnsTopicKey } from "$lib/types/sns";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { topicInfoDtoMock } from "$tests/mocks/sns-topics.mock";
 import { SnsTopicDefinitionsModalPo } from "$tests/page-objects/SnsTopicDefinitionsModal.page-object";
@@ -9,8 +8,6 @@ import { render } from "@testing-library/svelte";
 
 describe("SnsTopicDefinitionsModal", () => {
   const rootCanisterId = principal(1);
-  const topicKey2: SnsTopicKey = "ApplicationBusinessLogic";
-  const topicName2 = "Application Business Logic";
 
   const renderComponent = ({
     onClose = () => {},

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsModal.svelte.spec.ts
@@ -9,12 +9,6 @@ import { render } from "@testing-library/svelte";
 
 describe("SnsTopicDefinitionsModal", () => {
   const rootCanisterId = principal(1);
-  const criticalTopicKey1: SnsTopicKey = "CriticalDappOperations";
-  const criticalTopicName1 = "Critical Dapp Operations";
-  const criticalTopicKey2: SnsTopicKey = "TreasuryAssetManagement";
-  const criticalTopicName2 = "Treasury Asset Management";
-  const topicKey1: SnsTopicKey = "DaoCommunitySettings";
-  const topicName1 = "Dao Community Settings";
   const topicKey2: SnsTopicKey = "ApplicationBusinessLogic";
   const topicName2 = "Application Business Logic";
 
@@ -39,26 +33,26 @@ describe("SnsTopicDefinitionsModal", () => {
         topics: {
           topics: [
             topicInfoDtoMock({
-              topic: criticalTopicKey1,
-              name: criticalTopicName1,
+              topic: "CriticalDappOperations",
+              name: "CriticalDappOperations",
               description: "",
               isCritical: true,
             }),
             topicInfoDtoMock({
-              topic: criticalTopicKey2,
-              name: criticalTopicName2,
+              topic: "TreasuryAssetManagement",
+              name: "TreasuryAssetManagement",
               description: "",
               isCritical: true,
             }),
             topicInfoDtoMock({
-              topic: topicKey1,
-              name: topicName1,
+              topic: "DaoCommunitySettings",
+              name: "DaoCommunitySettings",
               description: "",
               isCritical: false,
             }),
             topicInfoDtoMock({
-              topic: topicKey2,
-              name: topicName2,
+              topic: "ApplicationBusinessLogic",
+              name: "ApplicationBusinessLogic",
               description: "",
               isCritical: false,
             }),
@@ -73,13 +67,13 @@ describe("SnsTopicDefinitionsModal", () => {
     const po = renderComponent();
 
     expect([...(await po.getCriticalTopicNames())]).toEqual([
-      criticalTopicName1,
-      criticalTopicName2,
+      "CriticalDappOperations",
+      "TreasuryAssetManagement",
     ]);
 
     expect(await po.getNonCriticalTopicNames()).toEqual([
-      topicName1,
-      topicName2,
+      "ApplicationBusinessLogic",
+      "DaoCommunitySettings",
     ]);
   });
 


### PR DESCRIPTION
# Motivation

We want to apply the same sorting used for the proposals filter #6745 in other parts of the application.

This PR implements the sorting logic directly in the derived store. Since there is no need to retain the original data, we can apply it directly to the store and avoid duplication.

The sorting logic is as follows:
- First, critical topics are sorted alphabetically.
- Second, non-critical topics are sorted alphabetically.

[NNS1-3792](https://dfinity.atlassian.net/browse/NNS1-3792)

https://github.com/user-attachments/assets/0660382f-3027-4f7b-b32f-c5dc0e42bfa5

# Changes

- Introduce sorting logic to `createSnsTopicsProjectStore`.

# Tests

- Add test to validate new sorting logic.
- Fix existing tests to easily visualize sorting.
- Tested in beta.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3792]: https://dfinity.atlassian.net/browse/NNS1-3792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ