### PR TITLE
feat(security): add hardware wallet permissions policy

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- Added support for hardware wallet connections through browser permissions
+
 #### Security
 
 #### Not Published

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -313,6 +313,9 @@ fn security_headers() -> Vec<HeaderField> {
         ),
         // "Referrer-Policy: no-referrer" would be more strict, but breaks local dev deployment same-origin is still ok from a security perspective
         ("Referrer-Policy".to_string(), "same-origin".to_string()),
+        // camera is required for QR codes
+        // clipboard r&w is required for copying/pasting into the nns-dapp
+        // hid & usb are required for HW
         (
             "Permissions-Policy".to_string(),
             "accelerometer=(),\

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -334,7 +334,7 @@ fn security_headers() -> Vec<HeaderField> {
          gamepad=(),\
          geolocation=(),\
          gyroscope=(),\
-         hid=(),\
+         hid=(self),\
          idle-detection=(),\
          interest-cohort=(),\
          keyboard-map=(),\
@@ -351,7 +351,7 @@ fn security_headers() -> Vec<HeaderField> {
          sync-script=(),\
          sync-xhr=(),\
          trust-token-redemption=(),\
-         usb=(),\
+         usb=(self),\
          vertical-scroll=(),\
          web-share=(),\
          window-placement=(),\


### PR DESCRIPTION
# Motivation

#6779 introduced Permissions Policy for the application to explicitly enable the necessary native features.

The initial implementation was missing the permissions for HW:
- hid
- usb

<img width="1523" alt="Screenshot 2025-05-20 at 13 31 26" src="https://github.com/user-attachments/assets/fe878e79-e8ed-4bd2-8e8d-1e6050effb7a" />

<img width="1545" alt="Screenshot 2025-05-20 at 13 31 40" src="https://github.com/user-attachments/assets/b6a9ae08-e476-4efc-aeee-4275c053a6f2" />

# Changes

- Adds permissions for `hid` and `usb`.

# Tests

- Tested by mstrasinskis in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [x] Add entry to changelog (if necessary).
