### PR TITLE
feat(disburse-maturity): isEnoughMaturityToDisburse

### DIFF
--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -10,6 +10,9 @@ export const MAX_NEURONS_MERGED = 2;
 export const MIN_NEURON_STAKE = 100_000_000n;
 export const MAX_CONCURRENCY = 10;
 export const MATURITY_MODULATION_VARIANCE_PERCENTAGE = 0.95;
+// The minimum amount of ICP to disburse in a single transaction.
+// https://github.com/dfinity/ic/blob/b9c23dd08c76349a3dd1b422e39988bea8363d33/rs/nns/governance/src/governance/disburse_maturity.rs#L29
+export const MINIMUM_DISBURSEMENT = 100_000_000n;
 // Neuron ids are random u64. Max digits of a u64 is 20.
 export const MAX_NEURON_ID_DIGITS = 20;
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -14,6 +14,7 @@ import {
   MAX_AGE_BONUS,
   MAX_DISSOLVE_DELAY_BONUS,
   MAX_NEURONS_MERGED,
+  MINIMUM_DISBURSEMENT,
   MIN_NEURON_STAKE,
   NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS,
   TOPICS_TO_FOLLOW_NNS,
@@ -781,6 +782,24 @@ export const isEnoughMaturityToSpawn = ({
   return (
     maturitySelected >=
     Number(MIN_NEURON_STAKE) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
+  );
+};
+
+export const isEnoughMaturityToDisburse = ({
+  neuron: { fullNeuron },
+  percentage,
+}: {
+  neuron: NeuronInfo;
+  percentage: number;
+}): boolean => {
+  if (isNullish(fullNeuron)) return false;
+
+  const maturitySelected = Math.floor(
+    (Number(fullNeuron.maturityE8sEquivalent) * percentage) / 100
+  );
+  return (
+    maturitySelected >=
+    Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
   );
 };
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -785,6 +785,7 @@ export const isEnoughMaturityToSpawn = ({
   );
 };
 
+/// Checks if the neuron has enough maturity to disburse maturity. Expected percentage: 0–100.
 export const isEnoughMaturityToDisburse = ({
   neuron: { fullNeuron },
   percentage,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -785,7 +785,17 @@ export const isEnoughMaturityToSpawn = ({
   );
 };
 
-/// Checks if the neuron has enough maturity to disburse maturity. Expected percentage: 0–100.
+/** Checks if the neuron has enough maturity to disburse maturity.
+ *
+ * The function calculates the selected maturity based on the provided percentage
+ * and compares it to the minimum required disbursement, adjusted by the maturity modulation variance.
+ * In the worst case maturity modulation (-500) the amount should be at least: 100_000_000 e8s
+ *
+ * @param {Object} params
+ * @param {NeuronInfo} params.neuron - The neuron whose maturity will be checked.
+ * @param {number} params.percentage - The percentage (0–100) of the neuron's maturity to disburse.
+ * @returns {boolean} True if the selected maturity is enough to disburse, false otherwise.
+ */
 export const isEnoughMaturityToDisburse = ({
   neuron: { fullNeuron },
   percentage,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1419,7 +1419,7 @@ describe("neuron-utils", () => {
       );
     });
 
-    it("return false if not enough maturity because of variation", () => {
+    it("return false if not enough maturity", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1464,6 +1464,17 @@ describe("neuron-utils", () => {
       };
       expect(
         isEnoughMaturityToDisburse({ neuron: neuron2, percentage: 50 })
+      ).toBe(true);
+
+      const neuron3 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          maturityE8sEquivalent: JUST_ENOUGH_MATURITY * 100n,
+        },
+      };
+      expect(
+        isEnoughMaturityToDisburse({ neuron: neuron3, percentage: 100 })
       ).toBe(true);
     });
   });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1419,30 +1419,6 @@ describe("neuron-utils", () => {
       );
     });
 
-    it("returns false if not enough maturity", () => {
-      const neuron = {
-        ...mockNeuron,
-        fullNeuron: {
-          ...mockFullNeuron,
-          maturityE8sEquivalent: MINIMUM_DISBURSEMENT - 1_000n,
-        },
-      };
-      expect(isEnoughMaturityToDisburse({ neuron, percentage: 100 })).toBe(
-        false
-      );
-
-      const neuron2 = {
-        ...mockNeuron,
-        fullNeuron: {
-          ...mockFullNeuron,
-          maturityE8sEquivalent: MINIMUM_DISBURSEMENT * 2n,
-        },
-      };
-      expect(
-        isEnoughMaturityToDisburse({ neuron: neuron2, percentage: 10 })
-      ).toBe(false);
-    });
-
     it("return false if not enough maturity because of variation", () => {
       const neuron = {
         ...mockNeuron,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -9,8 +9,10 @@ import {
 } from "$lib/constants/constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import {
+  MATURITY_MODULATION_VARIANCE_PERCENTAGE,
   MAX_NEURONS_MERGED,
   MIN_NEURON_STAKE,
+  MINIMUM_DISBURSEMENT,
 } from "$lib/constants/neurons.constants";
 import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -30,11 +32,11 @@ import {
   filterIneligibleNnsNeurons,
   followeesByTopic,
   followeesNeurons,
-  formatVotingPower,
-  formatVotingPowerDetailed,
   formattedMaturity,
   formattedStakedMaturity,
   formattedTotalMaturity,
+  formatVotingPower,
+  formatVotingPowerDetailed,
   getDissolvingTimeInSeconds,
   getDissolvingTimestampSeconds,
   getNeuronById,
@@ -47,6 +49,7 @@ import {
   hasEnoughMaturityToStake,
   hasJoinedCommunityFund,
   hasValidStake,
+  isEnoughMaturityToDisburse,
   isEnoughMaturityToSpawn,
   isEnoughToStakeNeuron,
   isHotKeyControllable,
@@ -1395,6 +1398,97 @@ describe("neuron-utils", () => {
       expect(isEnoughMaturityToSpawn({ neuron: neuron2, percentage: 10 })).toBe(
         false
       );
+    });
+  });
+
+  describe("isEnoughMaturityToDisburse", () => {
+    const JUST_ENOUGH_MATURITY = BigInt(
+      Math.round(
+        Number(MINIMUM_DISBURSEMENT) /
+          Number(MATURITY_MODULATION_VARIANCE_PERCENTAGE)
+      )
+    );
+
+    it("return false if fullNeuron is not available", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: undefined,
+      };
+      expect(isEnoughMaturityToDisburse({ neuron, percentage: 100 })).toBe(
+        false
+      );
+    });
+
+    it("returns false if not enough maturity", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          maturityE8sEquivalent: MINIMUM_DISBURSEMENT - 1_000n,
+        },
+      };
+      expect(isEnoughMaturityToDisburse({ neuron, percentage: 100 })).toBe(
+        false
+      );
+
+      const neuron2 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          maturityE8sEquivalent: MINIMUM_DISBURSEMENT * 2n,
+        },
+      };
+      expect(
+        isEnoughMaturityToDisburse({ neuron: neuron2, percentage: 10 })
+      ).toBe(false);
+    });
+
+    it("return false if not enough maturity because of variation", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          maturityE8sEquivalent: JUST_ENOUGH_MATURITY - 1n,
+        },
+      };
+      expect(isEnoughMaturityToDisburse({ neuron, percentage: 100 })).toBe(
+        false
+      );
+
+      const neuron2 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          maturityE8sEquivalent: JUST_ENOUGH_MATURITY * 2n - 1n,
+        },
+      };
+      expect(
+        isEnoughMaturityToDisburse({ neuron: neuron2, percentage: 50 })
+      ).toBe(false);
+    });
+
+    it("return true if enough maturity", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          maturityE8sEquivalent: JUST_ENOUGH_MATURITY,
+        },
+      };
+      expect(isEnoughMaturityToDisburse({ neuron, percentage: 100 })).toBe(
+        true
+      );
+
+      const neuron2 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          maturityE8sEquivalent: JUST_ENOUGH_MATURITY * 2n,
+        },
+      };
+      expect(
+        isEnoughMaturityToDisburse({ neuron: neuron2, percentage: 50 })
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
# Motivation

To simplify the process of claiming matured rewards and avoid the extra steps of creating and disbursing a new neuron, the disburse maturity feature is introduced for NNS neurons (this approach is already used for SNS neurons).

This PR introduces a function to calculate if the provided maturity is enough for disbursement.

[Jira](https://dfinity.atlassian.net/browse/NNS1-3740)

# Changes

- Add `isEnoughMaturityToDisburse ` util.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet
