### PR TITLE
Sns topics/change success flow

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -101,6 +101,9 @@
     modal?.set(
       wizardStepIndex({ name: STEP_CONFIRM_DEACTIVATING_CATCH_ALL, steps })
     );
+  const openFirstStep = () =>
+    modal?.set(wizardStepIndex({ name: STEP_TOPICS, steps }));
+
   const openPrevStep = () => {
     if (
       currentStep?.name === STEP_NEURON &&
@@ -110,7 +113,7 @@
         wizardStepIndex({ name: STEP_CONFIRM_OVERRIDE_LEGACY, steps })
       );
     } else {
-      modal?.set(wizardStepIndex({ name: STEP_TOPICS, steps }));
+      openFirstStep();
     }
   };
 
@@ -203,11 +206,15 @@
     });
 
     if (success) {
+      await reloadNeuron();
+      // Reset forms state
+      selectedTopics = [];
+      followeeNeuronIdHex = "";
+
+      openFirstStep();
       toastsSuccess({
         labelKey: $i18n.follow_sns_topics.success_set_following,
       });
-      await reloadNeuron();
-      closeModal();
     } else {
       toastsError({
         labelKey: "follow_sns_topics.error_add_following",
@@ -295,7 +302,7 @@
         labelKey: "follow_sns_topics.success_removing_catch_all",
       });
       await reloadNeuron();
-      openPrevStep();
+      openFirstStep();
     }
 
     stopBusy("remove-sns-catch-all-followee");
@@ -330,14 +337,14 @@
       {topicInfos}
       {neuron}
       bind:selectedTopics
-      {openPrevStep}
+      openPrevStep={openFirstStep}
       {openNextStep}
     />
   {/if}
   {#if currentStep?.name === STEP_CONFIRM_DEACTIVATING_CATCH_ALL && nonNullish(catchAllLegacyFollowings)}
     <FollowSnsNeuronsByTopicStepDeactivateCatchAll
       {catchAllLegacyFollowings}
-      cancel={openPrevStep}
+      cancel={openFirstStep}
       confirm={confirmDeactivateCatchAllFollowee}
     />
   {/if}

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -279,7 +279,8 @@ describe("FollowSnsNeuronsByTopicModal", () => {
 
     // After successful set following
     expect(reloadNeuronSpy).toBeCalledTimes(1);
-    expect(closeModalSpy).toBeCalledTimes(1);
+    expect(closeModalSpy).toBeCalledTimes(0);
+    expect(await topicsStepPo.isPresent()).toEqual(true);
     expect(get(busyStore)).toEqual([]);
     expect(get(toastsStore)).toMatchObject([
       {


### PR DESCRIPTION
# Motivation

Currently, after a successful vote delegation, the modal window closes immediately, which offers little feedback to the user.

This update improves the flow by showing the first step of the modal again after a successful delegation. This allows the user to verify that the vote delegation has been correctly applied — indicated by green checkmarks next to the selected topics.

# Changes

- Show the first step of the modal instead of closing it after vote delegation.

# Tests

- Updated.
- Verified locally

https://github.com/user-attachments/assets/4738b329-7f7a-4129-963c-43591253b14d

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.