### PR TITLE
feat(utils): add hidden balance character generator

### DIFF
--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -85,4 +85,4 @@ export const shortenWithMiddleEllipsis = (
 };
 
 export const renderPrivacyModeBalance = (count: number) =>
-  count < 0 ? "" : "•".repeat(count);
+  "•".repeat(Math.max(0, count));

--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -83,3 +83,5 @@ export const shortenWithMiddleEllipsis = (
     ? `${text.slice(0, splitLength)}...${text.slice(-1 * splitLength)}`
     : text;
 };
+
+export const renderPrivacyModeBalance = (count: number) => "•".repeat(count);

--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -84,4 +84,5 @@ export const shortenWithMiddleEllipsis = (
     : text;
 };
 
-export const renderPrivacyModeBalance = (count: number) => "•".repeat(count);
+export const renderPrivacyModeBalance = (count: number) =>
+  count < 0 ? "" : "•".repeat(count);

--- a/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -2,6 +2,7 @@ import {
   formatCurrencyNumber,
   formatNumber,
   formatPercentage,
+  renderPrivacyModeBalance,
   shortenWithMiddleEllipsis,
 } from "$lib/utils/format.utils";
 
@@ -116,6 +117,22 @@ describe("format.utils", () => {
       expect(formatCurrencyNumber(1000000000)).toBe("1.00B");
       expect(formatCurrencyNumber(9990000000)).toBe("9.99B");
       expect(formatCurrencyNumber(24800000000)).toBe("24.80B");
+    });
+  });
+
+  describe("renderPrivacyModeBalance", () => {
+    it("returns empty string for 0 count", () => {
+      expect(renderPrivacyModeBalance(0)).toBe("");
+    });
+
+    it("returns the correct number of bullets ", () => {
+      expect(renderPrivacyModeBalance(1)).toBe("•");
+      expect(renderPrivacyModeBalance(3)).toBe("•••");
+      expect(renderPrivacyModeBalance(5)).toBe("•••••");
+    });
+
+    it("returns empty string for negative counts", () => {
+      expect(renderPrivacyModeBalance(-1)).toBe("");
     });
   });
 });


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. When hidden, the design requires the "hidden" character to be displayed multiple times, depending on the context and available space. This PR adds a new utility to generate these "hidden" characters.

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

-  Added a new utility.

# Tests

-  Added unit tests.

# Todos

-  [ ] Add an entry to the changelog (if necessary)
Not necessary

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ