### PR TITLE
feat(ui): add inline copy feedback component

### DIFF
--- a/frontend/src/lib/components/ui/Copy.svelte
+++ b/frontend/src/lib/components/ui/Copy.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { IconCopy } from "@dfinity/gix-components";
+
+  type Props = {
+    value: string;
+  };
+  const { value }: Props = $props();
+
+  const copyToClipboard = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    await navigator?.clipboard.writeText(value);
+  };
+</script>
+
+<button
+  data-tid="copy-component"
+  onclick={copyToClipboard}
+  aria-label={`${$i18n.core.copy}: ${value}`}
+  class="icon-only"
+>
+  <IconCopy />
+</button>
+
+<style lang="scss">
+  button {
+    height: var(--padding-4x);
+    width: var(--padding-4x);
+    min-width: var(--padding-4x);
+
+    &.icon-only {
+      color: var(--primary);
+    }
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -37,7 +37,8 @@
     "or": "or",
     "add": "Add",
     "not_applicable": "N/A",
-    "view_more": "View more"
+    "view_more": "View more",
+    "copy": "Copy to clipboard"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -41,6 +41,7 @@ interface I18nCore {
   add: string;
   not_applicable: string;
   view_more: string;
+  copy: string;
 }
 
 interface I18nError {
@@ -710,16 +711,16 @@ interface I18nProposal_detail__vote {
   vote_status_registering: string;
   vote_status_updating: string;
   expiration: string;
-  immediate_majority: string;
-  immediate_majority_description: string;
-  immediate_super_majority: string;
-  immediate_super_majority_description: string;
+  decision_intro: string;
   standard_majority: string;
   standard_majority_description: string;
+  immediate_majority: string;
+  immediate_majority_description: string;
+  super_majority_decision_intro: string;
   standard_super_majority: string;
   standard_super_majority_description: string;
-  decision_intro: string;
-  super_majority_decision_intro: string;
+  immediate_super_majority: string;
+  immediate_super_majority_description: string;
   cast_votes: string;
   cast_votes_needs: string;
   no_nns_neurons: string;

--- a/frontend/src/tests/lib/components/ui/Copy.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Copy.spec.ts
@@ -1,0 +1,38 @@
+import Copy from "$lib/components/ui/Copy.svelte";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("Copy Component", () => {
+  const renderComponent = (props: { value: string }) => {
+    const testId = "copy-component";
+    const { container } = render(Copy, props);
+    return ButtonPo.under({
+      element: new JestPageObjectElement(container),
+      testId,
+    });
+  };
+  const value = "test-copy";
+
+  it("should render an accessible button", async () => {
+    const po = renderComponent({ value });
+
+    expect(await po.getAriaLabel()).toEqual(`Copy to clipboard: ${value}`);
+  });
+
+  it("should copy value to clipboard", async () => {
+    Object.assign(window.navigator, {
+      clipboard: {
+        writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+      },
+    });
+    const po = renderComponent({ value });
+
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledTimes(0);
+
+    await po.click();
+
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(value);
+  });
+});


### PR DESCRIPTION
# Motivation

We want to give in-place feedback to the users whenever they click any element that gets copied into their clipboard. The nns-dapp currently uses a component defined in Gix, but designers want to move away from this version.

This first PR introduces the new component to the nns-dapp repository.

[NNS1-3835](https://dfinity.atlassian.net/browse/NNS1-3835)

# Changes

- New component `Copy` with in-place feedback on successful copy.

# Tests

- Unit tests for the new component.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.