### PR TITLE
style(portfolio): ui tweaks to portfolio cards

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+- Styles for the SNS Projects Portfolio Cards
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -68,7 +68,7 @@
 <Card testId="launch-project-card">
   <div class="wrapper">
     <div class="background-icon">
-      <IconRocketLaunch size="220px" />
+      <IconRocketLaunch size="270px" />
     </div>
     <div class="header">
       <div class="title-wrapper">
@@ -202,14 +202,13 @@
 
     .background-icon {
       position: absolute;
-      bottom: 5px;
-      right: -30px;
-      opacity: 0.1;
+      right: -60px;
+      opacity: 0.07;
       z-index: 0;
       // TODO: Introduce in GIX once it is part of the design system
-      color: #3d4d9973;
+      color: #3d4d99;
       pointer-events: none;
-      transform: rotate(270deg) scale(1.2);
+      transform: rotate(270deg);
     }
 
     .header {

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -176,6 +176,7 @@
   @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
   @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "../../themes/mixins/portfolio";
 
   .wrapper {
     display: flex;
@@ -206,7 +207,7 @@
       opacity: 0.1;
       z-index: 0;
       // TODO: Introduce in GIX once it is part of the design system
-      color: rgba(#3d4d99, 0.7);
+      color: #3d4d9973;
       pointer-events: none;
       transform: rotate(270deg) scale(1.2);
     }
@@ -216,6 +217,8 @@
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
       gap: var(--padding-0_5x);
+
+      @include portfolio.card-tag;
 
       .title-wrapper {
         display: flex;

--- a/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchProjectCard.svelte
@@ -67,6 +67,9 @@
 
 <Card testId="launch-project-card">
   <div class="wrapper">
+    <div class="background-icon">
+      <IconRocketLaunch size="220px" />
+    </div>
     <div class="header">
       <div class="title-wrapper">
         <div>
@@ -181,6 +184,8 @@
     height: 100%;
     background-color: var(--card-background-tint);
     min-height: 240px;
+    position: relative;
+    overflow: hidden;
 
     gap: var(--padding-2x);
     padding: var(--padding-2x);
@@ -192,6 +197,18 @@
 
       /* Required to give space to the StackedCards dots */
       padding-bottom: var(--card-stacked-dots-space);
+    }
+
+    .background-icon {
+      position: absolute;
+      bottom: 5px;
+      right: -30px;
+      opacity: 0.1;
+      z-index: 0;
+      // TODO: Introduce in GIX once it is part of the design system
+      color: rgba(#3d4d99, 0.7);
+      pointer-events: none;
+      transform: rotate(270deg) scale(1.2);
     }
 
     .header {

--- a/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
+++ b/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
@@ -95,6 +95,7 @@
   @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
   @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "../../themes/mixins/portfolio";
 
   .wrapper {
     display: flex;
@@ -121,6 +122,8 @@
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
       gap: var(--padding-0_5x);
+
+      @include portfolio.card-tag;
 
       .title-wrapper {
         display: flex;

--- a/frontend/src/lib/themes/mixins/_portfolio.scss
+++ b/frontend/src/lib/themes/mixins/_portfolio.scss
@@ -1,0 +1,4 @@
+@mixin card-tag {
+  --tag-background: #4d79ff40;
+  --tag-text: #4d79ff;
+}


### PR DESCRIPTION
# Motivation

Ongoing swap cards on the Portfolio page should feature a rocket icon in their background. Additionally, both ongoing swaps and new SNS proposals should have a custom color for their tags.

<img width="469" alt="Screenshot 2025-05-25 at 12 21 12" src="https://github.com/user-attachments/assets/f77ca62c-f213-4032-9ec6-ecdf2cab5fb1" />

https://github.com/user-attachments/assets/54b9ed0b-e0ea-4255-91cb-1978c691d1c3

# Changes

- Added a background icon to the `LaunchedProjectCard`.
- Introduced a mixin for custom styles for the `Tag`, which is used in the `LaunchedProjectCard` and `NewSnsProposalCard`.

# Tests

- Not necessary.

# Todos

- [x] Add entry to changelog (if necessary).