### PR TITLE
refactor(api): migrate getTransactions to next-gen index canister

### DIFF
--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -2,7 +2,6 @@ import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
 import type { Agent, Identity } from "@dfinity/agent";
 import {
-  IcrcIndexCanister,
   IcrcIndexNgCanister,
   type IcrcAccount,
   type IcrcGetTransactions,
@@ -33,7 +32,7 @@ export const getTransactions = async ({
 }: GetTransactionsParams): Promise<GetTransactionsResponse> => {
   const {
     canister: { getTransactions },
-  } = await indexCanister({ identity, canisterId: indexCanisterId });
+  } = await indexNgCanister({ identity, canisterId: indexCanisterId });
 
   const { oldest_tx_id, ...rest } = await getTransactions({
     max_results: maxResults,
@@ -44,33 +43,6 @@ export const getTransactions = async ({
   return {
     oldestTxId: fromNullable(oldest_tx_id),
     ...rest,
-  };
-};
-
-// TODO(yhabib): Migrate all methods to the indexNgCanister
-const indexCanister = async ({
-  identity,
-  canisterId,
-}: {
-  identity: Identity;
-  canisterId: Principal;
-}): Promise<{
-  canister: IcrcIndexCanister;
-  agent: Agent;
-}> => {
-  const agent = await createAgent({
-    identity,
-    host: HOST,
-  });
-
-  const canister = IcrcIndexCanister.create({
-    agent,
-    canisterId,
-  });
-
-  return {
-    canister,
-    agent,
   };
 };
 

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -44,6 +44,7 @@ describe("icrc-index api", () => {
       indexNgCanisterMock.getTransactions.mockResolvedValue({
         transactions,
         oldest_tx_id: [oldestTxId],
+        balance: 0n,
       });
       const result = await getTransactions(params);
 
@@ -68,6 +69,7 @@ describe("icrc-index api", () => {
       indexNgCanisterMock.getTransactions.mockResolvedValue({
         transactions,
         oldest_tx_id: [oldestTxId],
+        balance: 0n,
       });
       const start = 23n;
       await getTransactions({

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -24,6 +24,7 @@ describe("icrc-index api", () => {
   };
 
   const indexCanisterMock = mock<IcrcIndexCanister>();
+  let spyOnIndexCanisterCreate;
 
   const indexNgCanisterMock = mock<IcrcIndexNgCanister>();
   let spyOnIndexNgCanisterCreate;
@@ -31,6 +32,10 @@ describe("icrc-index api", () => {
   const agentMock = mock<HttpAgent>();
 
   beforeEach(() => {
+    spyOnIndexCanisterCreate = vi
+      .spyOn(IcrcIndexCanister, "create")
+      .mockImplementation(() => indexCanisterMock);
+
     spyOnIndexNgCanisterCreate = vi
       .spyOn(IcrcIndexNgCanister, "create")
       .mockImplementation(() => indexNgCanisterMock);

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -24,7 +24,6 @@ describe("icrc-index api", () => {
   };
 
   const indexCanisterMock = mock<IcrcIndexCanister>();
-  let spyOnIndexCanisterCreate;
 
   const indexNgCanisterMock = mock<IcrcIndexNgCanister>();
   let spyOnIndexNgCanisterCreate;
@@ -32,10 +31,6 @@ describe("icrc-index api", () => {
   const agentMock = mock<HttpAgent>();
 
   beforeEach(() => {
-    spyOnIndexCanisterCreate = vi
-      .spyOn(IcrcIndexCanister, "create")
-      .mockImplementation(() => indexCanisterMock);
-
     spyOnIndexNgCanisterCreate = vi
       .spyOn(IcrcIndexNgCanister, "create")
       .mockImplementation(() => indexNgCanisterMock);

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -10,7 +10,7 @@ import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import type { HttpAgent } from "@dfinity/agent";
-import { IcrcIndexCanister, IcrcIndexNgCanister } from "@dfinity/ledger-icrc";
+import { IcrcIndexNgCanister } from "@dfinity/ledger-icrc";
 import { mock } from "vitest-mock-extended";
 
 describe("icrc-index api", () => {
@@ -23,19 +23,12 @@ describe("icrc-index api", () => {
     indexCanisterId: principal(0),
   };
 
-  const indexCanisterMock = mock<IcrcIndexCanister>();
-  let spyOnIndexCanisterCreate;
-
   const indexNgCanisterMock = mock<IcrcIndexNgCanister>();
   let spyOnIndexNgCanisterCreate;
 
   const agentMock = mock<HttpAgent>();
 
   beforeEach(() => {
-    spyOnIndexCanisterCreate = vi
-      .spyOn(IcrcIndexCanister, "create")
-      .mockImplementation(() => indexCanisterMock);
-
     spyOnIndexNgCanisterCreate = vi
       .spyOn(IcrcIndexNgCanister, "create")
       .mockImplementation(() => indexNgCanisterMock);
@@ -48,20 +41,20 @@ describe("icrc-index api", () => {
     const oldestTxId = 1234n;
 
     it("returns list of transaction", async () => {
-      indexCanisterMock.getTransactions.mockResolvedValue({
+      indexNgCanisterMock.getTransactions.mockResolvedValue({
         transactions,
         oldest_tx_id: [oldestTxId],
       });
       const result = await getTransactions(params);
 
-      expect(spyOnIndexCanisterCreate).toBeCalledTimes(1);
-      expect(spyOnIndexCanisterCreate).toBeCalledWith({
+      expect(spyOnIndexNgCanisterCreate).toBeCalledTimes(1);
+      expect(spyOnIndexNgCanisterCreate).toBeCalledWith({
         agent: agentMock,
         canisterId: params.indexCanisterId,
       });
 
-      expect(indexCanisterMock.getTransactions).toBeCalledTimes(1);
-      expect(indexCanisterMock.getTransactions).toBeCalledWith({
+      expect(indexNgCanisterMock.getTransactions).toBeCalledTimes(1);
+      expect(indexNgCanisterMock.getTransactions).toBeCalledWith({
         max_results: params.maxResults,
         start: undefined,
         account: params.account,
@@ -72,7 +65,7 @@ describe("icrc-index api", () => {
     });
 
     it("passes start parameter", async () => {
-      indexCanisterMock.getTransactions.mockResolvedValue({
+      indexNgCanisterMock.getTransactions.mockResolvedValue({
         transactions,
         oldest_tx_id: [oldestTxId],
       });
@@ -82,14 +75,14 @@ describe("icrc-index api", () => {
         start,
       });
 
-      expect(spyOnIndexCanisterCreate).toBeCalledTimes(1);
-      expect(spyOnIndexCanisterCreate).toBeCalledWith({
+      expect(spyOnIndexNgCanisterCreate).toBeCalledTimes(1);
+      expect(spyOnIndexNgCanisterCreate).toBeCalledWith({
         agent: agentMock,
         canisterId: params.indexCanisterId,
       });
 
-      expect(indexCanisterMock.getTransactions).toBeCalledTimes(1);
-      expect(indexCanisterMock.getTransactions).toBeCalledWith({
+      expect(indexNgCanisterMock.getTransactions).toBeCalledTimes(1);
+      expect(indexNgCanisterMock.getTransactions).toBeCalledWith({
         max_results: params.maxResults,
         start,
         account: params.account,
@@ -98,7 +91,7 @@ describe("icrc-index api", () => {
 
     it("throws an error if canister throws", async () => {
       const err = new Error("test");
-      indexCanisterMock.getTransactions.mockRejectedValue(err);
+      indexNgCanisterMock.getTransactions.mockRejectedValue(err);
 
       const call = () => getTransactions(params);
 


### PR DESCRIPTION
# Motivation

The ic-js library [introduced](https://github.com/dfinity/ic-js/pull/562) the next-generation version of ICRC index canisters. The nns-dapp was using the old implementation until the new one was introduced in #6815, which added a new method. The goal is to migrate existing methods to the next-generation version and deprecate the old one from ic-js.

# Changes

- Migrate the `getTransactions` API method to use the next-generation index canister.
- Remove `indexCanister` as it is no longer used.

# Tests

- Update `getTransactions` tests to use mocks and spies for the next-generation canisters.  

# Todos

-  [ ] Add an entry to the changelog (if necessary)
Not necessary.