### PR TITLE
feat(delegation-state-column): getSnsNeuronVoteDelegationState util

### DIFF
--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -28,6 +28,7 @@ import {
   getSnsNeuronState,
   getSnsNeuronTags,
 } from "$lib/utils/sns-neuron.utils";
+import { getSnsTopicFollowings } from "$lib/utils/sns-topics.utils";
 import {
   createAscendingComparator,
   createDescendingComparator,
@@ -101,6 +102,26 @@ export const tableNeuronsFromNeuronInfos = ({
       isPublic: isPublicNeuron(neuronInfo),
     };
   });
+};
+
+export const getSnsNeuronVoteDelegationState = ({
+  topicCount,
+  neuron,
+}: {
+  topicCount: number;
+  neuron: SnsNeuron;
+}): NeuronsTableVoteDelegationState => {
+  // If there are no topics, no delegation by topic is possible.
+  if (topicCount === 0) return "none";
+
+  const followedTopicCount = new Set(
+    getSnsTopicFollowings(neuron).map(({ topic }) => topic)
+  ).size;
+  return followedTopicCount === 0
+    ? "none"
+    : followedTopicCount === topicCount
+      ? "all"
+      : "some";
 };
 
 export const tableNeuronsFromSnsNeurons = ({

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -6,6 +6,7 @@ import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import { type IcpSwapUsdPricesStoreData } from "$lib/derived/icp-swap.derived";
 import type {
   NeuronsTableColumnId,
+  NeuronsTableVoteDelegationState,
   TableNeuron,
   TableNeuronComparator,
 } from "$lib/types/neurons-table";

--- a/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   compareByMaturity,
   compareByStake,
   compareByState,
+  getSnsNeuronVoteDelegationState,
   tableNeuronsFromNeuronInfos,
   tableNeuronsFromSnsNeurons,
 } from "$lib/utils/neurons-table.utils";
@@ -258,6 +259,88 @@ describe("neurons-table.utils", () => {
           tags: [{ text: "Hotkey control" }],
         },
       ]);
+    });
+  });
+
+  describe("getSnsNeuronVoteDelegationState", () => {
+    const neuronId = { id: Uint8Array.from([1, 2, 3]) };
+
+    it('should return "none" if no delegation', () => {
+      const neuron = createMockSnsNeuron({
+        topicFollowees: {},
+      });
+
+      expect(
+        getSnsNeuronVoteDelegationState({
+          topicCount: 2,
+          neuron,
+        })
+      ).toEqual("none");
+    });
+
+    it('should return "none" if no topics', () => {
+      const neuron = createMockSnsNeuron({
+        sourceNnsNeuronId: 0n,
+        topicFollowees: {
+          DaoCommunitySettings: [
+            {
+              neuronId,
+            },
+          ],
+        },
+      });
+
+      expect(
+        getSnsNeuronVoteDelegationState({
+          topicCount: 0,
+          neuron,
+        })
+      ).toEqual("none");
+    });
+
+    it('should return "all" when all topics are delegated', () => {
+      const neuron = createMockSnsNeuron({
+        sourceNnsNeuronId: 0n,
+        topicFollowees: {
+          DaoCommunitySettings: [
+            {
+              neuronId,
+            },
+          ],
+          CriticalDappOperations: [
+            {
+              neuronId,
+            },
+          ],
+        },
+      });
+
+      expect(
+        getSnsNeuronVoteDelegationState({
+          topicCount: 2,
+          neuron,
+        })
+      ).toEqual("all");
+    });
+
+    it('should return "some" when there are delegations but not for all topics', () => {
+      const neuron = createMockSnsNeuron({
+        sourceNnsNeuronId: 0n,
+        topicFollowees: {
+          DaoCommunitySettings: [
+            {
+              neuronId,
+            },
+          ],
+        },
+      });
+
+      expect(
+        getSnsNeuronVoteDelegationState({
+          topicCount: 2,
+          neuron,
+        })
+      ).toEqual("some");
     });
   });
 


### PR DESCRIPTION
# Motivation

To improve the overview of a user’s vote delegation state, it’s planned to display the delegation status icon directly in the neuron table by adding a new column: “Vote Delegation” (see screenshot).

This PR adds a new util to calculate the vote delegation status.

[Draft MVP PR](https://github.com/dfinity/nns-dapp/pull/6802/files)
[Demo](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/)

# Changes

- Add getSnsNeuronVoteDelegationState util.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.