### PR TITLE
style(votes): add expand icon rotation feedback

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotesResults.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResults.svelte
@@ -117,9 +117,11 @@
     )
   );
 
+  let expanded = $state(false);
   let toggleParticipationContent = $state(() => {});
   let toggleMajorityContent = $state(() => {});
   let toggleAllContent = $derived(() => {
+    expanded = !expanded;
     toggleParticipationContent();
     toggleMajorityContent();
   });
@@ -229,7 +231,7 @@
 
   <div class="votes-results-legends">
     <button
-      class="votes-results-legends-header"
+      class="votes-results-legends-expand-button"
       onclick={toggleAllContent}
       data-tid="toggle-content-button"
     >
@@ -238,7 +240,7 @@
           ? $i18n.proposal_detail__vote.super_majority_decision_intro
           : $i18n.proposal_detail__vote.decision_intro}
       </h3>
-      <span class="icon" aria-hidden="true">
+      <span class="icon" aria-hidden="true" class:expanded>
         <IconExpandMore />
       </span>
     </button>
@@ -438,18 +440,24 @@
     flex-direction: column;
     row-gap: var(--padding-0_5x);
 
-    .votes-results-legends-header {
+    .votes-results-legends-expand-button {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      padding: 0;
 
       h3 {
         color: var(--content-color);
       }
 
+      transition: transform ease-out var(--animation-time-normal);
       .icon {
         padding: 0;
         color: var(--primary);
+
+        &.expanded {
+          transform: rotate(-180deg);
+        }
       }
     }
 


### PR DESCRIPTION
# Motivation

We want to change how the voting results for a proposal are displayed. This PR improves the user experience by rotating the expand icon to indicate what action will occur the next time users click on it.


https://github.com/user-attachments/assets/4f329583-95b0-4838-a59a-2be55ceea3ca


[NNS1-3753](https://dfinity.atlassian.net/browse/NNS1-3753)

# Changes

- Styles have been added to rotate the icon based on the expanded state of both collapsible regions.

# Tests

- The feature has been manually tested.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

[NNS1-3753]: https://dfinity.atlassian.net/browse/NNS1-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ