### PR TITLE
feat(delegation-state-column): New NeuronVoteDelegationCell component

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronVoteDelegationCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronVoteDelegationCell.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { TableNeuron } from "$lib/types/neurons-table";
+  import {
+    IconCheckCircle,
+    IconCheckCircleFill,
+    Tooltip,
+  } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import { nonNullish } from "@dfinity/utils";
+
+  type Props = {
+    rowData: TableNeuron;
+  };
+
+  const { rowData }: Props = $props();
+  const voteDelegationState = $derived(rowData.voteDelegationState);
+  const isVisible = $derived(
+    nonNullish(voteDelegationState) && voteDelegationState !== "none"
+  );
+  const tooltipText = $derived(
+    voteDelegationState === "all"
+      ? $i18n.neuron_detail.vote_delegation_tooltip_all
+      : voteDelegationState === "some"
+        ? $i18n.neuron_detail.vote_delegation_tooltip_some
+        : ""
+  );
+</script>
+
+<div data-tid="neuron-vote-delegation-cell-component">
+  {#if isVisible}
+    <Tooltip text={tooltipText}>
+      {#if voteDelegationState === "all"}
+        <div data-tid="icon-all" role="status" aria-label={tooltipText}>
+          <IconCheckCircleFill size={21} />
+        </div>
+      {:else if voteDelegationState === "some"}
+        <div data-tid="icon-some" role="status" aria-label={tooltipText}>
+          <IconCheckCircle size="18px" />
+        </div>
+      {/if}
+    </Tooltip>
+  {/if}
+</div>
+
+<style lang="scss">
+  div {
+    display: flex;
+    justify-content: center;
+    color: var(--elements-icons);
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -744,6 +744,8 @@
     "auto_stake_maturity_on_success": "Automatically staking new maturity.",
     "auto_stake_maturity_off_success": "Stopped automatically staking new maturity.",
     "maturity_title": "Maturity",
+    "vote_delegation_tooltip_all": "This neuron delegates voting on all topics.",
+    "vote_delegation_tooltip_some": "Partial voting delegation is active.",
     "maturity_last_distribution": "Last Maturity Distribution",
     "maturity_last_distribution_info": "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed. <a href=\"https://wiki.internetcomputer.org/wiki/Roll-over_of_NNS_voting_rewards\" rel=\"noopener noreferrer\" aria-label=\"more info about the voting rewards\" target=\"_blank\">Learn more</a>",
     "stake_maturity": "Stake",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -777,6 +777,8 @@ interface I18nNeuron_detail {
   auto_stake_maturity_on_success: string;
   auto_stake_maturity_off_success: string;
   maturity_title: string;
+  vote_delegation_tooltip_all: string;
+  vote_delegation_tooltip_some: string;
   maturity_last_distribution: string;
   maturity_last_distribution_info: string;
   stake_maturity: string;

--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -19,6 +19,8 @@ export type TableNeuron = {
   state: NeuronState;
   tags: NeuronTagData[];
   isPublic: boolean;
+  // TODO(sns-topics): make it required after the NNS table is updated
+  voteDelegationState?: NeuronsTableVoteDelegationState;
 };
 
 export type NeuronsTableColumnId =
@@ -26,6 +28,7 @@ export type NeuronsTableColumnId =
   | "stake"
   | "maturity"
   | "dissolveDelay"
+  | "voteDelegation"
   | "state";
 
 // Should define a partial ordering on TableNeuron by return -1 if a < b, +1 if
@@ -38,3 +41,5 @@ export type NeuronsTableColumn = ResponsiveTableColumn<
 >;
 
 export type NeuronsTableOrder = ResponsiveTableOrder<NeuronsTableColumnId>;
+
+export type NeuronsTableVoteDelegationState = "all" | "some" | "none";

--- a/frontend/src/tests/page-objects/NeuronVoteDelegationCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronVoteDelegationCell.page-object.ts
@@ -1,0 +1,25 @@
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export default class NeuronVoteDelegationCellPo extends BasePageObject {
+  private static readonly TID = "neuron-vote-delegation-cell-component";
+
+  static under(element: PageObjectElement): NeuronVoteDelegationCellPo {
+    return new NeuronVoteDelegationCellPo(
+      element.byTestId(NeuronVoteDelegationCellPo.TID)
+    );
+  }
+
+  async getVoteDelegationState(): Promise<string> {
+    return ((await this.root.getClasses()) ?? [])[0];
+  }
+
+  getTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
+  }
+
+  getTooltipText(): Promise<string> {
+    return this.getTooltipPo().getTooltipText();
+  }
+}


### PR DESCRIPTION
# Motivation

To improve the overview of a user’s vote delegation state, it’s planned to display the delegation status icon directly in the neuron table by adding a new column: “Vote Delegation” (see screenshot).

This PR adds a new component that will be used as the cell content for this column in both the NNS and SNS tables.

[Draft MVP PR](https://github.com/dfinity/nns-dapp/pull/6802/files)
[Demo](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/)

![Screenshot 2025-05-08 at 13 38 40](https://github.com/user-attachments/assets/700ce2e2-2581-4d59-90a8-97dcdce72357)

# Changes

- Add voteDelegationState to TableNeuron type.
- New `NeuronVoteDelegationCell` component.

# Tests

- Only PO is created. The spec will be added later.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.