### PR TITLE
chore(deps): upgrade gix components for svelte 5 compatibility

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "6.0.0-next-2025-05-21",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-05-21.tgz",
-      "integrity": "sha512-RfQGEV03yz7XGhgMWex2FhAfLG1rAzd4/FHo2tIdPZeAaD95nKpS0VeR7PuDVT/SvmdJKmO7wqEtVGALVXMH5g==",
+      "version": "6.0.0-next-2025-05-22",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-05-22.tgz",
+      "integrity": "sha512-qrVhS3TtHHv/5p706zIHYdqTzWIPeifPXGtKvMq3T1f3p0ljUt8qJJTXi2eFPyFWgf84w5YHx6hzIVsbJCUzUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.2.4",
@@ -7288,9 +7288,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "6.0.0-next-2025-05-21",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-05-21.tgz",
-      "integrity": "sha512-RfQGEV03yz7XGhgMWex2FhAfLG1rAzd4/FHo2tIdPZeAaD95nKpS0VeR7PuDVT/SvmdJKmO7wqEtVGALVXMH5g==",
+      "version": "6.0.0-next-2025-05-22",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-05-22.tgz",
+      "integrity": "sha512-qrVhS3TtHHv/5p706zIHYdqTzWIPeifPXGtKvMq3T1f3p0ljUt8qJJTXi2eFPyFWgf84w5YHx6hzIVsbJCUzUQ==",
       "requires": {
         "dompurify": "^3.2.4",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/layout/Content.svelte
+++ b/frontend/src/lib/components/layout/Content.svelte
@@ -3,13 +3,20 @@
   import Title from "$lib/components/header/Title.svelte";
   import { Content } from "@dfinity/gix-components";
 
-  export let back: (() => Promise<void>) | undefined = undefined;
+  type Props = {
+    back?: () => Promise<void>;
+  };
+
+  const { back }: Props = $props();
 </script>
 
-<Content back={back !== undefined} on:nnsBack={async () => await back?.()}>
-  <Title slot="title" />
+<Content onBack={back}>
+  {#snippet title()}
+    <Title />
+  {/snippet}
 
-  <HeaderToolbar slot="toolbar-end" />
-
-  <slot />
+  {#snippet toolbarEnd()}
+    <HeaderToolbar />
+  {/snippet}
+  <div> </div>
 </Content>

--- a/frontend/src/lib/components/layout/Content.svelte
+++ b/frontend/src/lib/components/layout/Content.svelte
@@ -2,12 +2,13 @@
   import HeaderToolbar from "$lib/components/header/HeaderToolbar.svelte";
   import Title from "$lib/components/header/Title.svelte";
   import { Content } from "@dfinity/gix-components";
+  import type { Snippet } from "svelte";
 
   type Props = {
     back?: () => Promise<void>;
+    children: Snippet;
   };
-
-  const { back }: Props = $props();
+  const { back, children }: Props = $props();
 </script>
 
 <Content onBack={back}>
@@ -18,5 +19,5 @@
   {#snippet toolbarEnd()}
     <HeaderToolbar />
   {/snippet}
-  <div> </div>
+  {@render children()}
 </Content>

--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -5,8 +5,14 @@
   import SelectUniverseNav from "$lib/components/universe/SelectUniverseNav.svelte";
   import { SplitContent } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
+  import type { Snippet } from "svelte";
 
-  export let resetScrollPositionAfterNavigation = false;
+  type Props = {
+    resetScrollPositionAfterNavigation?: boolean;
+    children: Snippet;
+  };
+  const { resetScrollPositionAfterNavigation = false, children }: Props =
+    $props();
 
   let splitContent: SplitContent | undefined;
 
@@ -19,15 +25,23 @@
 
 <div class="container">
   <SplitContent bind:this={splitContent}>
-    <div class="nav" slot="start">
-      <SelectUniverseNav />
-    </div>
+    {#snippet start()}
+      <div class="nav">
+        <SelectUniverseNav />
+      </div>
+    {/snippet}
 
-    <Title slot="title" />
+    {#snippet title()}
+      <Title />
+    {/snippet}
 
-    <HeaderToolbar slot="toolbar-end" />
+    {#snippet toolbarEnd()}
+      <HeaderToolbar />
+    {/snippet}
 
-    <slot slot="end" />
+    {#snippet end()}
+      {@render children()}
+    {/snippet}
   </SplitContent>
 </div>
 

--- a/frontend/src/routes/(app)/(home)/+layout.svelte
+++ b/frontend/src/routes/(app)/(home)/+layout.svelte
@@ -5,6 +5,12 @@
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { ENABLE_PORTFOLIO_PAGE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const title = $ENABLE_PORTFOLIO_PAGE
     ? $i18n.navigation.portfolio
@@ -15,10 +21,10 @@
   <Layout>
     <Content>
       {#if $ENABLE_PORTFOLIO_PAGE}
-        <slot />
+        {@render children()}
       {:else}
         <IslandWidthMain>
-          <slot />
+          {@render children()}
         </IslandWidthMain>
       {/if}
     </Content>

--- a/frontend/src/routes/(app)/(nns)/canister/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/canister/+layout.svelte
@@ -3,12 +3,18 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = (): Promise<void> => goto(AppPath.Canisters);
 </script>
 
 <Layout>
   <Content {back}>
-    <slot />
+    {@render children()}
   </Content>
 </Layout>

--- a/frontend/src/routes/(app)/(nns)/canisters/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/canisters/+layout.svelte
@@ -3,12 +3,18 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 </script>
 
 <LayoutList title={$i18n.navigation.canisters}>
   <Layout>
     <Content>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutList>

--- a/frontend/src/routes/(app)/(nns)/launchpad/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/launchpad/+layout.svelte
@@ -3,12 +3,18 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 </script>
 
 <LayoutList title={$i18n.sns_launchpad.header}>
   <Layout>
     <Content>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutList>

--- a/frontend/src/routes/(app)/(nns)/portfolio/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+layout.svelte
@@ -3,12 +3,18 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 </script>
 
 <LayoutList title={$i18n.navigation.portfolio}>
   <Layout>
     <Content>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutList>

--- a/frontend/src/routes/(app)/(nns)/project/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/project/+layout.svelte
@@ -3,12 +3,18 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import { projectPageOrigin } from "$lib/derived/routes.derived";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = (): Promise<void> => goto($projectPageOrigin);
 </script>
 
 <Layout>
   <Content {back}>
-    <slot />
+    {@render children()}
   </Content>
 </Layout>

--- a/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/reporting/+layout.svelte
@@ -4,6 +4,12 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { referrerPathStore } from "$lib/stores/routes.store";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = async () => {
     if ($referrerPathStore.length > 0) {
@@ -19,6 +25,6 @@
 
 <Layout>
   <Content {back}>
-    <slot />
+    {@render children()}
   </Content>
 </Layout>

--- a/frontend/src/routes/(app)/(nns)/settings/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/settings/+layout.svelte
@@ -4,6 +4,12 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { referrerPathStore } from "$lib/stores/routes.store";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = async () => {
     if ($referrerPathStore.length > 0) {
@@ -19,6 +25,6 @@
 
 <Layout>
   <Content {back}>
-    <slot />
+    {@render children()}
   </Content>
 </Layout>

--- a/frontend/src/routes/(app)/(nns)/staking/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/staking/+layout.svelte
@@ -3,12 +3,18 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 </script>
 
 <LayoutList title={$i18n.navigation.neurons}>
   <Layout>
     <Content>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutList>

--- a/frontend/src/routes/(app)/(nns)/tokens/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+layout.svelte
@@ -4,13 +4,19 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 </script>
 
 <LayoutList title={$i18n.navigation.tokens}>
   <Layout>
     <Content>
       <IslandWidthMain>
-        <slot />
+        {@render children()}
       </IslandWidthMain>
     </Content>
   </Layout>

--- a/frontend/src/routes/(app)/(u)/(detail)/neuron/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/neuron/+layout.svelte
@@ -4,6 +4,12 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
   import { neuronsPathStore } from "$lib/derived/paths.derived";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = (): Promise<void> => goto($neuronsPathStore);
 </script>
@@ -11,7 +17,7 @@
 <LayoutNavGuard>
   <Layout>
     <Content {back}>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutNavGuard>

--- a/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
@@ -4,6 +4,12 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
   import { proposalsPageOrigin } from "$lib/derived/routes.derived";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = async () => goto($proposalsPageOrigin);
 </script>
@@ -11,7 +17,7 @@
 <LayoutNavGuard>
   <Layout>
     <Content {back}>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutNavGuard>

--- a/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
@@ -4,6 +4,12 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
   import { walletPageOrigin } from "$lib/derived/routes.derived";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = (): Promise<void> => goto($walletPageOrigin);
 </script>
@@ -11,7 +17,7 @@
 <LayoutNavGuard>
   <Layout>
     <Content {back}>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutNavGuard>

--- a/frontend/src/routes/(app)/(u)/(list)/accounts/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/accounts/+layout.svelte
@@ -6,6 +6,12 @@
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { accountsTitleStore } from "$lib/derived/accounts-title.derived";
   import { accountsPageOrigin } from "$lib/derived/routes.derived";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = (): Promise<void> => goto($accountsPageOrigin);
 </script>
@@ -14,7 +20,7 @@
   <Layout>
     <Content {back}>
       <IslandWidthMain>
-        <slot />
+        {@render children()}
       </IslandWidthMain>
     </Content>
   </Layout>

--- a/frontend/src/routes/(app)/(u)/(list)/neurons/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/neurons/+layout.svelte
@@ -5,6 +5,12 @@
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { neuronsPageOrigin } from "$lib/derived/routes.derived";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 
   const back = (): Promise<void> => goto($neuronsPageOrigin);
 </script>
@@ -12,7 +18,7 @@
 <LayoutList title={$i18n.navigation.neurons}>
   <Layout>
     <Content {back}>
-      <slot />
+      {@render children()}
     </Content>
   </Layout>
 </LayoutList>

--- a/frontend/src/routes/(app)/(u)/(list)/proposals/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/proposals/+layout.svelte
@@ -3,12 +3,18 @@
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import UniverseSplitContent from "$lib/components/layout/UniverseSplitContent.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    children: Snippet;
+  };
+  const { children }: Props = $props();
 </script>
 
 <LayoutList title={$i18n.navigation.voting}>
   <Layout>
     <UniverseSplitContent resetScrollPositionAfterNavigation>
-      <slot />
+      {@render children()}
     </UniverseSplitContent>
   </Layout>
 </LayoutList>

--- a/frontend/src/tests/lib/components/layout/LayoutChildrenTest.svelte
+++ b/frontend/src/tests/lib/components/layout/LayoutChildrenTest.svelte
@@ -1,0 +1,3 @@
+<scripts lang="ts"> </scripts>
+
+<div>Children</div>

--- a/frontend/src/tests/lib/components/layout/LayoutChildrenTest.svelte
+++ b/frontend/src/tests/lib/components/layout/LayoutChildrenTest.svelte
@@ -1,3 +1,0 @@
-<scripts lang="ts"> </scripts>
-
-<div>Children</div>

--- a/frontend/src/tests/lib/components/layout/LayoutTest.svelte
+++ b/frontend/src/tests/lib/components/layout/LayoutTest.svelte
@@ -6,7 +6,7 @@
   export let content = "";
   export let spy: (() => void) | undefined = undefined;
 
-  const back = () => spy?.();
+  const back = async () => spy?.();
 </script>
 
 <Layout>

--- a/frontend/src/tests/lib/components/layout/UniverseSplitContent.spec.ts
+++ b/frontend/src/tests/lib/components/layout/UniverseSplitContent.spec.ts
@@ -1,9 +1,17 @@
 import UniverseSplitContent from "$lib/components/layout/UniverseSplitContent.svelte";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { render } from "@testing-library/svelte";
 
 describe("UniverseSplitContent", () => {
+  const renderComponent = () => {
+    return render(UniverseSplitContent, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
+  };
   beforeEach(() => {
     resetIdentity();
 
@@ -13,12 +21,12 @@ describe("UniverseSplitContent", () => {
   });
 
   it("should render the universe nav", () => {
-    const { getByTestId } = render(UniverseSplitContent);
+    const { getByTestId } = renderComponent();
     expect(getByTestId("select-universe-nav-title")).not.toBeNull();
   });
 
   it("should render a header", () => {
-    const { getByText } = render(UniverseSplitContent);
+    const { getByText } = renderComponent();
 
     expect(getByText("the header")).toBeInTheDocument();
   });
@@ -26,14 +34,14 @@ describe("UniverseSplitContent", () => {
   it("should render the login button in the header", () => {
     setNoIdentity();
 
-    const { getByTestId } = render(UniverseSplitContent);
+    const { getByTestId } = renderComponent();
     expect(getByTestId("toolbar-login")).not.toBeNull();
   });
 
   it("should render the account menu", () => {
     resetIdentity();
 
-    const { getByTestId } = render(UniverseSplitContent);
+    const { getByTestId } = renderComponent();
     expect(getByTestId("account-menu")).not.toBeNull();
   });
 });

--- a/frontend/src/tests/mocks/snippet.mock.ts
+++ b/frontend/src/tests/mocks/snippet.mock.ts
@@ -1,0 +1,6 @@
+import { createRawSnippet } from "svelte";
+
+export const createMockSnippet = (testId: string = "test-id") =>
+  createRawSnippet(() => ({
+    render: () => `<span data-tid=${testId}>Mock Snippet</span>`,
+  }));

--- a/frontend/src/tests/routes/app/accounts/layout.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/layout.spec.ts
@@ -6,12 +6,21 @@ import { referrerPathStore } from "$lib/stores/routes.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import AccountsLayout from "$routes/(app)/(u)/(list)/accounts/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Accounts layout", () => {
+  const renderComponent = () => {
+    return render(AccountsLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
+  };
+
   beforeEach(() => {
     layoutTitleStore.set({ title: "" });
     page.mock({
@@ -23,7 +32,7 @@ describe("Accounts layout", () => {
   });
 
   it("should set title and header layout to 'My ICP Tokens' when NNS Universe", () => {
-    render(AccountsLayout);
+    renderComponent();
 
     expect(get(layoutTitleStore)).toEqual({
       title: "ICP Tokens",
@@ -44,7 +53,7 @@ describe("Accounts layout", () => {
       },
     });
 
-    render(AccountsLayout);
+    renderComponent();
 
     expect(get(layoutTitleStore)).toEqual({
       title: "TTRS Tokens",
@@ -53,13 +62,13 @@ describe("Accounts layout", () => {
   });
 
   it("should not show the split content navigation", () => {
-    const { queryByTestId } = render(AccountsLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(queryByTestId("select-universe-nav-title")).not.toBeInTheDocument();
   });
 
   it("should render back button", () => {
-    const { queryByTestId } = render(AccountsLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(queryByTestId("back")).toBeInTheDocument();
   });
@@ -68,7 +77,7 @@ describe("Accounts layout", () => {
     page.mock({
       routeId: AppPath.Accounts,
     });
-    const { queryByTestId } = render(AccountsLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(get(pageStore).path).toEqual(AppPath.Accounts);
     await fireEvent.click(queryByTestId("back"));
@@ -81,7 +90,7 @@ describe("Accounts layout", () => {
     page.mock({
       routeId: AppPath.Accounts,
     });
-    const { queryByTestId } = render(AccountsLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(get(pageStore).path).toEqual(AppPath.Accounts);
     await fireEvent.click(queryByTestId("back"));

--- a/frontend/src/tests/routes/app/canisters/layout.spec.ts
+++ b/frontend/src/tests/routes/app/canisters/layout.spec.ts
@@ -1,5 +1,6 @@
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import CanistersLayout from "$routes/(app)/(nns)/canisters/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -9,7 +10,11 @@ describe("Canisters layout", () => {
   });
 
   it("should set title and header layout to 'Canisters'", () => {
-    render(CanistersLayout);
+    render(CanistersLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
 
     expect(get(layoutTitleStore)).toEqual({
       title: "Canisters",

--- a/frontend/src/tests/routes/app/home/layout.spec.ts
+++ b/frontend/src/tests/routes/app/home/layout.spec.ts
@@ -4,10 +4,19 @@ import { layoutTitleStore } from "$lib/stores/layout.store";
 import { page } from "$mocks/$app/stores";
 import HomeLayout from "$routes/(app)/(home)/+layout.svelte";
 import en from "$tests/mocks/i18n.mock";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Home layout", () => {
+  const renderComponent = () => {
+    return render(HomeLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
+  };
+
   beforeEach(() => {
     layoutTitleStore.set({ title: "" });
     page.mock({
@@ -19,7 +28,7 @@ describe("Home layout", () => {
   });
 
   it("should set title and header layout to 'Tokens'", () => {
-    render(HomeLayout);
+    renderComponent();
 
     expect(get(layoutTitleStore)).toEqual({
       title: en.navigation.tokens,
@@ -28,13 +37,13 @@ describe("Home layout", () => {
   });
 
   it("should not show the split content navigation", () => {
-    const { queryByTestId } = render(HomeLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(queryByTestId("select-universe-nav-title")).not.toBeInTheDocument();
   });
 
   it("should render menu toggle button", () => {
-    const { queryByTestId } = render(HomeLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(queryByTestId("menu-toggle")).toBeInTheDocument();
   });
@@ -43,7 +52,7 @@ describe("Home layout", () => {
     it("should show the Portfolio title", () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_PORTFOLIO_PAGE", true);
 
-      render(HomeLayout);
+      renderComponent();
 
       expect(get(layoutTitleStore)).toEqual({
         title: en.navigation.portfolio,

--- a/frontend/src/tests/routes/app/neurons/layout.spec.ts
+++ b/frontend/src/tests/routes/app/neurons/layout.spec.ts
@@ -4,16 +4,25 @@ import { layoutTitleStore } from "$lib/stores/layout.store";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import NeuronsLayout from "$routes/(app)/(u)/(list)/neurons/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Neurons layout", () => {
+  const renderComponent = () => {
+    return render(NeuronsLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
+  };
+
   beforeEach(() => {
     layoutTitleStore.set({ title: "" });
   });
 
   it("should set title and header layout to 'Neuron Staking'", () => {
-    render(NeuronsLayout);
+    renderComponent();
 
     expect(get(layoutTitleStore)).toEqual({
       title: "Neuron Staking",
@@ -22,7 +31,7 @@ describe("Neurons layout", () => {
   });
 
   it("should have a back button", () => {
-    const { getByTestId } = render(NeuronsLayout);
+    const { getByTestId } = renderComponent();
     const backButton = getByTestId("back");
 
     expect(backButton).toBeInTheDocument();
@@ -33,7 +42,7 @@ describe("Neurons layout", () => {
       routeId: AppPath.Neurons,
     });
 
-    const { getByTestId } = render(NeuronsLayout);
+    const { getByTestId } = renderComponent();
     const backButton = getByTestId("back");
 
     expect(get(pageStore).path).toEqual(AppPath.Neurons);
@@ -48,7 +57,7 @@ describe("Neurons layout", () => {
     });
     referrerPathStore.pushPath(AppPath.Portfolio);
 
-    const { getByTestId } = render(NeuronsLayout);
+    const { getByTestId } = renderComponent();
     const backButton = getByTestId("back");
 
     expect(get(pageStore).path).toEqual(AppPath.Neurons);

--- a/frontend/src/tests/routes/app/portfolio/layout.spec.ts
+++ b/frontend/src/tests/routes/app/portfolio/layout.spec.ts
@@ -1,5 +1,6 @@
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import PortfolioLayout from "$routes/(app)/(nns)/portfolio/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -9,7 +10,11 @@ describe("Portfolio layout", () => {
   });
 
   it("should set title and header layout to 'Portfolio'", () => {
-    render(PortfolioLayout);
+    render(PortfolioLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
 
     expect(get(layoutTitleStore)).toEqual({
       title: "Portfolio",

--- a/frontend/src/tests/routes/app/project/layout.spec.ts
+++ b/frontend/src/tests/routes/app/project/layout.spec.ts
@@ -3,10 +3,19 @@ import { pageStore } from "$lib/derived/page.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import ProjectLayout from "$routes/(app)/(nns)/project/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Project layout", () => {
+  const renderComponent = () => {
+    return render(ProjectLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
+  };
+
   describe("back button", () => {
     it("should navigate to Portfolio page if previous page was Portfolio page", async () => {
       page.mock({
@@ -14,7 +23,7 @@ describe("Project layout", () => {
       });
       referrerPathStore.pushPath(AppPath.Portfolio);
 
-      const { queryByTestId } = render(ProjectLayout);
+      const { queryByTestId } = renderComponent();
 
       expect(get(pageStore).path).toEqual(AppPath.Project);
       await fireEvent.click(queryByTestId("back"));
@@ -26,7 +35,7 @@ describe("Project layout", () => {
       page.mock({
         routeId: AppPath.Project,
       });
-      const { queryByTestId } = render(ProjectLayout);
+      const { queryByTestId } = renderComponent();
 
       expect(get(pageStore).path).toEqual(AppPath.Project);
       await fireEvent.click(queryByTestId("back"));

--- a/frontend/src/tests/routes/app/proposals/layout.spec.ts
+++ b/frontend/src/tests/routes/app/proposals/layout.spec.ts
@@ -5,10 +5,19 @@ import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import Layout from "$routes/(app)/(u)/(detail)/proposal/+layout.svelte";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Proposal Layout", () => {
+  const renderComponent = (props?) => {
+    return render(Layout, {
+      props: {
+        children: createMockSnippet(),
+        ...props,
+      },
+    });
+  };
   it("should go back to the proposal page if coming from proposals page", async () => {
     page.mock({
       data: {
@@ -16,7 +25,7 @@ describe("Proposal Layout", () => {
       },
       routeId: AppPath.Proposal,
     });
-    const { queryByTestId } = render(Layout);
+    const { queryByTestId } = renderComponent();
 
     const { path } = get(pageStore);
     expect(path).toEqual(AppPath.Proposal);
@@ -39,7 +48,7 @@ describe("Proposal Layout", () => {
       },
       routeId: AppPath.Proposal,
     });
-    const { queryByTestId } = render(Layout);
+    const { queryByTestId } = renderComponent();
 
     const backButton = queryByTestId("back");
     expect(backButton).toBeInTheDocument();
@@ -59,7 +68,7 @@ describe("Proposal Layout", () => {
       },
       routeId: AppPath.Proposal,
     });
-    const { queryByTestId } = render(Layout);
+    const { queryByTestId } = renderComponent();
 
     const backButton = queryByTestId("back");
     expect(backButton).toBeInTheDocument();
@@ -81,7 +90,7 @@ describe("Proposal Layout", () => {
     });
     referrerPathStore.pushPath(AppPath.Launchpad);
 
-    const { queryByTestId } = render(Layout);
+    const { queryByTestId } = renderComponent();
 
     const { path } = get(pageStore);
     expect(path).toEqual(AppPath.Proposal);
@@ -103,7 +112,7 @@ describe("Proposal Layout", () => {
     });
     referrerPathStore.pushPath(AppPath.Portfolio);
 
-    const { queryByTestId } = render(Layout);
+    const { queryByTestId } = renderComponent();
 
     const { path } = get(pageStore);
     expect(path).toEqual(AppPath.Proposal);

--- a/frontend/src/tests/routes/app/reporting/layout.spec.ts
+++ b/frontend/src/tests/routes/app/reporting/layout.spec.ts
@@ -5,6 +5,7 @@ import { pageStore } from "$lib/derived/page.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import Layout from "$routes/(app)/(nns)/reporting/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -22,7 +23,11 @@ describe("Layout", () => {
       routeId: AppPath.Reporting,
     });
 
-    return render(Layout);
+    return render(Layout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
   };
 
   it("should stay in the page if feature flag is on", () => {

--- a/frontend/src/tests/routes/app/settings/layout.spec.ts
+++ b/frontend/src/tests/routes/app/settings/layout.spec.ts
@@ -4,6 +4,7 @@ import { pageStore } from "$lib/derived/page.derived";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import Layout from "$routes/(app)/(nns)/settings/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -16,7 +17,11 @@ describe("Layout", () => {
       },
       routeId: AppPath.Settings,
     });
-    const { queryByTestId } = render(Layout);
+    const { queryByTestId } = render(Layout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
 
     const { path } = get(pageStore);
     expect(path).toEqual(AppPath.Settings);

--- a/frontend/src/tests/routes/app/tokens/layout.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/layout.spec.ts
@@ -1,5 +1,6 @@
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import TokensLayout from "$routes/(app)/(nns)/tokens/+layout.svelte";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -9,7 +10,11 @@ describe("Tokens layout", () => {
   });
 
   it("should set title and header layout to 'Tokens'", () => {
-    render(TokensLayout);
+    render(TokensLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
 
     expect(get(layoutTitleStore)).toEqual({
       title: "Tokens",

--- a/frontend/src/tests/routes/app/wallet/layout.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/layout.spec.ts
@@ -5,12 +5,21 @@ import { referrerPathStore } from "$lib/stores/routes.store";
 import { page } from "$mocks/$app/stores";
 import WalletLayout from "$routes/(app)/(u)/(detail)/wallet/+layout.svelte";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { createMockSnippet } from "$tests/mocks/snippet.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Wallet layout", () => {
+  const renderComponent = () => {
+    return render(WalletLayout, {
+      props: {
+        children: createMockSnippet(),
+      },
+    });
+  };
+
   it("back button should navigate to tokens page if universe is not NNS", async () => {
     page.mock({
       routeId: AppPath.Wallet,
@@ -19,7 +28,7 @@ describe("Wallet layout", () => {
         account: mockSnsMainAccount.identifier,
       },
     });
-    const { queryByTestId } = render(WalletLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(get(pageStore).path).toEqual(AppPath.Wallet);
     await fireEvent.click(queryByTestId("back"));
@@ -35,7 +44,7 @@ describe("Wallet layout", () => {
         account: mockMainAccount.identifier,
       },
     });
-    const { queryByTestId } = render(WalletLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(get(pageStore).path).toEqual(AppPath.Wallet);
     await fireEvent.click(queryByTestId("back"));
@@ -56,7 +65,7 @@ describe("Wallet layout", () => {
     });
     referrerPathStore.pushPath(AppPath.Portfolio);
 
-    const { queryByTestId } = render(WalletLayout);
+    const { queryByTestId } = renderComponent();
 
     expect(get(pageStore).path).toEqual(AppPath.Wallet);
     await fireEvent.click(queryByTestId("back"));


### PR DESCRIPTION
# Motivation

The Gix component library is migrating to Svelte 5. Some components will introduce breaking changes due to incompatible APIs between versions 4 and 5. We aim to progressively implement these upgrades to minimize effort.

This update introduces the following breaking changes:
* https://github.com/dfinity/gix-components/pull/650
* https://github.com/dfinity/gix-components/pull/649
* https://github.com/dfinity/gix-components/pull/648

# Changes

- Refactored the list of impacted components to align with their new interface.  
-  Updated the list of consumers for the impacted components.  
-  Introduced `createMockSnippet` to render a mock snippet, allowing tests to run against a `Layout` with a mock `children`.

# Tests

- CI should pass as before.
- Manual tests in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/portfolio/)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.