### PR TITLE
feat(disburse-maturity): Display "disburse" button

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
+  import NnsDisburseMaturityButton from "$lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte";
   import NnsStakeMaturityButton from "$lib/components/neuron-detail/actions/NnsStakeMaturityButton.svelte";
   import SpawnNeuronButton from "$lib/components/neuron-detail/actions/SpawnNeuronButton.svelte";
   import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { authStore } from "$lib/stores/auth.store";
+  import { ENABLE_DISBURSE_MATURITY } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import {
     formattedMaturity,
     isNeuronControllable,
+    isNeuronControlledByHardwareWallet,
   } from "$lib/utils/neuron.utils";
   import { IconExpandCircleDown } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
@@ -22,6 +25,13 @@
     isNeuronControllable({
       neuron,
       identity: $authStore.identity,
+      accounts: $icpAccountsStore,
+    })
+  );
+  // Can be ignored after the Ledger support is fully implemented.
+  const isControlledByHW = $derived(
+    isNeuronControlledByHardwareWallet({
+      neuron,
       accounts: $icpAccountsStore,
     })
   );
@@ -41,6 +51,10 @@
   >
   {#if isControllable}
     <NnsStakeMaturityButton {neuron} />
-    <SpawnNeuronButton {neuron} />
+    {#if !isControlledByHW && $ENABLE_DISBURSE_MATURITY}
+      <NnsDisburseMaturityButton {neuron} />
+    {:else}
+      <SpawnNeuronButton {neuron} />
+    {/if}
   {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
@@ -2,6 +2,7 @@
   import DisburseMaturityButton from "$lib/components/neuron-detail/actions/DisburseMaturityButton.svelte";
   import {
     MATURITY_MODULATION_VARIANCE_PERCENTAGE,
+    MIN_DISBURSEMENT_ICP_EQUIVALENT,
     MINIMUM_DISBURSEMENT,
     ULPS_PER_MATURITY,
   } from "$lib/constants/neurons.constants";
@@ -26,14 +27,10 @@
       })
   );
   const getDisabledText = () => {
-    const minIcpEquivalent =
-      Number(MINIMUM_DISBURSEMENT) /
-      ULPS_PER_MATURITY /
-      MATURITY_MODULATION_VARIANCE_PERCENTAGE;
     return replacePlaceholders(
       $i18n.neuron_detail.disburse_maturity_disabled_tooltip,
       {
-        $amount: formatNumber(minIcpEquivalent, {
+        $amount: formatNumber(Number(MIN_DISBURSEMENT_ICP_EQUIVALENT), {
           minFraction: 4,
           maxFraction: 4,
         }),

--- a/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import {
+    MATURITY_MODULATION_VARIANCE_PERCENTAGE,
+    MINIMUM_DISBURSEMENT,
+    ULPS_PER_MATURITY,
+  } from "$lib/constants/neurons.constants";
+  import { i18n } from "$lib/stores/i18n";
+  import { formatNumber, formatPercentage } from "$lib/utils/format.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { openNnsNeuronModal } from "$lib/utils/modals.utils";
+  import { isEnoughMaturityToDisburse } from "$lib/utils/neuron.utils";
+  import { Tooltip } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { nonNullish } from "@dfinity/utils";
+
+  type Props = {
+    neuron: NeuronInfo;
+  };
+
+  const { neuron }: Props = $props();
+  const enoughMaturity = $derived(
+    nonNullish(neuron.fullNeuron) &&
+      // Same logic as in SpawnNeuronButton
+      isEnoughMaturityToDisburse({
+        neuron,
+        percentage: 100,
+      })
+  );
+  const minIcpEquivalent =
+    Number(MINIMUM_DISBURSEMENT) /
+    ULPS_PER_MATURITY /
+    MATURITY_MODULATION_VARIANCE_PERCENTAGE;
+
+  const showModal = () =>
+    openNnsNeuronModal({
+      type: "disburse-maturity",
+      data: { neuron },
+    });
+</script>
+
+<TestIdWrapper testId="disburse-maturity-button-component">
+  {#if enoughMaturity}
+    <button
+      data-tid="disburse-maturity-button"
+      class="secondary"
+      onclick={showModal}
+    >
+      {$i18n.neuron_detail.disburse_maturity}
+    </button>
+  {:else}
+    <Tooltip
+      id="disburse-maturity-button"
+      text={replacePlaceholders(
+        $i18n.neuron_detail.disburse_maturity_disabled_tooltip,
+        {
+          $amount: formatNumber(minIcpEquivalent, {
+            minFraction: 4,
+            maxFraction: 4,
+          }),
+          $min: formatNumber(Number(MINIMUM_DISBURSEMENT) / ULPS_PER_MATURITY, {
+            minFraction: 0,
+            maxFraction: 0,
+          }),
+          $variability: formatPercentage(
+            MATURITY_MODULATION_VARIANCE_PERCENTAGE,
+            {
+              minFraction: 0,
+              maxFraction: 0,
+            }
+          ),
+        }
+      )}
+    >
+      <button data-tid="disburse-maturity-button" disabled class="secondary">
+        {$i18n.neuron_detail.disburse_maturity}
+      </button>
+    </Tooltip>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
@@ -2,7 +2,7 @@
   import DisburseMaturityButton from "$lib/components/neuron-detail/actions/DisburseMaturityButton.svelte";
   import {
     MATURITY_MODULATION_VARIANCE_PERCENTAGE,
-    MIN_DISBURSEMENT_ICP_EQUIVALENT,
+    MIN_DISBURSEMENT_WITH_VARIANCE_ICP,
     MINIMUM_DISBURSEMENT,
     ULPS_PER_MATURITY,
   } from "$lib/constants/neurons.constants";
@@ -30,7 +30,7 @@
     return replacePlaceholders(
       $i18n.neuron_detail.disburse_maturity_disabled_tooltip,
       {
-        $amount: formatNumber(Number(MIN_DISBURSEMENT_ICP_EQUIVALENT), {
+        $amount: formatNumber(MIN_DISBURSEMENT_WITH_VARIANCE_ICP, {
           minFraction: 4,
           maxFraction: 4,
         }),

--- a/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import DisburseMaturityButton from "$lib/components/neuron-detail/actions/DisburseMaturityButton.svelte";
   import {
     MATURITY_MODULATION_VARIANCE_PERCENTAGE,
     MINIMUM_DISBURSEMENT,
@@ -10,7 +10,6 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import { isEnoughMaturityToDisburse } from "$lib/utils/neuron.utils";
-  import { Tooltip } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
 
@@ -21,17 +20,37 @@
   const { neuron }: Props = $props();
   const enoughMaturity = $derived(
     nonNullish(neuron.fullNeuron) &&
-      // Same logic as in SpawnNeuronButton
       isEnoughMaturityToDisburse({
         neuron,
         percentage: 100,
       })
   );
-  const minIcpEquivalent =
-    Number(MINIMUM_DISBURSEMENT) /
-    ULPS_PER_MATURITY /
-    MATURITY_MODULATION_VARIANCE_PERCENTAGE;
-
+  const getDisabledText = () => {
+    const minIcpEquivalent =
+      Number(MINIMUM_DISBURSEMENT) /
+      ULPS_PER_MATURITY /
+      MATURITY_MODULATION_VARIANCE_PERCENTAGE;
+    return replacePlaceholders(
+      $i18n.neuron_detail.disburse_maturity_disabled_tooltip,
+      {
+        $amount: formatNumber(minIcpEquivalent, {
+          minFraction: 4,
+          maxFraction: 4,
+        }),
+        $min: formatNumber(Number(MINIMUM_DISBURSEMENT) / ULPS_PER_MATURITY, {
+          minFraction: 0,
+          maxFraction: 0,
+        }),
+        $variability: formatPercentage(
+          MATURITY_MODULATION_VARIANCE_PERCENTAGE,
+          {
+            minFraction: 0,
+            maxFraction: 0,
+          }
+        ),
+      }
+    );
+  };
   const showModal = () =>
     openNnsNeuronModal({
       type: "disburse-maturity",
@@ -39,42 +58,7 @@
     });
 </script>
 
-<TestIdWrapper testId="disburse-maturity-button-component">
-  {#if enoughMaturity}
-    <button
-      data-tid="disburse-maturity-button"
-      class="secondary"
-      onclick={showModal}
-    >
-      {$i18n.neuron_detail.disburse_maturity}
-    </button>
-  {:else}
-    <Tooltip
-      id="disburse-maturity-button"
-      text={replacePlaceholders(
-        $i18n.neuron_detail.disburse_maturity_disabled_tooltip,
-        {
-          $amount: formatNumber(minIcpEquivalent, {
-            minFraction: 4,
-            maxFraction: 4,
-          }),
-          $min: formatNumber(Number(MINIMUM_DISBURSEMENT) / ULPS_PER_MATURITY, {
-            minFraction: 0,
-            maxFraction: 0,
-          }),
-          $variability: formatPercentage(
-            MATURITY_MODULATION_VARIANCE_PERCENTAGE,
-            {
-              minFraction: 0,
-              maxFraction: 0,
-            }
-          ),
-        }
-      )}
-    >
-      <button data-tid="disburse-maturity-button" disabled class="secondary">
-        {$i18n.neuron_detail.disburse_maturity}
-      </button>
-    </Tooltip>
-  {/if}
-</TestIdWrapper>
+<DisburseMaturityButton
+  on:click={showModal}
+  disabledText={enoughMaturity ? undefined : getDisabledText()}
+/>

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -13,6 +13,20 @@ export const MATURITY_MODULATION_VARIANCE_PERCENTAGE = 0.95;
 // The minimum amount of ICP to disburse in a single transaction.
 // https://github.com/dfinity/ic/blob/b9c23dd08c76349a3dd1b422e39988bea8363d33/rs/nns/governance/src/governance/disburse_maturity.rs#L29
 export const MINIMUM_DISBURSEMENT = 100_000_000n;
+// The minimum maturity to disburse with the maturity modulation variance applied.
+export const MIN_DISBURSEMENT_WITH_VARIANCE = BigInt(
+  Math.round(
+    Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
+  )
+);
+// The minimum maturity ICP equivalent to disburse with the maturity modulation variance applied.
+export const MIN_DISBURSEMENT_WITH_VARIANCE_ICP = BigInt(
+  Math.round(
+    Number(MINIMUM_DISBURSEMENT) /
+      (ULPS_PER_MATURITY * MATURITY_MODULATION_VARIANCE_PERCENTAGE)
+  )
+);
+
 // Neuron ids are random u64. Max digits of a u64 is 20.
 export const MAX_NEURON_ID_DIGITS = 20;
 

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -19,6 +19,13 @@ export const MIN_DISBURSEMENT_WITH_VARIANCE = BigInt(
     Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
   )
 );
+// The minimum maturity ICP equivalent to disburse with the maturity modulation variance applied.
+export const MIN_DISBURSEMENT_WITH_VARIANCE_ICP = BigInt(
+  Math.round(
+    Number(MINIMUM_DISBURSEMENT) /
+      (ULPS_PER_MATURITY * MATURITY_MODULATION_VARIANCE_PERCENTAGE)
+  )
+);
 
 // Neuron ids are random u64. Max digits of a u64 is 20.
 export const MAX_NEURON_ID_DIGITS = 20;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -20,12 +20,10 @@ export const MIN_DISBURSEMENT_WITH_VARIANCE = BigInt(
   )
 );
 // The minimum maturity ICP equivalent to disburse with the maturity modulation variance applied.
-export const MIN_DISBURSEMENT_WITH_VARIANCE_ICP = BigInt(
-  Math.round(
-    Number(MINIMUM_DISBURSEMENT) /
-      (ULPS_PER_MATURITY * MATURITY_MODULATION_VARIANCE_PERCENTAGE)
-  )
-);
+export const MIN_DISBURSEMENT_WITH_VARIANCE_ICP =
+  Number(MINIMUM_DISBURSEMENT) /
+  ULPS_PER_MATURITY /
+  MATURITY_MODULATION_VARIANCE_PERCENTAGE;
 
 // Neuron ids are random u64. Max digits of a u64 is 20.
 export const MAX_NEURON_ID_DIGITS = 20;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -19,13 +19,6 @@ export const MIN_DISBURSEMENT_WITH_VARIANCE = BigInt(
     Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
   )
 );
-// The minimum maturity ICP equivalent to disburse with the maturity modulation variance applied.
-export const MIN_DISBURSEMENT_WITH_VARIANCE_ICP = BigInt(
-  Math.round(
-    Number(MINIMUM_DISBURSEMENT) /
-      (ULPS_PER_MATURITY * MATURITY_MODULATION_VARIANCE_PERCENTAGE)
-  )
-);
 
 // Neuron ids are random u64. Max digits of a u64 is 20.
 export const MAX_NEURON_ID_DIGITS = 20;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -793,6 +793,7 @@
     "split_neuron_success": "Your neuron has successfully been split.",
     "split_neuron_disabled_tooltip": "Neuron needs a minimum stake of $amount $token to be splittable.",
     "spawn_neuron_disabled_tooltip": "You need at least the equivalent of $amount ICP ($min / $variability) to spawn a new neuron from maturity.",
+    "disburse_maturity_disabled_tooltip": "You need at least the equivalent of $amount ICP ($min / $variability) to disburse maturity.",
     "hotkeys_title": "Hotkeys",
     "add_hotkey": "Add Hotkey",
     "no_notkeys": "No hotkeys",

--- a/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
@@ -80,6 +80,10 @@
       <SpawnNeuronModal on:nnsClose={close} {neuron} />
     {/if}
 
+    {#if type === "disburse-maturity"}
+      NnsDisburseMaturityModal
+    {/if}
+
     {#if type === "auto-stake-maturity"}
       <NnsAutoStakeMaturityModal on:nnsClose={close} {neuron} />
     {/if}

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -826,6 +826,7 @@ interface I18nNeuron_detail {
   split_neuron_success: string;
   split_neuron_disabled_tooltip: string;
   spawn_neuron_disabled_tooltip: string;
+  disburse_maturity_disabled_tooltip: string;
   hotkeys_title: string;
   add_hotkey: string;
   no_notkeys: string;

--- a/frontend/src/lib/types/nns-neuron-detail.modal.ts
+++ b/frontend/src/lib/types/nns-neuron-detail.modal.ts
@@ -13,6 +13,7 @@ export type NnsNeuronModalType =
   | "stake-maturity"
   | "merge-maturity"
   | "spawn"
+  | "disburse-maturity"
   | "join-community-fund"
   | "dev-add-maturity"
   | "voting-history"

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -14,7 +14,7 @@ import {
   MAX_AGE_BONUS,
   MAX_DISSOLVE_DELAY_BONUS,
   MAX_NEURONS_MERGED,
-  MINIMUM_DISBURSEMENT,
+  MIN_DISBURSEMENT_WITH_VARIANCE,
   MIN_NEURON_STAKE,
   NOTIFICATION_PERIOD_BEFORE_REWARD_LOSS_STARTS_DAYS,
   TOPICS_TO_FOLLOW_NNS,
@@ -808,10 +808,7 @@ export const isEnoughMaturityToDisburse = ({
   const maturitySelected = Math.floor(
     (Number(fullNeuron.maturityE8sEquivalent) * percentage) / 100
   );
-  return (
-    maturitySelected >=
-    Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
-  );
+  return maturitySelected >= MIN_DISBURSEMENT_WITH_VARIANCE;
 };
 
 export const isSpawning = (neuron: NeuronInfo): boolean =>

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -1,4 +1,5 @@
 import NnsAvailableMaturityItemAction from "$lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import NeuronContextActionsTest from "$tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
@@ -76,6 +77,7 @@ describe("NnsAvailableMaturityItemAction", () => {
     expect(await po.hasStakeButton()).toBe(true);
   });
 
+  // TODO: Remove this once the ENABLE_DISBURSE_MATURITY feature flag is no longer needed.
   it("should not render buttons if user is not the controller", async () => {
     const po = renderComponent({
       ...mockNeuron,
@@ -95,5 +97,59 @@ describe("NnsAvailableMaturityItemAction", () => {
     expect(await po.getTooltipIconPo().getTooltipPo().getTooltipId()).toBe(
       "available-maturity-tooltip"
     );
+  });
+
+  describe("when ENABLE_DISBURSE_MATURITY flag enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_DISBURSE_MATURITY", true);
+    });
+
+    it("should render Disburse button", async () => {
+      const po = renderComponent({
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: mockIdentity.getPrincipal().toText(),
+        },
+      });
+
+      expect(await po.hasStakeButton()).toBe(true);
+      expect(await po.hasSpawnButton()).toBe(false);
+      expect(await po.hasDisburseMaturityButton()).toBe(true);
+    });
+
+    it("should render Spawn button if controlled by attached Ledger device", async () => {
+      setAccountsForTesting({
+        main: mockMainAccount,
+        subAccounts: [],
+        hardwareWallets: [mockHardwareWalletAccount],
+      });
+
+      const po = renderComponent({
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: mockHardwareWalletAccount.principal.toText(),
+        },
+      });
+
+      expect(await po.hasStakeButton()).toBe(true);
+      expect(await po.hasSpawnButton()).toBe(true);
+      expect(await po.hasDisburseMaturityButton()).toBe(false);
+    });
+
+    it("should render no buttons when the user is not the controller", async () => {
+      const po = renderComponent({
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: mockCanisterId.toText(),
+        },
+      });
+
+      expect(await po.hasStakeButton()).toBe(false);
+      expect(await po.hasDisburseMaturityButton()).toBe(false);
+      expect(await po.hasSpawnButton()).toBe(false);
+    });
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -118,6 +118,22 @@ describe("NnsAvailableMaturityItemAction", () => {
       expect(await po.hasDisburseMaturityButton()).toBe(true);
     });
 
+    // TODO: Remove this once the ENABLE_DISBURSE_MATURITY feature flag is no longer needed.
+    it("should not render Disburse button w/o the feature flag", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_DISBURSE_MATURITY", false);
+      const po = renderComponent({
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: mockIdentity.getPrincipal().toText(),
+        },
+      });
+
+      expect(await po.hasStakeButton()).toBe(true);
+      expect(await po.hasSpawnButton()).toBe(true);
+      expect(await po.hasDisburseMaturityButton()).toBe(false);
+    });
+
     it("should render Spawn button if controlled by attached Ledger device", async () => {
       setAccountsForTesting({
         main: mockMainAccount,

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.spec.ts
@@ -10,7 +10,7 @@ import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
 describe("NnsDisburseMaturityButton", () => {
-  const ENOUGH_MATURITY = BigInt(
+  const minMaturityForDisbursement = BigInt(
     Math.round(
       Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
     )
@@ -29,7 +29,7 @@ describe("NnsDisburseMaturityButton", () => {
       ...mockNeuron,
       fullNeuron: {
         ...mockNeuron.fullNeuron,
-        maturityE8sEquivalent: ENOUGH_MATURITY,
+        maturityE8sEquivalent: minMaturityForDisbursement,
       },
     });
 
@@ -42,7 +42,7 @@ describe("NnsDisburseMaturityButton", () => {
       ...mockNeuron,
       fullNeuron: {
         ...mockNeuron.fullNeuron,
-        maturityE8sEquivalent: ENOUGH_MATURITY - 1n,
+        maturityE8sEquivalent: minMaturityForDisbursement - 1n,
       },
     });
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.spec.ts
@@ -1,0 +1,55 @@
+import NnsDisburseMaturityButton from "$lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte";
+import {
+  MATURITY_MODULATION_VARIANCE_PERCENTAGE,
+  MINIMUM_DISBURSEMENT,
+} from "$lib/constants/neurons.constants";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { DisburseMaturityButtonPo } from "$tests/page-objects/DisburseMaturityButton.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+
+describe("NnsDisburseMaturityButton", () => {
+  const ENOUGH_MATURITY = BigInt(
+    Math.round(
+      Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
+    )
+  );
+  const renderComponent = (neuron: NeuronInfo) => {
+    const { container } = render(NnsDisburseMaturityButton, {
+      props: {
+        neuron,
+      },
+    });
+    return DisburseMaturityButtonPo.under(new JestPageObjectElement(container));
+  };
+
+  it("is enabled when there is enough maturity", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        maturityE8sEquivalent: ENOUGH_MATURITY,
+      },
+    });
+
+    expect(await po.isPresent()).toBe(true);
+    expect(await po.isDisabled()).toBe(false);
+  });
+
+  it("is disabled when there is not enough maturity", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        maturityE8sEquivalent: ENOUGH_MATURITY - 1n,
+      },
+    });
+
+    expect(await po.isPresent()).toBe(true);
+    expect(await po.isDisabled()).toBe(true);
+    expect(await po.getTooltipText()).toBe(
+      "You need at least the equivalent of 1.0526 ICP (1 / 95%) to disburse maturity."
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsDisburseMaturityButton.spec.ts
@@ -1,8 +1,5 @@
 import NnsDisburseMaturityButton from "$lib/components/neuron-detail/actions/NnsDisburseMaturityButton.svelte";
-import {
-  MATURITY_MODULATION_VARIANCE_PERCENTAGE,
-  MINIMUM_DISBURSEMENT,
-} from "$lib/constants/neurons.constants";
+import { MIN_DISBURSEMENT_WITH_VARIANCE } from "$lib/constants/neurons.constants";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { DisburseMaturityButtonPo } from "$tests/page-objects/DisburseMaturityButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -10,11 +7,7 @@ import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
 describe("NnsDisburseMaturityButton", () => {
-  const minMaturityForDisbursement = BigInt(
-    Math.round(
-      Number(MINIMUM_DISBURSEMENT) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
-    )
-  );
+  const minMaturityForDisbursement = MIN_DISBURSEMENT_WITH_VARIANCE;
   const renderComponent = (neuron: NeuronInfo) => {
     const { container } = render(NnsDisburseMaturityButton, {
       props: {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -9,10 +9,9 @@ import {
 } from "$lib/constants/constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import {
-  MATURITY_MODULATION_VARIANCE_PERCENTAGE,
   MAX_NEURONS_MERGED,
+  MIN_DISBURSEMENT_WITH_VARIANCE,
   MIN_NEURON_STAKE,
-  MINIMUM_DISBURSEMENT,
 } from "$lib/constants/neurons.constants";
 import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -1402,12 +1401,7 @@ describe("neuron-utils", () => {
   });
 
   describe("isEnoughMaturityToDisburse", () => {
-    const JUST_ENOUGH_MATURITY = BigInt(
-      Math.round(
-        Number(MINIMUM_DISBURSEMENT) /
-          Number(MATURITY_MODULATION_VARIANCE_PERCENTAGE)
-      )
-    );
+    const JUST_ENOUGH_MATURITY = MIN_DISBURSEMENT_WITH_VARIANCE;
 
     it("return false if fullNeuron is not available", () => {
       const neuron = {

--- a/frontend/src/tests/page-objects/NnsAvailableMaturityItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAvailableMaturityItemAction.page-object.ts
@@ -1,4 +1,5 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { DisburseMaturityButtonPo } from "$tests/page-objects/DisburseMaturityButton.page-object";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -20,6 +21,10 @@ export class NnsAvailableMaturityItemActionPo extends BasePageObject {
     return this.getButton("spawn-neuron-button");
   }
 
+  getDisburseMaturityButton(): DisburseMaturityButtonPo {
+    return DisburseMaturityButtonPo.under(this.root);
+  }
+
   getMaturity(): Promise<string> {
     return this.getText("available-maturity");
   }
@@ -30,5 +35,9 @@ export class NnsAvailableMaturityItemActionPo extends BasePageObject {
 
   hasSpawnButton(): Promise<boolean> {
     return this.getSpawnButton().isPresent();
+  }
+
+  hasDisburseMaturityButton(): Promise<boolean> {
+    return this.getDisburseMaturityButton().isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

To simplify the process of claiming matured rewards and avoid the extra steps of creating and disbursing a new neuron, the disburse maturity feature is introduced for NNS neurons (this approach is already used for SNS neurons).

This PR adds (behind the flag) the "Disburse" button to the neuron page.

[Jira](https://dfinity.atlassian.net/browse/NNS1-3740)

# Changes

- New `NnsDisburseMaturityButton` component.
- Display disburse maturity button on page.
- Added a new modal key "disburse-maturity" to display a modal (comes later).

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet
