### PR TITLE
chore(deps): upgrade rust to 1.87 and fix warnings

### DIFF
--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -129,7 +129,6 @@ impl Partitions {
 /// Note: Would prefer to use `TryFrom`, but that causes a conflict.  `DefaultMemoryImpl` a type alias which
 /// may refer to a type that has a generic implementation of `TryFrom`.  This is frustrating.
 impl From<DefaultMemoryImpl> for Partitions {
-    #[must_use]
     fn from(memory: DefaultMemoryImpl) -> Self {
         let memory_manager = MemoryManager::init(memory);
         Partitions { memory_manager }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.86.0"
+channel = "1.87.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

#6840 is attempting to upgrade Rust to the latest version but is [failing](https://github.com/dfinity/nns-dapp/actions/runs/15060150698/job/42333677679?pr=6840). The compiler appears to have become smarter and can now detect that the `#[must_use]` attribute has no effect when applied to methods of a trait implementation.

# Changes

- Upgrade Rust to 1.87
- Remove `#[must_use]` from trait implementation.

# Tests

- Pipeline should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.