### PR TITLE
chore(deps): upgrade vite to 6.3.5 to patch security vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,7 @@
         "svelte-preprocess": "^6.0.3",
         "typescript": "^5.5",
         "typescript-eslint": "^8.24.0",
-        "vite": "^6.3.3",
+        "vite": "^6.3.5",
         "vitest": "^3.1.2",
         "vitest-mock-extended": "^3.0.1"
       },
@@ -6548,9 +6548,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
-      "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11221,9 +11221,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "vite": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
-      "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
     "svelte-preprocess": "^6.0.3",
     "typescript": "^5.5",
     "typescript-eslint": "^8.24.0",
-    "vite": "^6.3.3",
+    "vite": "^6.3.5",
     "vitest": "^3.1.2",
     "vitest-mock-extended": "^3.0.1"
   },


### PR DESCRIPTION
# Motivation

Upgrades vite to handle security vulnerability.

[GHSA-859w-5945-r5v3](https://github.com/advisories/GHSA-859w-5945-r5v3)

[SCAVM-1177](https://dfinity.atlassian.net/browse/SCAVM-1177)

# Changes

- Run `npm run vite@latest`

# Tests

- Tests should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[SCAVM-1177]: https://dfinity.atlassian.net/browse/SCAVM-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ