### PR TITLE
refactor: Migrate NeuronsTable components to svelte 5

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronActionsCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronActionsCell.svelte
@@ -3,7 +3,10 @@
   import { IconRight } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
 
-  export let rowData: TableNeuron;
+  type Props = {
+    rowData: TableNeuron;
+  };
+  const { rowData }: Props = $props();
 </script>
 
 {#if nonNullish(rowData.rowHref)}

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronDissolveDelayCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronDissolveDelayCell.svelte
@@ -3,13 +3,17 @@
   import type { TableNeuron } from "$lib/types/neurons-table";
   import { secondsToDuration } from "@dfinity/utils";
 
-  export let rowData: TableNeuron;
+  type Props = {
+    rowData: TableNeuron;
+  };
+  const { rowData }: Props = $props();
 
-  let dissolveDelayDuration: string;
-  $: dissolveDelayDuration = secondsToDuration({
-    seconds: rowData.dissolveDelaySeconds,
-    i18n: $i18n.time,
-  });
+  const dissolveDelayDuration = $derived(
+    secondsToDuration({
+      seconds: rowData.dissolveDelaySeconds,
+      i18n: $i18n.time,
+    })
+  );
 </script>
 
 <div data-tid="neuron-dissolve-delay-cell-component">

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -5,7 +5,10 @@
   import { IconPublicBadge, Tooltip } from "@dfinity/gix-components";
   import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
 
-  export let rowData: TableNeuron;
+  type Props = {
+    rowData: TableNeuron;
+  };
+  const { rowData }: Props = $props();
 </script>
 
 <div data-tid="neuron-id-cell-component" class="container">

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronMaturityCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronMaturityCell.svelte
@@ -2,7 +2,10 @@
   import MaturityWithTooltip from "$lib/components/neurons/MaturityWithTooltip.svelte";
   import type { TableNeuron } from "$lib/types/neurons-table";
 
-  export let rowData: TableNeuron;
+  type Props = {
+    rowData: TableNeuron;
+  };
+  const { rowData }: Props = $props();
 </script>
 
 <div data-tid="neuron-maturity-cell-component">

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte
@@ -4,7 +4,10 @@
   import { ENABLE_USD_VALUES_FOR_NEURONS } from "$lib/stores/feature-flags.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
 
-  export let rowData: TableNeuron;
+  type Props = {
+    rowData: TableNeuron;
+  };
+  const { rowData }: Props = $props();
 </script>
 
 <div data-tid="neuron-stake-cell-component" class="container">

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
@@ -6,10 +6,14 @@
   import { Tooltip } from "@dfinity/gix-components";
   import { NeuronState } from "@dfinity/nns";
 
-  export let rowData: TableNeuron;
+  type Props = {
+    rowData: TableNeuron;
+  };
+  const { rowData }: Props = $props();
 
-  let stateInfo: StateInfo | undefined;
-  $: stateInfo = getStateInfo(rowData.state);
+  const stateInfo: StateInfo | undefined = $derived(
+    getStateInfo(rowData.state)
+  );
 </script>
 
 {#if stateInfo !== undefined}

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
@@ -26,7 +26,7 @@
   >
     <div class="status" data-tid="neuron-state-info">
       <span class="icon">
-        <svelte:component this={stateInfo.Icon} size={ICON_SIZE_SMALL_PIXELS} />
+        <stateInfo.Icon size={ICON_SIZE_SMALL_PIXELS} />
       </span>
       {$i18n.neuron_state[stateInfo.textKey]}
     </div>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -28,79 +28,77 @@
   // Make sure to update neurons-table-order-sorted-neuron-ids-store.utils when sorting is changed
   const neuronsSortedById = $derived([...neurons].sort(compareById));
 
-  const columns = $derived(
-    (
-      [
-        {
-          id: "id",
-          title: $i18n.neurons.title,
-          cellComponent: NeuronIdCell,
-          alignment: "left",
-          templateColumns: ["minmax(min-content, max-content)"],
-        },
-        {
-          title: "",
-          alignment: "left",
-          templateColumns: ["1fr"],
-        },
-        {
-          id: "stake",
-          title: $i18n.neuron_detail.stake,
-          cellComponent: NeuronStakeCell,
-          alignment: "right",
-          templateColumns: ["max-content"],
-        },
-        {
-          title: "",
-          alignment: "left",
-          templateColumns: ["1fr"],
-        },
-        {
-          id: "maturity",
-          title: $i18n.neuron_detail.maturity_title,
-          cellComponent: NeuronMaturityCell,
-          alignment: "right",
-          templateColumns: ["max-content"],
-        },
-        {
-          title: "",
-          alignment: "left",
-          templateColumns: ["1fr"],
-        },
-        {
-          id: "dissolveDelay",
-          title: $i18n.neurons.dissolve_delay_title,
-          cellComponent: NeuronDissolveDelayCell,
-          alignment: "left",
-          templateColumns: ["max-content"],
-        },
-        {
-          title: "",
-          alignment: "left",
-          templateColumns: ["1fr"],
-        },
-        {
-          id: "state",
-          title: $i18n.neurons.state,
-          cellComponent: NeuronStateCell,
-          alignment: "left",
-          templateColumns: ["max-content"],
-        },
-        {
-          title: "",
-          cellComponent: NeuronActionsCell,
-          alignment: "right",
-          templateColumns: ["max-content"],
-        },
-      ] as NeuronsTableColumn[]
-    ).map((column) => ({
-      ...column,
-      ...(column.id &&
-        comparatorsByColumnId[column.id] && {
-          comparator: comparatorsByColumnId[column.id],
-        }),
-    }))
-  );
+  const columns = (
+    [
+      {
+        id: "id",
+        title: $i18n.neurons.title,
+        cellComponent: NeuronIdCell,
+        alignment: "left",
+        templateColumns: ["minmax(min-content, max-content)"],
+      },
+      {
+        title: "",
+        alignment: "left",
+        templateColumns: ["1fr"],
+      },
+      {
+        id: "stake",
+        title: $i18n.neuron_detail.stake,
+        cellComponent: NeuronStakeCell,
+        alignment: "right",
+        templateColumns: ["max-content"],
+      },
+      {
+        title: "",
+        alignment: "left",
+        templateColumns: ["1fr"],
+      },
+      {
+        id: "maturity",
+        title: $i18n.neuron_detail.maturity_title,
+        cellComponent: NeuronMaturityCell,
+        alignment: "right",
+        templateColumns: ["max-content"],
+      },
+      {
+        title: "",
+        alignment: "left",
+        templateColumns: ["1fr"],
+      },
+      {
+        id: "dissolveDelay",
+        title: $i18n.neurons.dissolve_delay_title,
+        cellComponent: NeuronDissolveDelayCell,
+        alignment: "left",
+        templateColumns: ["max-content"],
+      },
+      {
+        title: "",
+        alignment: "left",
+        templateColumns: ["1fr"],
+      },
+      {
+        id: "state",
+        title: $i18n.neurons.state,
+        cellComponent: NeuronStateCell,
+        alignment: "left",
+        templateColumns: ["max-content"],
+      },
+      {
+        title: "",
+        cellComponent: NeuronActionsCell,
+        alignment: "right",
+        templateColumns: ["max-content"],
+      },
+    ] as NeuronsTableColumn[]
+  ).map((column) => ({
+    ...column,
+    ...(column.id &&
+      comparatorsByColumnId[column.id] && {
+        comparator: comparatorsByColumnId[column.id],
+      }),
+  }));
 
   const getRowStyle = (neuron: TableNeuron) => {
     if (neuron.state === NeuronState.Spawning) {

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -18,85 +18,89 @@
   } from "$lib/utils/neurons-table.utils";
   import { NeuronState } from "@dfinity/nns";
 
-  export let neurons: TableNeuron[];
+  type Props = {
+    neurons: TableNeuron[];
+  };
+  const { neurons }: Props = $props();
 
   // Make sure there is a consistent order even if the selected sorting
   // criteria don't tiebreak all neurons.
   // Make sure to update neurons-table-order-sorted-neuron-ids-store.utils when sorting is changed
-  let neuronsSortedById: TableNeuron[];
-  $: neuronsSortedById = [...neurons].sort(compareById);
+  const neuronsSortedById = $derived([...neurons].sort(compareById));
 
-  const columns = (
-    [
-      {
-        id: "id",
-        title: $i18n.neurons.title,
-        cellComponent: NeuronIdCell,
-        alignment: "left",
-        templateColumns: ["minmax(min-content, max-content)"],
-      },
-      {
-        title: "",
-        alignment: "left",
-        templateColumns: ["1fr"],
-      },
-      {
-        id: "stake",
-        title: $i18n.neuron_detail.stake,
-        cellComponent: NeuronStakeCell,
-        alignment: "right",
-        templateColumns: ["max-content"],
-      },
-      {
-        title: "",
-        alignment: "left",
-        templateColumns: ["1fr"],
-      },
-      {
-        id: "maturity",
-        title: $i18n.neuron_detail.maturity_title,
-        cellComponent: NeuronMaturityCell,
-        alignment: "right",
-        templateColumns: ["max-content"],
-      },
-      {
-        title: "",
-        alignment: "left",
-        templateColumns: ["1fr"],
-      },
-      {
-        id: "dissolveDelay",
-        title: $i18n.neurons.dissolve_delay_title,
-        cellComponent: NeuronDissolveDelayCell,
-        alignment: "left",
-        templateColumns: ["max-content"],
-      },
-      {
-        title: "",
-        alignment: "left",
-        templateColumns: ["1fr"],
-      },
-      {
-        id: "state",
-        title: $i18n.neurons.state,
-        cellComponent: NeuronStateCell,
-        alignment: "left",
-        templateColumns: ["max-content"],
-      },
-      {
-        title: "",
-        cellComponent: NeuronActionsCell,
-        alignment: "right",
-        templateColumns: ["max-content"],
-      },
-    ] as NeuronsTableColumn[]
-  ).map((column) => ({
-    ...column,
-    ...(column.id &&
-      comparatorsByColumnId[column.id] && {
-        comparator: comparatorsByColumnId[column.id],
-      }),
-  }));
+  const columns = $derived(
+    (
+      [
+        {
+          id: "id",
+          title: $i18n.neurons.title,
+          cellComponent: NeuronIdCell,
+          alignment: "left",
+          templateColumns: ["minmax(min-content, max-content)"],
+        },
+        {
+          title: "",
+          alignment: "left",
+          templateColumns: ["1fr"],
+        },
+        {
+          id: "stake",
+          title: $i18n.neuron_detail.stake,
+          cellComponent: NeuronStakeCell,
+          alignment: "right",
+          templateColumns: ["max-content"],
+        },
+        {
+          title: "",
+          alignment: "left",
+          templateColumns: ["1fr"],
+        },
+        {
+          id: "maturity",
+          title: $i18n.neuron_detail.maturity_title,
+          cellComponent: NeuronMaturityCell,
+          alignment: "right",
+          templateColumns: ["max-content"],
+        },
+        {
+          title: "",
+          alignment: "left",
+          templateColumns: ["1fr"],
+        },
+        {
+          id: "dissolveDelay",
+          title: $i18n.neurons.dissolve_delay_title,
+          cellComponent: NeuronDissolveDelayCell,
+          alignment: "left",
+          templateColumns: ["max-content"],
+        },
+        {
+          title: "",
+          alignment: "left",
+          templateColumns: ["1fr"],
+        },
+        {
+          id: "state",
+          title: $i18n.neurons.state,
+          cellComponent: NeuronStateCell,
+          alignment: "left",
+          templateColumns: ["max-content"],
+        },
+        {
+          title: "",
+          cellComponent: NeuronActionsCell,
+          alignment: "right",
+          templateColumns: ["max-content"],
+        },
+      ] as NeuronsTableColumn[]
+    ).map((column) => ({
+      ...column,
+      ...(column.id &&
+        comparatorsByColumnId[column.id] && {
+          comparator: comparatorsByColumnId[column.id],
+        }),
+    }))
+  );
 
   const getRowStyle = (neuron: TableNeuron) => {
     if (neuron.state === NeuronState.Spawning) {


### PR DESCRIPTION
# Motivation

Since changes are planned for some NeuronsTable components, it’s a good opportunity to migrate them to Svelte 5.

# Changes

- Change neuron table components to svelte 5 syntax.

# Tests

- Should pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.