### PR TITLE
feat(portfolio): integrate privacy display in headers cards

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -17,8 +17,10 @@
     topHeldTokens: UserTokenData[];
     usdAmount: number;
     numberOfTopStakedTokens: number;
+    icon?: Component;
   };
-  const { topHeldTokens, usdAmount, numberOfTopStakedTokens }: Props = $props();
+  const { topHeldTokens, usdAmount, numberOfTopStakedTokens, icon }: Props =
+    $props();
 
   const href = AppPath.Tokens;
 

--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -17,10 +17,8 @@
     topHeldTokens: UserTokenData[];
     usdAmount: number;
     numberOfTopStakedTokens: number;
-    icon?: Component;
   };
-  const { topHeldTokens, usdAmount, numberOfTopStakedTokens, icon }: Props =
-    $props();
+  const { topHeldTokens, usdAmount, numberOfTopStakedTokens }: Props = $props();
 
   const href = AppPath.Tokens;
 

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import PrivacyAwareAmount from "$lib/components/ui/PrivacyAwareAmount.svelte";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { formatCurrencyNumber } from "$lib/utils/format.utils";
@@ -15,7 +16,7 @@
 
   const { usdAmount, href, title, linkText, icon }: Props = $props();
 
-  const usdAmountFormatted = $derived(
+  const formattedAmount = $derived(
     $authSignedInStore
       ? formatCurrencyNumber(usdAmount)
       : PRICE_NOT_AVAILABLE_PLACEHOLDER
@@ -30,7 +31,7 @@
     <div class="text-content">
       <h5 class="title">{title}</h5>
       <p class="amount" data-tid="amount" aria-label={`${title}: ${usdAmount}`}>
-        ${usdAmountFormatted}
+        $<PrivacyAwareAmount value={formattedAmount} length={3} />
       </p>
     </div>
   </div>

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -16,7 +16,7 @@
 
   const { usdAmount, href, title, linkText, icon }: Props = $props();
 
-  const formattedAmount = $derived(
+  const usdAmountFormatted = $derived(
     $authSignedInStore
       ? formatCurrencyNumber(usdAmount)
       : PRICE_NOT_AVAILABLE_PLACEHOLDER
@@ -31,7 +31,7 @@
     <div class="text-content">
       <h5 class="title">{title}</h5>
       <p class="amount" data-tid="amount" aria-label={`${title}: ${usdAmount}`}>
-        $<PrivacyAwareAmount value={formattedAmount} length={3} />
+        $<PrivacyAwareAmount value={usdAmountFormatted} length={3} />
       </p>
     </div>
   </div>

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -141,15 +141,6 @@ describe("HeldTokensCard", () => {
       expect(await po.getAmount()).toBe("$•••");
     });
 
-    it("should show the usd amount", async () => {
-      const po = renderComponent({
-        topHeldTokens: mockTokens,
-        usdAmount: 6000,
-      });
-
-      expect(await po.getAmount()).toBe("$6’000");
-    });
-
     it("should show all the tokens with their balance", async () => {
       const po = renderComponent({
         topHeldTokens: mockTokens,

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -1,4 +1,5 @@
 import HeldTokensCard from "$lib/components/portfolio/HeldTokensCard.svelte";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCToken as CkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
@@ -118,6 +119,26 @@ describe("HeldTokensCard", () => {
 
     beforeEach(() => {
       resetIdentity();
+    });
+
+    it("should show the usd amount", async () => {
+      const po = renderComponent({
+        topHeldTokens: mockTokens,
+        usdAmount: 6000,
+      });
+
+      expect(await po.getAmount()).toBe("$6’000");
+    });
+
+    it("should hide the usd amount", async () => {
+      balancePrivacyOptionStore.set("hide");
+
+      const po = renderComponent({
+        topHeldTokens: mockTokens,
+        usdAmount: 6000,
+      });
+
+      expect(await po.getAmount()).toBe("$•••");
     });
 
     it("should show the usd amount", async () => {

--- a/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
@@ -1,5 +1,6 @@
 import StakedTokensCard from "$lib/components/portfolio/StakedTokensCard.svelte";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import type { TableProject } from "$lib/types/staking";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
@@ -188,6 +189,16 @@ describe("StakedTokensCard", () => {
       });
 
       expect(await po.getAmount()).toBe("$5’000");
+    });
+
+    it("should show the usd amount", async () => {
+      balancePrivacyOptionStore.set("hide");
+
+      const po = renderComponent({
+        usdAmount: 5000,
+      });
+
+      expect(await po.getAmount()).toBe("$•••");
     });
 
     it("should show all the projects with their maturity, staked in usd and staked in native currency", async () => {

--- a/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
@@ -191,7 +191,7 @@ describe("StakedTokensCard", () => {
       expect(await po.getAmount()).toBe("$5’000");
     });
 
-    it("should show the usd amount", async () => {
+    it("should hide the usd amount", async () => {
       balancePrivacyOptionStore.set("hide");
 
       const po = renderComponent({


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR adds the `PrivacyAwareAmount` to the portfolio header cards.

<img width="1243" alt="Screenshot 2025-05-21 at 21 19 50" src="https://github.com/user-attachments/assets/60d1c449-2495-4865-a2bc-cbcd3dcdf02c" />

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- Wrap the amount value with the `PrivacyAwareAmount`.

# Tests

- Add a unit test to cover the hide flow.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ