### PR TITLE
feat(display): implement hidden balance formatting in the USD value banner

### DIFF
--- a/frontend/src/lib/components/ui/UsdValueHeadless.svelte
+++ b/frontend/src/lib/components/ui/UsdValueHeadless.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
   import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
+  import { isBalancePrivacyOptionStore } from "$lib/derived/balance-privacy-active.derived";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
-  import { formatCurrencyNumber, formatNumber } from "$lib/utils/format.utils";
+  import {
+    formatCurrencyNumber,
+    formatNumber,
+    renderPrivacyModeBalance,
+  } from "$lib/utils/format.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import type { Snippet } from "svelte";
 
@@ -33,9 +38,11 @@
   const hasPricesAndUnpricedTokens = $derived(hasPrices && hasUnpricedTokens);
 
   const usdAmountFormatted = $derived(
-    nonNullish(usdAmount) && hasPrices
-      ? formatCurrencyNumber(usdAmount)
-      : absentValue
+    $isBalancePrivacyOptionStore
+      ? renderPrivacyModeBalance(5)
+      : nonNullish(usdAmount) && hasPrices
+        ? formatCurrencyNumber(usdAmount)
+        : absentValue
   );
   const icpPrice = $derived(
     isNullish($icpSwapUsdPricesStore) || $icpSwapUsdPricesStore === "error"
@@ -49,7 +56,11 @@
       : undefined
   );
   const icpAmountFormatted = $derived(
-    nonNullish(icpAmount) ? formatNumber(icpAmount) : absentValue
+    $isBalancePrivacyOptionStore
+      ? renderPrivacyModeBalance(3)
+      : nonNullish(icpAmount)
+        ? formatNumber(icpAmount)
+        : absentValue
   );
 </script>
 

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
@@ -114,7 +114,7 @@ describe("UsdValueHeadless", () => {
     expect(await po.getIcpAmountFormatted()).toBe("5.00");
   });
 
-  it("should hide balance if user is logged in and has toggle hide balance", async () => {
+  it("should hide balance if user is logged in and hide balance is toggled", async () => {
     balancePrivacyOptionStore.set("hide");
     resetIdentity();
 

--- a/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
+++ b/frontend/src/tests/lib/components/ui/UsdValueHeadless.spec.ts
@@ -1,5 +1,7 @@
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import UsdValueHeadlessTest from "$tests/lib/components/ui/UsdValueHeadlessTest.svelte";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { UsdValueHeadlessPo } from "$tests/page-objects/UsdValueHeadless.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setIcpPrice } from "$tests/utils/icp-swap.test-utils";
@@ -110,5 +112,18 @@ describe("UsdValueHeadless", () => {
 
     expect(await po.getUsdAmountFormatted()).toBe("1’000");
     expect(await po.getIcpAmountFormatted()).toBe("5.00");
+  });
+
+  it("should hide balance if user is logged in and has toggle hide balance", async () => {
+    balancePrivacyOptionStore.set("hide");
+    resetIdentity();
+
+    const po = renderComponent({
+      usdAmount: 1000,
+      hasUnpricedTokens: false,
+    });
+
+    expect(await po.getUsdAmountFormatted()).toBe("•••••");
+    expect(await po.getIcpAmountFormatted()).toBe("•••");
   });
 });


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR modifies the `UsdValueHeadless` component to format the amount either as a number or the hidden characters.

https://github.com/user-attachments/assets/1dacdc62-5afd-488c-93f4-7516c42592a9

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

Note: This PR does not yet provide a way to toggle the hidden/show value.

# Changes

- Format amounts based on the hide balance toggle.

# Tests

- Unit test to cover the hidden value.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ