### PR TITLE
Update minimum dissolve delay for ineligibility reason

### DIFF
--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -46,13 +46,15 @@
   <VotingCardNeuronList>
     {#each ineligibleNeurons as neuron}
       <li class="value" title={neuron.neuronIdString}>
-        <span class="label">
+        <span class="label" data-tid="ineligible-neuron-id">
           {shortenWithMiddleEllipsis(
             neuron.neuronIdString,
             SNS_NEURON_ID_DISPLAY_LENGTH
           )}
         </span>
-        <small class="value">{reasonText(neuron)}</small>
+        <small class="value" data-tid="ineligible-neuron-reason"
+          >{reasonText(neuron)}</small
+        >
       </li>
     {/each}
   </VotingCardNeuronList>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte
@@ -4,12 +4,13 @@
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { definedNeuronsStore } from "$lib/derived/neurons.derived";
   import { registerNnsVotes } from "$lib/services/nns-vote-registration.services";
+  import { networkEconomicsStore } from "$lib/stores/network-economics.store";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import {
     voteRegistrationStore,
+    votingNeuronSelectStore,
     type VoteRegistrationStoreEntry,
   } from "$lib/stores/vote-registration.store";
-  import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
   import {
     SELECTED_PROPOSAL_CONTEXT_KEY,
     type SelectedProposalContext,
@@ -142,8 +143,12 @@
   let hasNeurons = false;
   $: hasNeurons = $definedNeuronsStore.length > 0;
 
+  // TODO(mstr): Rename to `minDissolveDelayToVoteSeconds`
   let minSnsDissolveDelaySeconds: bigint;
-  $: minSnsDissolveDelaySeconds = BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);
+  $: minSnsDissolveDelaySeconds =
+    $networkEconomicsStore.parameters?.votingPowerEconomics
+      ?.neuronMinimumDissolveDelayToVoteSeconds ??
+    BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);
 </script>
 
 <VotingCard

--- a/frontend/src/tests/page-objects/IneligibleNeuronList.page-object.ts
+++ b/frontend/src/tests/page-objects/IneligibleNeuronList.page-object.ts
@@ -1,0 +1,32 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class IneligibleNeuronListPo extends BasePageObject {
+  private static readonly TID = "ineligible-neurons";
+
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): IneligibleNeuronListPo {
+    return new IneligibleNeuronListPo(
+      element.byTestId(IneligibleNeuronListPo.TID)
+    );
+  }
+
+  async getNeuronIdTexts(): Promise<string[]> {
+    return Promise.all(
+      (await this.root.allByTestId("ineligible-neuron-id")).map((el) =>
+        el.getText()
+      )
+    );
+  }
+
+  async getIneligibleReasonTexts(): Promise<string[]> {
+    return Promise.all(
+      (await this.root.allByTestId("ineligible-neuron-reason")).map((el) =>
+        el.getText()
+      )
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/VotingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingCard.page-object.ts
@@ -1,4 +1,5 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { IneligibleNeuronListPo } from "$tests/page-objects/IneligibleNeuronList.page-object";
 import { StakeNeuronToVotePo } from "$tests/page-objects/StakeNeuronToVote.page-object";
 import { VotingConfirmationToolbarPo } from "$tests/page-objects/VotingConfirmationToolbar.page-object";
 import { VotingNeuronSelectListPo } from "$tests/page-objects/VotingNeuronSelectList.page-object";
@@ -62,6 +63,10 @@ export class VotingCardPo extends BasePageObject {
 
   getIneligibleNeurons(): PageObjectElement {
     return this.root.byTestId("ineligible-neurons");
+  }
+
+  getIneligibleNeuronListPo(): IneligibleNeuronListPo {
+    return IneligibleNeuronListPo.under(this.root);
   }
 
   async getIneligibleNeuronsHeaderText(): Promise<string> {


### PR DESCRIPTION
# Motivation

Since the governance canister now provides `neuronMinimumDissolveDelayToVoteSeconds` via the network economics API, it should also be used when displaying the minimum dissolve delay in the ineligible neuron description.

# Changes

- Use the `neuronMinimumDissolveDelayToVoteSeconds` parameter for the displayed ineligible reason.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.