### PR TITLE
feat(portfolio): add alternative navigation controls to stacked cards

### DIFF
--- a/frontend/src/lib/components/portfolio/StackedCards.svelte
+++ b/frontend/src/lib/components/portfolio/StackedCards.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" module>
+  import { i18n } from "$lib/stores/i18n";
   import { IconLeft, IconRight } from "@dfinity/gix-components";
   import type { Component } from "svelte";
   import { onDestroy } from "svelte";
@@ -101,7 +102,7 @@
         <button
           class="ghost"
           onclick={prevCard}
-          aria-label="Previuos Card"
+          aria-label={$i18n.portfolio.previous_card}
           data-tid="prev-button"><IconLeft size="24px" /></button
         >
         <span class="current-card-index" data-tid="activeIndex"
@@ -110,7 +111,7 @@
         <button
           class="ghost"
           onclick={nextCard}
-          aria-label="Next Card"
+          aria-label={$i18n.portfolio.next_card}
           data-tid="next-button"><IconRight size="24px" /></button
         >
       </div>

--- a/frontend/src/lib/components/portfolio/StackedCards.svelte
+++ b/frontend/src/lib/components/portfolio/StackedCards.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" module>
+  import { IconLeft, IconRight } from "@dfinity/gix-components";
   import type { Component } from "svelte";
   import { onDestroy } from "svelte";
 
@@ -9,6 +10,7 @@
 
   const REFRESH_INTERVAL = 5000;
   const SWIPE_THRESHOLD = 50;
+  const MAX_NUMBER_OF_DOTS = 7;
 </script>
 
 <script lang="ts">
@@ -94,7 +96,25 @@
       {/each}
     </div>
 
-    {#if cards.length > 1}
+    {#if cards.length > MAX_NUMBER_OF_DOTS}
+      <div class="buttons-container" data-tid="buttons-container">
+        <button
+          class="ghost"
+          onclick={prevCard}
+          aria-label="Previuos Card"
+          data-tid="prev-button"><IconLeft size="24px" /></button
+        >
+        <span class="current-card-index" data-tid="activeIndex"
+          >{activeIndex + 1}</span
+        >
+        <button
+          class="ghost"
+          onclick={nextCard}
+          aria-label="Next Card"
+          data-tid="next-button"><IconRight size="24px" /></button
+        >
+      </div>
+    {:else if cards.length > 1}
       <div class="dots-container" data-tid="dots-container">
         {#each cards as _, i}
           <button
@@ -112,8 +132,6 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
-
   :root {
     --card-stacked-dots-space: 34px;
     --elastic-out: cubic-bezier(0.16, 1.1, 0.3, 1.2);
@@ -172,6 +190,27 @@
         &.exiting {
           animation: fade-out 250ms ease-out forwards;
         }
+      }
+    }
+
+    .buttons-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: var(--padding-1_5x);
+      position: absolute;
+      bottom: var(--padding-0_5x);
+
+      button {
+        color: var(--button-secondary-color);
+        padding: 0;
+        display: flex;
+        align-items: center;
+      }
+
+      .current-card-index {
+        color: var(--text-description);
+        font-weight: var(--font-weight-bold);
       }
     }
 

--- a/frontend/src/lib/components/portfolio/StackedCards.svelte
+++ b/frontend/src/lib/components/portfolio/StackedCards.svelte
@@ -206,6 +206,7 @@
         padding: 0;
         display: flex;
         align-items: center;
+        cursor: pointer;
       }
 
       .current-card-index {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1283,7 +1283,9 @@
     "new_sns_proposal_card_title": "Create New SNS",
     "new_sns_proposal_card_link": "Vote",
     "new_sns_proposal_card_adopt": "Adopt",
-    "new_sns_proposal_card_reject": "Reject"
+    "new_sns_proposal_card_reject": "Reject",
+    "next_card": "Next Card",
+    "previous_card": "Previous Card"
   },
   "highlight": {
     "topics_feature_title": "New feature ",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1352,6 +1352,8 @@ interface I18nPortfolio {
   new_sns_proposal_card_link: string;
   new_sns_proposal_card_adopt: string;
   new_sns_proposal_card_reject: string;
+  next_card: string;
+  previous_card: string;
 }
 
 interface I18nHighlight {

--- a/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
@@ -133,42 +133,43 @@ describe("StackedCards Component", () => {
 
     expect(cardWrappers.length).toBe(MAX_NUMBER_OF_DOTS + 1);
     expect(await buttonsContainerPo.isPresent()).toBe(true);
-    expect(await buttonsContainerPo.getCurrentIndex()).toBe(1);
+    expect(await buttonsContainerPo.getDisplayedCurrentIndex()).toBe(1);
   });
 
   it("should navigate with prev/next buttons", async () => {
-    const cards = Array(MAX_NUMBER_OF_DOTS + 2).fill({ component: Card });
+    const totalCards = MAX_NUMBER_OF_DOTS + 2;
+    const cards = Array(totalCards).fill({ component: Card });
     const po = renderComponent(cards);
     const buttonsContainerPo = await po.getButtonsContainerPo();
     const prevButton = buttonsContainerPo.getPrevButton();
     const nextButton = buttonsContainerPo.getNextButton();
 
     expect(await po.getActiveCardIndex()).toBe(0);
-    expect(await buttonsContainerPo.getCurrentIndex()).toBe(1); // 1-indexed
+    expect(await buttonsContainerPo.getDisplayedCurrentIndex()).toBe(1); // 1-indexed
 
     await nextButton.click();
     expect(await po.getActiveCardIndex()).toBe(1);
-    expect(await buttonsContainerPo.getCurrentIndex()).toBe(2);
+    expect(await buttonsContainerPo.getDisplayedCurrentIndex()).toBe(2);
 
     await nextButton.click();
     expect(await po.getActiveCardIndex()).toBe(2);
-    expect(await buttonsContainerPo.getCurrentIndex()).toBe(3);
+    expect(await buttonsContainerPo.getDisplayedCurrentIndex()).toBe(3);
 
     await prevButton.click();
     expect(await po.getActiveCardIndex()).toBe(1);
-    expect(await buttonsContainerPo.getCurrentIndex()).toBe(2);
+    expect(await buttonsContainerPo.getDisplayedCurrentIndex()).toBe(2);
 
-    // Test wrap-around behavior
-    const totalCards = MAX_NUMBER_OF_DOTS + 2;
     for (let i = 0; i < totalCards - 1; i++) {
       await nextButton.click();
     }
     expect(await po.getActiveCardIndex()).toBe(0);
-    expect(await buttonsContainerPo.getCurrentIndex()).toBe(1);
+    expect(await buttonsContainerPo.getDisplayedCurrentIndex()).toBe(1);
 
     await prevButton.click();
     expect(await po.getActiveCardIndex()).toBe(totalCards - 1);
-    expect(await buttonsContainerPo.getCurrentIndex()).toBe(totalCards);
+    expect(await buttonsContainerPo.getDisplayedCurrentIndex()).toBe(
+      totalCards
+    );
   });
 
   it("should reset timer when navigating with buttons", async () => {

--- a/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
@@ -4,6 +4,8 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { StackedCardsPo } from "$tests/page-objects/StackedCards.page-object";
 import { render } from "@testing-library/svelte";
 
+const MAX_NUMBER_OF_DOTS = 7;
+
 describe("StackedCards Component", () => {
   const renderComponent = (cards: unknown[]) => {
     const { container } = render(StackedCards, { props: { cards } });
@@ -13,30 +15,42 @@ describe("StackedCards Component", () => {
   it("should render empty when no cards are provided", async () => {
     const po = renderComponent([]);
     const dotsPo = await po.getDots();
+    const hasDotsNavigation = await po.hasDotsNavigation();
+    const hasButtonsNavigation = await po.hasButtonsNavigation();
 
     expect(dotsPo.length).toBe(0);
+    expect(hasDotsNavigation).toBe(false);
+    expect(hasButtonsNavigation).toBe(false);
   });
 
-  it("should render a single card without dots", async () => {
+  it("should render a single card without dots or buttons", async () => {
     const cards = [{ component: Card }];
     const po = renderComponent(cards);
     const dotsPo = await po.getDots();
     const cardWrappers = await po.getCardWrappers();
+    const hasDotsNavigation = await po.hasDotsNavigation();
+    const hasButtonsNavigation = await po.hasButtonsNavigation();
 
     expect(dotsPo.length).toBe(0);
     expect(cardWrappers.length).toBe(1);
+    expect(hasDotsNavigation).toBe(false);
+    expect(hasButtonsNavigation).toBe(false);
   });
 
-  it("should render multiple cards with dots", async () => {
+  it("should render multiple cards with dots when cards are <= MAX_NUMBER_OF_DOTS", async () => {
     const cards = [{ component: Card }, { component: Card }];
     const po = renderComponent(cards);
     const dotsPo = await po.getDots();
     const cardWrappers = await po.getCardWrappers();
+    const hasDotsNavigation = await po.hasDotsNavigation();
+    const hasButtonsNavigation = await po.hasButtonsNavigation();
 
     expect(dotsPo.length).toBe(2);
     expect(cardWrappers.length).toBe(2);
     expect(await po.getActiveCardIndex()).toBe(0);
     expect(await po.getActiveDotIndex()).toBe(0);
+    expect(hasDotsNavigation).toBe(true);
+    expect(hasButtonsNavigation).toBe(false);
   });
 
   it("should change active card when clicking a dot", async () => {
@@ -105,5 +119,73 @@ describe("StackedCards Component", () => {
 
     vi.advanceTimersByTime(1);
     expect(await po.getActiveCardIndex()).toBe(0);
+  });
+
+  it("should render buttons instead of dots when cards are > MAX_NUMBER_OF_DOTS", async () => {
+    const cards = Array(MAX_NUMBER_OF_DOTS + 1).fill({ component: Card });
+    const po = renderComponent(cards);
+    const cardWrappers = await po.getCardWrappers();
+    const hasDotsNavigation = await po.hasDotsNavigation();
+    const hasButtonsNavigation = await po.hasButtonsNavigation();
+    
+    expect(cardWrappers.length).toBe(MAX_NUMBER_OF_DOTS + 1);
+    expect(hasDotsNavigation).toBe(false);
+    expect(hasButtonsNavigation).toBe(true);
+    expect(await po.getCurrentIndexDisplay()).toBe(1); // 1-indexed
+  });
+
+  it("should navigate with prev/next buttons", async () => {
+    const cards = Array(MAX_NUMBER_OF_DOTS + 2).fill({ component: Card });
+    const po = renderComponent(cards);
+    const prevButton = await po.getPrevButton();
+    const nextButton = await po.getNextButton();
+
+    expect(await po.getActiveCardIndex()).toBe(0);
+    expect(await po.getCurrentIndexDisplay()).toBe(1); // 1-indexed
+
+    await nextButton.click();
+    expect(await po.getActiveCardIndex()).toBe(1);
+    expect(await po.getCurrentIndexDisplay()).toBe(2);
+
+    await nextButton.click();
+    expect(await po.getActiveCardIndex()).toBe(2);
+    expect(await po.getCurrentIndexDisplay()).toBe(3);
+
+    await prevButton.click();
+    expect(await po.getActiveCardIndex()).toBe(1);
+    expect(await po.getCurrentIndexDisplay()).toBe(2);
+
+    // Test wrap-around behavior
+    const totalCards = MAX_NUMBER_OF_DOTS + 2;
+    for (let i = 0; i < totalCards - 1; i++) {
+      await nextButton.click();
+    }
+    expect(await po.getActiveCardIndex()).toBe(0);
+    expect(await po.getCurrentIndexDisplay()).toBe(1);
+
+    await prevButton.click();
+    expect(await po.getActiveCardIndex()).toBe(totalCards - 1);
+    expect(await po.getCurrentIndexDisplay()).toBe(totalCards);
+  });
+
+  it("should reset timer when navigating with buttons", async () => {
+    vi.useFakeTimers();
+
+    const cards = Array(MAX_NUMBER_OF_DOTS + 1).fill({ component: Card });
+    const po = renderComponent(cards);
+    const nextButton = await po.getNextButton();
+
+    expect(await po.getActiveCardIndex()).toBe(0);
+
+    vi.advanceTimersByTime(4000);
+
+    await nextButton.click();
+    expect(await po.getActiveCardIndex()).toBe(1);
+
+    vi.advanceTimersByTime(4999);
+    expect(await po.getActiveCardIndex()).toBe(1);
+
+    vi.advanceTimersByTime(1);
+    expect(await po.getActiveCardIndex()).toBe(2);
   });
 });

--- a/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
@@ -127,7 +127,7 @@ describe("StackedCards Component", () => {
     const cardWrappers = await po.getCardWrappers();
     const hasDotsNavigation = await po.hasDotsNavigation();
     const hasButtonsNavigation = await po.hasButtonsNavigation();
-    
+
     expect(cardWrappers.length).toBe(MAX_NUMBER_OF_DOTS + 1);
     expect(hasDotsNavigation).toBe(false);
     expect(hasButtonsNavigation).toBe(true);

--- a/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StackedCards.spec.ts
@@ -14,13 +14,13 @@ describe("StackedCards Component", () => {
 
   it("should render empty when no cards are provided", async () => {
     const po = renderComponent([]);
+    const buttonsContainerPo = await po.getButtonsContainerPo();
+    const dotsContainerPo = await po.getDotsContainerPo();
     const dotsPo = await po.getDots();
-    const hasDotsNavigation = await po.hasDotsNavigation();
-    const hasButtonsNavigation = await po.hasButtonsNavigation();
 
+    expect(await buttonsContainerPo.isPresent()).toBe(false);
+    expect(await dotsContainerPo.isPresent()).toBe(false);
     expect(dotsPo.length).toBe(0);
-    expect(hasDotsNavigation).toBe(false);
-    expect(hasButtonsNavigation).toBe(false);
   });
 
   it("should render a single card without dots or buttons", async () => {
@@ -28,13 +28,13 @@ describe("StackedCards Component", () => {
     const po = renderComponent(cards);
     const dotsPo = await po.getDots();
     const cardWrappers = await po.getCardWrappers();
-    const hasDotsNavigation = await po.hasDotsNavigation();
-    const hasButtonsNavigation = await po.hasButtonsNavigation();
+    const buttonsContainerPo = await po.getButtonsContainerPo();
+    const dotsContainerPo = await po.getDotsContainerPo();
 
-    expect(dotsPo.length).toBe(0);
     expect(cardWrappers.length).toBe(1);
-    expect(hasDotsNavigation).toBe(false);
-    expect(hasButtonsNavigation).toBe(false);
+    expect(await buttonsContainerPo.isPresent()).toBe(false);
+    expect(await dotsContainerPo.isPresent()).toBe(false);
+    expect(dotsPo.length).toBe(0);
   });
 
   it("should render multiple cards with dots when cards are <= MAX_NUMBER_OF_DOTS", async () => {
@@ -42,15 +42,16 @@ describe("StackedCards Component", () => {
     const po = renderComponent(cards);
     const dotsPo = await po.getDots();
     const cardWrappers = await po.getCardWrappers();
-    const hasDotsNavigation = await po.hasDotsNavigation();
-    const hasButtonsNavigation = await po.hasButtonsNavigation();
+    const buttonsContainerPo = await po.getButtonsContainerPo();
+    const dotsContainerPo = await po.getDotsContainerPo();
 
-    expect(dotsPo.length).toBe(2);
-    expect(cardWrappers.length).toBe(2);
+    expect(await buttonsContainerPo.isPresent()).toBe(false);
+
     expect(await po.getActiveCardIndex()).toBe(0);
     expect(await po.getActiveDotIndex()).toBe(0);
-    expect(hasDotsNavigation).toBe(true);
-    expect(hasButtonsNavigation).toBe(false);
+    expect(await dotsContainerPo.isPresent()).toBe(true);
+    expect(dotsPo.length).toBe(2);
+    expect(cardWrappers.length).toBe(2);
   });
 
   it("should change active card when clicking a dot", async () => {
@@ -125,35 +126,37 @@ describe("StackedCards Component", () => {
     const cards = Array(MAX_NUMBER_OF_DOTS + 1).fill({ component: Card });
     const po = renderComponent(cards);
     const cardWrappers = await po.getCardWrappers();
-    const hasDotsNavigation = await po.hasDotsNavigation();
-    const hasButtonsNavigation = await po.hasButtonsNavigation();
+    const buttonsContainerPo = await po.getButtonsContainerPo();
+    const dotsContainerPo = await po.getDotsContainerPo();
+
+    expect(await dotsContainerPo.isPresent()).toBe(false);
 
     expect(cardWrappers.length).toBe(MAX_NUMBER_OF_DOTS + 1);
-    expect(hasDotsNavigation).toBe(false);
-    expect(hasButtonsNavigation).toBe(true);
-    expect(await po.getCurrentIndexDisplay()).toBe(1); // 1-indexed
+    expect(await buttonsContainerPo.isPresent()).toBe(true);
+    expect(await buttonsContainerPo.getCurrentIndex()).toBe(1);
   });
 
   it("should navigate with prev/next buttons", async () => {
     const cards = Array(MAX_NUMBER_OF_DOTS + 2).fill({ component: Card });
     const po = renderComponent(cards);
-    const prevButton = await po.getPrevButton();
-    const nextButton = await po.getNextButton();
+    const buttonsContainerPo = await po.getButtonsContainerPo();
+    const prevButton = buttonsContainerPo.getPrevButton();
+    const nextButton = buttonsContainerPo.getNextButton();
 
     expect(await po.getActiveCardIndex()).toBe(0);
-    expect(await po.getCurrentIndexDisplay()).toBe(1); // 1-indexed
+    expect(await buttonsContainerPo.getCurrentIndex()).toBe(1); // 1-indexed
 
     await nextButton.click();
     expect(await po.getActiveCardIndex()).toBe(1);
-    expect(await po.getCurrentIndexDisplay()).toBe(2);
+    expect(await buttonsContainerPo.getCurrentIndex()).toBe(2);
 
     await nextButton.click();
     expect(await po.getActiveCardIndex()).toBe(2);
-    expect(await po.getCurrentIndexDisplay()).toBe(3);
+    expect(await buttonsContainerPo.getCurrentIndex()).toBe(3);
 
     await prevButton.click();
     expect(await po.getActiveCardIndex()).toBe(1);
-    expect(await po.getCurrentIndexDisplay()).toBe(2);
+    expect(await buttonsContainerPo.getCurrentIndex()).toBe(2);
 
     // Test wrap-around behavior
     const totalCards = MAX_NUMBER_OF_DOTS + 2;
@@ -161,11 +164,11 @@ describe("StackedCards Component", () => {
       await nextButton.click();
     }
     expect(await po.getActiveCardIndex()).toBe(0);
-    expect(await po.getCurrentIndexDisplay()).toBe(1);
+    expect(await buttonsContainerPo.getCurrentIndex()).toBe(1);
 
     await prevButton.click();
     expect(await po.getActiveCardIndex()).toBe(totalCards - 1);
-    expect(await po.getCurrentIndexDisplay()).toBe(totalCards);
+    expect(await buttonsContainerPo.getCurrentIndex()).toBe(totalCards);
   });
 
   it("should reset timer when navigating with buttons", async () => {
@@ -173,7 +176,8 @@ describe("StackedCards Component", () => {
 
     const cards = Array(MAX_NUMBER_OF_DOTS + 1).fill({ component: Card });
     const po = renderComponent(cards);
-    const nextButton = await po.getNextButton();
+    const buttonsContainerPo = await po.getButtonsContainerPo();
+    const nextButton = buttonsContainerPo.getNextButton();
 
     expect(await po.getActiveCardIndex()).toBe(0);
 

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -81,7 +81,7 @@ class ButtonsContainerPo extends BasePageObject {
     return NavigationButtonPo.next(this.root);
   }
 
-  async getCurrentIndex(): Promise<number> {
+  async getDisplayedCurrentIndex(): Promise<number> {
     const indexText = await this.root.byTestId("activeIndex").getText();
     return parseInt(indexText, 10);
   }
@@ -143,7 +143,9 @@ export class StackedCardsPo extends BasePageObject {
 
   async getCurrentIndexDisplay(): Promise<number | null> {
     const buttonsContainer = await this.getButtonsContainerPo();
-    return buttonsContainer ? await buttonsContainer.getCurrentIndex() : null;
+    return buttonsContainer
+      ? await buttonsContainer.getDisplayedCurrentIndex()
+      : null;
   }
 
   async getActiveCardPo(): Promise<BasePortfolioCardPo> {

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -123,34 +123,26 @@ export class StackedCardsPo extends BasePageObject {
     return -1;
   }
 
-  async getDotsContainer(): Promise<DotsContainerPo | null> {
+  async getDotsContainerPo(): Promise<DotsContainerPo | null> {
     return DotsContainerPo.under(this.root);
   }
 
-  async getButtonsContainer(): Promise<ButtonsContainerPo | null> {
+  async getButtonsContainerPo(): Promise<ButtonsContainerPo | null> {
     return ButtonsContainerPo.under(this.root);
   }
 
-  async hasDotsNavigation(): Promise<boolean> {
-    return (await this.getDotsContainer()) !== null;
-  }
-
-  async hasButtonsNavigation(): Promise<boolean> {
-    return (await this.getButtonsContainer()) !== null;
-  }
-
   async getPrevButton(): Promise<NavigationButtonPo | null> {
-    const buttonsContainer = await this.getButtonsContainer();
+    const buttonsContainer = await this.getButtonsContainerPo();
     return buttonsContainer ? buttonsContainer.getPrevButton() : null;
   }
 
   async getNextButton(): Promise<NavigationButtonPo | null> {
-    const buttonsContainer = await this.getButtonsContainer();
+    const buttonsContainer = await this.getButtonsContainerPo();
     return buttonsContainer ? buttonsContainer.getNextButton() : null;
   }
 
   async getCurrentIndexDisplay(): Promise<number | null> {
-    const buttonsContainer = await this.getButtonsContainer();
+    const buttonsContainer = await this.getButtonsContainerPo();
     return buttonsContainer ? await buttonsContainer.getCurrentIndex() : null;
   }
 

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -36,6 +36,57 @@ class DotButtonPo extends ButtonPo {
   }
 }
 
+class NavigationButtonPo extends ButtonPo {
+  static prev(element: PageObjectElement): NavigationButtonPo {
+    return new NavigationButtonPo(element.byTestId("prev-button"));
+  }
+
+  static next(element: PageObjectElement): NavigationButtonPo {
+    return new NavigationButtonPo(element.byTestId("next-button"));
+  }
+}
+
+class DotsContainerPo extends BasePageObject {
+  private static readonly TID = "dots-container";
+
+  static under(element: PageObjectElement): DotsContainerPo | null {
+    try {
+      return new DotsContainerPo(element.byTestId(DotsContainerPo.TID));
+    } catch {
+      return null;
+    }
+  }
+
+  async getDots(): Promise<DotButtonPo[]> {
+    return DotButtonPo.allUnder(this.root);
+  }
+}
+
+class ButtonsContainerPo extends BasePageObject {
+  private static readonly TID = "buttons-container";
+
+  static under(element: PageObjectElement): ButtonsContainerPo | null {
+    try {
+      return new ButtonsContainerPo(element.byTestId(ButtonsContainerPo.TID));
+    } catch {
+      return null;
+    }
+  }
+
+  getPrevButton(): NavigationButtonPo {
+    return NavigationButtonPo.prev(this.root);
+  }
+
+  getNextButton(): NavigationButtonPo {
+    return NavigationButtonPo.next(this.root);
+  }
+
+  async getCurrentIndex(): Promise<number> {
+    const indexText = await this.root.byTestId("activeIndex").getText();
+    return parseInt(indexText, 10);
+  }
+}
+
 export class StackedCardsPo extends BasePageObject {
   private static readonly TID = "stacked-cards-component";
 
@@ -70,6 +121,37 @@ export class StackedCardsPo extends BasePageObject {
       }
     }
     return -1;
+  }
+
+  async getDotsContainer(): Promise<DotsContainerPo | null> {
+    return DotsContainerPo.under(this.root);
+  }
+
+  async getButtonsContainer(): Promise<ButtonsContainerPo | null> {
+    return ButtonsContainerPo.under(this.root);
+  }
+
+  async hasDotsNavigation(): Promise<boolean> {
+    return (await this.getDotsContainer()) !== null;
+  }
+
+  async hasButtonsNavigation(): Promise<boolean> {
+    return (await this.getButtonsContainer()) !== null;
+  }
+
+  async getPrevButton(): Promise<NavigationButtonPo | null> {
+    const buttonsContainer = await this.getButtonsContainer();
+    return buttonsContainer ? buttonsContainer.getPrevButton() : null;
+  }
+
+  async getNextButton(): Promise<NavigationButtonPo | null> {
+    const buttonsContainer = await this.getButtonsContainer();
+    return buttonsContainer ? buttonsContainer.getNextButton() : null;
+  }
+
+  async getCurrentIndexDisplay(): Promise<number | null> {
+    const buttonsContainer = await this.getButtonsContainer();
+    return buttonsContainer ? await buttonsContainer.getCurrentIndex() : null;
   }
 
   async getActiveCardPo(): Promise<BasePortfolioCardPo> {


### PR DESCRIPTION
# Motivation

The `StackedCards` component displays controls below the cards, allowing users to:  
1. Identify their current card in the total.  
2. Navigate between the cards.  

However, in scenarios with too many cards (projects), the dots may overflow. This PR introduces an alternative set of controls using buttons (previous and next) for card navigation.

https://github.com/user-attachments/assets/cb4c518c-2f31-4d86-a4bf-73f74e1d6852

[NNS1-3641](https://dfinity.atlassian.net/browse/NNS1-3641)

# Changes

- Add alternative controls when there are too many cards.

# Tests

- Add a unit test for the new behavior.  
- Update existing tests to ensure that only one type of control is being rendered.
- Tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

[NNS1-3641]: https://dfinity.atlassian.net/browse/NNS1-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ