### PR TITLE
remove blockers

### DIFF
--- a/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
@@ -5,15 +5,10 @@ import {
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
-import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 
 vi.mock("$lib/api/sns-aggregator.api");
 
-const blockedPaths = ["$lib/api/sns-aggregator.api"];
-
 describe("sns-aggregator api-service", () => {
-  blockAllCallsTo(blockedPaths);
-
   const successData = [aggregatorSnsMockDto, aggregatorSnsMockDto];
   let resolveFn = undefined;
   let rejectFn = undefined;

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -38,7 +38,6 @@ import { snsTicketMock } from "$tests/mocks/sns.mock";
 import { ProjectDetailPo } from "$tests/page-objects/ProjectDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
-import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
@@ -57,18 +56,7 @@ vi.mock("$lib/api/icp-ledger.api");
 vi.mock("$lib/api/location.api");
 vi.mock("$lib/api/proposals.api");
 
-const blockedApiPaths = [
-  "$lib/api/nns-dapp.api",
-  "$lib/api/sns.api",
-  "$lib/api/sns-swap-metrics.api",
-  "$lib/api/sns-sale.api",
-  "$lib/api/icp-ledger.api",
-  "$lib/api/location.api",
-  "$lib/api/proposals.api",
-];
-
 describe("ProjectDetail", () => {
-  blockAllCallsTo(blockedApiPaths);
   fakeLocationApi.install();
 
   const rootCanisterId = mockCanisterId;

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -38,7 +38,6 @@ import {
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { createTransactionWithId } from "$tests/mocks/icp-transactions.mock";
-import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { toastsStore } from "@dfinity/gix-components";
 import { Principal } from "@dfinity/principal";
@@ -48,11 +47,8 @@ import type { MockInstance } from "vitest";
 
 vi.mock("$lib/api/icp-ledger.api");
 vi.mock("$lib/api/canisters.api");
-const blockedApiPaths = ["$lib/api/canisters.api", "$lib/api/icp-ledger.api"];
 
 describe("canisters-services", () => {
-  blockAllCallsTo(blockedApiPaths);
-
   const newBalanceE8s = 100_000_000n;
   const exchangeRate = 10_000n;
   let spyQueryCanisters: MockInstance;

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -33,7 +33,6 @@ import {
   rootCanisterIdMock,
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
-import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { AnonymousIdentity, type HttpAgent } from "@dfinity/agent";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
@@ -65,15 +64,7 @@ vi.mock("$lib/proxy/api.import.proxy", () => {
   };
 });
 
-const blockedPaths = [
-  "$lib/api/sns-aggregator.api",
-  "$lib/api/sns-governance.api",
-  "$lib/api/sns.api",
-];
-
 describe("SNS public services", () => {
-  blockAllCallsTo(blockedPaths);
-
   beforeEach(() => {
     clearSnsAggregatorCache();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -2,14 +2,11 @@ import * as locationApi from "$lib/api/location.api";
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { loadUserCountry } from "$lib/services/user-country.services";
 import { userCountryStore } from "$lib/stores/user-country.store";
-import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/location.api");
 
 describe("location services", () => {
-  blockAllCallsTo(["$lib/api/location.api"]);
-
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });


### PR DESCRIPTION
# Motivation

#6922 will upgrade Node from version 18 to 22. This will introduce breaking changes, particularly in tests. To simplify the differences in the main PR, changes that can be applied in isolation will be introduced in separate PRs.



# Changes

- Removes `blockAllCallsTo` from tests that have mock pollution 


# Tests

- Tests should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?

Prev. PR: #6940 | Next PR: #6922