### PR TITLE
feat(portfolio): integrate adopted SNS proposal cards

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -32,8 +32,8 @@
     userTokens: UserToken[];
     tableProjects: TableProject[];
     snsProjects: SnsFullProject[];
-    adoptedSnsProposals: SnsFullProject[];
     openSnsProposals: ProposalInfo[];
+    adoptedSnsProposals?: SnsFullProject[];
   };
 
   const {
@@ -41,7 +41,8 @@
     tableProjects,
     snsProjects,
     openSnsProposals,
-    adoptedSnsProposals,
+    // TODO: To be removed in the router's PR
+    adoptedSnsProposals = [],
   }: Props = $props();
 
   const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AdoptedProposalCard from "$lib/components/portfolio/AdoptedProposalCard.svelte";
   import HeldTokensCard from "$lib/components/portfolio/HeldTokensCard.svelte";
   import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
   import LoginCard from "$lib/components/portfolio/LoginCard.svelte";
@@ -31,6 +32,7 @@
     userTokens: UserToken[];
     tableProjects: TableProject[];
     snsProjects: SnsFullProject[];
+    adoptedSnsProposals: SnsFullProject[];
     openSnsProposals: ProposalInfo[];
   };
 
@@ -39,6 +41,7 @@
     tableProjects,
     snsProjects,
     openSnsProposals,
+    adoptedSnsProposals,
   }: Props = $props();
 
   const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));
@@ -91,8 +94,6 @@
   const areStakedTokensLoading = $derived(
     tableProjects.some((project) => project.isStakeLoading)
   );
-  // Determines the display state of the staked tokens card
-  // Similar logic to heldTokensCard but for staked tokens
   const stakedTokensCard: TokensCardType = $derived(
     !$authSignedInStore
       ? "full"
@@ -152,7 +153,23 @@
       }))
   );
 
-  const cards: CardItem[] = $derived([...launchpadCards, ...openProposalCards]);
+  const adoptedSnsProposalsCards = $derived(
+    [...adoptedSnsProposals]
+      .sort(comparesByDecentralizationSaleOpenTimestampDesc)
+      .reverse()
+      .map((project) => project.summary)
+      .map<CardItem>((summary) => ({
+        // TODO: Svelte v5 migration - fix type
+        component: AdoptedProposalCard as unknown as Component,
+        props: { summary },
+      }))
+  );
+
+  const cards: CardItem[] = $derived([
+    ...launchpadCards,
+    ...openProposalCards,
+    ...adoptedSnsProposalsCards,
+  ]);
 </script>
 
 <main data-tid="portfolio-page-component">

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -6,6 +6,7 @@ import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import {
+  createSummary,
   mockSnsFullProject,
   mockToken,
   principal,
@@ -23,6 +24,7 @@ import { PortfolioPagePo } from "$tests/page-objects/PortfolioPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
 import type { ProposalInfo } from "@dfinity/nns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
@@ -32,11 +34,13 @@ describe("Portfolio page", () => {
     tableProjects = [],
     snsProjects = [],
     openSnsProposals = [],
+    adoptedSnsProposals = [],
   }: {
     userTokens?: UserToken[];
     tableProjects?: TableProject[];
     snsProjects?: SnsFullProject[];
     openSnsProposals?: ProposalInfo[];
+    adoptedSnsProposals?: SnsFullProject[];
   } = {}) => {
     const { container } = render(Portfolio, {
       props: {
@@ -44,6 +48,7 @@ describe("Portfolio page", () => {
         tableProjects,
         snsProjects,
         openSnsProposals,
+        adoptedSnsProposals,
       },
     });
 
@@ -143,7 +148,14 @@ describe("Portfolio page", () => {
   describe("StackedCards", () => {
     const mockSnsProjects: SnsFullProject[] = [
       mockSnsFullProject,
-      { ...mockSnsFullProject, rootCanisterId: principal(2) },
+      {
+        ...mockSnsFullProject,
+        rootCanisterId: principal(2),
+        summary: createSummary({
+          lifecycle: SnsSwapLifecycle.Adopted,
+          projectName: "AdoptedProject",
+        }),
+      },
     ];
 
     const mockSnsProposals = [
@@ -240,6 +252,64 @@ describe("Portfolio page", () => {
       expect(cardWrappers.length).toBe(2);
     });
 
+    it("should display StackedCards when adoptedSnsProposals is not empty", async () => {
+      const po = renderPage({ adoptedSnsProposals: mockSnsProjects });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(2);
+    });
+
+    it("should show all cards when snsProjects, openSnsProposals, and adoptedSnsProposals are not empty", async () => {
+      const po = renderPage({
+        snsProjects: mockSnsProjects,
+        adoptedSnsProposals: mockSnsProjects,
+        openSnsProposals: mockSnsProposals,
+      });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(6); // 2 snsProjects + 2 adoptedSnsProposals + 2 openSnsProposals
+    });
+
+    it("should sort launchpadCards", async () => {
+      const mockSnsProjects: SnsFullProject[] = [
+        {
+          ...mockSnsFullProject,
+          rootCanisterId: principal(1),
+          summary: createSummary({
+            projectName: "LaterTimestampProject",
+            swapOpenTimestampSeconds: 100_000_000n,
+          }),
+        },
+        {
+          ...mockSnsFullProject,
+          rootCanisterId: principal(1),
+          summary: createSummary({
+            projectName: "EarlierTimestampProject",
+            swapOpenTimestampSeconds: 1_000_000n,
+          }),
+        },
+      ];
+      const po = renderPage({ snsProjects: mockSnsProjects });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+      const dotsPo = await stackedCardsPo.getDots();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(2);
+
+      let activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("EarlierTimestampProject");
+
+      await dotsPo[1].click();
+
+      activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("LaterTimestampProject");
+    });
+
     it("should sort openSnsProposal", async () => {
       const po = renderPage({ openSnsProposals: mockSnsProposals });
       const stackedCardsPo = po.getStackedCardsPo();
@@ -258,6 +328,44 @@ describe("Portfolio page", () => {
       expect(await activeCard.getTitle()).toBe("TestDAO1");
     });
 
+    it("should sort adoptedSnsProposals", async () => {
+      const mockSnsProjects: SnsFullProject[] = [
+        {
+          ...mockSnsFullProject,
+          rootCanisterId: principal(1),
+          summary: createSummary({
+            projectName: "LaterTimestampAdoptedProject",
+            swapOpenTimestampSeconds: 100_000_000n,
+          }),
+        },
+        {
+          ...mockSnsFullProject,
+          rootCanisterId: principal(1),
+          summary: createSummary({
+            projectName: "EarlierTimestampAdoptedProject",
+            swapOpenTimestampSeconds: 1_000_000n,
+          }),
+        },
+      ];
+      const po = renderPage({ adoptedSnsProposals: mockSnsProjects });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+      const dotsPo = await stackedCardsPo.getDots();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(2);
+
+      let activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe(
+        "EarlierTimestampAdoptedProject"
+      );
+
+      await dotsPo[1].click();
+
+      activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("LaterTimestampAdoptedProject");
+    });
+
     it("should show all cards when snsProjects and openSnsProposals are not empty", async () => {
       const po = renderPage({
         snsProjects: mockSnsProjects,
@@ -270,28 +378,33 @@ describe("Portfolio page", () => {
       expect(cardWrappers.length).toBe(4);
     });
 
-    it("should show first on going swaps and then proposals", async () => {
+    it("should show first on going swaps, then open proposals, and then adopted proposals", async () => {
       const po = renderPage({
         snsProjects: mockSnsProjects.slice(0, 1),
         openSnsProposals: mockSnsProposals.slice(0, 1),
+        adoptedSnsProposals: mockSnsProjects.slice(1, 2),
       });
+
       const stackedCardsPo = po.getStackedCardsPo();
       const cardWrappers = await stackedCardsPo.getCardWrappers();
       const dotsPo = await stackedCardsPo.getDots();
 
       expect(await stackedCardsPo.isPresent()).toBe(true);
-      expect(cardWrappers.length).toBe(2);
+      expect(cardWrappers.length).toBe(3);
 
       let activeCard = await stackedCardsPo.getActiveCardPo();
-      expect(await activeCard.getTitle()).toBe("Tetris");
+      expect(await activeCard.getTitle()).toBe("Tetris"); // First sns project
 
       await dotsPo[1].click();
-
       activeCard = await stackedCardsPo.getActiveCardPo();
-      expect(await activeCard.getTitle()).toBe("TestDAO1");
+      expect(await activeCard.getTitle()).toBe("TestDAO1"); // Open proposal
+
+      await dotsPo[2].click();
+      activeCard = await stackedCardsPo.getActiveCardPo();
+      expect(await activeCard.getTitle()).toBe("AdoptedProject"); // Adopted proposal
     });
 
-    it("should hide TotalAssetsCard when not signed in and there are sns projects", async () => {
+    it("should hide TotalAssetsCard when not signed", async () => {
       setNoIdentity();
       const po = renderPage({ snsProjects: mockSnsProjects });
       const stackedCardsPo = po.getStackedCardsPo();

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -4,6 +4,7 @@ import { LaunchProjectCardPo } from "$tests/page-objects/LaunchProjectCard.page-
 import { NewSnsProposalCardPo } from "$tests/page-objects/NewSnsProposalCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AdoptedProposalCardPo } from "./AdoptedProposalCard.page-object";
 
 class ProjectCardWrapperPo extends BasePageObject {
   private static readonly TID = "project-card-wrapper";
@@ -157,6 +158,9 @@ export class StackedCardsPo extends BasePageObject {
     if (await activeCard.isPresent()) return activeCard;
 
     activeCard = NewSnsProposalCardPo.under(cardWrappers[activeIndex].root);
+    if (await activeCard.isPresent()) return activeCard;
+
+    activeCard = AdoptedProposalCardPo.under(cardWrappers[activeIndex].root);
     if (await activeCard.isPresent()) return activeCard;
 
     return null;

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -1,10 +1,10 @@
+import { AdoptedProposalCardPo } from "$tests/page-objects/AdoptedProposalCard.page-object";
 import type { BasePortfolioCardPo } from "$tests/page-objects/BasePortfolioCard.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { LaunchProjectCardPo } from "$tests/page-objects/LaunchProjectCard.page-object";
 import { NewSnsProposalCardPo } from "$tests/page-objects/NewSnsProposalCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AdoptedProposalCardPo } from "./AdoptedProposalCard.page-object";
 
 class ProjectCardWrapperPo extends BasePageObject {
   private static readonly TID = "project-card-wrapper";


### PR DESCRIPTION
# Motivation

We want to display proposals for new SNS projects on the Portfolio page that were approved before the swap begins. This PR utilizes the new card introduced in #6811 to showcase adopted proposals for new projects.

The order for displaying cards within the stacked card component is as follows:
1. Ongoing swaps
2. Proposals for new projects
3. Adopted proposals for new projects.

[NNS1-3639](https://dfinity.atlassian.net/browse/NNS1-3639)

# Changes

- Update Portfolio page to expected a new prop for adopted proposals.
- Sort adopted proposals based on the swap start.

# Tests

- Unit tests for the new prop in the page.
- Unit tests for checking the sorting is applied to each group of cards.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3639]: https://dfinity.atlassian.net/browse/NNS1-3639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ