### PR TITLE
feat(disburse-maturity): Total maturity util

### DIFF
--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1411,3 +1411,11 @@ export const hasEnoughDissolveDelayToVote = (
   { dissolveDelaySeconds }: NeuronInfo,
   minimumDissolveDelay: bigint
 ): boolean => dissolveDelaySeconds >= minimumDissolveDelay;
+
+export const totalMaturityDisbursementsInProgress = (
+  neuron: NeuronInfo
+): bigint =>
+  neuron.fullNeuron?.maturityDisbursementsInProgress?.reduce(
+    (acc, disbursement) => acc + (disbursement.amountE8s ?? 0n),
+    0n
+  ) ?? 0n;

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -3943,6 +3943,8 @@ describe("neuron-utils", () => {
 
   describe("totalMaturityDisbursementsInProgress", () => {
     it("should calculate total disbursements", () => {
+      const maturityDisbursementAmount1 = 100_000_000n;
+      const maturityDisbursementAmount2 = 200_000_000n;
       expect(
         totalMaturityDisbursementsInProgress({
           ...mockNeuron,
@@ -3951,16 +3953,16 @@ describe("neuron-utils", () => {
             maturityDisbursementsInProgress: [
               {
                 ...mockMaturityDisbursement,
-                amountE8s: 100_000_000n,
+                amountE8s: maturityDisbursementAmount1,
               },
               {
                 ...mockMaturityDisbursement,
-                amountE8s: 200_000_000n,
+                amountE8s: maturityDisbursementAmount2,
               },
             ],
           },
         })
-      ).toBe(100_000_000n + 200_000_000n);
+      ).toBe(maturityDisbursementAmount1 + maturityDisbursementAmount2);
     });
 
     it("should return 0 if no disbursements", () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -75,6 +75,7 @@ import {
   sortNeuronsByStake,
   sortNeuronsByVotingPowerRefreshedTimeout,
   topicsToFollow,
+  totalMaturityDisbursementsInProgress,
   userAuthorizedNeuron,
   validTopUpAmount,
   votedNeuronDetails,
@@ -91,6 +92,7 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import {
   mockFullNeuron,
+  mockMaturityDisbursement,
   mockNeuron,
   mockNeuronControlled,
   mockNeuronNotControlled,
@@ -3936,6 +3938,53 @@ describe("neuron-utils", () => {
           )
         ).toBe(false);
       });
+    });
+  });
+
+  describe("totalMaturityDisbursementsInProgress", () => {
+    it("should calculate total disbursements", () => {
+      expect(
+        totalMaturityDisbursementsInProgress({
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockNeuron.fullNeuron,
+            maturityDisbursementsInProgress: [
+              {
+                ...mockMaturityDisbursement,
+                amountE8s: 100_000_000n,
+              },
+              {
+                ...mockMaturityDisbursement,
+                amountE8s: 200_000_000n,
+              },
+            ],
+          },
+        })
+      ).toBe(100_000_000n + 200_000_000n);
+    });
+
+    it("should return 0 if no disbursements", () => {
+      expect(
+        totalMaturityDisbursementsInProgress({
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockNeuron.fullNeuron,
+            maturityDisbursementsInProgress: [],
+          },
+        })
+      ).toBe(0n);
+    });
+
+    it("should return 0 when maturityDisbursementsInProgress not available", () => {
+      expect(
+        totalMaturityDisbursementsInProgress({
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockNeuron.fullNeuron,
+            maturityDisbursementsInProgress: undefined,
+          },
+        })
+      ).toBe(0n);
     });
   });
 });

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -1,7 +1,12 @@
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { TableNeuron } from "$lib/types/neurons-table";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
-import type { KnownNeuron, Neuron, NeuronInfo } from "@dfinity/nns";
+import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import type {
+  KnownNeuron,
+  MaturityDisbursement,
+  Neuron,
+  NeuronInfo,
+} from "@dfinity/nns";
 import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
@@ -32,6 +37,16 @@ export const mockFullNeuron: Neuron = {
   votingPowerRefreshedTimestampSeconds: 0n,
   potentialVotingPower: 0n,
   decidingVotingPower: 0n,
+};
+
+export const mockMaturityDisbursement: MaturityDisbursement = {
+  timestampOfDisbursementSeconds: 1_000_000_000n,
+  amountE8s: 1_000_000n,
+  accountToDisburseTo: {
+    owner: mockPrincipal,
+    subaccount: undefined,
+  },
+  finalizeDisbursementTimestampSeconds: 1_000_000_000n,
 };
 
 export const createMockFullNeuron = (id: number | bigint) => {


### PR DESCRIPTION
# Motivation

To simplify the process of claiming matured rewards and avoid the extra steps of creating and disbursing a new neuron, the disburse maturity feature is introduced for NNS neurons (this approach is already used for SNS neurons).

This PR introduces a function to calculate total disbursements.

[Jira](https://dfinity.atlassian.net/browse/NNS1-3740)

# Changes

- Add `totalMaturityDisbursementsInProgress` util.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet
