### PR TITLE
refactor(portfolio): migrate balance cards to runes

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -17,8 +17,10 @@
     topHeldTokens: UserTokenData[];
     usdAmount: number;
     numberOfTopStakedTokens: number;
+    icon?: Component;
   };
-  const { topHeldTokens, usdAmount, numberOfTopStakedTokens }: Props = $props();
+  const { topHeldTokens, usdAmount, numberOfTopStakedTokens, icon }: Props =
+    $props();
 
   const href = AppPath.Tokens;
 
@@ -43,9 +45,9 @@
       title={$i18n.portfolio.held_tokens_card_title}
       linkText={$i18n.portfolio.held_tokens_card_link}
     >
-      <svelte:fragment slot="icon">
+      {#snippet icon()}
         <IconHeldTokens />
-      </svelte:fragment>
+      {/snippet}
     </TokensCardHeader>
     <div class="body" role="table">
       <div class="header" role="row">

--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -13,20 +13,22 @@
   import { IconAccountsPage, IconHeldTokens } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
 
-  export let topHeldTokens: UserTokenData[];
-  export let usdAmount: number;
-  export let numberOfTopStakedTokens: number;
+  type Props = {
+    topHeldTokens: UserTokenData[];
+    usdAmount: number;
+    numberOfTopStakedTokens: number;
+  };
+  const { topHeldTokens, usdAmount, numberOfTopStakedTokens }: Props = $props();
 
   const href = AppPath.Tokens;
 
-  let numberOfTopHeldTokens: number;
-  $: numberOfTopHeldTokens = topHeldTokens.length;
-
-  let showInfoRow: boolean;
-  $: showInfoRow = shouldShowInfoRow({
-    currentCardNumberOfTokens: numberOfTopHeldTokens,
-    otherCardNumberOfTokens: numberOfTopStakedTokens,
-  });
+  const numberOfTopHeldTokens = $derived(topHeldTokens.length);
+  const showInfoRow = $derived(
+    shouldShowInfoRow({
+      currentCardNumberOfTokens: numberOfTopHeldTokens,
+      otherCardNumberOfTokens: numberOfTopStakedTokens,
+    })
+  );
 </script>
 
 <Card testId="held-tokens-card">

--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -17,10 +17,8 @@
     topHeldTokens: UserTokenData[];
     usdAmount: number;
     numberOfTopStakedTokens: number;
-    icon?: Component;
   };
-  const { topHeldTokens, usdAmount, numberOfTopStakedTokens, icon }: Props =
-    $props();
+  const { topHeldTokens, usdAmount, numberOfTopStakedTokens }: Props = $props();
 
   const href = AppPath.Tokens;
 

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -46,9 +46,9 @@
       title={$i18n.portfolio.staked_tokens_card_title}
       linkText={$i18n.portfolio.staked_tokens_card_link}
     >
-      <svelte:fragment slot="icon">
+      {#snippet icon()}
         <IconNeuronsPage />
-      </svelte:fragment>
+      {/snippet}
     </TokensCardHeader>
     <div class="body" role="table">
       <div class="header" role="row">

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -14,20 +14,24 @@
   import { IconNeuronsPage, IconStakedTokens } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
 
-  export let topStakedTokens: TableProject[];
-  export let usdAmount: number;
-  export let numberOfTopHeldTokens: number;
+  type Props = {
+    topStakedTokens: TableProject[];
+    usdAmount: number;
+    numberOfTopHeldTokens: number;
+  };
+
+  const { topStakedTokens, usdAmount, numberOfTopHeldTokens }: Props = $props();
 
   const href = AppPath.Staking;
 
-  let numberOfTopStakedTokens: number;
-  $: numberOfTopStakedTokens = topStakedTokens.length;
+  const numberOfTopStakedTokens = $derived(topStakedTokens.length);
 
-  let showInfoRow: boolean;
-  $: showInfoRow = shouldShowInfoRow({
-    currentCardNumberOfTokens: numberOfTopStakedTokens,
-    otherCardNumberOfTokens: numberOfTopHeldTokens,
-  });
+  const showInfoRow = $derived(
+    shouldShowInfoRow({
+      currentCardNumberOfTokens: numberOfTopStakedTokens,
+      otherCardNumberOfTokens: numberOfTopHeldTokens,
+    })
+  );
 </script>
 
 <Card testId="staked-tokens-card">

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -3,15 +3,17 @@
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { formatCurrencyNumber } from "$lib/utils/format.utils";
   import { IconRight } from "@dfinity/gix-components";
+  import type { Snippet } from "svelte";
 
   type Props = {
     usdAmount: number;
     href: string;
     title: string;
     linkText: string;
+    icon: Snippet;
   };
 
-  const { usdAmount, href, title, linkText }: Props = $props();
+  const { usdAmount, href, title, linkText, icon }: Props = $props();
 
   const usdAmountFormatted = $derived(
     $authSignedInStore
@@ -23,7 +25,7 @@
 <div class="header">
   <div class="header-wrapper">
     <div class="icon" aria-hidden="true">
-      <slot name="icon" />
+      {@render icon()}
     </div>
     <div class="text-content">
       <h5 class="title">{title}</h5>

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -4,15 +4,20 @@
   import { formatCurrencyNumber } from "$lib/utils/format.utils";
   import { IconRight } from "@dfinity/gix-components";
 
-  export let usdAmount: number;
-  export let href: string;
-  export let title: string;
-  export let linkText: string;
+  type Props = {
+    usdAmount: number;
+    href: string;
+    title: string;
+    linkText: string;
+  };
 
-  let usdAmountFormatted: string;
-  $: usdAmountFormatted = $authSignedInStore
-    ? formatCurrencyNumber(usdAmount)
-    : PRICE_NOT_AVAILABLE_PLACEHOLDER;
+  const { usdAmount, href, title, linkText }: Props = $props();
+
+  const usdAmountFormatted = $derived(
+    $authSignedInStore
+      ? formatCurrencyNumber(usdAmount)
+      : PRICE_NOT_AVAILABLE_PLACEHOLDER
+  );
 </script>
 
 <div class="header">


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR migrates the two cards displaying balances in the Portfolio page to use Svelte runes, simplifying future changes to implement the visibility toggle.

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- Migrate `HeldTokensCard` to runes.
- Migrate `StakedTokensCard` to runes.
- Migrate `TokensCardHeader` to runes.

# Tests

- No logical changes have been made, so the tests should pass as they did before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ