### PR TITLE
refactor: Maturity section to svelte 5

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
@@ -13,14 +13,18 @@
   import { IconExpandCircleDown } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
 
-  export let neuron: NeuronInfo;
+  type Props = {
+    neuron: NeuronInfo;
+  };
 
-  let isControllable: boolean;
-  $: isControllable = isNeuronControllable({
-    neuron,
-    identity: $authStore.identity,
-    accounts: $icpAccountsStore,
-  });
+  const { neuron }: Props = $props();
+  const isControllable = $derived(
+    isNeuronControllable({
+      neuron,
+      identity: $authStore.identity,
+      accounts: $icpAccountsStore,
+    })
+  );
 </script>
 
 <CommonItemAction testId="nns-available-maturity-item-action-component">

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturitySection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturitySection.svelte
@@ -6,7 +6,10 @@
   import { Section } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
 
-  export let neuron: NeuronInfo;
+  type Props = {
+    neuron: NeuronInfo;
+  };
+  const { neuron }: Props = $props();
 </script>
 
 <Section testId="nns-neuron-maturity-section-component">


### PR DESCRIPTION
# Motivation

As part of the Svelte 5 upgrade, it’s better to modernize the component syntax before applying further changes.

# Changes

- Upgrade NnsAvailableMaturityItemAction.
- Upgrade NnsNeuronMaturitySection.

# Tests

- Should pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not required.