### PR TITLE
Fix sign-in button alignment on voting page

### DIFF
--- a/frontend/src/lib/themes/global.scss
+++ b/frontend/src/lib/themes/global.scss
@@ -6,3 +6,7 @@ div.split-pane + div.split-pane {
     display: none;
   }
 }
+
+[data-tid="bottom-sheet"] > span {
+  display: contents !important;
+}

--- a/frontend/src/lib/themes/global.scss
+++ b/frontend/src/lib/themes/global.scss
@@ -7,6 +7,7 @@ div.split-pane + div.split-pane {
   }
 }
 
+// Workaround to avoid extra styling in bottom sheet, that was introduced in gix https://github.com/dfinity/gix-components/pull/628/files#diff-cb6285c9f761dc189f57123ab2426f1ce3bbb85d99ed0be3a06b5889e8299286R53-R55
 [data-tid="bottom-sheet"] > span {
   display: contents !important;
 }


### PR DESCRIPTION
# Motivation

Workaround to avoid extra styling in bottom sheet that was introduced in [gix-components](https://github.com/dfinity/gix-components/pull/628/files#diff-cb6285c9f761dc189f57123ab2426f1ce3bbb85d99ed0be3a06b5889e8299286R53-R55) recently and which breaks the sign-in button aligment.

# Changes

- Ignore first spans in bottom sheets.

# Tests

- verified manually.

| Before | After |
|--------|--------|
| <img width="377" alt="image" src="https://github.com/user-attachments/assets/b2a7f927-b88b-4d0b-b4d3-656629b8d219" /> | <img width="378" alt="image" src="https://github.com/user-attachments/assets/b26af42a-6034-411e-926b-992d8e4adf4a" /> |

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.