### PR TITLE
refactor(portfolio): migrate USD value display to runes

### DIFF
--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -6,6 +6,7 @@
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
   import { i18n } from "$lib/stores/i18n";
   import { Spinner } from "@dfinity/gix-components";
+
   type Props = {
     usdAmount: number | undefined;
     hasUnpricedTokens: boolean;

--- a/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
+++ b/frontend/src/lib/components/portfolio/TotalAssetsCard.svelte
@@ -21,53 +21,53 @@
   }: Props = $props();
 </script>
 
-<UsdValueHeadless
-  {usdAmount}
-  {hasUnpricedTokens}
-  let:icpPrice
-  let:usdAmountFormatted
-  let:icpAmountFormatted
-  let:hasError
-  let:hasPricesAndUnpricedTokens
->
-  <Card testId="total-assets-card-component">
-    <div
-      class="wrapper"
-      class:full-width={isFullWidth}
-      data-tid="total-assets-card-component-wrapper"
-    >
-      <h3>{$i18n.portfolio.total_assets_title}</h3>
-      <div class="pricing">
-        <div class="totals">
-          <div class="primary-amount-row">
-            {#if !isLoading}
-              <span class="primary-amount" data-tid="primary-amount">
-                ${usdAmountFormatted}
-              </span>
-              {#if hasPricesAndUnpricedTokens}
-                <TooltipIcon>
-                  {$i18n.accounts.unpriced_tokens_warning}
-                </TooltipIcon>
+<UsdValueHeadless {usdAmount} {hasUnpricedTokens}>
+  {#snippet children({
+    usdAmountFormatted,
+    icpPrice,
+    icpAmountFormatted,
+    hasPricesAndUnpricedTokens,
+    hasError,
+  })}
+    <Card testId="total-assets-card-component">
+      <div
+        class="wrapper"
+        class:full-width={isFullWidth}
+        data-tid="total-assets-card-component-wrapper"
+      >
+        <h3>{$i18n.portfolio.total_assets_title}</h3>
+        <div class="pricing">
+          <div class="totals">
+            <div class="primary-amount-row">
+              {#if !isLoading}
+                <span class="primary-amount" data-tid="primary-amount">
+                  ${usdAmountFormatted}
+                </span>
+                {#if hasPricesAndUnpricedTokens}
+                  <TooltipIcon>
+                    {$i18n.accounts.unpriced_tokens_warning}
+                  </TooltipIcon>
+                {/if}
+              {:else}
+                <div>
+                  <Spinner inline size="small" />
+                </div>
               {/if}
-            {:else}
-              <div>
-                <Spinner inline size="small" />
-              </div>
-            {/if}
+            </div>
+            <div class="secondary-amount" data-tid="secondary-amount">
+              {#if !isLoading}
+                {icpAmountFormatted}
+              {:else}
+                {PRICE_NOT_AVAILABLE_PLACEHOLDER}
+              {/if}
+              {$i18n.core.icp}
+            </div>
           </div>
-          <div class="secondary-amount" data-tid="secondary-amount">
-            {#if !isLoading}
-              {icpAmountFormatted}
-            {:else}
-              {PRICE_NOT_AVAILABLE_PLACEHOLDER}
-            {/if}
-            {$i18n.core.icp}
-          </div>
+          <IcpExchangeRate {hasError} {icpPrice} />
         </div>
-        <IcpExchangeRate {hasError} {icpPrice} />
       </div>
-    </div>
-  </Card>
+    </Card>
+  {/snippet}
 </UsdValueHeadless>
 
 <style lang="scss">

--- a/frontend/src/lib/components/ui/UsdValueBanner.svelte
+++ b/frontend/src/lib/components/ui/UsdValueBanner.svelte
@@ -10,38 +10,39 @@
   const absentValue = "-/-";
 </script>
 
-<UsdValueHeadless
-  {usdAmount}
-  {hasUnpricedTokens}
-  let:icpPrice
-  let:usdAmountFormatted
-  let:icpAmountFormatted
-  let:hasError
-  let:hasPricesAndUnpricedTokens
-  ><div class="wrapper" data-tid="usd-value-banner-component">
-    <div class="table-banner-icon">
-      <slot name="icon" />
-    </div>
-    <div class="text-content">
-      <div class="totals">
-        <div class="primary-amount-row">
-          <span class="primary-amount" data-tid="primary-amount">
-            ${usdAmountFormatted}
-          </span>
-          {#if hasPricesAndUnpricedTokens}
-            <TooltipIcon>
-              {$i18n.accounts.unpriced_tokens_warning}
-            </TooltipIcon>
-          {/if}
-        </div>
-        <div class="secondary-amount" data-tid="secondary-amount">
-          {icpAmountFormatted}
-          {$i18n.core.icp}
-        </div>
+<UsdValueHeadless {usdAmount} {hasUnpricedTokens}>
+  {#snippet children({
+    usdAmountFormatted,
+    icpPrice,
+    icpAmountFormatted,
+    hasPricesAndUnpricedTokens,
+    hasError,
+  })}
+    <div class="wrapper" data-tid="usd-value-banner-component">
+      <div class="table-banner-icon">
+        <slot name="icon" />
       </div>
-      <IcpExchangeRate {icpPrice} {hasError} {absentValue} />
+      <div class="text-content">
+        <div class="totals">
+          <div class="primary-amount-row">
+            <span class="primary-amount" data-tid="primary-amount">
+              ${usdAmountFormatted}
+            </span>
+            {#if hasPricesAndUnpricedTokens}
+              <TooltipIcon>
+                {$i18n.accounts.unpriced_tokens_warning}
+              </TooltipIcon>
+            {/if}
+          </div>
+          <div class="secondary-amount" data-tid="secondary-amount">
+            {icpAmountFormatted}
+            {$i18n.core.icp}
+          </div>
+        </div>
+        <IcpExchangeRate {icpPrice} {hasError} {absentValue} />
+      </div>
     </div>
-  </div>
+  {/snippet}
 </UsdValueHeadless>
 
 <style lang="scss">

--- a/frontend/src/lib/components/ui/UsdValueHeadless.svelte
+++ b/frontend/src/lib/components/ui/UsdValueHeadless.svelte
@@ -4,11 +4,19 @@
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { formatCurrencyNumber, formatNumber } from "$lib/utils/format.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import type { Component } from "svelte";
+  import type { Snippet } from "svelte";
+
+  export type ChildrenProps = {
+    hasError: boolean;
+    hasPricesAndUnpricedTokens: boolean;
+    icpAmountFormatted: string;
+    icpPrice: number | undefined;
+    usdAmountFormatted: string;
+  };
 
   type Props = {
     absentValue?: string;
-    children: Component;
+    children: Snippet<[ChildrenProps]>;
     hasUnpricedTokens: boolean;
     usdAmount: number | undefined;
   };

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadlessTest.svelte
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadlessTest.svelte
@@ -7,21 +7,20 @@
   export let absentValue: string = PRICE_NOT_AVAILABLE_PLACEHOLDER;
 </script>
 
-<UsdValueHeadless
-  {usdAmount}
-  {hasUnpricedTokens}
-  {absentValue}
-  let:usdAmountFormatted
-  let:icpAmountFormatted
-  let:hasPricesAndUnpricedTokens
-  let:hasError
->
-  <div data-tid="usd-value-headless-consumer">
-    <span data-tid="usd-amount">{usdAmountFormatted}</span>
-    <span data-tid="icp-amount">{icpAmountFormatted}</span>
-    <span data-tid="has-prices-ans-unpriced-tokens"
-      >{hasPricesAndUnpricedTokens.toString()}</span
-    >
-    <span data-tid="has-error">{hasError.toString()}</span>
-  </div></UsdValueHeadless
->
+<UsdValueHeadless {usdAmount} {hasUnpricedTokens} {absentValue}>
+  {#snippet children({
+    usdAmountFormatted,
+    icpAmountFormatted,
+    hasPricesAndUnpricedTokens,
+    hasError,
+  })}
+    <div data-tid="usd-value-headless-consumer">
+      <span data-tid="usd-amount">{usdAmountFormatted}</span>
+      <span data-tid="icp-amount">{icpAmountFormatted}</span>
+      <span data-tid="has-prices-ans-unpriced-tokens"
+        >{hasPricesAndUnpricedTokens.toString()}</span
+      >
+      <span data-tid="has-error">{hasError.toString()}</span>
+    </div>
+  {/snippet}
+</UsdValueHeadless>


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR prepares the `UsdValueHeadless` component by migrating it to Svelte 5.

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- Refactor `UsdValueHeadless` to runes.
- Update consumers of `UsdValueHeadless` to use the new syntax.

# Tests

- Updated demo component for tests.
- Pipeline should pass as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necesasry.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ