### PR TITLE
feat(menu): integrate balance privacy toggle in account menu

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+- Privacy mode for balances
+
 #### Changed
 
 #### Deprecated

--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -7,6 +7,7 @@
   import LoginIconOnly from "$lib/components/header/LoginIconOnly.svelte";
   import Logout from "$lib/components/header/Logout.svelte";
   import ManageInternetIdentityButton from "$lib/components/header/ManageInternetIdentityButton.svelte";
+  import ToggleBalancePrivacyOption from "$lib/components/header/ToggleBalancePrivacyOption.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { i18n } from "$lib/stores/i18n";
   import { IconUser, Popover } from "@dfinity/gix-components";
@@ -33,6 +34,8 @@
     <Popover bind:visible anchor={button} direction="rtl">
       <div class="info">
         <AccountDetails />
+
+        <ToggleBalancePrivacyOption />
 
         <ManageInternetIdentityButton />
 

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -142,7 +142,7 @@ describe("AccountMenu", () => {
         await accountMenuPo.getToggleBalancePrivacyOptionPo();
 
       await accountMenuPo.openMenu();
-      expect(toggleBalancePrivacyOptionPo).toBe(true);
+      expect(await toggleBalancePrivacyOptionPo.isPresent()).toBe(true);
     });
 
     it("should not close menu when toggle privacy option button is clicked", async () => {

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -136,6 +136,27 @@ describe("AccountMenu", () => {
       );
     });
 
+    it("should render toggle privacy option button", async () => {
+      const { accountMenuPo } = renderComponent();
+      const toggleBalancePrivacyOptionPo =
+        await accountMenuPo.getToggleBalancePrivacyOptionPo();
+
+      await accountMenuPo.openMenu();
+      expect(toggleBalancePrivacyOptionPo).toBe(true);
+    });
+
+    it("should not close menu when toggle privacy option button is clicked", async () => {
+      const { accountMenuPo } = renderComponent();
+      const toggleBalancePrivacyOptionPo =
+        await accountMenuPo.getToggleBalancePrivacyOptionPo();
+
+      await accountMenuPo.openMenu();
+
+      expect(await accountMenuPo.isOpen()).toBe(true);
+      await toggleBalancePrivacyOptionPo.click();
+      expect(await accountMenuPo.isOpen()).toBe(true);
+    });
+
     describe("export feature flag", () => {
       beforeEach(() => {
         vi.spyOn(console, "error").mockImplementation(() => {});

--- a/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
+++ b/frontend/src/tests/lib/components/header/ToggleBalancePrivacyOption.spec.ts
@@ -9,9 +9,9 @@ import { get } from "svelte/store";
 describe("ToggleBalancePrivacyOption", () => {
   const renderComponent = () => {
     const { container } = render(ToggleBalancePrivacyOption);
-    const po = ToggleBalancePrivacyOptionPo.under({
-      element: new JestPageObjectElement(container),
-    });
+    const po = ToggleBalancePrivacyOptionPo.under(
+      new JestPageObjectElement(container)
+    );
 
     return po;
   };

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -1,7 +1,7 @@
 import { AccountDetailsPo } from "$tests/page-objects/AccountDetails.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
-import { ToggleBalancePrivacyOptionPageObject } from "$tests/page-objects/ToggleBalancePrivacyOption.page-object";
+import { ToggleBalancePrivacyOptionPo } from "$tests/page-objects/ToggleBalancePrivacyOption.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -74,7 +74,7 @@ export class AccountMenuPo extends BasePageObject {
     });
   }
 
-  getToggleBalancePrivacyOptionPo(): ToggleBalancePrivacyOptionPageObject {
-    return ToggleBalancePrivacyOptionPageObject.under({ element: this.root });
+  getToggleBalancePrivacyOptionPo(): ToggleBalancePrivacyOptionPo {
+    return ToggleBalancePrivacyOptionPo.under({ element: this.root });
   }
 }

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -75,6 +75,6 @@ export class AccountMenuPo extends BasePageObject {
   }
 
   getToggleBalancePrivacyOptionPo(): ToggleBalancePrivacyOptionPo {
-    return ToggleBalancePrivacyOptionPo.under({ element: this.root });
+    return ToggleBalancePrivacyOptionPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/AccountMenu.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountMenu.page-object.ts
@@ -1,6 +1,7 @@
 import { AccountDetailsPo } from "$tests/page-objects/AccountDetails.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { LinkPo } from "$tests/page-objects/Link.page-object";
+import { ToggleBalancePrivacyOptionPageObject } from "$tests/page-objects/ToggleBalancePrivacyOption.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -71,5 +72,9 @@ export class AccountMenuPo extends BasePageObject {
       element: this.root,
       testId: "reporting",
     });
+  }
+
+  getToggleBalancePrivacyOptionPo(): ToggleBalancePrivacyOptionPageObject {
+    return ToggleBalancePrivacyOptionPageObject.under({ element: this.root });
   }
 }

--- a/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
+++ b/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
@@ -1,15 +1,11 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { TogglePo } from "$tests/page-objects/Toggle.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BasePageObject } from "./base.page-object";
 
-export class ToggleBalancePrivacyOptionPo extends ButtonPo {
+export class ToggleBalancePrivacyOptionPo extends BasePageObject {
   private static TID = "toggle-balance-privacy-option-component";
 
-  static under({
-    element,
-  }: {
-    element: PageObjectElement;
-  }): ToggleBalancePrivacyOptionPo {
+  static under(element: PageObjectElement): ToggleBalancePrivacyOptionPo {
     return new ToggleBalancePrivacyOptionPo(
       element.byTestId(ToggleBalancePrivacyOptionPo.TID)
     );

--- a/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
+++ b/frontend/src/tests/page-objects/ToggleBalancePrivacyOption.page-object.ts
@@ -1,6 +1,6 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { TogglePo } from "$tests/page-objects/Toggle.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
 
 export class ToggleBalancePrivacyOptionPo extends BasePageObject {
   private static TID = "toggle-balance-privacy-option-component";


### PR DESCRIPTION
# Motivation

We want to introduce a toggle that allows users to hide or show their balances on the main pages. This PR builds on #6865 and utilizes this new component to display the option in the apps menu.

https://github.com/user-attachments/assets/39949c19-66d2-4992-9d22-6d98ac5c5ff7

[NNS1-3721](https://dfinity.atlassian.net/browse/NNS1-3721)

# Changes

- Introduce new entry in `AccountMenu` to toggle privacy mode.

# Tests

- Add a unit test to cover the new entry in the menu.
- Tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [x] Add entry to changelog (if necessary).

[NNS1-3721]: https://dfinity.atlassian.net/browse/NNS1-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ