### PR TITLE
feat(disburse-maturity): Display total disbursements in progress

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturitySection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturitySection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import NnsAvailableMaturityItemAction from "$lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte";
   import NnsStakedMaturityItemAction from "$lib/components/neuron-detail/NnsStakedMaturityItemAction.svelte";
+  import ViewActiveDisbursementsItemAction from "$lib/components/neuron-detail/ViewActiveDisbursementsItemAction.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { formattedTotalMaturity } from "$lib/utils/neuron.utils";
   import { Section } from "@dfinity/gix-components";
@@ -23,6 +24,7 @@
   <ul class="content">
     <NnsStakedMaturityItemAction {neuron} />
     <NnsAvailableMaturityItemAction {neuron} />
+    <ViewActiveDisbursementsItemAction {neuron} />
   </ul>
 </Section>
 

--- a/frontend/src/lib/components/neuron-detail/ViewActiveDisbursementsItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/ViewActiveDisbursementsItemAction.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { openNnsNeuronModal } from "$lib/utils/modals.utils";
+  import {
+    formatMaturity,
+    totalMaturityDisbursementsInProgress,
+  } from "$lib/utils/neuron.utils";
+  import { IconPace } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
+
+  type Props = {
+    neuron: NeuronInfo;
+  };
+  const { neuron }: Props = $props();
+  const totalMaturityDisbursements = $derived(
+    totalMaturityDisbursementsInProgress(neuron)
+  );
+  const showModal = () =>
+    openNnsNeuronModal({
+      type: "view-active-disbursements",
+      data: { neuron },
+    });
+</script>
+
+{#if totalMaturityDisbursements > 0n}
+  <CommonItemAction testId="view-active-disbursements-item-action-component">
+    <IconPace slot="icon" />
+    <span slot="title" data-tid="disbursement-total"
+      >{formatMaturity(totalMaturityDisbursements)}</span
+    >
+    <svelte:fragment slot="subtitle"
+      >{$i18n.neuron_detail.view_active_disbursements_status}</svelte:fragment
+    >
+
+    <button class="secondary" onclick={showModal}
+      >{$i18n.neuron_detail.view_active_disbursements}</button
+    >
+  </CommonItemAction>
+{/if}

--- a/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
@@ -79,6 +79,9 @@
     {#if type === "spawn"}
       <SpawnNeuronModal on:nnsClose={close} {neuron} />
     {/if}
+    {#if type === "view-active-disbursements"}
+      <!-- TODO: display <NnsActiveDisbursementsModal {close} {neuron} /> -->
+    {/if}
 
     {#if type === "auto-stake-maturity"}
       <NnsAutoStakeMaturityModal on:nnsClose={close} {neuron} />

--- a/frontend/src/lib/types/nns-neuron-detail.modal.ts
+++ b/frontend/src/lib/types/nns-neuron-detail.modal.ts
@@ -13,6 +13,7 @@ export type NnsNeuronModalType =
   | "stake-maturity"
   | "merge-maturity"
   | "spawn"
+  | "view-active-disbursements"
   | "join-community-fund"
   | "dev-add-maturity"
   | "voting-history"

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
@@ -40,4 +40,29 @@ describe("NnsNeuronMaturitySection", () => {
     expect(await po.hasStakedMaturityItemAction()).toBe(true);
     expect(await po.hasAvailableMaturityItemAction()).toBe(true);
   });
+
+  it("should render active disbursements item action when maturity disbursement in progress", async () => {
+    const neuron = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        maturityDisbursementsInProgress: [
+          {
+            amountE8s: 200_000_000n,
+            timestampOfDisbursementSeconds: undefined,
+            accountToDisburseTo: undefined,
+            finalizeDisbursementTimestampSeconds: undefined,
+          },
+        ],
+      },
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getViewActiveDisbursementsItemActionPo().isPresent()).toBe(
+      true
+    );
+    expect(
+      await po.getViewActiveDisbursementsItemActionPo().getDisbursementTotal()
+    ).toBe("2.00");
+  });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/ViewActiveDisbursementsItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/ViewActiveDisbursementsItemAction.spec.ts
@@ -1,0 +1,60 @@
+import ViewActiveDisbursementsItemAction from "$lib/components/neuron-detail/ViewActiveDisbursementsItemAction.svelte";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { ViewActiveDisbursementsItemActionPo } from "$tests/page-objects/ViewActiveDisbursementsItemAction.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+
+describe("ViewActiveDisbursementsItemAction", () => {
+  const renderComponent = (neuron: NeuronInfo) => {
+    const { container } = render(ViewActiveDisbursementsItemAction, {
+      props: {
+        neuron,
+      },
+    });
+
+    return ViewActiveDisbursementsItemActionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should not render components when no disbursements available", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        maturityDisbursementsInProgress: [],
+      },
+    });
+
+    expect(await po.isPresent()).toBe(false);
+  });
+
+  it("should render disbursement with total amount", async () => {
+    const disbursementAmount1 = 100_000_000n; // 1.00 ICP
+    const disbursementAmount2 = 200_000_000n; // 2.00 ICP
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        maturityDisbursementsInProgress: [
+          {
+            amountE8s: disbursementAmount1,
+            timestampOfDisbursementSeconds: undefined,
+            accountToDisburseTo: undefined,
+            finalizeDisbursementTimestampSeconds: undefined,
+          },
+          {
+            amountE8s: disbursementAmount2,
+            timestampOfDisbursementSeconds: undefined,
+            accountToDisburseTo: undefined,
+            finalizeDisbursementTimestampSeconds: undefined,
+          },
+        ],
+      },
+    });
+
+    expect(await po.isPresent()).toBe(true);
+    expect(await po.getDisbursementTotal()).toBe("3.00");
+  });
+});

--- a/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
@@ -1,5 +1,6 @@
 import { NnsAvailableMaturityItemActionPo } from "$tests/page-objects/NnsAvailableMaturityItemAction.page-object";
 import { NnsStakedMaturityItemActionPo } from "$tests/page-objects/NnsStakedMaturityItemAction.page-object";
+import { ViewActiveDisbursementsItemActionPo } from "$tests/page-objects/ViewActiveDisbursementsItemAction.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -30,5 +31,13 @@ export class NnsNeuronMaturitySectionPo extends BasePageObject {
 
   hasAvailableMaturityItemAction(): Promise<boolean> {
     return this.getAvailableMaturityItemActionPo().isPresent();
+  }
+
+  getViewActiveDisbursementsItemActionPo(): ViewActiveDisbursementsItemActionPo {
+    return ViewActiveDisbursementsItemActionPo.under(this.root);
+  }
+
+  hasViewActiveDisbursementsItemAction(): Promise<boolean> {
+    return this.getViewActiveDisbursementsItemActionPo().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/ViewActiveDisbursementsItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/ViewActiveDisbursementsItemAction.page-object.ts
@@ -1,0 +1,19 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ViewActiveDisbursementsItemActionPo extends BasePageObject {
+  private static readonly TID =
+    "view-active-disbursements-item-action-component";
+
+  static under(
+    element: PageObjectElement
+  ): ViewActiveDisbursementsItemActionPo {
+    return new ViewActiveDisbursementsItemActionPo(
+      element.byTestId(ViewActiveDisbursementsItemActionPo.TID)
+    );
+  }
+
+  async getDisbursementTotal(): Promise<string> {
+    return (await this.root.byTestId("disbursement-total").getText()).trim();
+  }
+}


### PR DESCRIPTION
# Motivation

To simplify the process of claiming matured rewards and avoid the extra steps of creating and disbursing a new neuron, the disburse maturity feature is introduced for NNS neurons (this approach is already used for SNS neurons).

This PR adds the "Disburse" modal to the neuron page.

[Jira](https://dfinity.atlassian.net/browse/NNS1-3740)

# Changes

- New ViewActiveDisbursementsItemAction component.
- Display it on the neuron details page.

# Tests

- Added.
- Verified manually that a user can disburse maturity to the main account.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet
