### PR TITLE
Inactive sns status

### DIFF
--- a/rs/sns_aggregator/src/types.rs
+++ b/rs/sns_aggregator/src/types.rs
@@ -13,7 +13,9 @@ pub mod upstream;
 
 // Re-export commonly used types to ensure that different versions of the same type are not used.
 pub use candid::{CandidType, Deserialize};
-pub use ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
+pub use ic_sns_governance::{
+    GetMetadataResponse, GetMetricsRequest, GetMetricsResponse, ListNervousSystemFunctionsResponse,
+};
 pub use ic_sns_ledger::{Tokens as SnsTokens, Value as Icrc1Value};
 pub use ic_sns_root::ListSnsCanistersResponse;
 pub use ic_sns_swap::GetStateResponse;

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -58,6 +58,7 @@ impl From<&UpstreamData> for SlowSnsData {
             canister_ids,
             list_sns_canisters,
             meta: _,
+            metrics: _,
             parameters,
             nervous_system_parameters,
             swap_state,

--- a/rs/sns_aggregator/src/types/upstream.rs
+++ b/rs/sns_aggregator/src/types/upstream.rs
@@ -7,6 +7,7 @@ use super::ic_sns_root::ListSnsCanistersResponse;
 use super::ic_sns_swap::{GetSaleParametersResponse, GetStateResponse};
 use super::ic_sns_wasm::DeployedSns;
 use super::{CandidType, Deserialize};
+use crate::types::ic_sns_governance::GetMetricsResponse;
 use crate::types::ic_sns_swap::{GetDerivedStateResponse, GetInitResponse, GetLifecycleResponse};
 use candid::Nat;
 use ic_cdk::api::management_canister::provisional::CanisterId;
@@ -34,7 +35,7 @@ pub struct SnsCache {
 pub type SnsIndex = u64;
 
 /// Information about an SNS that changes relatively slowly and that is common, i.e. not user specific.
-#[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
 pub struct UpstreamData {
     /// Index of the SNS in the SNS wasms canister
     pub index: u64,
@@ -44,6 +45,9 @@ pub struct UpstreamData {
     pub list_sns_canisters: ListSnsCanistersResponse,
     /// Governance metadata such as token name and logo.
     pub meta: GetMetadataResponse,
+    /// Governance metrics such as the last ledger block timestamp and
+    /// number of recently submitted proposals.
+    pub metrics: GetMetricsResponse,
     /// Governance functions.
     pub parameters: ListNervousSystemFunctionsResponse,
     /// Governance parameters such as tokenomics.
@@ -66,4 +70,29 @@ pub struct UpstreamData {
     pub lifecycle: Option<GetLifecycleResponse>,
     /// The topics and the corresponding proposal types of this SNS.
     pub topics: Option<ListTopicsResponse>,
+}
+
+impl Default for UpstreamData {
+    fn default() -> Self {
+        Self {
+            index: Default::default(),
+            canister_ids: Default::default(),
+            list_sns_canisters: Default::default(),
+            meta: Default::default(),
+            metrics: GetMetricsResponse {
+                get_metrics_result: None,
+            },
+            parameters: Default::default(),
+            nervous_system_parameters: Default::default(),
+            swap_state: Default::default(),
+            icrc1_metadata: Default::default(),
+            icrc1_fee: Default::default(),
+            icrc1_total_supply: Default::default(),
+            swap_params: Default::default(),
+            init: Default::default(),
+            derived_state: Default::default(),
+            lifecycle: Default::default(),
+            topics: Default::default(),
+        }
+    }
 }

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -10,10 +10,13 @@ use crate::types::ic_sns_swap::{
 };
 use crate::types::ic_sns_wasm::{DeployedSns, ListDeployedSnsesResponse};
 use crate::types::upstream::UpstreamData;
-use crate::types::{self, EmptyRecord, GetStateResponse, Icrc1Value, SnsTokens};
+use crate::types::{self, EmptyRecord, GetMetricsRequest, GetStateResponse, Icrc1Value, SnsTokens};
 use anyhow::anyhow;
 use candid::Principal;
 use ic_cdk::api::{call::RejectionCode, management_canister::provisional::CanisterId, time};
+
+/// default time window to get SNS metrics is 2 months.
+const DEFAULT_TIME_WINDOW: u64 = 2 * 30 * 24 * 3600;
 
 /// Updates one part of the cache:  Either the list of SNSs or one SNS.
 pub async fn update_cache() {
@@ -128,6 +131,18 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
             })
             .unwrap_or(existing_data.parameters);
 
+    crate::state::log(format!("Getting SNS index {index}... get_metrics"));
+    let arg: types::GetMetricsRequest = GetMetricsRequest {
+        time_window_seconds: Some(DEFAULT_TIME_WINDOW),
+    };
+    let metrics: types::GetMetricsResponse = ic_cdk::api::call::call(governance_canister_id, "get_metrics", (arg,))
+        .await
+        .map(|response: (_,)| response.0)
+        .map_err(|err| {
+            crate::state::log(format!("Call to SnsGovernance.get_metrics failed: {err:?}"));
+        })
+        .unwrap_or(existing_data.metrics);
+
     crate::state::log(format!("Getting SNS index {index}... get_state"));
     let swap_state: GetStateResponse = get_swap_state(swap_canister_id)
         .await
@@ -135,7 +150,6 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
         .unwrap_or(existing_data.swap_state);
 
     crate::state::log(format!("Getting SNS index {index}... icrc1_metadata"));
-    //let icrc1_metadata = Vec::new();
     let icrc1_metadata: Vec<(String, Icrc1Value)> =
         ic_cdk::api::call::call(ledger_canister_id, "icrc1_metadata", ((),))
             .await
@@ -144,7 +158,6 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
             .unwrap_or(existing_data.icrc1_metadata);
 
     crate::state::log(format!("Getting SNS index {index}... icrc1_fee"));
-    //let icrc1_fee = SnsTokens::default();
     let icrc1_fee: SnsTokens = ic_cdk::api::call::call(ledger_canister_id, "icrc1_fee", ((),))
         .await
         .map(|response: (_,)| response.0)
@@ -222,6 +235,7 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
         canister_ids: sns_canister_ids,
         list_sns_canisters,
         meta,
+        metrics,
         parameters,
         nervous_system_parameters,
         swap_state,


### PR DESCRIPTION
# Motivation

After extending the API of SNS Governance to expose its activeness metrics through `Sns_Governancw.get_metrics()`, we can enrich the upstream data fetched by the SNS aggregator to include it.

# Changes

<!-- List the changes that have been developed -->

