### PR TITLE
feat(api): add new method listSubaccounts

### DIFF
--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -3,10 +3,12 @@ import { HOST } from "$lib/constants/environment.constants";
 import type { Agent, Identity } from "@dfinity/agent";
 import {
   IcrcIndexCanister,
+  IcrcIndexNgCanister,
   type IcrcAccount,
   type IcrcGetTransactions,
 } from "@dfinity/ledger-icrc";
-import type { Principal } from "@dfinity/principal";
+import type { SubAccount } from "@dfinity/ledger-icrc/dist/candid/icrc_index";
+import { Principal } from "@dfinity/principal";
 import { fromNullable } from "@dfinity/utils";
 
 export interface GetTransactionsParams {
@@ -61,6 +63,7 @@ export const getLedgerId = async ({
   return ledgerId({ certified });
 };
 
+// TODO(yhabib): Migrate all methods to the indexNgCanister
 const indexCanister = async ({
   identity,
   canisterId,
@@ -77,6 +80,57 @@ const indexCanister = async ({
   });
 
   const canister = IcrcIndexCanister.create({
+    agent,
+    canisterId,
+  });
+
+  return {
+    canister,
+    agent,
+  };
+};
+
+export const listSubaccounts = async ({
+  identity,
+  indexCanisterId,
+  certified,
+}: {
+  identity: Identity;
+  indexCanisterId: Principal;
+  certified?: boolean;
+}): Promise<Array<SubAccount>> => {
+  const {
+    canister: { listSubaccounts },
+  } = await indexNgCanister({
+    identity,
+    canisterId: indexCanisterId,
+  });
+
+  const owner = identity.getPrincipal();
+  const subaccounts = await listSubaccounts({
+    owner,
+    certified,
+  });
+
+  return subaccounts;
+};
+
+const indexNgCanister = async ({
+  identity,
+  canisterId,
+}: {
+  identity: Identity;
+  canisterId: Principal;
+}): Promise<{
+  canister: IcrcIndexNgCanister;
+  agent: Agent;
+}> => {
+  const agent = await createAgent({
+    identity,
+    host: HOST,
+  });
+
+  const canister = IcrcIndexNgCanister.create({
     agent,
     canisterId,
   });

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -2,13 +2,15 @@ import * as agent from "$lib/api/agent.api";
 import {
   getLedgerId,
   getTransactions,
+  listSubaccounts,
   type GetTransactionsParams,
 } from "$lib/api/icrc-index.api";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import type { HttpAgent } from "@dfinity/agent";
-import { IcrcIndexCanister } from "@dfinity/ledger-icrc";
+import { IcrcIndexCanister, IcrcIndexNgCanister } from "@dfinity/ledger-icrc";
 import { mock } from "vitest-mock-extended";
 
 describe("icrc-index api", () => {
@@ -22,13 +24,22 @@ describe("icrc-index api", () => {
   };
 
   const indexCanisterMock = mock<IcrcIndexCanister>();
-  const agentMock = mock<HttpAgent>();
   let spyOnIndexCanisterCreate;
+
+  const indexNgCanisterMock = mock<IcrcIndexNgCanister>();
+  let spyOnIndexNgCanisterCreate;
+
+  const agentMock = mock<HttpAgent>();
 
   beforeEach(() => {
     spyOnIndexCanisterCreate = vi
       .spyOn(IcrcIndexCanister, "create")
       .mockImplementation(() => indexCanisterMock);
+
+    spyOnIndexNgCanisterCreate = vi
+      .spyOn(IcrcIndexNgCanister, "create")
+      .mockImplementation(() => indexNgCanisterMock);
+
     vi.spyOn(agent, "createAgent").mockResolvedValue(agentMock);
   });
 
@@ -120,6 +131,45 @@ describe("icrc-index api", () => {
           identity: mockIdentity,
           indexCanisterId,
           certified: true,
+        });
+
+      await expect(call).rejects.toThrowError(err);
+    });
+  });
+
+  describe("listSubaccounts", () => {
+    const subaccounts = [mockSubAccountArray, mockSubAccountArray];
+    const indexCanisterId = principal(0);
+
+    it("returns subaccounts", async () => {
+      indexNgCanisterMock.listSubaccounts.mockResolvedValue(subaccounts);
+      const result = await listSubaccounts({
+        identity: mockIdentity,
+        indexCanisterId,
+      });
+
+      expect(spyOnIndexNgCanisterCreate).toBeCalledTimes(1);
+      expect(spyOnIndexNgCanisterCreate).toBeCalledWith({
+        agent: agentMock,
+        canisterId: indexCanisterId,
+      });
+
+      expect(indexNgCanisterMock.listSubaccounts).toBeCalledTimes(1);
+      expect(indexNgCanisterMock.listSubaccounts).toBeCalledWith({
+        owner: mockIdentity.getPrincipal(),
+      });
+
+      expect(result).toEqual(subaccounts);
+    });
+
+    it("throws an error if canister throws", async () => {
+      const err = new Error("test");
+      indexNgCanisterMock.listSubaccounts.mockRejectedValue(err);
+
+      const call = () =>
+        listSubaccounts({
+          identity: mockIdentity,
+          indexCanisterId,
         });
 
       await expect(call).rejects.toThrowError(err);


### PR DESCRIPTION
# Motivation

We want to utilize the new function exposed by ic-js to [list subaccounts](https://github.com/dfinity/ic-js/pull/906), enabling users to easily retrieve the list of all subaccounts for an ICRC canister.

Note: This PR introduces a new canister object based on the NextGeneration Index canister. The existing one will be deprecated eventually, so a follow-up PR will migrate the existing methods to the new canister.

[NNS1-3793](https://dfinity.atlassian.net/browse/NNS1-3793)

# Changes

- Add a new canister object for the Next Generation IndexCanister.  
- Add an API function to call `list_subaccounts`.

# Tests

- Add unit tests for the API function.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3793]: https://dfinity.atlassian.net/browse/NNS1-3793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ