### PR TITLE
style(ui): elevate highlight component above bottom sheet

### DIFF
--- a/frontend/src/lib/components/ui/Highlight.svelte
+++ b/frontend/src/lib/components/ui/Highlight.svelte
@@ -97,7 +97,7 @@
     box-sizing: border-box;
 
     position: fixed;
-    z-index: 1000;
+    z-index: calc(var(--bottom-sheet-z-index) + 1);
     padding: var(--padding-2x) var(--padding-3x);
 
     border-radius: var(--border-radius);


### PR DESCRIPTION
# Motivation

The `Highlight` component displays announcements and information to users. We want this component to appear above the rest of the content on the page.

Before:

![image](https://github.com/user-attachments/assets/a3fa19af-4f5f-416c-ab3b-50e60293ad8e)

After:

<img width="697" alt="Screenshot 2025-05-30 at 13 24 23" src="https://github.com/user-attachments/assets/f5117438-9daa-4456-a4e7-c392d5d62986" />

# Changes

- Put `Highlight` above the `BottomSheet`.

# Tests

- Manually tested.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.