### PR TITLE
Fix disabled button width

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Fix disburse maturity disabled button width.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/neuron-detail/NeuronSelectPercentage.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronSelectPercentage.svelte
@@ -65,7 +65,7 @@
       <Tooltip id="disabled-disburse-button-modal" text={disabledText} top>
         <button
           data-tid="select-maturity-percentage-button"
-          class="primary"
+          class="primary disabled-button"
           on:click={selectPercentage}
           {disabled}
         >
@@ -97,5 +97,9 @@
       margin-top: var(--padding);
       text-align: right;
     }
+  }
+
+  .disabled-button {
+    width: 100%;
   }
 </style>


### PR DESCRIPTION
# Motivation

In the NNS/SNS disburse maturity modals, the 'Disburse' button's width fluctuates when insufficient percentage is selected due to the disabled button being wrapped by a Tooltip. This PR ensures the button maintains a consistent 100% width, improving its visual appearance.

# Changes

- Make the inner button to be 100%.

# Tests

- Tested manually

| Before | After |
|--------|--------|
| ![Screenshot 2025-06-08 at 19 40 18](https://github.com/user-attachments/assets/8d84e253-926a-4c1e-839b-33a6116fce05) | ![Screenshot 2025-06-08 at 19 40 06](https://github.com/user-attachments/assets/b133cb3d-303f-4a82-93ce-1e50429166e2) | 

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
