### PR TITLE
refactor(transactions): migrate fee fiat display to shared util  

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -3,7 +3,7 @@
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { formatNumber } from "$lib/utils/format.utils";
+  import { formatUsdValue } from "$lib/utils/format.utils";
   import { getUsdValue } from "$lib/utils/token.utils";
   import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
   import { isNullish, type TokenAmount, TokenAmountV2 } from "@dfinity/utils";
@@ -11,10 +11,9 @@
   type Props = {
     transactionFee: TokenAmount | TokenAmountV2;
   };
-
   const { transactionFee }: Props = $props();
 
-  const usdValue = $derived.by(() => {
+  const usdValueDisplay = $derived.by(() => {
     const ledgerCanisterId = getLedgerCanisterIdFromUniverse(
       $selectedUniverseStore
     );
@@ -23,16 +22,9 @@
       return 0;
 
     const tokenPrice = $icpSwapUsdPricesStore[ledgerCanisterId.toText()];
-    return getUsdValue({ amount: transactionFee, tokenPrice }) ?? 0;
+    const usdValue = getUsdValue({ amount: transactionFee, tokenPrice }) ?? 0;
+    return formatUsdValue(usdValue);
   });
-
-  const isAlmostZero = $derived(usdValue > 0 && usdValue < 0.01);
-  const formattedUsdValue = $derived(
-    isAlmostZero ? "0.01" : formatNumber(usdValue)
-  );
-  const usdValueDisplay = $derived(
-    `(${isAlmostZero ? "< " : ""}$${formattedUsdValue})`
-  );
 </script>
 
 <div data-tid="transaction-form-fee">
@@ -43,7 +35,7 @@
   <p class="value">
     <AmountDisplay amount={transactionFee} singleLine />
     <span class="usd-value" data-tid="transaction-form-fee-usd-value">
-      {usdValueDisplay}
+      ({usdValueDisplay})
     </span>
   </p>
 </div>

--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -6,12 +6,19 @@
   import { formatUsdValue } from "$lib/utils/format.utils";
   import { getUsdValue } from "$lib/utils/token.utils";
   import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
-  import { isNullish, type TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+  import {
+    isNullish,
+    nonNullish,
+    type TokenAmount,
+    TokenAmountV2,
+  } from "@dfinity/utils";
+  import type { Snippet } from "svelte";
 
   type Props = {
+    label?: Snippet;
     transactionFee: TokenAmount | TokenAmountV2;
   };
-  const { transactionFee }: Props = $props();
+  const { label, transactionFee }: Props = $props();
 
   const usdValueDisplay = $derived.by(() => {
     const ledgerCanisterId = getLedgerCanisterIdFromUniverse(
@@ -29,7 +36,11 @@
 
 <div data-tid="transaction-form-fee">
   <p class="fee label no-margin">
-    <slot name="label">{$i18n.accounts.transaction_fee}</slot>
+    {#if nonNullish(label)}
+      {@render label()}
+    {:else}
+      {$i18n.accounts.transaction_fee}
+    {/if}
   </p>
 
   <p class="value">

--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -6,19 +6,12 @@
   import { formatUsdValue } from "$lib/utils/format.utils";
   import { getUsdValue } from "$lib/utils/token.utils";
   import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
-  import {
-    isNullish,
-    nonNullish,
-    type TokenAmount,
-    TokenAmountV2,
-  } from "@dfinity/utils";
-  import type { Snippet } from "svelte";
+  import { isNullish, type TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
   type Props = {
-    label?: Snippet;
     transactionFee: TokenAmount | TokenAmountV2;
   };
-  const { label, transactionFee }: Props = $props();
+  const { transactionFee }: Props = $props();
 
   const usdValueDisplay = $derived.by(() => {
     const ledgerCanisterId = getLedgerCanisterIdFromUniverse(
@@ -36,11 +29,7 @@
 
 <div data-tid="transaction-form-fee">
   <p class="fee label no-margin">
-    {#if nonNullish(label)}
-      {@render label()}
-    {:else}
-      {$i18n.accounts.transaction_fee}
-    {/if}
+    {$i18n.accounts.transaction_fee}
   </p>
 
   <p class="value">


### PR DESCRIPTION
# Motivation

#6947 introduced a new utility to format fiat values, including support for small amounts. This PR utilizes this utility and refactors the consumer into runes.

[NNS1-3756](https://dfinity.atlassian.net/browse/NNS1-3756)

# Changes

- Refactor the component to use runes.
- Use the utility instead of custom logic in the component.
- Remove the unused slot from the component.

# Tests

- Tests should pass as they did before since there are no logical changes.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3756]: https://dfinity.atlassian.net/browse/NNS1-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ