### PR TITLE
feat(disburse-maturity): destination for disbursement

### DIFF
--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -229,10 +229,11 @@ export const spawnNeuron = async ({
 
 export type ApiDisburseMaturityParams = ApiManageNeuronParams & {
   percentageToDisburse: number;
+  // If toAccountIdentifier is not provided, the disbursement will be made to the users Main account.
+  // https://github.com/dfinity/ic/blob/e9618fe054cb9c1837ca3aab24f98cf08366602c/rs/nns/governance/api/src/types.rs#L944-L948
   toAccountIdentifier?: AccountIdentifierHex;
 };
 
-// If the accountIdentifier is not provided, the disbursement will be made to the users Main account.
 export const disburseMaturity = async ({
   neuronId,
   percentageToDisburse,

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -6,6 +6,7 @@ import { HOST } from "$lib/constants/environment.constants";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { hashCode, logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Agent, Identity } from "@dfinity/agent";
+import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import type {
   E8s,
   KnownNeuron,
@@ -227,16 +228,16 @@ export const spawnNeuron = async ({
 };
 
 export type ApiDisburseMaturityParams = ApiManageNeuronParams & {
-  // TODO(disburse-maturity): Add sub and external accounts support.
-  // account?: Principal;
-  // subAccount?: string;
   percentageToDisburse: number;
+  toAccountIdentifier?: AccountIdentifierHex;
 };
 
+// If the accountIdentifier is not provided, the disbursement will be made to the users Main account.
 export const disburseMaturity = async ({
   neuronId,
   percentageToDisburse,
   identity,
+  toAccountIdentifier,
 }: ApiDisburseMaturityParams): Promise<void> => {
   logWithTimestamp(`Disburse maturity (${hashCode(neuronId)}) call...`);
 
@@ -244,6 +245,7 @@ export const disburseMaturity = async ({
   await canister.disburseMaturity({
     neuronId,
     percentageToDisburse,
+    toAccountIdentifier,
   });
 
   logWithTimestamp(`Disburse maturity (${hashCode(neuronId)}) complete.`);

--- a/frontend/src/lib/modals/neurons/NnsDisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsDisburseMaturityModal.svelte
@@ -15,17 +15,17 @@
 
   const { neuron, close }: Props = $props();
   const disburseMaturity = async ({
-    detail: { percentageToDisburse },
+    detail: { percentageToDisburse, destinationAddress: toAccountIdentifier },
   }: CustomEvent<{
     percentageToDisburse: number;
     destinationAddress: string;
   }>) => {
     startBusy({ initiator: "disburse-maturity" });
 
-    // TODO(disburse-maturity): switch to account identifier when API supports it
     const { success } = await disburseMaturityService({
       neuronId: neuron.neuronId,
       percentageToDisburse,
+      toAccountIdentifier,
     });
 
     stopBusy("disburse-maturity");

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -70,7 +70,10 @@ import {
 } from "$lib/utils/neuron.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import { AnonymousIdentity, type Identity } from "@dfinity/agent";
-import type { TransactionWithId } from "@dfinity/ledger-icp";
+import type {
+  AccountIdentifierHex,
+  TransactionWithId,
+} from "@dfinity/ledger-icp";
 import {
   NeuronVisibility,
   Topic,
@@ -829,9 +832,11 @@ export const spawnNeuron = async ({
 export const disburseMaturity = async ({
   neuronId,
   percentageToDisburse,
+  toAccountIdentifier,
 }: {
   neuronId: NeuronId;
   percentageToDisburse: number;
+  toAccountIdentifier?: AccountIdentifierHex;
 }): Promise<{ success: boolean }> => {
   try {
     const identity: Identity =
@@ -841,8 +846,10 @@ export const disburseMaturity = async ({
       neuronId,
       percentageToDisburse,
       identity,
+      toAccountIdentifier,
     });
 
+    // TODO(disburse-maturity): Consider calling reloadNeuron. The other neurons shouldn't be affected by disbursement.
     await listNeurons();
 
     return { success: true };

--- a/frontend/src/tests/lib/modals/neurons/NnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsDisburseMaturityModal.spec.ts
@@ -144,6 +144,7 @@ describe("NnsDisburseMaturityModal", () => {
       neuronId: neuron.neuronId,
       percentageToDisburse: 100,
       identity: mockIdentity,
+      toAccountIdentifier: mockMainAccount.identifier,
     });
     expect(close).toHaveBeenCalledTimes(0);
     expect(get(busyStore)).toEqual([

--- a/frontend/src/tests/lib/modals/neurons/NnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsDisburseMaturityModal.spec.ts
@@ -3,7 +3,10 @@ import { MIN_DISBURSEMENT_WITH_VARIANCE } from "$lib/constants/neurons.constants
 import NnsDisburseMaturityModal from "$lib/modals/neurons/NnsDisburseMaturityModal.svelte";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
-import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { DisburseMaturityModalPo } from "$tests/page-objects/DisburseMaturityModal.page-object";
@@ -176,6 +179,45 @@ describe("NnsDisburseMaturityModal", () => {
         text: "Maturity successfully disbursed.",
       },
     ]);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("should disburse maturity to entered destination", async () => {
+    const neuron = testNeuron();
+    const close = vi.fn();
+    const spyDisburseMaturity = vi
+      .spyOn(api, "disburseMaturity")
+      .mockResolvedValue();
+    // Add the neuron to the store to avoid extra query from getIdentityOfControllerByNeuronId
+    neuronsStore.setNeurons({
+      neurons: [neuron],
+      certified: true,
+    });
+    const po = await renderNnsDisburseMaturityModal({ neuron, close });
+
+    await po.setPercentage(50);
+    await po.getSelectDestinationAddressPo().toggleSelect();
+    await po
+      .getSelectDestinationAddressPo()
+      .enterAddress(mockHardwareWalletAccount.identifier);
+
+    await po.clickNextButton();
+
+    expect(
+      await po.getNeuronConfirmActionScreenPo().getConfirmButton().isDisabled()
+    ).toEqual(false);
+    expect(spyDisburseMaturity).toHaveBeenCalledTimes(0);
+
+    await po.clickConfirmButton();
+    await runResolvedPromises();
+
+    expect(spyDisburseMaturity).toHaveBeenCalledTimes(1);
+    expect(spyDisburseMaturity).toHaveBeenCalledWith({
+      neuronId: neuron.neuronId,
+      percentageToDisburse: 50,
+      identity: mockIdentity,
+      toAccountIdentifier: mockHardwareWalletAccount.identifier,
+    });
     expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1230,7 +1230,7 @@ describe("neurons-services", () => {
   });
 
   describe("disburseMaturity", () => {
-    it("should disburse maturity", async () => {
+    it("should call disburse maturity api", async () => {
       neuronsStore.pushNeurons({ neurons, certified: true });
       expect(spyDisburseMaturity).toBeCalledTimes(0);
       const { success } = await services.disburseMaturity({
@@ -1238,11 +1238,6 @@ describe("neurons-services", () => {
         percentageToDisburse: 50,
       });
 
-      expect(spyDisburseMaturity).toBeCalledWith({
-        identity: mockIdentity,
-        neuronId: controlledNeuron.neuronId,
-        percentageToDisburse: 50,
-      });
       expect(spyDisburseMaturity).toBeCalledTimes(1);
       expect(spyDisburseMaturity).toBeCalledWith({
         identity: mockIdentity,
@@ -1252,7 +1247,26 @@ describe("neurons-services", () => {
       expect(success).toBe(true);
     });
 
-    it("should not disburse maturity if no identity", async () => {
+    it("should provide account identifier", async () => {
+      neuronsStore.pushNeurons({ neurons, certified: true });
+      expect(spyDisburseMaturity).toBeCalledTimes(0);
+      const { success } = await services.disburseMaturity({
+        neuronId: controlledNeuron.neuronId,
+        percentageToDisburse: 50,
+        toAccountIdentifier: mockMainAccount.identifier,
+      });
+
+      expect(spyDisburseMaturity).toBeCalledTimes(1);
+      expect(spyDisburseMaturity).toBeCalledWith({
+        identity: mockIdentity,
+        neuronId: controlledNeuron.neuronId,
+        percentageToDisburse: 50,
+        toAccountIdentifier: mockMainAccount.identifier,
+      });
+      expect(success).toBe(true);
+    });
+
+    it("should not call disburse maturity if no identity provided", async () => {
       setNoIdentity();
 
       const { success } = await services.disburseMaturity({


### PR DESCRIPTION
# Motivation

To simplify the process of claiming matured rewards and avoid the extra steps of creating and disbursing a new neuron, the disburse maturity feature is introduced for NNS neurons (this approach is already used for SNS neurons).

The UI components already support custom destinations via account identifier (hex string).
This PR ensures the correct API call is made using the provided destination.

# Changes

- Added `toAccountIdentifier` field to the disburse maturity API.
- Passed the `toAccountIdentifier` value from the components to the API layer for use in the request.

# Tests

- Updated.
- Tested locally that disbursement works with the custom account identifier.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
