### PR TITLE
refactor(ui): migrate Amounts components to svelte 5

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -7,16 +7,31 @@
   import { Copy } from "@dfinity/gix-components";
   import { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
-  export let amount: TokenAmount | TokenAmountV2 | UnavailableTokenAmount;
-  export let label: string | undefined = undefined;
-  export let inline = false;
-  export let singleLine = false;
-  export let title = false;
-  export let copy = false;
-  export let text = false;
-  export let size: "inherit" | "huge" | undefined = undefined;
-  export let sign: "+" | "-" | "" = "";
-  export let detailed: boolean | "height_decimals" = false;
+  type Props = {
+    amount: TokenAmount | TokenAmountV2 | UnavailableTokenAmount;
+    label?: string;
+    inline?: boolean;
+    singleLine?: boolean;
+    title?: boolean;
+    copy?: boolean;
+    text?: boolean;
+    size?: "inherit" | "huge";
+    sign?: "+" | "-" | "";
+    detailed?: boolean | "height_decimals";
+  };
+
+  const {
+    amount,
+    label = undefined,
+    inline = false,
+    singleLine = false,
+    title = false,
+    copy = false,
+    text = false,
+    size = undefined,
+    sign = "",
+    detailed = false,
+  }: Props = $props();
 
   const isValidAmount = (
     amount:

--- a/frontend/src/lib/components/ic/AmountWithUsd.svelte
+++ b/frontend/src/lib/components/ic/AmountWithUsd.svelte
@@ -4,8 +4,12 @@
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
   import { nonNullish, TokenAmountV2 } from "@dfinity/utils";
 
-  export let amount: TokenAmountV2 | UnavailableTokenAmount;
-  export let amountInUsd: number | undefined;
+  type Props = {
+    amount: TokenAmountV2 | UnavailableTokenAmount;
+    amountInUsd: number | undefined;
+  };
+
+  const { amount, amountInUsd }: Props = $props();
 </script>
 
 <div class="values" data-tid="amount-with-usd-component">


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR migrates two existing components to use Svelte runes, simplifying future changes to implement the visibility toggle.

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- Migrates `AmountWithUsd` to runes.
- Migrates `AmountDisplay` to runes.

# Tests

- No logical changes have been made, so the tests should pass as they did before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ