### PR TITLE
feat(balances): add balance display settings store

### DIFF
--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -8,7 +8,7 @@ export enum StoreLocalStorageKey {
   HideZeroBalances = "nnsHideZeroBalanceTokens",
   HideZeroNeurons = "nnsHideZeroNeuronProjects",
   HighlightDisplay = "nnsHighlightDisplay-",
-  BalancePrivacyOption = "nnsBalancePrivacyOption",
+  BalancePrivacyMode = "nnsBalancePrivacyMode",
 }
 
 export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -8,6 +8,7 @@ export enum StoreLocalStorageKey {
   HideZeroBalances = "nnsHideZeroBalanceTokens",
   HideZeroNeurons = "nnsHideZeroNeuronProjects",
   HighlightDisplay = "nnsHighlightDisplay-",
+  BalancePrivacyOption = "nnsBalancePrivacyOption",
 }
 
 export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/stores/balance-privacy-option.store.ts
+++ b/frontend/src/lib/stores/balance-privacy-option.store.ts
@@ -1,0 +1,12 @@
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
+import { writableStored } from "$lib/stores/writable-stored";
+import type { Writable } from "svelte/store";
+
+export type BalancePrivacyOption = "show" | "hide";
+
+export type BalancePrivacyOptionStore = Writable<BalancePrivacyOption>;
+
+export const balancesVisibility = writableStored<BalancePrivacyOption>({
+  key: StoreLocalStorageKey.BalancePrivacyOption,
+  defaultValue: "show",
+});

--- a/frontend/src/lib/stores/balance-privacy-option.store.ts
+++ b/frontend/src/lib/stores/balance-privacy-option.store.ts
@@ -7,6 +7,6 @@ export type BalancePrivacyOption = "show" | "hide";
 export type BalancePrivacyOptionStore = Writable<BalancePrivacyOption>;
 
 export const balancePrivacyOptionStore = writableStored<BalancePrivacyOption>({
-  key: StoreLocalStorageKey.BalancePrivacyOption,
+  key: StoreLocalStorageKey.BalancePrivacyMode,
   defaultValue: "show",
 });

--- a/frontend/src/lib/stores/balance-privacy-option.store.ts
+++ b/frontend/src/lib/stores/balance-privacy-option.store.ts
@@ -6,7 +6,7 @@ export type BalancePrivacyOption = "show" | "hide";
 
 export type BalancePrivacyOptionStore = Writable<BalancePrivacyOption>;
 
-export const balancesVisibility = writableStored<BalancePrivacyOption>({
+export const balancePrivacyOptionStore = writableStored<BalancePrivacyOption>({
   key: StoreLocalStorageKey.BalancePrivacyOption,
   defaultValue: "show",
 });

--- a/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
+++ b/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
@@ -1,22 +1,22 @@
 import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
-import { balancesVisibility } from "$lib/stores/balance-privacy-option.store";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import { get } from "svelte/store";
 
 describe("balancesVisibility", () => {
   it("should be initialized with the default value", () => {
-    expect(get(balancesVisibility)).toBe("show");
+    expect(get(balancePrivacyOptionStore)).toBe("show");
   });
 
   it("should update value", () => {
-    balancesVisibility.set("hide");
-    expect(get(balancesVisibility)).toBe("hide");
+    balancePrivacyOptionStore.set("hide");
+    expect(get(balancePrivacyOptionStore)).toBe("hide");
 
-    balancesVisibility.set("show");
-    expect(get(balancesVisibility)).toBe("show");
+    balancePrivacyOptionStore.set("show");
+    expect(get(balancePrivacyOptionStore)).toBe("show");
   });
 
   it("should write to local storage", () => {
-    balancesVisibility.set("hide");
+    balancePrivacyOptionStore.set("hide");
 
     expect(
       window.localStorage.getItem(StoreLocalStorageKey.BalancePrivacyOption)

--- a/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
+++ b/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
@@ -1,0 +1,25 @@
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
+import { balancesVisibility } from "$lib/stores/balance-privacy-option.store";
+import { get } from "svelte/store";
+
+describe("balancesVisibility", () => {
+  it("should be initialized with the default value", () => {
+    expect(get(balancesVisibility)).toBe("show");
+  });
+
+  it("should update value", () => {
+    balancesVisibility.set("hide");
+    expect(get(balancesVisibility)).toBe("hide");
+
+    balancesVisibility.set("show");
+    expect(get(balancesVisibility)).toBe("show");
+  });
+
+  it("should write to local storage", () => {
+    balancesVisibility.set("hide");
+
+    expect(
+      window.localStorage.getItem(StoreLocalStorageKey.BalancePrivacyOption)
+    ).toEqual('"hide"');
+  });
+});

--- a/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
+++ b/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
@@ -19,7 +19,7 @@ describe("balancesVisibility", () => {
     balancePrivacyOptionStore.set("hide");
 
     expect(
-      window.localStorage.getItem(StoreLocalStorageKey.BalancePrivacyOption)
+      window.localStorage.getItem(StoreLocalStorageKey.BalancePrivacyMode)
     ).toEqual('"hide"');
   });
 });


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR introduces a new writable store, which is a store that is saved in local storage, to track the user's selection of `hide/show`.

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- Add new writable store.

# Tests

- Add unit tests for the store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ