### PR TITLE
refactor(lists): migrate consumers of infinite scroll components to runes

### DIFF
--- a/frontend/src/lib/components/accounts/UiTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/UiTransactionsList.svelte
@@ -18,7 +18,7 @@
   const isEmpty = $derived(transactions.length === 0);
   const showSkeleton = $derived(isEmpty && loading);
   const showNoTransactions = $derived(isEmpty && !loading);
-  const disabledInifiteScroll = $derived(loading || completed);
+  const disabledInfiteScroll = $derived(loading || completed);
 </script>
 
 <div data-tid="transactions-list" class="container">
@@ -28,7 +28,7 @@
   {:else if showNoTransactions}
     <NoTransactions />
   {:else}
-    <InfiniteScroll on:nnsIntersect disabled={disabledInifiteScroll}>
+    <InfiniteScroll on:nnsIntersect disabled={disabledInfiteScroll}>
       {#each transactions as transaction (transaction.domKey)}
         <div animate:flip={{ duration: 250 }}>
           <TransactionCard {transaction} />

--- a/frontend/src/lib/components/accounts/UiTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/UiTransactionsList.svelte
@@ -7,15 +7,18 @@
   import { InfiniteScroll, Spinner } from "@dfinity/gix-components";
   import { flip } from "svelte/animate";
 
-  export let transactions: UiTransaction[];
-  export let loading: boolean;
-  export let completed = false;
+  type Props = {
+    transactions: UiTransaction[];
+    loading: boolean;
+    completed?: boolean;
+  };
 
-  $: isEmpty = transactions.length === 0;
+  const { transactions, loading, completed = false }: Props = $props();
 
-  $: showSkeleton = isEmpty && loading;
-  $: showNoTransactions = isEmpty && !loading;
-  $: disabledInifiteScroll = loading || completed;
+  const isEmpty = $derived(transactions.length === 0);
+  const showSkeleton = $derived(isEmpty && loading);
+  const showNoTransactions = $derived(isEmpty && !loading);
+  const disabledInifiteScroll = $derived(loading || completed);
 </script>
 
 <div data-tid="transactions-list" class="container">

--- a/frontend/src/lib/components/proposals/NnsProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsList.svelte
@@ -18,8 +18,8 @@
 
   type Props = {
     hidden: boolean;
-    disableInfiniteScroll?: boolean;
-    loading?: boolean;
+    disableInfiniteScroll: boolean;
+    loading: boolean;
     loadingAnimation?: "spinner" | "skeleton";
   };
   const { hidden, disableInfiniteScroll, loading, loadingAnimation }: Props =

--- a/frontend/src/lib/components/proposals/NnsProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsList.svelte
@@ -13,21 +13,22 @@
   import { filteredActionableProposals } from "$lib/derived/proposals.derived";
   import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
   import { InfiniteScroll } from "@dfinity/gix-components";
-  import type { ProposalInfo } from "@dfinity/nns";
   import { isNullish } from "@dfinity/utils";
   import { fade } from "svelte/transition";
-  export let hidden: boolean;
-  export let disableInfiniteScroll: boolean;
-  export let loading: boolean;
-  export let loadingAnimation: "spinner" | "skeleton" | undefined;
+
+  type Props = {
+    hidden: boolean;
+    disableInfiniteScroll?: boolean;
+    loading?: boolean;
+    loadingAnimation?: "spinner" | "skeleton";
+  };
+  const { hidden, disableInfiniteScroll, loading, loadingAnimation }: Props =
+    $props();
 
   // Prevent pre-rendering issue "IntersectionObserver is not defined"
   // Note: Another solution would be to lazy load the InfiniteScroll component
-  let display = true;
-  $: display = !building;
-
-  let actionableProposals: ProposalInfo[] | undefined;
-  $: actionableProposals = $actionableNnsProposalsStore.proposals;
+  const display = $derived(!building);
+  const actionableProposals = $derived($actionableNnsProposalsStore.proposals);
 </script>
 
 <TestIdWrapper testId="nns-proposal-list-component">

--- a/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
@@ -2,8 +2,13 @@
   import UniverseSummary from "$lib/components/universe/UniverseSummary.svelte";
   import type { Universe } from "$lib/types/universe";
   import { InfiniteScroll } from "@dfinity/gix-components";
+  import type { Snippet } from "svelte";
 
-  export let universe: Universe;
+  type Props = {
+    universe: Universe;
+    children: Snippet;
+  };
+  const { children, universe }: Props = $props();
 </script>
 
 <div class="container" data-tid="universe-with-actionable-proposals-component">
@@ -12,7 +17,7 @@
   </div>
 
   <InfiniteScroll layout="grid" disabled>
-    <slot />
+    {@render children()}
   </InfiniteScroll>
 </div>
 

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -15,11 +15,20 @@
   import { fromNullable, isNullish } from "@dfinity/utils";
   import { fade } from "svelte/transition";
 
-  export let proposals: SnsProposalActionableData[] | undefined;
-  export let actionableSelected: boolean;
-  export let nsFunctions: SnsNervousSystemFunction[] | undefined;
-  export let disableInfiniteScroll = false;
-  export let loadingNextPage = false;
+  type Props = {
+    proposals: SnsProposalActionableData[] | undefined;
+    actionableSelected: boolean;
+    nsFunctions: SnsNervousSystemFunction[] | undefined;
+    disableInfiniteScroll?: boolean;
+    loadingNextPage?: boolean;
+  };
+  const {
+    proposals,
+    actionableSelected,
+    nsFunctions,
+    disableInfiniteScroll = false,
+    loadingNextPage = false,
+  }: Props = $props();
 </script>
 
 <TestIdWrapper testId="sns-proposal-list-component">


### PR DESCRIPTION
# Motivation

We want to upgrade the version of Gix in the nns-dapp to address an issue with Infinite Scrolling. The latest version of GIX introduced a breaking change to `InfiniteScroll` when migrating it to Svelte 5.

This PR prepares consumers of these components for the upgrade by migrating them to runes.

# Changes

- Refactor `UiTransactionsList` to support runes.
- Refactor `NnsProposalsList` to support runes.
- Refactor `SnsProposalsList` to support runes.
- Refactor `UniverseWithActionableProposals` to support runes.

# Tests

- Pipeline should work as before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.