### PR TITLE
feat(portfolio): load adopted SNS proposals for display

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,6 +15,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Swipe gestures for project cards on the portfolio page
+* Display upcoming swaps in the portfolio page
 
 #### Changed
 

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -32,7 +32,6 @@
     userTokens: UserToken[];
     tableProjects: TableProject[];
     snsProjects: SnsFullProject[];
-    adoptedSnsProposals: SnsFullProject[];
     openSnsProposals: ProposalInfo[];
     adoptedSnsProposals?: SnsFullProject[];
   };
@@ -42,7 +41,8 @@
     tableProjects,
     snsProjects,
     openSnsProposals,
-    adoptedSnsProposals,
+    // TODO: To be removed in the router's PR
+    adoptedSnsProposals = [],
   }: Props = $props();
 
   const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -33,7 +33,7 @@
     tableProjects: TableProject[];
     snsProjects: SnsFullProject[];
     openSnsProposals: ProposalInfo[];
-    adoptedSnsProposals?: SnsFullProject[];
+    adoptedSnsProposals: SnsFullProject[];
   };
 
   const {
@@ -41,8 +41,7 @@
     tableProjects,
     snsProjects,
     openSnsProposals,
-    // TODO: To be removed in the router's PR
-    adoptedSnsProposals = [],
+    adoptedSnsProposals,
   }: Props = $props();
 
   const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -32,6 +32,7 @@
     userTokens: UserToken[];
     tableProjects: TableProject[];
     snsProjects: SnsFullProject[];
+    adoptedSnsProposals: SnsFullProject[];
     openSnsProposals: ProposalInfo[];
     adoptedSnsProposals?: SnsFullProject[];
   };
@@ -41,8 +42,7 @@
     tableProjects,
     snsProjects,
     openSnsProposals,
-    // TODO: To be removed in the router's PR
-    adoptedSnsProposals = [],
+    adoptedSnsProposals,
   }: Props = $props();
 
   const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -82,6 +82,10 @@
       swapLifecycle: SnsSwapLifecycle.Open,
       projects: $snsProjectsActivePadStore,
     })}
+    adoptedSnsProposals={filterProjectsStatus({
+      swapLifecycle: SnsSwapLifecycle.Adopted,
+      projects: $snsProjectsActivePadStore,
+    })}
     openSnsProposals={$openSnsProposalsStore}
   /></TestIdWrapper
 >

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -366,18 +366,6 @@ describe("Portfolio page", () => {
       expect(await activeCard.getTitle()).toBe("LaterTimestampAdoptedProject");
     });
 
-    it("should show all cards when snsProjects and openSnsProposals are not empty", async () => {
-      const po = renderPage({
-        snsProjects: mockSnsProjects,
-        openSnsProposals: mockSnsProposals,
-      });
-      const stackedCardsPo = po.getStackedCardsPo();
-      const cardWrappers = await stackedCardsPo.getCardWrappers();
-
-      expect(await stackedCardsPo.isPresent()).toBe(true);
-      expect(cardWrappers.length).toBe(4);
-    });
-
     it("should show first on going swaps, then open proposals, and then adopted proposals", async () => {
       const po = renderPage({
         snsProjects: mockSnsProjects.slice(0, 1),

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -5,7 +5,6 @@ import { LaunchProjectCardPo } from "$tests/page-objects/LaunchProjectCard.page-
 import { NewSnsProposalCardPo } from "$tests/page-objects/NewSnsProposalCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { AdoptedProposalCardPo } from "./AdoptedProposalCard.page-object";
 
 class ProjectCardWrapperPo extends BasePageObject {
   private static readonly TID = "project-card-wrapper";

--- a/frontend/src/tests/page-objects/StackedCards.page-object.ts
+++ b/frontend/src/tests/page-objects/StackedCards.page-object.ts
@@ -5,6 +5,7 @@ import { LaunchProjectCardPo } from "$tests/page-objects/LaunchProjectCard.page-
 import { NewSnsProposalCardPo } from "$tests/page-objects/NewSnsProposalCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AdoptedProposalCardPo } from "./AdoptedProposalCard.page-object";
 
 class ProjectCardWrapperPo extends BasePageObject {
   private static readonly TID = "project-card-wrapper";

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -14,7 +14,10 @@ import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
+import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
+import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { snsProposalsStore } from "$lib/stores/sns.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
@@ -28,8 +31,14 @@ import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
+import {
+  mockLifecycleResponse,
+  mockSnsToken,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
 import { PortfolioRoutePo } from "$tests/page-objects/PortfolioRoute.page-object";
@@ -438,6 +447,60 @@ describe("Portfolio route", () => {
         expect(stakedTokensTitles).not.toContain(["Tetris"]);
 
         expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(true);
+      });
+
+      it.only("should render cards for on-going swaps, open sns proposals and adopted sns proposals", async () => {
+        const rootCanisterIdForOpenProject = Principal.from("aaaaa-aa");
+        const rootCanisterIdForAdoptedProject = Principal.from("2vxsx-fae");
+        const proposals = [{ ...mockProposalInfo, status: 1 }];
+
+        snsAggregatorIncludingAbortedProjectsStore.setData([
+          {
+            ...aggregatorSnsMockDto,
+            canister_ids: {
+              ...aggregatorSnsMockDto.canister_ids,
+              root_canister_id: rootCanisterIdForOpenProject.toText(),
+            },
+          },
+          {
+            ...aggregatorSnsMockDto,
+            canister_ids: {
+              ...aggregatorSnsMockDto.canister_ids,
+              root_canister_id: rootCanisterIdForAdoptedProject.toText(),
+            },
+          },
+        ]);
+
+        snsLifecycleStore.setData({
+          certified: true,
+          rootCanisterId: rootCanisterIdForOpenProject,
+          data: {
+            ...mockLifecycleResponse,
+            lifecycle: [SnsSwapLifecycle.Open],
+          },
+        });
+
+        snsLifecycleStore.setData({
+          certified: true,
+          rootCanisterId: rootCanisterIdForAdoptedProject,
+          data: {
+            ...mockLifecycleResponse,
+            lifecycle: [SnsSwapLifecycle.Adopted],
+          },
+        });
+
+        snsProposalsStore.setProposals({
+          proposals,
+          certified: false,
+        });
+
+        const po = await renderPage();
+        const pagePo = po.getPortfolioPagePo();
+        const stackedCardsPo = pagePo.getStackedCardsPo();
+        const cardWrappers = await stackedCardsPo.getCardWrappers();
+
+        expect(await stackedCardsPo.isPresent()).toBe(true);
+        expect(cardWrappers.length).toBe(3);
       });
     });
   });

--- a/frontend/src/tests/routes/app/portfolio/page.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/page.spec.ts
@@ -449,7 +449,7 @@ describe("Portfolio route", () => {
         expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(true);
       });
 
-      it.only("should render cards for on-going swaps, open sns proposals and adopted sns proposals", async () => {
+      it("should render cards for on-going swaps, open sns proposals and adopted sns proposals", async () => {
         const rootCanisterIdForOpenProject = Principal.from("aaaaa-aa");
         const rootCanisterIdForAdoptedProject = Principal.from("2vxsx-fae");
         const proposals = [{ ...mockProposalInfo, status: 1 }];


### PR DESCRIPTION
# Motivation

We want to display proposals for new SNS projects on the Portfolio page that were approved before the swap begins. This PR follows #6822 and loads adopted proposals, passing them to the Portfolio page for display in the stacked card set.

https://github.com/user-attachments/assets/0969d4ab-764f-401e-8a74-c121fa35b9af

[NNS1-3639](https://dfinity.atlassian.net/browse/NNS1-3639)

# Changes

- Retrieve the list of adopted proposals and provide them to the Portfolio page.

# Tests

- Add a test to verify that the expected number of cards is displayed when passing one ongoing swap, one adopted SNS project proposal, and one open SNS project proposal.

# Todos

- [x] Add entry to changelog (if necessary).


[NNS1-3639]: https://dfinity.atlassian.net/browse/NNS1-3639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ