### PR TITLE
PoC: Use include_topic_filtering flag to evaluate setFollowing support

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -27,9 +27,8 @@
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import { getContext, onMount } from "svelte";
+  import { getContext } from "svelte";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
-  import { refreshUnsupportedFilterByTopicSnsesStore } from "$lib/services/public/sns-proposals.services";
   import { get, type Readable } from "svelte/store";
 
   const { store }: SelectedSnsNeuronContext =

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -87,17 +87,6 @@
     nonNullish($snsTopicsStore[rootCanisterId?.toText()]) &&
     // TODO(mstr): remove this after "Personal DAO" is upgraded
     isSetFollowingApiSupported;
-
-  // TODO(mstr): remove this after "Personal DAO" is upgraded
-  onMount(async () => {
-    const PERSONAL_DAO_CANISTER_ID = "izscx-raaaa-aaaaq-aaesq-cai";
-    if (
-      rootCanisterId &&
-      rootCanisterId.toText() === PERSONAL_DAO_CANISTER_ID
-    ) {
-      refreshUnsupportedFilterByTopicSnsesStore(rootCanisterId);
-    }
-  });
 </script>
 
 <CardInfo noMargin testId="sns-neuron-following-card-component">

--- a/frontend/src/lib/services/public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/public/sns-proposals.services.ts
@@ -63,6 +63,22 @@ export const registerVote = async ({
   }
 };
 
+const updateUnsupportedFilterByTopicSnsesStore = async ({
+  rootCanisterId,
+  includeTopicFiltering,
+}: {
+  rootCanisterId: Principal;
+  includeTopicFiltering: boolean | undefined;
+}): Promise<void> => {
+  if (isNullish(includeTopicFiltering)) {
+    unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
+  } else if (includeTopicFiltering) {
+    unsupportedFilterByTopicSnsesStore.delete(rootCanisterId.toText());
+  } else {
+    unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
+  }
+};
+
 export const loadSnsProposals = async ({
   rootCanisterId,
   snsFunctions,
@@ -119,14 +135,10 @@ export const loadSnsProposals = async ({
       });
 
       const includeTopicFiltering = fromNullable(include_topic_filtering);
-
-      if (isNullish(includeTopicFiltering)) {
-        unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
-      } else if (includeTopicFiltering) {
-        unsupportedFilterByTopicSnsesStore.delete(rootCanisterId.toText());
-      } else {
-        unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
-      }
+      updateUnsupportedFilterByTopicSnsesStore({
+        rootCanisterId,
+        includeTopicFiltering,
+      });
     },
     onError: (err) => {
       toastsError({

--- a/frontend/src/lib/services/public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/public/sns-proposals.services.ts
@@ -27,6 +27,7 @@ import type {
 } from "@dfinity/sns";
 import { fromNullable, isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
+import { getCurrentIdentity } from "../auth.services";
 
 export const registerVote = async ({
   rootCanisterId,
@@ -148,6 +149,29 @@ export const loadSnsProposals = async ({
     },
     logMessage: "loadSnsProposals",
   });
+};
+
+export const refreshUnsupportedFilterByTopicSnsesStore = async (
+  rootCanisterId: Principal
+): Promise<void> => {
+  try {
+    const { include_topic_filtering } = await queryProposals({
+      params: {},
+      identity: getCurrentIdentity(),
+      certified: false,
+      rootCanisterId,
+    });
+    const includeTopicFiltering = fromNullable(include_topic_filtering);
+    updateUnsupportedFilterByTopicSnsesStore({
+      rootCanisterId,
+      includeTopicFiltering,
+    });
+  } catch (err) {
+    console.error(
+      "Error while refreshing unsupportedFilterByTopicSnsesStore",
+      err
+    );
+  }
 };
 
 /**

--- a/frontend/src/lib/services/public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/public/sns-proposals.services.ts
@@ -27,7 +27,6 @@ import type {
 } from "@dfinity/sns";
 import { fromNullable, isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
-import { getCurrentIdentity } from "../auth.services";
 
 export const registerVote = async ({
   rootCanisterId,
@@ -149,29 +148,6 @@ export const loadSnsProposals = async ({
     },
     logMessage: "loadSnsProposals",
   });
-};
-
-export const refreshUnsupportedFilterByTopicSnsesStore = async (
-  rootCanisterId: Principal
-): Promise<void> => {
-  try {
-    const { include_topic_filtering } = await queryProposals({
-      params: {},
-      identity: getCurrentIdentity(),
-      certified: false,
-      rootCanisterId,
-    });
-    const includeTopicFiltering = fromNullable(include_topic_filtering);
-    updateUnsupportedFilterByTopicSnsesStore({
-      rootCanisterId,
-      includeTopicFiltering,
-    });
-  } catch (err) {
-    console.error(
-      "Error while refreshing unsupportedFilterByTopicSnsesStore",
-      err
-    );
-  }
 };
 
 /**

--- a/frontend/src/lib/services/public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/public/sns-proposals.services.ts
@@ -63,22 +63,6 @@ export const registerVote = async ({
   }
 };
 
-const updateUnsupportedFilterByTopicSnsesStore = async ({
-  rootCanisterId,
-  includeTopicFiltering,
-}: {
-  rootCanisterId: Principal;
-  includeTopicFiltering: boolean | undefined;
-}): Promise<void> => {
-  if (isNullish(includeTopicFiltering)) {
-    unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
-  } else if (includeTopicFiltering) {
-    unsupportedFilterByTopicSnsesStore.delete(rootCanisterId.toText());
-  } else {
-    unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
-  }
-};
-
 export const loadSnsProposals = async ({
   rootCanisterId,
   snsFunctions,
@@ -135,10 +119,14 @@ export const loadSnsProposals = async ({
       });
 
       const includeTopicFiltering = fromNullable(include_topic_filtering);
-      updateUnsupportedFilterByTopicSnsesStore({
-        rootCanisterId,
-        includeTopicFiltering,
-      });
+
+      if (isNullish(includeTopicFiltering)) {
+        unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
+      } else if (includeTopicFiltering) {
+        unsupportedFilterByTopicSnsesStore.delete(rootCanisterId.toText());
+      } else {
+        unsupportedFilterByTopicSnsesStore.add(rootCanisterId.toText());
+      }
     },
     onError: (err) => {
       toastsError({


### PR DESCRIPTION
# Motivation


Actionable proposals are fetched only for SNSes with votable neurons. This is acceptable, given the low likelihood that users without votable neurons will update their followings.

https://github.com/dfinity/nns-dapp/blob/01a5844e54797c3e9e98350635b630b1aae68c11/frontend/src/lib/services/actionable-sns-proposals.services.ts#L54-L62

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
