### PR TITLE
chore: update team name to governance-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dfinity/nns-team
+* @dfinity/governance-team

--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: mstrasinskis, nns-team, yhabib
+          reviewers: mstrasinskis, governance-team, yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             Cargo.lock

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -15,7 +15,7 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="orbit"
-clap.define short=s long=station desc="The orbit station to use" variable=STATION default="nns-team"
+clap.define short=s long=station desc="The orbit station to use" variable=STATION default="governance-team"
 clap.define long=skip-checks desc="Skip the checks that dfx-orbit is set up correctly" variable=SKIP_CHECKS nargs=0
 clap.define short=c long=commit desc="The commit to download the wasm for" variable=COMMIT default="main"
 clap.define long=install-mode desc="Install mode" variable=INSTALL_MODE default="upgrade"


### PR DESCRIPTION
# Motivation

The name of the [nns-team](https://github.com/orgs/dfinity/teams/nns-team) has changed to [governance-team](https://github.com/orgs/dfinity/teams/governance-team). More information can be found [here](https://dfinity.slack.com/archives/CGJND92DA/p1747828796597669?thread_ts=1747671441.856149&cid=CGJND92DA) and [here](https://dfinity.slack.com/archives/CGJND92DA/p1747740057505439).

# Changes

- Update references from the old team name to the new one.

# Tests

Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.