### PR TITLE
feat(store): add balance visibility logic

### DIFF
--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -8,7 +8,7 @@ export enum StoreLocalStorageKey {
   HideZeroBalances = "nnsHideZeroBalanceTokens",
   HideZeroNeurons = "nnsHideZeroNeuronProjects",
   HighlightDisplay = "nnsHighlightDisplay-",
-  BalancePrivacyMode = "nnsBalancePrivacyMode",
+  BalancePrivacyOption = "nnsBalancePrivacyOption",
 }
 
 export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/derived/balance-privacy-active.derived.ts
+++ b/frontend/src/lib/derived/balance-privacy-active.derived.ts
@@ -2,7 +2,7 @@ import { authSignedInStore } from "$lib/derived/auth.derived";
 import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import { derived } from "svelte/store";
 
-export const isPrivacyModeStore = derived(
+export const isBalancePrivacyOptionStore = derived(
   [balancePrivacyOptionStore, authSignedInStore],
   ([$balancePrivacyOptionStore, isSignedIn]) =>
     $balancePrivacyOptionStore === "hide" && isSignedIn

--- a/frontend/src/lib/derived/balance-privacy-active.derived.ts
+++ b/frontend/src/lib/derived/balance-privacy-active.derived.ts
@@ -1,0 +1,9 @@
+import { authSignedInStore } from "$lib/derived/auth.derived";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
+import { derived } from "svelte/store";
+
+export const isPrivacyModeStore = derived(
+  [balancePrivacyOptionStore, authSignedInStore],
+  ([$balancePrivacyOptionStore, isSignedIn]) =>
+    $balancePrivacyOptionStore === "hide" && isSignedIn
+);

--- a/frontend/src/lib/stores/balance-privacy-option.store.ts
+++ b/frontend/src/lib/stores/balance-privacy-option.store.ts
@@ -6,7 +6,7 @@ export type BalancePrivacyOption = "show" | "hide";
 
 export type BalancePrivacyOptionStore = Writable<BalancePrivacyOption>;
 
-export const balancesVisibility = writableStored<BalancePrivacyOption>({
+export const balancePrivacyOptionStore = writableStored<BalancePrivacyOption>({
   key: StoreLocalStorageKey.BalancePrivacyOption,
   defaultValue: "show",
 });

--- a/frontend/src/lib/stores/balance-privacy-option.store.ts
+++ b/frontend/src/lib/stores/balance-privacy-option.store.ts
@@ -6,7 +6,7 @@ export type BalancePrivacyOption = "show" | "hide";
 
 export type BalancePrivacyOptionStore = Writable<BalancePrivacyOption>;
 
-export const balancePrivacyOptionStore = writableStored<BalancePrivacyOption>({
-  key: StoreLocalStorageKey.BalancePrivacyMode,
+export const balancesVisibility = writableStored<BalancePrivacyOption>({
+  key: StoreLocalStorageKey.BalancePrivacyOption,
   defaultValue: "show",
 });

--- a/frontend/src/tests/lib/derived/balance-privacy-active.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/balance-privacy-active.derived.spec.ts
@@ -1,0 +1,40 @@
+import { isPrivacyModeStore } from "$lib/derived/balance-privacy-active.derived";
+import { authStore } from "$lib/stores/auth.store";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { get } from "svelte/store";
+
+describe("balance-privacy-active.derived", () => {
+  beforeEach(() => {
+    balancePrivacyOptionStore.set("show");
+  });
+
+  it("should be false by default", () => {
+    const value = get(isPrivacyModeStore);
+    expect(value).toBe(false);
+  });
+
+  it("should be false when user is not signed in and privacy mode is 'hide'", () => {
+    balancePrivacyOptionStore.set("hide");
+    authStore.setForTesting(null);
+
+    const value = get(isPrivacyModeStore);
+    expect(value).toBe(false);
+  });
+
+  it("should be false when user is signed in but privacy mode is 'show'", () => {
+    authStore.setForTesting(mockIdentity);
+    balancePrivacyOptionStore.set("show");
+
+    const value = get(isPrivacyModeStore);
+    expect(value).toBe(false);
+  });
+
+  it("should be true when user is signed in and privacy mode is 'hide'", () => {
+    authStore.setForTesting(mockIdentity);
+    balancePrivacyOptionStore.set("hide");
+
+    const value = get(isPrivacyModeStore);
+    expect(value).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/derived/balance-privacy-active.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/balance-privacy-active.derived.spec.ts
@@ -1,4 +1,4 @@
-import { isPrivacyModeStore } from "$lib/derived/balance-privacy-active.derived";
+import { isBalancePrivacyOptionStore } from "$lib/derived/balance-privacy-active.derived";
 import { authStore } from "$lib/stores/auth.store";
 import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
@@ -10,7 +10,7 @@ describe("balance-privacy-active.derived", () => {
   });
 
   it("should be false by default", () => {
-    const value = get(isPrivacyModeStore);
+    const value = get(isBalancePrivacyOptionStore);
     expect(value).toBe(false);
   });
 
@@ -18,7 +18,7 @@ describe("balance-privacy-active.derived", () => {
     balancePrivacyOptionStore.set("hide");
     authStore.setForTesting(null);
 
-    const value = get(isPrivacyModeStore);
+    const value = get(isBalancePrivacyOptionStore);
     expect(value).toBe(false);
   });
 
@@ -26,7 +26,7 @@ describe("balance-privacy-active.derived", () => {
     authStore.setForTesting(mockIdentity);
     balancePrivacyOptionStore.set("show");
 
-    const value = get(isPrivacyModeStore);
+    const value = get(isBalancePrivacyOptionStore);
     expect(value).toBe(false);
   });
 
@@ -34,7 +34,7 @@ describe("balance-privacy-active.derived", () => {
     authStore.setForTesting(mockIdentity);
     balancePrivacyOptionStore.set("hide");
 
-    const value = get(isPrivacyModeStore);
+    const value = get(isBalancePrivacyOptionStore);
     expect(value).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
+++ b/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
@@ -1,22 +1,22 @@
 import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
-import { balancesVisibility } from "$lib/stores/balance-privacy-option.store";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import { get } from "svelte/store";
 
 describe("balancesVisibility", () => {
   it("should be initialized with the default value", () => {
-    expect(get(balancesVisibility)).toBe("show");
+    expect(get(balancePrivacyOptionStore)).toBe("show");
   });
 
   it("should update value", () => {
-    balancesVisibility.set("hide");
-    expect(get(balancesVisibility)).toBe("hide");
+    balancePrivacyOptionStore.set("hide");
+    expect(get(balancePrivacyOptionStore)).toBe("hide");
 
-    balancesVisibility.set("show");
-    expect(get(balancesVisibility)).toBe("show");
+    balancePrivacyOptionStore.set("show");
+    expect(get(balancePrivacyOptionStore)).toBe("show");
   });
 
   it("should write to local storage", () => {
-    balancesVisibility.set("hide");
+    balancePrivacyOptionStore.set("hide");
 
     expect(
       window.localStorage.getItem(StoreLocalStorageKey.BalancePrivacyOption)

--- a/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
+++ b/frontend/src/tests/lib/stores/balance-privacy-option.store.spec.ts
@@ -1,25 +1,25 @@
 import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
-import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
+import { balancesVisibility } from "$lib/stores/balance-privacy-option.store";
 import { get } from "svelte/store";
 
 describe("balancesVisibility", () => {
   it("should be initialized with the default value", () => {
-    expect(get(balancePrivacyOptionStore)).toBe("show");
+    expect(get(balancesVisibility)).toBe("show");
   });
 
   it("should update value", () => {
-    balancePrivacyOptionStore.set("hide");
-    expect(get(balancePrivacyOptionStore)).toBe("hide");
+    balancesVisibility.set("hide");
+    expect(get(balancesVisibility)).toBe("hide");
 
-    balancePrivacyOptionStore.set("show");
-    expect(get(balancePrivacyOptionStore)).toBe("show");
+    balancesVisibility.set("show");
+    expect(get(balancesVisibility)).toBe("show");
   });
 
   it("should write to local storage", () => {
-    balancePrivacyOptionStore.set("hide");
+    balancesVisibility.set("hide");
 
     expect(
-      window.localStorage.getItem(StoreLocalStorageKey.BalancePrivacyMode)
+      window.localStorage.getItem(StoreLocalStorageKey.BalancePrivacyOption)
     ).toEqual('"hide"');
   });
 });


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR adds a new derived store to determine whether the balances should be visible. The logic is as follows:
* If the user is signed in and has marked the option to hide the balance, it will return `true`.
* In all other cases, it will return `false`.

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- Add new derived store.

# Tests

- Add unit tests for the derived store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ