### PR TITLE
refactor(proposals): eliminate duplicate sort operation

### DIFF
--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -585,13 +585,16 @@ export const generateSnsProposalTopicsFilterData = ({
     .filter(({ topic }) => nonNullish(topic))
     .map((topicInfo) => {
       const topic = snsTopicToTopicKey(fromDefinedNullable(topicInfo.topic));
+      const name = fromDefinedNullable(topicInfo.name);
+      const isCritical = fromDefinedNullable(topicInfo.is_critical);
+      const checked = getCheckedState(topic);
 
       return {
-        name: fromDefinedNullable(topicInfo.name),
-        isCritical: fromDefinedNullable(topicInfo.is_critical),
+        name,
+        isCritical,
         id: topic,
         value: topic,
-        checked: getCheckedState(topic),
+        checked,
       };
     });
 

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -582,24 +582,17 @@ export const generateSnsProposalTopicsFilterData = ({
   const i18nKeys = get(i18n);
 
   const existingFilters: Filter<SnsProposalTopicFilterId>[] = topics
-    .filter((topic) => nonNullish(topic.topic))
-    .map((topic) => ({
-      name: fromDefinedNullable(topic.name),
-      isCritical: fromDefinedNullable(topic.is_critical),
-      topic: snsTopicToTopicKey(fromDefinedNullable(topic.topic)),
-    }))
-    .map(({ name, isCritical, topic }) => ({
-      id: topic,
-      value: topic,
-      name,
-      isCritical,
-      checked: getCheckedState(topic),
-    }))
-    // sorts filters with critical topics first, then alphabetically within each group
-    .sort((a, b) => {
-      if (a.isCritical && !b.isCritical) return -1;
-      if (!a.isCritical && b.isCritical) return 1;
-      return a.name.localeCompare(b.name);
+    .filter(({ topic }) => nonNullish(topic))
+    .map((topicInfo) => {
+      const topic = snsTopicToTopicKey(fromDefinedNullable(topicInfo.topic));
+
+      return {
+        name: fromDefinedNullable(topicInfo.name),
+        isCritical: fromDefinedNullable(topicInfo.is_critical),
+        id: topic,
+        value: topic,
+        checked: getCheckedState(topic),
+      };
     });
 
   const allSnsProposalsWithoutTopicFilter = {

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -929,53 +929,6 @@ describe("sns-proposals utils", () => {
       expect(daoSettingsFilter?.checked).toBe(true);
     });
 
-    it("should sort topics with critical topics first, then alphabetically", () => {
-      const topics: TopicInfoWithUnknown[] = [
-        {
-          ...topicInfoMock,
-          name: ["Z Topic"],
-          topic: [{ Governance: null }],
-          is_critical: [false],
-        },
-        {
-          ...topicInfoMock,
-          name: ["B Topic"],
-          topic: [{ DaoCommunitySettings: null }],
-          is_critical: [true],
-        },
-        {
-          ...topicInfoMock,
-          name: ["A Topic"],
-          topic: [{ ApplicationBusinessLogic: null }],
-          is_critical: [false],
-        },
-        {
-          ...topicInfoMock,
-          name: ["C Topic"],
-          topic: [{ CriticalDappOperations: null }],
-          is_critical: [true],
-        },
-      ];
-
-      const result = generateSnsProposalTopicsFilterData({
-        topics,
-        filters: [],
-      });
-
-      // Should have 4 topic filters + the 'without topic' filter
-      expect(result.length).toBe(5);
-
-      // Critical topics should come first alphabetically
-      expect(result[0].id).toBe("DaoCommunitySettings");
-      expect(result[1].id).toBe("CriticalDappOperations");
-
-      // Then non-critical topics alphabetically
-      expect(result[2].id).toBe("ApplicationBusinessLogic");
-      expect(result[3].id).toBe("Governance");
-
-      expect(result[4].id).toBe(ALL_SNS_PROPOSALS_WITHOUT_TOPIC);
-    });
-
     it("should show all proposals when default setupt of filters", () => {
       const topics: TopicInfoWithUnknown[] = [
         {


### PR DESCRIPTION
# Motivation

With the introduction of sorting topics directly in the derived store in #6788, it is no longer necessary to sort them before providing them to the filters on the proposals page.

# Changes

-  Removed the sorting operation from `generateSnsProposalTopicsFilterData`.

# Tests

-  Removed outdated test since sorting no longer occurs at the utility level.

# Todos

-  [ ] Add entry to changelog (if necessary). 
Not necessary.