### PR TITLE
(sns-topics): Fix not visible tag backgrounds

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- Fix tag background styling in the vote delegation modal (dark theme).
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte
@@ -356,3 +356,13 @@
     />
   {/if}
 </WizardModal>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  // Ensure all tag backgrounds in the modal are visible in dark mode.
+  @include media.dark-theme {
+    // Same color as the checkbox background on the first step.
+    --tag-background: var(--input-background);
+  }
+</style>


### PR DESCRIPTION
# Motivation

The modal content background currently uses the same color as the tag background, making the tags hard to distinguish in dark mode.

There is no general solution for this yet, so in this PR, the tag background color in the vote delegation modal is changed to match the input background color. This ensures better contrast and visual consistency with the checkboxes rendered in the same context.

# Changes

- Override tag background color in the vote delegation modal for the dark theme.

| Before | After |
|--------|--------|
| <img width="452" alt="image" src="https://github.com/user-attachments/assets/bbb8e465-1e11-41ce-a38a-785b4454feae" /> | <img width="452" alt="image" src="https://github.com/user-attachments/assets/80361c8f-cd99-4663-a4ab-2cebd73529ca" /> |
| <img width="447" alt="image" src="https://github.com/user-attachments/assets/82d153f9-35c2-48bc-b3cc-5f61e1da2d40" /> | <img width="447" alt="image" src="https://github.com/user-attachments/assets/033fed5b-4ffb-4200-8856-46053e2ce112" /> | 

# Tests

- Manually verified that the tags are clearly visible in dark mode.

# Todos

- [ ] Add entry to changelog (if necessary).
