### PR TITLE
feat(ui): add privacy-aware amount display

### DIFF
--- a/frontend/src/lib/components/ui/PrivacyAwareAmount.svelte
+++ b/frontend/src/lib/components/ui/PrivacyAwareAmount.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { isBalancePrivacyOptionStore } from "$lib/derived/balance-privacy-active.derived";
+  import { renderPrivacyModeBalance } from "$lib/utils/format.utils";
+
+  type Props = {
+    value: string;
+    length: number;
+  };
+
+  const { value, length }: Props = $props();
+
+  const renderedValue = $derived(
+    $isBalancePrivacyOptionStore ? renderPrivacyModeBalance(length) : value
+  );
+</script>
+
+{renderedValue}

--- a/frontend/src/tests/lib/components/ui/PrivacyAwareAmount.spec.ts
+++ b/frontend/src/tests/lib/components/ui/PrivacyAwareAmount.spec.ts
@@ -1,0 +1,48 @@
+import PrivacyAwareAmount from "$lib/components/ui/PrivacyAwareAmount.svelte";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("PrivacyAwareAmount", () => {
+  const renderComponent = (props: { value: unknown; length: number }) => {
+    const { container } = render(PrivacyAwareAmount, { props });
+    return new JestPageObjectElement(container);
+  };
+
+  it("should display the provided value when user is not signed-in", async () => {
+    setNoIdentity();
+    balancePrivacyOptionStore.set("show");
+
+    const value = "-/-";
+    const po = renderComponent({ value, length: 3 });
+    expect(await po.getText()).toBe(value);
+  });
+
+  it("should display the provided value when user is signed-in but hide was not toggled", async () => {
+    resetIdentity();
+    balancePrivacyOptionStore.set("show");
+
+    const value = "123.21";
+    const po = renderComponent({ value, length: 3 });
+    expect(await po.getText()).toBe(value);
+  });
+
+  it("should show hide characters when user is signed-in and hide was toggled", async () => {
+    resetIdentity();
+    balancePrivacyOptionStore.set("hide");
+
+    const value = "123.21";
+    const po = renderComponent({ value, length: 3 });
+    expect(await po.getText()).toBe("•••");
+  });
+
+  it("should show the specified number of hide characters when user is signed-in and hide was toggled", async () => {
+    resetIdentity();
+    balancePrivacyOptionStore.set("hide");
+
+    const value = "123.21";
+    const po = renderComponent({ value, length: 6 });
+    expect(await po.getText()).toBe("••••••");
+  });
+});


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR adds a new component that determines whether to display the provided value or hide it with placeholder characters. This component will later be used by various other components.

# Changes

- New component `PrivacyAwareAmount`

# Tests

- Unit tests for the new component.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.