### PR TITLE
feat(launchpad): implement alternative info box for proposal's info

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -13,6 +13,8 @@
   let proposalId: ProposalId | undefined;
   $: proposalId = getProjectProposal(summary);
 
+  // TODO: Reconciliate with proposalInfo for a long term solution
+  let loadProposalError: boolean = false;
   let proposalInfo: ProposalInfo | undefined;
 
   const loadProposalFromId = (proposalId: ProposalId | undefined) => {
@@ -20,6 +22,9 @@
       loadProposal({
         proposalId,
         silentErrorMessages: true,
+        handleError: () => {
+          loadProposalError = true;
+        },
         setProposal: (proposal: ProposalInfo) => {
           // User might navigate quickly between proposals - previous / next.
           // e.g. the update call of previous proposal id 3n might be fetched after user has navigated to next proposal id 2n
@@ -38,9 +43,9 @@
 {#if nonNullish(proposalInfo)}
   <h3>{$i18n.sns_project_detail.swap_proposal}</h3>
   <NnsProposalCard {proposalInfo} />
-{:else if nonNullish(proposalId)}
+{:else if loadProposalError && nonNullish(proposalId)}
   <h3>{$i18n.sns_project_detail.swap_proposal}</h3>
-  <div class="info-message">
+  <div class="info-message" data-tid="proposal-card-alternative-info">
     <IconInfo size="24" />
     <span class="stack">
       <span>

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -4,6 +4,7 @@
   import { loadProposal } from "$lib/services/public/proposals.services";
   import { i18n } from "$lib/stores/i18n";
   import type { SnsSummary } from "$lib/types/sns";
+  import { IconInfo } from "@dfinity/gix-components";
   import type { ProposalId, ProposalInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
 
@@ -18,6 +19,7 @@
     if (nonNullish(proposalId)) {
       loadProposal({
         proposalId,
+        silentErrorMessages: true,
         setProposal: (proposal: ProposalInfo) => {
           // User might navigate quickly between proposals - previous / next.
           // e.g. the update call of previous proposal id 3n might be fetched after user has navigated to next proposal id 2n
@@ -36,10 +38,48 @@
 {#if nonNullish(proposalInfo)}
   <h3>{$i18n.sns_project_detail.swap_proposal}</h3>
   <NnsProposalCard {proposalInfo} />
+{:else if nonNullish(proposalId)}
+  <h3>{$i18n.sns_project_detail.swap_proposal}</h3>
+  <div class="info-message">
+    <IconInfo size="24" />
+    <span>
+      You can find the proposal details on the
+      <a
+        href="https://dashboard.internetcomputer.org/proposal/{proposalId}"
+        target="_blank">dashboard</a
+      >.
+    </span>
+  </div>
 {/if}
 
 <style lang="scss">
   h3 {
     margin: var(--padding-8x) 0 var(--padding-3x);
+  }
+
+  .info-message {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-2x);
+    padding: 14px 16px;
+    margin: 16px 0;
+    background-color: #f0f7ff;
+    border-left: 4px solid #2196f3;
+    border-radius: 4px;
+    color: #333;
+    font-size: 16px;
+    line-height: 1.5;
+  }
+
+  .info-message a {
+    color: #0d6efd;
+    text-decoration: underline;
+    margin-left: 4px;
+  }
+
+  /* Optional hover effect for the entire message */
+  .info-message:hover {
+    background-color: #e3f2fd;
+    transition: background-color 0.2s ease;
   }
 </style>

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -42,12 +42,26 @@
   <h3>{$i18n.sns_project_detail.swap_proposal}</h3>
   <div class="info-message">
     <IconInfo size="24" />
-    <span>
-      You can find the proposal details on the
+    <span class="stack">
+      <span>
+        You can find the proposal details on the <a
+          href="https://dashboard.internetcomputer.org/proposal/{proposalId}"
+          target="_blank"
+          rel="noopener noreferrer">dashboard</a
+        >
+        or on
+        <a
+          href="https://f2djv-5aaaa-aaaah-qdbea-cai.raw.icp0.io/proposal/{proposalId}"
+          target="_blank"
+          rel="noopener noreferrer">vpgeek</a
+        >.
+      </span>
       <a
-        href="https://dashboard.internetcomputer.org/proposal/{proposalId}"
-        target="_blank">dashboard</a
-      >.
+        href="https://forum.dfinity.org/t/nns-governance-bug-in-proposal-136693/48224"
+        class="small"
+        target="_blank"
+        rel="noopener noreferrer">why is the proposal not in the dapp?</a
+      >
     </span>
   </div>
 {/if}
@@ -60,26 +74,27 @@
   .info-message {
     display: flex;
     align-items: center;
-    gap: var(--padding-2x);
-    padding: 14px 16px;
-    margin: 16px 0;
-    background-color: #f0f7ff;
-    border-left: 4px solid #2196f3;
+    gap: var(--padding);
+    padding: var(--padding-1_5x) var(--padding-2x);
+    margin: var(--padding-2x) 0;
+    background: var(--card-background);
+    border-left: 4px solid var(--primary);
     border-radius: 4px;
-    color: #333;
-    font-size: 16px;
     line-height: 1.5;
   }
-
-  .info-message a {
-    color: #0d6efd;
-    text-decoration: underline;
-    margin-left: 4px;
+  .stack {
+    display: flex;
+    flex-direction: column;
   }
 
-  /* Optional hover effect for the entire message */
-  .info-message:hover {
-    background-color: #e3f2fd;
-    transition: background-color 0.2s ease;
+  .info-message {
+    a {
+      color: var(--button-secondary-color);
+    }
+
+    .small {
+      font-size: var(--font-size-small);
+      color: var(--content-color);
+    }
   }
 </style>

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -53,14 +53,14 @@
         <a
           href="https://f2djv-5aaaa-aaaah-qdbea-cai.raw.icp0.io/proposal/{proposalId}"
           target="_blank"
-          rel="noopener noreferrer">vpgeek</a
+          rel="noopener noreferrer">vpGeek</a
         >.
       </span>
       <a
         href="https://forum.dfinity.org/t/nns-governance-bug-in-proposal-136693/48224"
         class="small"
         target="_blank"
-        rel="noopener noreferrer">why is the proposal not in the dapp?</a
+        rel="noopener noreferrer">Why is the proposal not in the dapp?</a
       >
     </span>
   </div>


### PR DESCRIPTION
# Motivation

We want to show an info-box about where to find an Sns project's proposal in case the nns-dapp can't load it.
This PR introduces this new box with links to the dashboard and vpGeek. Additionally, there is a link to a forum post.

![Screenshot 2025-05-19 at 21 10 50](https://github.com/user-attachments/assets/7750c9eb-ced5-47b6-be9c-c98e4126d221)

![Screenshot 2025-05-19 at 21 10 58](https://github.com/user-attachments/assets/244e58d1-49f5-4bc9-b80f-e63ad6bbb64e)

# Changes

- Remove toast message when a proposal can't load from the proposal details.
- Show info box if proposal can't be loaded but we have the `proposalId`.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
