### PR TITLE
feat(utils): fiat value formatter with support for small amounts

### DIFF
--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -86,3 +86,9 @@ export const shortenWithMiddleEllipsis = (
 
 export const renderPrivacyModeBalance = (count: number) =>
   "•".repeat(Math.max(0, count));
+
+export const formatUsdValue = (usdValue: number): string => {
+  const isAlmostZero = usdValue > 0 && usdValue < 0.01;
+  const formattedValue = isAlmostZero ? "0.01" : formatNumber(usdValue);
+  return `${isAlmostZero ? "< " : ""}$${formattedValue}`;
+};

--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -87,8 +87,5 @@ export const shortenWithMiddleEllipsis = (
 export const renderPrivacyModeBalance = (count: number) =>
   "•".repeat(Math.max(0, count));
 
-export const formatUsdValue = (usdValue: number): string => {
-  const isAlmostZero = usdValue > 0 && usdValue < 0.01;
-  const formattedValue = isAlmostZero ? "0.01" : formatNumber(usdValue);
-  return `${isAlmostZero ? "< " : ""}$${formattedValue}`;
-};
+export const formatUsdValue = (usdValue: number): string =>
+  usdValue > 0 && usdValue < 0.01 ? "< $0.01" : `$${formatNumber(usdValue)}`;

--- a/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -2,6 +2,7 @@ import {
   formatCurrencyNumber,
   formatNumber,
   formatPercentage,
+  formatUsdValue,
   renderPrivacyModeBalance,
   shortenWithMiddleEllipsis,
 } from "$lib/utils/format.utils";
@@ -133,6 +134,24 @@ describe("format.utils", () => {
 
     it("returns empty string for negative counts", () => {
       expect(renderPrivacyModeBalance(-1)).toBe("");
+    });
+  });
+
+  describe("formatUsdValue", () => {
+    it("should format zero value", () => {
+      expect(formatUsdValue(0)).toEqual("$0.00");
+    });
+
+    it("should format almost zero values as < $0.01", () => {
+      expect(formatUsdValue(0.001)).toEqual("< $0.01");
+      expect(formatUsdValue(0.009)).toEqual("< $0.01");
+      expect(formatUsdValue(0.0099)).toEqual("< $0.01");
+    });
+
+    it("should format values >= 0.01 normally", () => {
+      expect(formatUsdValue(0.01)).toEqual("$0.01");
+      expect(formatUsdValue(1.23)).toEqual("$1.23");
+      expect(formatUsdValue(123.45)).toEqual("($123.45");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -151,7 +151,7 @@ describe("format.utils", () => {
     it("should format values >= 0.01 normally", () => {
       expect(formatUsdValue(0.01)).toEqual("$0.01");
       expect(formatUsdValue(1.23)).toEqual("$1.23");
-      expect(formatUsdValue(123.45)).toEqual("($123.45");
+      expect(formatUsdValue(123.45)).toEqual("$123.45");
     });
   });
 });


### PR DESCRIPTION
# Motivation

#6601 introduced fiat values in transaction forms. The next step in the transaction wizard modal, the Review step, should also display fiat values. This PR introduces a new utility function that can be used by both the transaction form modal and the transaction summary modal.

[NNS1-3756](https://dfinity.atlassian.net/browse/NNS1-3756)

# Changes

- Add new utility to format fiat values with support for very small numbers

# Tests

- Unit tests

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3756]: https://dfinity.atlassian.net/browse/NNS1-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ