### PR TITLE
feat(disburse-maturity): api

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -5,6 +5,7 @@ import {
   claimOrRefreshNeuron,
   claimOrRefreshNeuronByMemo,
   disburse,
+  disburseMaturity,
   getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -28,6 +29,7 @@ import {
   type ApiAutoStakeMaturityParams,
   type ApiChangeNeuronVisibilityParams,
   type ApiClaimNeuronParams,
+  type ApiDisburseMaturityParams,
   type ApiDisburseParams,
   type ApiIncreaseDissolveDelayParams,
   type ApiManageHotkeyParams,
@@ -200,6 +202,9 @@ export const governanceApiService = {
   },
   spawnNeuron(params: ApiSpawnNeuronParams) {
     return clearCacheAfter(spawnNeuron(params));
+  },
+  disburseMaturity(params: ApiDisburseMaturityParams) {
+    return clearCacheAfter(disburseMaturity(params));
   },
   splitNeuron(params: ApiSplitNeuronParams) {
     return clearCacheAfter(splitNeuron(params));

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -226,6 +226,29 @@ export const spawnNeuron = async ({
   return newNeuronId;
 };
 
+export type ApiDisburseMaturityParams = ApiManageNeuronParams & {
+  // TODO(disburse-maturity): Add sub and external accounts support.
+  // account?: Principal;
+  // subAccount?: string;
+  percentageToDisburse: number;
+};
+
+export const disburseMaturity = async ({
+  neuronId,
+  percentageToDisburse,
+  identity,
+}: ApiDisburseMaturityParams): Promise<void> => {
+  logWithTimestamp(`Disburse maturity (${hashCode(neuronId)}) call...`);
+
+  const { canister } = await governanceCanister({ identity });
+  await canister.disburseMaturity({
+    neuronId,
+    percentageToDisburse,
+  });
+
+  logWithTimestamp(`Disburse maturity (${hashCode(neuronId)}) complete.`);
+};
+
 // Shared by addHotkey and removeHotkey
 export type ApiManageHotkeyParams = ApiManageNeuronParams & {
   principal: Principal;

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -889,6 +889,39 @@ describe("neurons api-service", () => {
     });
   });
 
+  describe("disburseMaturity", () => {
+    const params = {
+      neuronId,
+      percentageToDisburse: 50,
+      identity: mockIdentity,
+    };
+
+    it("should call disburseMaturity api", async () => {
+      vi.spyOn(api, "disburseMaturity").mockResolvedValueOnce(undefined);
+      expect(await governanceApiService.disburseMaturity(params)).toEqual(
+        undefined
+      );
+      expect(api.disburseMaturity).toHaveBeenCalledWith(params);
+      expect(api.disburseMaturity).toHaveBeenCalledTimes(1);
+    });
+
+    it("should invalidate the cache", async () => {
+      await shouldInvalidateCache({
+        apiFunc: api.disburseMaturity,
+        apiServiceFunc: governanceApiService.disburseMaturity,
+        params,
+      });
+    });
+
+    it("should invalidate the cache on failure", async () => {
+      await shouldInvalidateCacheOnFailure({
+        apiFunc: api.disburseMaturity,
+        apiServiceFunc: governanceApiService.disburseMaturity,
+        params,
+      });
+    });
+  });
+
   describe("splitNeuron", () => {
     const params = {
       neuronId,

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -490,11 +490,7 @@ describe("neurons-api", () => {
 
     it("throws error when disburseMaturity fails", async () => {
       const error = new Error();
-      mockGovernanceCanister.disburseMaturity.mockImplementation(
-        vi.fn(() => {
-          throw error;
-        })
-      );
+      mockGovernanceCanister.disburseMaturity.mockRejectedValue(error);
 
       const call = () =>
         disburseMaturity({

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -4,6 +4,7 @@ import {
   changeNeuronVisibility,
   claimOrRefreshNeuronByMemo,
   disburse,
+  disburseMaturity,
   getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -464,6 +465,44 @@ describe("neurons-api", () => {
           percentageToSpawn: 50,
           neuronId: 10n,
         });
+      await expect(call).rejects.toThrow(error);
+    });
+  });
+
+  describe("disburseMaturity", () => {
+    it("disburse the maturity of a neuron successfully", async () => {
+      mockGovernanceCanister.disburseMaturity.mockImplementation(
+        vi.fn().mockResolvedValue(undefined)
+      );
+
+      await disburseMaturity({
+        identity: mockIdentity,
+        percentageToDisburse: 50,
+        neuronId: 10n,
+      });
+
+      expect(mockGovernanceCanister.disburseMaturity).toBeCalledTimes(1);
+      expect(mockGovernanceCanister.disburseMaturity).toBeCalledWith({
+        percentageToDisburse: 50,
+        neuronId: 10n,
+      });
+    });
+
+    it("throws error when disburseMaturity fails", async () => {
+      const error = new Error();
+      mockGovernanceCanister.disburseMaturity.mockImplementation(
+        vi.fn(() => {
+          throw error;
+        })
+      );
+
+      const call = () =>
+        disburseMaturity({
+          identity: mockIdentity,
+          percentageToDisburse: 50,
+          neuronId: 10n,
+        });
+
       await expect(call).rejects.toThrow(error);
     });
   });


### PR DESCRIPTION
# Motivation

To simplify the process of claiming matured rewards and avoid the extra steps of creating and disbursing a new neuron, the disburse maturity feature is introduced for NNS neurons (this approach is already used for SNS neurons).

This PR introduces a basic API to disburse maturity to the user’s main account only (sub-account and external address support planned for later).

[Jira](https://dfinity.atlassian.net/browse/NNS1-3740)

# Changes

- Add `disburseMaturity` api.
- Add `disburseMaturity` api-service which additionally invalidates the cache.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.