### PR TITLE
refactor(api): migrate getLedgerId to next-gen index canister

### DIFF
--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -47,22 +47,6 @@ export const getTransactions = async ({
   };
 };
 
-export const getLedgerId = async ({
-  identity,
-  indexCanisterId,
-  certified,
-}: {
-  identity: Identity;
-  indexCanisterId: Principal;
-  certified?: boolean;
-}): Promise<Principal> => {
-  const {
-    canister: { ledgerId },
-  } = await indexCanister({ identity, canisterId: indexCanisterId });
-
-  return ledgerId({ certified });
-};
-
 // TODO(yhabib): Migrate all methods to the indexNgCanister
 const indexCanister = async ({
   identity,
@@ -88,6 +72,22 @@ const indexCanister = async ({
     canister,
     agent,
   };
+};
+
+export const getLedgerId = async ({
+  identity,
+  indexCanisterId,
+  certified,
+}: {
+  identity: Identity;
+  indexCanisterId: Principal;
+  certified?: boolean;
+}): Promise<Principal> => {
+  const {
+    canister: { ledgerId },
+  } = await indexNgCanister({ identity, canisterId: indexCanisterId });
+
+  return ledgerId({ certified });
 };
 
 export const listSubaccounts = async ({

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -24,6 +24,7 @@ describe("icrc-index api", () => {
   };
 
   const indexCanisterMock = mock<IcrcIndexCanister>();
+  let spyOnIndexCanisterCreate;
 
   const indexNgCanisterMock = mock<IcrcIndexNgCanister>();
   let spyOnIndexNgCanisterCreate;
@@ -31,6 +32,10 @@ describe("icrc-index api", () => {
   const agentMock = mock<HttpAgent>();
 
   beforeEach(() => {
+    spyOnIndexCanisterCreate = vi
+      .spyOn(IcrcIndexCanister, "create")
+      .mockImplementation(() => indexCanisterMock);
+
     spyOnIndexNgCanisterCreate = vi
       .spyOn(IcrcIndexNgCanister, "create")
       .mockImplementation(() => indexNgCanisterMock);
@@ -49,10 +54,11 @@ describe("icrc-index api", () => {
       });
       const result = await getTransactions(params);
 
-      expect(result).not.toBeUndefined();
-
-      expect(result.transactions).toEqual(transactions);
-      expect(result.oldestTxId).toEqual(oldestTxId);
+      expect(spyOnIndexCanisterCreate).toBeCalledTimes(1);
+      expect(spyOnIndexCanisterCreate).toBeCalledWith({
+        agent: agentMock,
+        canisterId: params.indexCanisterId,
+      });
 
       expect(indexCanisterMock.getTransactions).toBeCalledTimes(1);
       expect(indexCanisterMock.getTransactions).toBeCalledWith({
@@ -60,6 +66,9 @@ describe("icrc-index api", () => {
         start: undefined,
         account: params.account,
       });
+
+      expect(result.transactions).toEqual(transactions);
+      expect(result.oldestTxId).toEqual(oldestTxId);
     });
 
     it("passes start parameter", async () => {
@@ -71,6 +80,12 @@ describe("icrc-index api", () => {
       await getTransactions({
         ...params,
         start,
+      });
+
+      expect(spyOnIndexCanisterCreate).toBeCalledTimes(1);
+      expect(spyOnIndexCanisterCreate).toBeCalledWith({
+        agent: agentMock,
+        canisterId: params.indexCanisterId,
       });
 
       expect(indexCanisterMock.getTransactions).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -101,30 +101,30 @@ describe("icrc-index api", () => {
     const ledgerCanisterId = principal(1);
 
     it("returns ledger id", async () => {
-      indexCanisterMock.ledgerId.mockResolvedValue(ledgerCanisterId);
+      indexNgCanisterMock.ledgerId.mockResolvedValue(ledgerCanisterId);
       const resultPrincipal = await getLedgerId({
         identity: mockIdentity,
         indexCanisterId,
         certified: true,
       });
 
-      expect(spyOnIndexCanisterCreate).toBeCalledTimes(1);
-      expect(spyOnIndexCanisterCreate).toBeCalledWith({
+      expect(spyOnIndexNgCanisterCreate).toBeCalledTimes(1);
+      expect(spyOnIndexNgCanisterCreate).toBeCalledWith({
         agent: agentMock,
         canisterId: indexCanisterId,
       });
 
       expect(resultPrincipal).toEqual(ledgerCanisterId);
 
-      expect(indexCanisterMock.ledgerId).toBeCalledTimes(1);
-      expect(indexCanisterMock.ledgerId).toBeCalledWith({
+      expect(indexNgCanisterMock.ledgerId).toBeCalledTimes(1);
+      expect(indexNgCanisterMock.ledgerId).toBeCalledWith({
         certified: true,
       });
     });
 
     it("throws an error if canister throws", async () => {
       const err = new Error("test");
-      indexCanisterMock.ledgerId.mockRejectedValue(err);
+      indexNgCanisterMock.ledgerId.mockRejectedValue(err);
 
       const call = () =>
         getLedgerId({

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -24,7 +24,6 @@ describe("icrc-index api", () => {
   };
 
   const indexCanisterMock = mock<IcrcIndexCanister>();
-  let spyOnIndexCanisterCreate;
 
   const indexNgCanisterMock = mock<IcrcIndexNgCanister>();
   let spyOnIndexNgCanisterCreate;
@@ -32,10 +31,6 @@ describe("icrc-index api", () => {
   const agentMock = mock<HttpAgent>();
 
   beforeEach(() => {
-    spyOnIndexCanisterCreate = vi
-      .spyOn(IcrcIndexCanister, "create")
-      .mockImplementation(() => indexCanisterMock);
-
     spyOnIndexNgCanisterCreate = vi
       .spyOn(IcrcIndexNgCanister, "create")
       .mockImplementation(() => indexNgCanisterMock);


### PR DESCRIPTION
# Motivation

The ic-js library [introduced](https://github.com/dfinity/ic-js/pull/562) the next-generation version of ICRC index canisters. The nns-dapp was using the old implementation until the new one was introduced in #6815, which added a new method. The goal is to migrate existing methods to the next-generation version and deprecate the old one from ic-js.

# Changes

- Migrate the `getLedgerId` API method to use the next-generation index canister.

# Tests

- Update `getLedgerId` tests to use mocks and spies for the next-generation canisters.  
- Refactor `getTransactions` tests to follow the same structure as the other tests.

# Todos

- [ ] Add an entry to the changelog (if necessary)
Not necessary.