### PR TITLE
feat(proposals): add collapsible vote condition status component

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
@@ -8,18 +8,18 @@
   import type { Snippet } from "svelte";
 
   type Props = {
-    testId: string;
-    toggleContent: () => void;
-    status?: "default" | "success" | "failed";
-    title: Snippet;
     children: Snippet;
+    status?: "default" | "success" | "failed";
+    testId: string;
+    title: Snippet;
+    toggleContent: () => void;
   };
   let {
+    children,
     status = "default",
     testId,
-    toggleContent = $bindable(),
     title,
-    children,
+    toggleContent = $bindable(),
   }: Props = $props();
 </script>
 

--- a/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
@@ -33,15 +33,15 @@
     {@render title()}
 
     {#if status === "default"}
-      <span class="icon default">
+      <span class="icon default" data-tid="vote-result-condition-default-icon">
         <IconCheckCircleV2 size={20} />
       </span>
     {:else if status === "success"}
-      <span class="icon success">
+      <span class="icon success" data-tid="vote-result-condition-success-icon">
         <IconCheckCircleFill size={20} />
       </span>
     {:else if status === "failed"}
-      <span class="icon failed">
+      <span class="icon failed" data-tid="vote-result-condition-failed-icon">
         <IconCloseCircleFill size={20} />
       </span>
     {/if}

--- a/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
@@ -23,28 +23,29 @@
   }: Props = $props();
 </script>
 
-<Collapsible
-  expandButton={false}
-  externalToggle={true}
-  bind:toggleContent
-  wrapHeight
->
+<Collapsible expandButton={false} externalToggle bind:toggleContent wrapHeight>
   <div slot="header" class="wrapper" data-tid={testId}>
     {@render title()}
-
-    {#if status === "default"}
-      <span class="icon default" data-tid="vote-result-condition-default-icon">
-        <IconCheckCircleV2 size={20} />
-      </span>
-    {:else if status === "success"}
-      <span class="icon success" data-tid="vote-result-condition-success-icon">
-        <IconCheckCircleFill size={20} />
-      </span>
-    {:else if status === "failed"}
-      <span class="icon failed" data-tid="vote-result-condition-failed-icon">
-        <IconCloseCircleFill size={20} />
-      </span>
-    {/if}
+    <span
+      class="icon"
+      data-tid={`${testId}-status`}
+      data-status={status}
+      aria-label={`Condition status: ${status}`}
+    >
+      {#if status === "default"}
+        <span class="default" aria-hidden="true">
+          <IconCheckCircleV2 size={20} />
+        </span>
+      {:else if status === "success"}
+        <span class="success" aria-hidden="true">
+          <IconCheckCircleFill size={20} />
+        </span>
+      {:else if status === "failed"}
+        <span class="failed" aria-hidden="true">
+          <IconCloseCircleFill size={20} />
+        </span>
+      {/if}
+    </span>
   </div>
   {@render children()}
 </Collapsible>
@@ -56,17 +57,17 @@
     justify-content: space-between;
     flex-grow: 1;
 
-    .icon.default {
-      /* TODO: Add to GIX once it is part of the design system */
-      color: #bec2d6;
-    }
-
-    .icon.success {
-      color: var(--positive-emphasis);
-    }
-
-    .icon.failed {
-      color: var(--negative-emphasis);
+    .icon {
+      .default {
+        /* TODO: Add to GIX once it is part of the design system */
+        color: #bec2d6;
+      }
+      .success {
+        color: var(--positive-emphasis);
+      }
+      .failed {
+        color: var(--negative-emphasis);
+      }
     }
   }
 </style>

--- a/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResultsConditionStatus.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import {
+    Collapsible,
+    IconCheckCircleFill,
+    IconCheckCircleV2,
+    IconCloseCircleFill,
+  } from "@dfinity/gix-components";
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    testId: string;
+    toggleContent: () => void;
+    status?: "default" | "success" | "failed";
+    title: Snippet;
+    children: Snippet;
+  };
+  let {
+    status = "default",
+    testId,
+    toggleContent = $bindable(),
+    title,
+    children,
+  }: Props = $props();
+</script>
+
+<Collapsible
+  expandButton={false}
+  externalToggle={true}
+  bind:toggleContent
+  wrapHeight
+>
+  <div slot="header" class="wrapper" data-tid={testId}>
+    {@render title()}
+
+    {#if status === "default"}
+      <span class="icon default">
+        <IconCheckCircleV2 size={20} />
+      </span>
+    {:else if status === "success"}
+      <span class="icon success">
+        <IconCheckCircleFill size={20} />
+      </span>
+    {:else if status === "failed"}
+      <span class="icon failed">
+        <IconCloseCircleFill size={20} />
+      </span>
+    {/if}
+  </div>
+  {@render children()}
+</Collapsible>
+
+<style lang="scss">
+  .wrapper {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-grow: 1;
+
+    .icon.default {
+      /* TODO: Add to GIX once it is part of the design system */
+      color: #bec2d6;
+    }
+
+    .icon.success {
+      color: var(--positive-emphasis);
+    }
+
+    .icon.failed {
+      color: var(--negative-emphasis);
+    }
+  }
+</style>


### PR DESCRIPTION
# Motivation

We want to change how the voting results are displayed for a proposal. This PR adds a new component based on `VotesResultsMajorityDescription` to render a collapsible area with a title and an icon. The icon will change based on the condition, and the content can be collapsed or uncollapsed from the outside.

Note: `VotesResultsMajorityDescription` will be remove in a later iteration.

Note 2: Screenshot has been taken with other changes not present in this PR.

![Screenshot 2025-05-27 at 08 24 26](https://github.com/user-attachments/assets/5b6252bc-2830-4779-bd03-eee9bd7c2937)

[NNS1-3753](https://dfinity.atlassian.net/browse/NNS1-3753)

# Changes

- A new component to display the status of a condition for a proposal to pass.

# Tests

- Unit tests for the new component.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3753]: https://dfinity.atlassian.net/browse/NNS1-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ