### PR TITLE
feat(menu): create balance privacy toggle component

### DIFF
--- a/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
+++ b/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { isBalancePrivacyOptionStore } from "$lib/derived/balance-privacy-active.derived";
+  import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
+  import { i18n } from "$lib/stores/i18n";
+  import { IconEyeOpen, Toggle } from "@dfinity/gix-components";
+
+  let checked = $derived($isBalancePrivacyOptionStore);
+
+  const onToggle = () => {
+    checked = !checked;
+    balancePrivacyOptionStore.set(checked ? "hide" : "show");
+  };
+</script>
+
+<div class="wrapper" data-tid="balance-privacy-option">
+  <span class="text">
+    <IconEyeOpen />
+    {$i18n.navigation.toggle_balance_privacy_mode}
+  </span>
+  <Toggle
+    bind:checked
+    on:nnsToggle={onToggle}
+    ariaLabel={$i18n.navigation.toggle_balance_privacy_mode}
+  />
+</div>
+
+<style lang="scss">
+  @use "../../themes/mixins/account-menu";
+
+  .wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .text {
+      display: flex;
+      align-items: center;
+      gap: var(--padding-0_5x);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
+++ b/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
@@ -12,7 +12,12 @@
   };
 </script>
 
-<button class="wrapper" {onclick}>
+<button
+  class="wrapper"
+  {onclick}
+  aria-label={$i18n.navigation.toggle_balance_privacy_mode}
+  data-tid="toggle-balance-privacy-option-component"
+>
   <span class="text">
     <IconEyeOpen />
     {$i18n.navigation.toggle_balance_privacy_mode}

--- a/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
+++ b/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
@@ -6,31 +6,30 @@
 
   let checked = $derived($isBalancePrivacyOptionStore);
 
-  const onToggle = () => {
+  const onclick = () => {
     checked = !checked;
     balancePrivacyOptionStore.set(checked ? "hide" : "show");
   };
 </script>
 
-<div class="wrapper">
+<button class="wrapper" {onclick}>
   <span class="text">
     <IconEyeOpen />
     {$i18n.navigation.toggle_balance_privacy_mode}
   </span>
   <Toggle
     bind:checked
-    on:nnsToggle={onToggle}
     ariaLabel={$i18n.navigation.toggle_balance_privacy_mode}
   />
-</div>
+</button>
 
 <style lang="scss">
   @use "../../themes/mixins/account-menu";
 
   .wrapper {
-    display: flex;
+    @include account-menu.button;
     justify-content: space-between;
-    align-items: center;
+    padding: 0;
 
     .text {
       display: flex;

--- a/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
+++ b/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
@@ -40,6 +40,7 @@
     @include account-menu.button;
     justify-content: space-between;
     padding: 0;
+    cursor: pointer;
 
     .text {
       display: flex;

--- a/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
+++ b/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
@@ -2,11 +2,17 @@
   import { isBalancePrivacyOptionStore } from "$lib/derived/balance-privacy-active.derived";
   import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
   import { i18n } from "$lib/stores/i18n";
-  import { IconEyeOpen, Toggle } from "@dfinity/gix-components";
+  import { IconEyeClosed, IconEyeOpen, Toggle } from "@dfinity/gix-components";
 
   let checked = $derived($isBalancePrivacyOptionStore);
+  const label = $derived(
+    checked
+      ? $i18n.navigation.privacy_mode_show
+      : $i18n.navigation.privacy_mode_hide
+  );
+  const Icon = $derived(checked ? IconEyeOpen : IconEyeClosed);
 
-  const onclick = () => {
+  const toggle = () => {
     checked = !checked;
     balancePrivacyOptionStore.set(checked ? "hide" : "show");
   };
@@ -14,18 +20,17 @@
 
 <button
   class="wrapper"
-  {onclick}
-  aria-label={$i18n.navigation.toggle_balance_privacy_mode}
+  onclick={toggle}
+  aria-label={label}
   data-tid="toggle-balance-privacy-option-component"
 >
   <span class="text">
-    <IconEyeOpen />
-    {$i18n.navigation.toggle_balance_privacy_mode}
+    <Icon />
+    <span data-tid="label">
+      {label}
+    </span>
   </span>
-  <Toggle
-    bind:checked
-    ariaLabel={$i18n.navigation.toggle_balance_privacy_mode}
-  />
+  <Toggle bind:checked ariaLabel={label} on:nnsToggle={toggle} />
 </button>
 
 <style lang="scss">

--- a/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
+++ b/frontend/src/lib/components/header/ToggleBalancePrivacyOption.svelte
@@ -12,7 +12,7 @@
   };
 </script>
 
-<div class="wrapper" data-tid="balance-privacy-option">
+<div class="wrapper">
   <span class="text">
     <IconEyeOpen />
     {$i18n.navigation.toggle_balance_privacy_mode}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -153,7 +153,8 @@
     "source_code": "Source Code",
     "settings": "Settings",
     "reporting": "Reporting",
-    "portfolio": "Portfolio"
+    "portfolio": "Portfolio",
+    "toggle_balance_privacy_mode": "Hide Balance"
   },
   "alfred": {
     "no_results": "No results found",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -154,7 +154,8 @@
     "settings": "Settings",
     "reporting": "Reporting",
     "portfolio": "Portfolio",
-    "toggle_balance_privacy_mode": "Hide Balance"
+    "privacy_mode_hide": "Hide Balance",
+    "privacy_mode_show": "Show Balance"
   },
   "alfred": {
     "no_results": "No results found",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -160,6 +160,7 @@ interface I18nNavigation {
   settings: string;
   reporting: string;
   portfolio: string;
+  toggle_balance_privacy_mode: string;
 }
 
 interface I18nAlfred {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -160,7 +160,8 @@ interface I18nNavigation {
   settings: string;
   reporting: string;
   portfolio: string;
-  toggle_balance_privacy_mode: string;
+  privacy_mode_hide: string;
+  privacy_mode_show: string;
 }
 
 interface I18nAlfred {

--- a/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
+++ b/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
@@ -2,14 +2,16 @@ import ToggleBalancePrivacyOption from "$lib/components/header/ToggleBalancePriv
 import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { TogglePo } from "$tests/page-objects/Toggle.page-object";
+import { ToggleBalancePrivacyOptionPageObject } from "$tests/page-objects/ToggleBalancePrivacyOption.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
 import { get } from "svelte/store";
 
 describe("ToggleBalancePrivacyOption", () => {
   const renderComponent = () => {
     const { container } = render(ToggleBalancePrivacyOption);
-    const po = TogglePo.under(new JestPageObjectElement(container));
+    const po = ToggleBalancePrivacyOptionPageObject.under({
+      element: new JestPageObjectElement(container),
+    });
 
     return po;
   };
@@ -22,25 +24,25 @@ describe("ToggleBalancePrivacyOption", () => {
     balancePrivacyOptionStore.set("hide");
     const po = renderComponent();
 
-    expect(await po.isEnabled()).toBe(true);
+    expect(await po.isToggleEnabled()).toBe(true);
   });
 
   it("should initialize the toggle to on if the store is show", async () => {
     balancePrivacyOptionStore.set("show");
     const po = renderComponent();
 
-    expect(await po.isEnabled()).toBe(false);
+    expect(await po.isToggleEnabled()).toBe(false);
   });
 
   it("should mutate the store when the toggle is clicked", async () => {
     balancePrivacyOptionStore.set("hide");
     const po = renderComponent();
 
-    expect(await po.isEnabled()).toBe(true);
+    expect(await po.isToggleEnabled()).toBe(true);
 
-    await po.toggle();
+    await po.click();
 
-    expect(await po.isEnabled()).toBe(false);
+    expect(await po.isToggleEnabled()).toBe(false);
     expect(get(balancePrivacyOptionStore)).toBe("show");
   });
 });

--- a/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
+++ b/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
@@ -1,0 +1,46 @@
+import ToggleBalancePrivacyOption from "$lib/components/header/ToggleBalancePrivacyOption.svelte";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { TogglePo } from "$tests/page-objects/Toggle.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import { get } from "svelte/store";
+
+describe("ToggleBalancePrivacyOption", () => {
+  const renderComponent = () => {
+    const { container } = render(ToggleBalancePrivacyOption);
+    const po = TogglePo.under(new JestPageObjectElement(container));
+
+    return po;
+  };
+
+  beforeEach(() => {
+    resetIdentity();
+  });
+
+  it("should initialize the toggle to off if the store is hide", async () => {
+    balancePrivacyOptionStore.set("hide");
+    const po = renderComponent();
+
+    expect(await po.isEnabled()).toBe(true);
+  });
+
+  it("should initialize the toggle to on if the store is show", async () => {
+    balancePrivacyOptionStore.set("show");
+    const po = renderComponent();
+
+    expect(await po.isEnabled()).toBe(false);
+  });
+
+  it("should mutate the store when the toggle is clicked", async () => {
+    balancePrivacyOptionStore.set("hide");
+    const po = renderComponent();
+
+    expect(await po.isEnabled()).toBe(true);
+
+    await po.toggle();
+
+    expect(await po.isEnabled()).toBe(false);
+    expect(get(balancePrivacyOptionStore)).toBe("show");
+  });
+});

--- a/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
+++ b/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
@@ -20,21 +20,21 @@ describe("ToggleBalancePrivacyOption", () => {
     resetIdentity();
   });
 
-  it("should initialize the toggle to off if the store is hide", async () => {
+  it("should initialize the toggle to Off if the privacyStore is set to hide", async () => {
     balancePrivacyOptionStore.set("hide");
     const po = renderComponent();
 
     expect(await po.isToggleEnabled()).toBe(true);
   });
 
-  it("should initialize the toggle to on if the store is show", async () => {
+  it("should initialize the toggle to On if the privacyStore is set to show", async () => {
     balancePrivacyOptionStore.set("show");
     const po = renderComponent();
 
     expect(await po.isToggleEnabled()).toBe(false);
   });
 
-  it("should mutate the store when the toggle is clicked", async () => {
+  it("should mutate the store when the button is clicked", async () => {
     balancePrivacyOptionStore.set("hide");
     const po = renderComponent();
 
@@ -44,5 +44,28 @@ describe("ToggleBalancePrivacyOption", () => {
 
     expect(await po.isToggleEnabled()).toBe(false);
     expect(get(balancePrivacyOptionStore)).toBe("show");
+  });
+
+  it("should mutate the store when the toggle is changed", async () => {
+    balancePrivacyOptionStore.set("hide");
+    const po = renderComponent();
+
+    expect(await po.isToggleEnabled()).toBe(true);
+
+    await po.getToggle().click();
+
+    expect(await po.isToggleEnabled()).toBe(false);
+    expect(get(balancePrivacyOptionStore)).toBe("show");
+  });
+
+  it("should change the label based on the operation", async () => {
+    balancePrivacyOptionStore.set("hide");
+    const po = renderComponent();
+
+    expect(await po.getText("label")).toBe("Show Balance");
+
+    await po.click();
+
+    expect(await po.getText("label")).toBe("Hide Balance");
   });
 });

--- a/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
+++ b/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
@@ -2,14 +2,14 @@ import ToggleBalancePrivacyOption from "$lib/components/header/ToggleBalancePriv
 import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { ToggleBalancePrivacyOptionPageObject } from "$tests/page-objects/ToggleBalancePrivacyOption.page-object";
+import { ToggleBalancePrivacyOptionPo } from "$tests/page-objects/ToggleBalancePrivacyOption.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
 import { get } from "svelte/store";
 
 describe("ToggleBalancePrivacyOption", () => {
   const renderComponent = () => {
     const { container } = render(ToggleBalancePrivacyOption);
-    const po = ToggleBalancePrivacyOptionPageObject.under({
+    const po = ToggleBalancePrivacyOptionPo.under({
       element: new JestPageObjectElement(container),
     });
 

--- a/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
+++ b/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
@@ -1,6 +1,6 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { TogglePo } from "$tests/page-objects/Toggle.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ButtonPo } from "./Button.page-object";
-import { TogglePo } from "./Toggle.page-object";
 
 export class ToggleBalancePrivacyOptionPageObject extends ButtonPo {
   private static TID = "toggle-balance-privacy-option-component";

--- a/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
+++ b/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
@@ -2,16 +2,16 @@ import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { TogglePo } from "$tests/page-objects/Toggle.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ToggleBalancePrivacyOptionPageObject extends ButtonPo {
+export class ToggleBalancePrivacyOptionPo extends ButtonPo {
   private static TID = "toggle-balance-privacy-option-component";
 
   static under({
     element,
   }: {
     element: PageObjectElement;
-  }): ToggleBalancePrivacyOptionPageObject {
-    return new ToggleBalancePrivacyOptionPageObject(
-      element.byTestId(ToggleBalancePrivacyOptionPageObject.TID)
+  }): ToggleBalancePrivacyOptionPo {
+    return new ToggleBalancePrivacyOptionPo(
+      element.byTestId(ToggleBalancePrivacyOptionPo.TID)
     );
   }
 

--- a/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
+++ b/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
@@ -1,0 +1,25 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ButtonPo } from "./Button.page-object";
+import { TogglePo } from "./Toggle.page-object";
+
+export class ToggleBalancePrivacyOptionPageObject extends ButtonPo {
+  private static TID = "toggle-balance-privacy-option-component";
+
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): ToggleBalancePrivacyOptionPageObject {
+    return new ToggleBalancePrivacyOptionPageObject(
+      element.byTestId(ToggleBalancePrivacyOptionPageObject.TID)
+    );
+  }
+
+  getToggle(): TogglePo {
+    return TogglePo.under(this.root);
+  }
+
+  async isToggleEnabled(): Promise<boolean> {
+    return this.getToggle().isEnabled();
+  }
+}


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR creates a new component that will be displayed in the menu entries.

Note: The [Figma designs](https://www.figma.com/design/29OdZHbNaOk9RkrfESucjb/NNS-1.03-WIP?node-id=12650-33136&t=dnaTDwnUEaOXBmlH-4) display a differently styled checkbox. This change in the checkbox design should be implemented consistently across all instances.

Note: This video is taken from a PR with additional changes.

https://github.com/user-attachments/assets/39949c19-66d2-4992-9d22-6d98ac5c5ff7

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- New component to be displayed in the Menu with a toggle to change between privacy modes.

# Tests

- Add a unit test to cover the new component.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ