### PR TITLE
feat(disburse-maturity): service

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -826,6 +826,33 @@ export const spawnNeuron = async ({
   }
 };
 
+export const disburseMaturity = async ({
+  neuronId,
+  percentageToDisburse,
+}: {
+  neuronId: NeuronId;
+  percentageToDisburse: number;
+}): Promise<{ success: boolean }> => {
+  try {
+    const identity: Identity =
+      await getIdentityOfControllerByNeuronId(neuronId);
+
+    await governanceApiService.disburseMaturity({
+      neuronId,
+      percentageToDisburse,
+      identity,
+    });
+
+    await listNeurons();
+
+    return { success: true };
+  } catch (err) {
+    toastsShow(mapNeuronErrorToToastMessage(err));
+
+    return { success: false };
+  }
+};
+
 export const startDissolving = async (
   neuronId: NeuronId
 ): Promise<NeuronId | undefined> => {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -136,6 +136,7 @@ describe("neurons-services", () => {
   let spyRefreshVotingPower;
   let spyStakeMaturity;
   let spySpawnNeuron;
+  let spyDisburseMaturity;
   let spyMergeNeurons;
   let spySimulateMergeNeurons;
   let spyAddHotkey;
@@ -195,6 +196,7 @@ describe("neurons-services", () => {
     spySpawnNeuron = vi
       .spyOn(api, "spawnNeuron")
       .mockImplementation(() => Promise.resolve(newSpawnedNeuronId));
+    spyDisburseMaturity = vi.spyOn(api, "disburseMaturity").mockResolvedValue();
     spyMergeNeurons = vi.spyOn(api, "mergeNeurons").mockResolvedValue();
     spySimulateMergeNeurons = vi
       .spyOn(api, "simulateMergeNeurons")
@@ -1224,6 +1226,43 @@ describe("neurons-services", () => {
       expectToastError(en.error.not_authorized_neuron_action);
       expect(spySpawnNeuron).not.toBeCalled();
       expect(newNeuronId).toBeUndefined();
+    });
+  });
+
+  describe("disburseMaturity", () => {
+    it("should disburse maturity", async () => {
+      neuronsStore.pushNeurons({ neurons, certified: true });
+      expect(spyDisburseMaturity).toBeCalledTimes(0);
+      const { success } = await services.disburseMaturity({
+        neuronId: controlledNeuron.neuronId,
+        percentageToDisburse: 50,
+      });
+
+      expect(spyDisburseMaturity).toBeCalledWith({
+        identity: mockIdentity,
+        neuronId: controlledNeuron.neuronId,
+        percentageToDisburse: 50,
+      });
+      expect(spyDisburseMaturity).toBeCalledTimes(1);
+      expect(spyDisburseMaturity).toBeCalledWith({
+        identity: mockIdentity,
+        neuronId: controlledNeuron.neuronId,
+        percentageToDisburse: 50,
+      });
+      expect(success).toBe(true);
+    });
+
+    it("should not disburse maturity if no identity", async () => {
+      setNoIdentity();
+
+      const { success } = await services.disburseMaturity({
+        neuronId: controlledNeuron.neuronId,
+        percentageToDisburse: 50,
+      });
+
+      expectToastError(en.error.missing_identity);
+      expect(spyDisburseMaturity).toBeCalledTimes(0);
+      expect(success).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Motivation

To simplify the process of claiming matured rewards and avoid the extra steps of creating and disbursing a new neuron, the disburse maturity feature is introduced for NNS neurons (this approach is already used for SNS neurons).

This PR introduces a basic service to disburse maturity to the user’s main account only (sub-account and external address support planned for later).

[Jira](https://dfinity.atlassian.net/browse/NNS1-3740)

# Changes

- Add disburseMaturity service.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet