### PR TITLE
feat(portfolio): add swipe navigation to stacked cards

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 - Topic-based filtering for SNS proposals
 - Topic-based SNS neuron voting delegation
+- Swipe gestures for project cards on the portfolio page
 
 #### Changed
 

--- a/frontend/src/lib/components/portfolio/StackedCards.svelte
+++ b/frontend/src/lib/components/portfolio/StackedCards.svelte
@@ -13,7 +13,15 @@
   const { cards = [] }: Props = $props();
 
   let activeIndex = $state(0);
+
   let intervalId: number | undefined;
+  let touchStartX: number = 0;
+  let touchEndX: number = 0;
+
+  const prevCard = () => {
+    const newIndex = (activeIndex - 1 + cards.length) % cards.length;
+    setCard(newIndex);
+  };
 
   const nextCard = () => {
     const newIndex = (activeIndex + 1) % cards.length;
@@ -25,6 +33,24 @@
 
     activeIndex = newIndex;
     resetTimer();
+  };
+
+  const handleTouchStart = (event: TouchEvent) => {
+    touchStartX = event.touches[0].clientX;
+    clearInterval();
+  };
+
+  const handleTouchEnd = (event: TouchEvent) => {
+    touchEndX = event.changedTouches[0].clientX;
+    handleSwipe();
+  };
+
+  const handleSwipe = () => {
+    const swipeDistance = touchEndX - touchStartX;
+    const minSwipeDistance = 50;
+    if (Math.abs(swipeDistance) < minSwipeDistance) return;
+    if (swipeDistance > 0) prevCard();
+    else nextCard();
   };
 
   const clearInterval = () => {
@@ -43,7 +69,12 @@
   resetTimer();
 </script>
 
-<div class="stacked-cards" data-tid="stacked-cards-component">
+<div
+  class="stacked-cards"
+  data-tid="stacked-cards-component"
+  ontouchstart={handleTouchStart}
+  ontouchend={handleTouchEnd}
+>
   {#if cards.length > 0}
     <div class="cards-wrapper">
       {#each cards as card, i}
@@ -87,6 +118,7 @@
     width: 100%;
     align-items: center;
     position: relative;
+    touch-action: pan-y;
 
     .cards-wrapper {
       position: relative;


### PR DESCRIPTION
# Motivation

This PR follows up on #6798 and introduces a swiping effect for touch devices for the `StackedCard` component, making navigation easier on mobile devices.

https://github.com/user-attachments/assets/3a6337ed-57d4-4503-8cb0-13d7eedfc33a

[NNS1-3641](https://dfinity.atlassian.net/browse/NNS1-3641)

# Changes

- Introduce a swipe gesture to navigate back and forth within the stacked cards component.

# Tests

- There are no logical changes, so tests should pass as before.  
- I manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/) on my mobile by following the steps outlined [here](https://www.notion.so/dfinityorg/NNS-dapp-on-DevEnv-2882138a87fa45c39bf0966591c3dd73#929a5ccd7edd4b428efbc765aedf4d84).

# Todos

-  [x] Add an entry to the changelog (if necessary). 

[NNS1-3641]: https://dfinity.atlassian.net/browse/NNS1-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ