### PR TITLE
fix(scroll): upgrade gix to restore infinite scrolling

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,9 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- Added support for hardware wallet connections through browser permissions
+- Infinite scrolling in Voting and Proposals lists
+
 #### Security
 
 #### Not Published

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,7 +22,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
-- Added support for hardware wallet connections through browser permissions
 - Infinite scrolling in Voting and Proposals lists
 
 #### Security

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "6.0.0-next-2025-04-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-04-28.tgz",
-      "integrity": "sha512-eNp+4AZAClL0TB1KdpgSbG5BTxZvUqppzHK8oxwfjTZY3AZdqxK3eWISmhAI3mztZsgLOdPiPk9O0zg+fKHjgg==",
+      "version": "6.0.0-next-2025-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-05-21.tgz",
+      "integrity": "sha512-RfQGEV03yz7XGhgMWex2FhAfLG1rAzd4/FHo2tIdPZeAaD95nKpS0VeR7PuDVT/SvmdJKmO7wqEtVGALVXMH5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.2.4",
@@ -7288,9 +7288,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "6.0.0-next-2025-04-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-04-28.tgz",
-      "integrity": "sha512-eNp+4AZAClL0TB1KdpgSbG5BTxZvUqppzHK8oxwfjTZY3AZdqxK3eWISmhAI3mztZsgLOdPiPk9O0zg+fKHjgg==",
+      "version": "6.0.0-next-2025-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-05-21.tgz",
+      "integrity": "sha512-RfQGEV03yz7XGhgMWex2FhAfLG1rAzd4/FHo2tIdPZeAaD95nKpS0VeR7PuDVT/SvmdJKmO7wqEtVGALVXMH5g==",
       "requires": {
         "dompurify": "^3.2.4",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
@@ -120,7 +120,7 @@
   {ledgerCanisterId}
 >
   <UiTransactionsList
-    on:nnsIntersect={loadNextTransactions}
+    {loadNextTransactions}
     transactions={uiTransactions}
     {loading}
     {completed}

--- a/frontend/src/lib/components/accounts/UiTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/UiTransactionsList.svelte
@@ -36,7 +36,7 @@
   {:else}
     <InfiniteScroll
       onIntersect={loadNextTransactions}
-      disabled={disabledInifiteScroll}
+      disabled={disabledInfiteScroll}
     >
       {#each transactions as transaction (transaction.domKey)}
         <div animate:flip={{ duration: 250 }}>

--- a/frontend/src/lib/components/accounts/UiTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/UiTransactionsList.svelte
@@ -11,9 +11,15 @@
     transactions: UiTransaction[];
     loading: boolean;
     completed?: boolean;
+    loadNextTransactions: () => Promise<void>;
   };
 
-  const { transactions, loading, completed = false }: Props = $props();
+  const {
+    transactions,
+    loading,
+    completed = false,
+    loadNextTransactions,
+  }: Props = $props();
 
   const isEmpty = $derived(transactions.length === 0);
   const showSkeleton = $derived(isEmpty && loading);
@@ -28,7 +34,10 @@
   {:else if showNoTransactions}
     <NoTransactions />
   {:else}
-    <InfiniteScroll on:nnsIntersect disabled={disabledInfiteScroll}>
+    <InfiniteScroll
+      onIntersect={loadNextTransactions}
+      disabled={disabledInifiteScroll}
+    >
       {#each transactions as transaction (transaction.domKey)}
         <div animate:flip={{ duration: 250 }}>
           <TransactionCard {transaction} />

--- a/frontend/src/lib/components/neuron-detail/Ballots/Ballots.svelte
+++ b/frontend/src/lib/components/neuron-detail/Ballots/Ballots.svelte
@@ -26,7 +26,7 @@
     fakeLoading = false;
   });
   let fakeLoading = false;
-  const showMore = () => {
+  const showMore = async () => {
     if (fakeLoading) {
       return;
     }
@@ -48,7 +48,7 @@
       <span>{$i18n.neuron_detail.vote}</span>
     </h4>
 
-    <InfiniteScroll on:nnsIntersect={showMore} disabled={disableInfiniteScroll}>
+    <InfiniteScroll onIntersect={showMore} disabled={disableInfiniteScroll}>
       {#each ballotsToShow as ballot}
         <li>
           <BallotSummary {ballot} />

--- a/frontend/src/lib/components/proposals/NnsProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsList.svelte
@@ -75,7 +75,7 @@
         {:else if actionableProposals?.length === 0}
           <ActionableProposalsEmpty />
         {:else}
-          <InfiniteScroll layout="grid" onIntersect={async () => {}}>
+          <InfiniteScroll layout="grid" disabled onIntersect={async () => {}}>
             {#each actionableProposals ?? [] as proposalInfo (proposalInfo.id)}
               <NnsProposalCard {hidden} actionable {proposalInfo} />
             {/each}

--- a/frontend/src/lib/components/proposals/NnsProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsList.svelte
@@ -21,9 +21,16 @@
     disableInfiniteScroll: boolean;
     loading: boolean;
     loadingAnimation?: "spinner" | "skeleton";
+    loadNextProposals: () => Promise<void>;
   };
-  const { hidden, disableInfiniteScroll, loading, loadingAnimation }: Props =
-    $props();
+
+  const {
+    hidden,
+    disableInfiniteScroll,
+    loading,
+    loadingAnimation,
+    loadNextProposals,
+  }: Props = $props();
 
   // Prevent pre-rendering issue "IntersectionObserver is not defined"
   // Note: Another solution would be to lazy load the InfiniteScroll component
@@ -44,7 +51,7 @@
         {:else}
           <ListLoader loading={loadingAnimation === "spinner"}>
             <InfiniteScroll
-              on:nnsIntersect
+              onIntersect={loadNextProposals}
               layout="grid"
               disabled={disableInfiniteScroll || loading}
             >

--- a/frontend/src/lib/components/proposals/NnsProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsList.svelte
@@ -75,7 +75,6 @@
         {:else if actionableProposals?.length === 0}
           <ActionableProposalsEmpty />
         {:else}
-          <!-- TODO: Fix once GIX makes the cb optional -->
           <InfiniteScroll layout="grid" onIntersect={async () => {}}>
             {#each actionableProposals ?? [] as proposalInfo (proposalInfo.id)}
               <NnsProposalCard {hidden} actionable {proposalInfo} />

--- a/frontend/src/lib/components/proposals/NnsProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsList.svelte
@@ -75,7 +75,8 @@
         {:else if actionableProposals?.length === 0}
           <ActionableProposalsEmpty />
         {:else}
-          <InfiniteScroll layout="grid" disabled>
+          <!-- TODO: Fix once GIX makes the cb optional -->
+          <InfiniteScroll layout="grid" onIntersect={async () => {}}>
             {#each actionableProposals ?? [] as proposalInfo (proposalInfo.id)}
               <NnsProposalCard {hidden} actionable {proposalInfo} />
             {/each}

--- a/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
@@ -16,7 +16,7 @@
     <UniverseSummary {universe} />
   </div>
 
-  <InfiniteScroll layout="grid" disabled>
+  <InfiniteScroll layout="grid" disabled onIntersect={async () => {}}>
     {@render children()}
   </InfiniteScroll>
 </div>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -71,7 +71,6 @@
       {:else if proposals.length === 0}
         <ActionableProposalsEmpty />
       {:else}
-        <!-- TODO: Remove noop once GIX is fixed -->
         <InfiniteScroll layout="grid" onIntersect={async () => {}}>
           {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
             <SnsProposalCard

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -71,7 +71,7 @@
       {:else if proposals.length === 0}
         <ActionableProposalsEmpty />
       {:else}
-        <InfiniteScroll layout="grid" onIntersect={async () => {}}>
+        <InfiniteScroll layout="grid" disabled onIntersect={async () => {}}>
           {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
             <SnsProposalCard
               actionable={proposalData.isActionable}

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -21,13 +21,16 @@
     nsFunctions: SnsNervousSystemFunction[] | undefined;
     disableInfiniteScroll?: boolean;
     loadingNextPage?: boolean;
+    loadNextPage: () => Promise<void>;
   };
+
   const {
     proposals,
     actionableSelected,
     nsFunctions,
     disableInfiniteScroll = false,
     loadingNextPage = false,
+    loadNextPage,
   }: Props = $props();
 </script>
 
@@ -44,7 +47,7 @@
         <ListLoader loading={loadingNextPage}>
           <InfiniteScroll
             layout="grid"
-            on:nnsIntersect
+            onIntersect={loadNextPage}
             disabled={disableInfiniteScroll}
           >
             {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
@@ -68,7 +71,8 @@
       {:else if proposals.length === 0}
         <ActionableProposalsEmpty />
       {:else}
-        <InfiniteScroll layout="grid" disabled>
+        <!-- TODO: Remove noop once GIX is fixed -->
+        <InfiniteScroll layout="grid" onIntersect={async () => {}}>
           {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
             <SnsProposalCard
               actionable={proposalData.isActionable}

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -58,7 +58,7 @@
     }
   };
 
-  const findNextProposals = () =>
+  const loadNextProposals = () =>
     wrapProposalLoading(
       listNextProposals({
         beforeProposal: lastProposalId($sortedProposals.proposals),
@@ -134,5 +134,5 @@
   {disableInfiniteScroll}
   {loading}
   {loadingAnimation}
-  on:nnsIntersect={findNextProposals}
+  {loadNextProposals}
 />

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -422,7 +422,7 @@
 
           {#if $selectedAccountStore.account !== undefined}
             <UiTransactionsList
-              on:nnsIntersect={loadNextTransactions}
+              {loadNextTransactions}
               transactions={uiTransactions ?? []}
               loading={loadingTransactions}
               completed={completedTransactions}

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -151,7 +151,7 @@
     {proposals}
     actionableSelected={$actionableProposalsActiveStore}
     nsFunctions={$nsFunctionsStore}
-    on:nnsIntersect={loadNextPage}
+    {loadNextPage}
     {disableInfiniteScroll}
     {loadingNextPage}
   />

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -90,7 +90,7 @@
     (() => fetchProposals($snsFiltersStore))();
 
   let loadingNextPage = false;
-  let loadNextPage: () => void;
+  let loadNextPage: () => Promise<void>;
   $: loadNextPage = async () => {
     const selectedProjectCanisterId = $snsOnlyProjectStore;
     if (


### PR DESCRIPTION
# Motivation

We want to upgrade the version of Gix in the nns-dapp to address an issue with Infinite Scrolling. The latest version of GIX introduced a breaking change to `InfiniteScroll` when migrating it to Svelte 5.

This PR builds on top of #6859 and refactors how these components consume the `InfiniteScroll`.

Note: This upgrade fixes the issue of all lists not fetching next pages.

Before:

Not all votes are being loaded: 

https://github.com/user-attachments/assets/4b71cf51-d18f-427e-a9f7-97f67adc4fa4

Not all proposals for a project are being loaded by scrolling:

https://github.com/user-attachments/assets/b81273ff-3d87-4b7d-a881-4fe0cb39c2b9


After:

All votes are being loaded: 

https://github.com/user-attachments/assets/bcf125c9-f567-48d7-9d30-b3b4c29b0291

All proposals for a project are being loaded by scrolling:

https://github.com/user-attachments/assets/6d9ba8f7-db19-414a-bcb8-24e0b7048159

# Changes

- Upgrade the GIX component library to the latest version.  
- Update the consumers of `InfiniteScroll` to the new interface.

# Tests

- Pipeline should work as before.
- Manually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/portfolio/).

# Todos

- [x] Add entry to changelog (if necessary).