### PR TITLE
refactor(wallet): migrate SNS wallet to runes

### DIFF
--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -32,14 +32,12 @@
       : undefined
   );
 
-  // TODO(yhabib): figure out why Svelte thinks that this value changes overtime
-  // svelte-ignore non_reactive_update
-  let transactions: IcrcWalletTransactionsList;
-
   let wallet: IcrcWalletPage;
+  let transactions: IcrcWalletTransactionsList | undefined = $state();
 
   const reloadAccount = async () => await wallet?.reloadAccount?.();
-  const reloadTransactions = () => transactions?.reloadTransactions?.();
+  const reloadTransactions = () =>
+    transactions?.reloadTransactions?.() || Promise.resolve();
 </script>
 
 <IcrcWalletPage

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -36,7 +36,6 @@
   // svelte-ignore non_reactive_update
   let transactions: IcrcWalletTransactionsList;
 
-  // TODO: Svelte v5 migration - marked as potentially undefined because of SnsWallet.spec.ts
   let wallet: IcrcWalletPage;
 
   const reloadAccount = async () => await wallet?.reloadAccount?.();

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -6,33 +6,38 @@
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { tokensByLedgerCanisterIdStore } from "$lib/derived/tokens.derived";
   import type { CanisterId } from "$lib/types/canister";
-  import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import type { WalletStore } from "$lib/types/wallet.context";
   import { nonNullish } from "@dfinity/utils";
   import { writable } from "svelte/store";
 
-  export let accountIdentifier: string | undefined | null = undefined;
+  type Props = {
+    accountIdentifier: string | undefined | null;
+  };
+  const { accountIdentifier }: Props = $props();
 
   const selectedAccountStore = writable<WalletStore>({
     account: undefined,
     neurons: [],
   });
 
-  let ledgerCanisterId: CanisterId | undefined;
-  $: ledgerCanisterId = $snsProjectSelectedStore?.summary.ledgerCanisterId;
+  const ledgerCanisterId: CanisterId | undefined = $derived(
+    $snsProjectSelectedStore?.summary.ledgerCanisterId
+  );
+  const indexCanisterId: CanisterId | undefined = $derived(
+    $snsProjectSelectedStore?.summary.indexCanisterId
+  );
+  const token = $derived(
+    nonNullish(ledgerCanisterId)
+      ? $tokensByLedgerCanisterIdStore[ledgerCanisterId.toText()]
+      : undefined
+  );
 
-  let indexCanisterId: CanisterId | undefined;
-  $: indexCanisterId = $snsProjectSelectedStore?.summary.indexCanisterId;
-
-  let token: IcrcTokenMetadata | undefined;
-  $: token = nonNullish(ledgerCanisterId)
-    ? $tokensByLedgerCanisterIdStore[ledgerCanisterId.toText()]
-    : undefined;
-
+  // TODO(yhabib): figure out why Svelte thinks that this value changes overtime
+  // svelte-ignore non_reactive_update
   let transactions: IcrcWalletTransactionsList;
 
   // TODO: Svelte v5 migration - marked as potentially undefined because of SnsWallet.spec.ts
-  let wallet: IcrcWalletPage | undefined;
+  let wallet: IcrcWalletPage;
 
   const reloadAccount = async () => await wallet?.reloadAccount?.();
   const reloadTransactions = () => transactions?.reloadTransactions?.();

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -37,7 +37,7 @@
 
   const reloadAccount = async () => await wallet?.reloadAccount?.();
   const reloadTransactions = () =>
-    transactions?.reloadTransactions?.() || Promise.resolve();
+    transactions?.reloadTransactions?.() ?? Promise.resolve();
 </script>
 
 <IcrcWalletPage


### PR DESCRIPTION
# Motivation

We aim to introduce changes to the `SnsWallet` component. This PR refactors the component using runes to simplify the addition of new features.

[NNS1-3793](https://dfinity.atlassian.net/browse/NNS1-3793)

# Changes

- Refactor `SnsWallet` to use runes.

# Tests

- All tests should pass as before since no logical changes were made.

# Todos

-  [ ] Add an entry to the changelog (if necessary). 
Not necessary.

[NNS1-3793]: https://dfinity.atlassian.net/browse/NNS1-3793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ