### PR TITLE
refactor(portfolio): migrate page component to runes

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -13,9 +13,8 @@
   import TotalAssetsCard from "$lib/components/portfolio/TotalAssetsCard.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
-  import type { SnsSummary } from "$lib/types/sns";
   import type { TableProject } from "$lib/types/staking";
-  import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+  import type { UserToken } from "$lib/types/tokens-page";
   import {
     compareProposalInfoByDeadlineTimestampSeconds,
     getTopHeldTokens,
@@ -28,43 +27,44 @@
   import { TokenAmountV2, isNullish } from "@dfinity/utils";
   import type { Component } from "svelte";
 
-  export let userTokens: UserToken[] = [];
-  export let tableProjects: TableProject[];
-  export let snsProjects: SnsFullProject[];
-  export let openSnsProposals: ProposalInfo[];
+  type Props = {
+    userTokens: UserToken[];
+    tableProjects: TableProject[];
+    snsProjects: SnsFullProject[];
+    openSnsProposals: ProposalInfo[];
+  };
 
-  let totalTokensBalanceInUsd: number;
-  $: totalTokensBalanceInUsd = getTotalBalanceInUsd(userTokens);
+  const { userTokens, tableProjects, snsProjects, openSnsProposals }: Props =
+    $props();
 
-  let hasUnpricedTokens: boolean;
-  $: hasUnpricedTokens = userTokens.some(
-    (token) =>
-      token.balance instanceof TokenAmountV2 &&
-      token.balance.toUlps() > 0n &&
-      (!("balanceInUsd" in token) || isNullish(token.balanceInUsd))
+  const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));
+  const hasUnpricedTokens = $derived(
+    userTokens.some(
+      (token) =>
+        token.balance instanceof TokenAmountV2 &&
+        token.balance.toUlps() > 0n &&
+        (!("balanceInUsd" in token) || isNullish(token.balanceInUsd))
+    )
   );
-  let totalStakedInUsd: number;
-  $: totalStakedInUsd = getTotalStakeInUsd(tableProjects);
-
-  let hasUnpricedStake: boolean;
-  $: hasUnpricedStake = tableProjects.some(
-    (project) =>
-      project.stake instanceof TokenAmountV2 &&
-      project.stake.toUlps() > 0n &&
-      (!("stakeInUsd" in project) || isNullish(project.stakeInUsd))
+  const totalStakedInUsd = $derived(getTotalStakeInUsd(tableProjects));
+  const hasUpricedStake = $derived(
+    tableProjects.some(
+      (project) =>
+        project.stake instanceof TokenAmountV2 &&
+        project.stake.toUlps() > 0n &&
+        (!("stakeInUsd" in project) || isNullish(project.stakeInUsd))
+    )
+  );
+  const hasUnpricedTokensOrStake = $derived(
+    hasUnpricedTokens || hasUpricedStake
   );
 
-  let hasUnpricedTokensOrStake: boolean;
-  $: hasUnpricedTokensOrStake = hasUnpricedTokens || hasUnpricedStake;
+  const totalUsdAmount = $derived(
+    $authSignedInStore ? totalTokensBalanceInUsd + totalStakedInUsd : undefined
+  );
 
-  let totalUsdAmount: number | undefined;
-  $: totalUsdAmount = $authSignedInStore
-    ? totalTokensBalanceInUsd + totalStakedInUsd
-    : undefined;
-
-  let areHeldTokensLoading: boolean;
-  $: areHeldTokensLoading = userTokens.some(
-    (token) => token.balance === "loading"
+  const areHeldTokensLoading = $derived(
+    userTokens.some((token) => token.balance === "loading")
   );
 
   // Determines the display state of the held tokens card
@@ -73,79 +73,82 @@
   // - 'empty': Shows empty state when user has no tokens
   type TokensCardType = "empty" | "skeleton" | "full";
 
-  let heldTokensCard: TokensCardType;
-  $: heldTokensCard = !$authSignedInStore
-    ? "full"
-    : areHeldTokensLoading
-      ? "skeleton"
-      : totalTokensBalanceInUsd === 0
-        ? "empty"
-        : "full";
+  const heldTokensCard: TokensCardType = $derived(
+    !$authSignedInStore
+      ? "full"
+      : areHeldTokensLoading
+        ? "skeleton"
+        : totalTokensBalanceInUsd === 0
+          ? "empty"
+          : "full"
+  );
 
-  let areStakedTokensLoading: boolean;
-  $: areStakedTokensLoading = tableProjects.some(
-    (project) => project.isStakeLoading
+  const areStakedTokensLoading = $derived(
+    tableProjects.some((project) => project.isStakeLoading)
   );
 
   // Determines the display state of the staked tokens card
   // Similar logic to heldTokensCard but for staked tokens
-  let stakedTokensCard: TokensCardType;
-  $: stakedTokensCard = !$authSignedInStore
-    ? "full"
-    : areStakedTokensLoading
-      ? "skeleton"
-      : totalStakedInUsd === 0
-        ? "empty"
-        : "full";
+  const stakedTokensCard: TokensCardType = $derived(
+    !$authSignedInStore
+      ? "full"
+      : areStakedTokensLoading
+        ? "skeleton"
+        : totalStakedInUsd === 0
+          ? "empty"
+          : "full"
+  );
 
   // Controls whether the staked tokens card should show a primary action
   // Primary action is shown when there are tokens but no stakes
   // This helps guide users to stake their tokens when possible
-  let hasNoStakedTokensCardAPrimaryAction: boolean;
-  $: hasNoStakedTokensCardAPrimaryAction =
-    stakedTokensCard === "empty" && heldTokensCard === "full";
+  const hasNoStakedTokensCardAPrimaryAction = $derived(
+    stakedTokensCard === "empty" && heldTokensCard === "full"
+  );
 
   // Global loading state that tracks if either held or staked tokens are loading
   // TotalAssetsCard will show this if either held or staked are loading
-  let isSomethingLoading: boolean;
-  $: isSomethingLoading = areHeldTokensLoading || areStakedTokensLoading;
+  const isSomethingLoading = $derived(
+    areHeldTokensLoading || areStakedTokensLoading
+  );
 
-  let topHeldTokens: UserTokenData[];
-  $: topHeldTokens = getTopHeldTokens({
-    userTokens: userTokens,
-    isSignedIn: $authSignedInStore,
-  });
+  const topHeldTokens = $derived(
+    getTopHeldTokens({
+      userTokens: userTokens,
+      isSignedIn: $authSignedInStore,
+    })
+  );
 
-  let topStakedTokens: TableProject[];
-  $: topStakedTokens = getTopStakedTokens({
-    projects: tableProjects,
-    isSignedIn: $authSignedInStore,
-  });
+  const topStakedTokens = $derived(
+    getTopStakedTokens({
+      projects: tableProjects,
+      isSignedIn: $authSignedInStore,
+    })
+  );
 
-  let snsSummaries: SnsSummary[];
-  $: snsSummaries = snsProjects
-    .sort(comparesByDecentralizationSaleOpenTimestampDesc)
-    .reverse()
-    .map((project) => project.summary);
+  const launchpadCards = $derived(
+    [...snsProjects]
+      .sort(comparesByDecentralizationSaleOpenTimestampDesc)
+      .reverse()
+      .map((project) => project.summary)
+      .map<CardItem>((summary) => ({
+        // TODO: Svelte v5 migration - fix type
+        component: LaunchProjectCard as unknown as Component,
+        props: { summary },
+      }))
+  );
 
-  let launchpadCards: CardItem[];
-  $: launchpadCards = snsSummaries.map<CardItem>((summary) => ({
-    // TODO: Svelte v5 migration - fix type
-    component: LaunchProjectCard as unknown as Component,
-    props: { summary },
-  }));
+  const openProposalCards = $derived(
+    [...openSnsProposals]
+      .sort(compareProposalInfoByDeadlineTimestampSeconds)
+      .map((proposalInfo) => ({
+        // TODO: Svelte v5 migration - fix type
+        component: NewSnsProposalCard as unknown as Component,
+        props: { proposalInfo },
+      }))
+  );
 
-  let openProposalCards: CardItem[];
-  $: openProposalCards = openSnsProposals
-    .sort(compareProposalInfoByDeadlineTimestampSeconds)
-    .map((proposalInfo) => ({
-      // TODO: Svelte v5 migration - fix type
-      component: NewSnsProposalCard as unknown as Component,
-      props: { proposalInfo },
-    }));
-
-  let cards: CardItem[] = [];
-  $: cards = [...launchpadCards, ...openProposalCards];
+  const cards: CardItem[] = $derived([...launchpadCards, ...openProposalCards]);
 </script>
 
 <main data-tid="portfolio-page-component">

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -34,8 +34,12 @@
     openSnsProposals: ProposalInfo[];
   };
 
-  const { userTokens, tableProjects, snsProjects, openSnsProposals }: Props =
-    $props();
+  const {
+    userTokens = [],
+    tableProjects,
+    snsProjects,
+    openSnsProposals,
+  }: Props = $props();
 
   const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));
   const hasUnpricedTokens = $derived(

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -46,6 +46,7 @@
         (!("balanceInUsd" in token) || isNullish(token.balanceInUsd))
     )
   );
+
   const totalStakedInUsd = $derived(getTotalStakeInUsd(tableProjects));
   const hasUpricedStake = $derived(
     tableProjects.some(
@@ -55,6 +56,7 @@
         (!("stakeInUsd" in project) || isNullish(project.stakeInUsd))
     )
   );
+
   const hasUnpricedTokensOrStake = $derived(
     hasUnpricedTokens || hasUpricedStake
   );
@@ -63,16 +65,15 @@
     $authSignedInStore ? totalTokensBalanceInUsd + totalStakedInUsd : undefined
   );
 
-  const areHeldTokensLoading = $derived(
-    userTokens.some((token) => token.balance === "loading")
-  );
-
   // Determines the display state of the held tokens card
   // - 'full': Shows card with data (or when user is not signed in, visitor data)
   // - 'loading': Shows skeleton while data is being fetched
   // - 'empty': Shows empty state when user has no tokens
   type TokensCardType = "empty" | "skeleton" | "full";
 
+  const areHeldTokensLoading = $derived(
+    userTokens.some((token) => token.balance === "loading")
+  );
   const heldTokensCard: TokensCardType = $derived(
     !$authSignedInStore
       ? "full"
@@ -86,7 +87,6 @@
   const areStakedTokensLoading = $derived(
     tableProjects.some((project) => project.isStakeLoading)
   );
-
   // Determines the display state of the staked tokens card
   // Similar logic to heldTokensCard but for staked tokens
   const stakedTokensCard: TokensCardType = $derived(


### PR DESCRIPTION
# Motivation

We aim to display proposals for new SNS projects on the Portfolio page that were approved before the swap begins. This PR prepares the Portfolio page to introduce the pre-swap cards by migrating to runes.

[NNS1-3639](https://dfinity.atlassian.net/browse/NNS1-3639)

# Changes

-  Refactored the page to use runes.

# Tests

-  Tests should pass as before since there were no logical changes.

# Todos

-  [ ] Add an entry to the changelog (if necessary)
Not necessary.

[NNS1-3639]: https://dfinity.atlassian.net/browse/NNS1-3639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ