### PR TITLE
feat(store): add token price store by canister

### DIFF
--- a/frontend/src/lib/derived/token-price.derived.ts
+++ b/frontend/src/lib/derived/token-price.derived.ts
@@ -1,0 +1,30 @@
+import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+import { tokensByLedgerCanisterIdStore } from "$lib/derived/tokens.derived";
+import { getLedgerCanisterIdFromToken } from "$lib/utils/token.utils";
+import {
+  isNullish,
+  type TokenAmount,
+  type TokenAmountV2,
+} from "@dfinity/utils";
+import { derived } from "svelte/store";
+
+export const tokenPriceStore = (amount: TokenAmountV2 | TokenAmount) => {
+  return derived(
+    [tokensByLedgerCanisterIdStore, icpSwapUsdPricesStore],
+    ([$tokensByLedgerCanisterIdStore, $icpSwapUsdPricesStore]) => {
+      const ledgerCanisterId = getLedgerCanisterIdFromToken(
+        amount.token,
+        $tokensByLedgerCanisterIdStore
+      );
+
+      if (
+        isNullish(ledgerCanisterId) ||
+        isNullish($icpSwapUsdPricesStore) ||
+        $icpSwapUsdPricesStore === "error"
+      )
+        return undefined;
+
+      return $icpSwapUsdPricesStore[ledgerCanisterId];
+    }
+  );
+};

--- a/frontend/src/tests/lib/derived/token-price.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/token-price.derived.spec.ts
@@ -1,0 +1,141 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { CKUSDC_LEDGER_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { tokenPriceStore } from "$lib/derived/token-price.derived";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { Principal } from "@dfinity/principal";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+import { get } from "svelte/store";
+
+describe("token-price.derived", () => {
+  const snsRootCanisterIdText = "aax3a-h4aaa-aaaaa-qaahq-cai";
+  const snsLedgerCanisterIdText = "c2lt4-zmaaa-aaaaa-qaaiq-cai";
+  const snsToken = {
+    ...mockSnsToken,
+    symbol: "SNS1",
+  };
+
+  const mockTokensByLedgerCanisterId = {
+    [LEDGER_CANISTER_ID.toText()]: {
+      name: "Internet Computer",
+      symbol: "ICP",
+      decimals: 8,
+      fee: 10_000n,
+    },
+    [CKUSDC_LEDGER_CANISTER_ID.toText()]: mockCkUSDCToken,
+    [snsLedgerCanisterIdText]: snsToken,
+  };
+
+  const mockTokenAmountV2 = TokenAmountV2.fromUlps({
+    amount: 100_000_000n, // 1 ICP
+    token: ICPToken,
+  });
+
+  describe("tokenPriceStore", () => {
+    beforeEach(() => {
+      Object.entries(mockTokensByLedgerCanisterId).forEach(
+        ([canisterId, token]) => {
+          tokensStore.setToken({
+            canisterId: Principal.fromText(canisterId),
+            token,
+            certified: true,
+          });
+        }
+      );
+    });
+
+    it("should return undefined when icpSwapUsdPricesStore is undefined", () => {
+      icpSwapTickersStore.set([]);
+
+      const store = tokenPriceStore(mockTokenAmountV2);
+      expect(get(store)).toBeUndefined();
+    });
+
+    it("should return undefined when icpSwapUsdPricesStore is 'error'", () => {
+      icpSwapTickersStore.set("error");
+
+      const store = tokenPriceStore(mockTokenAmountV2);
+      expect(get(store)).toBeUndefined();
+    });
+
+    it("should return undefined when ledger canister ID is not found", () => {
+      const ckusdcTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        last_price: "12.4",
+      };
+      icpSwapTickersStore.set([ckusdcTicker]);
+
+      const unknownTokenAmount = TokenAmountV2.fromUlps({
+        amount: 100_000_000n,
+        token: { name: "Unknown", symbol: "UNK", decimals: 8 },
+      });
+
+      const store = tokenPriceStore(unknownTokenAmount);
+      expect(get(store)).toBeUndefined();
+    });
+
+    it("should return ICP price for ICP token", () => {
+      const ckusdcTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        last_price: "12.4",
+      };
+      icpSwapTickersStore.set([ckusdcTicker]);
+
+      const store = tokenPriceStore(mockTokenAmountV2);
+      expect(get(store)).toBe(12.4);
+    });
+
+    it("should return ckUSDC price for ckUSDC token", () => {
+      const ckusdcTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        last_price: "12.4",
+      };
+      icpSwapTickersStore.set([ckusdcTicker]);
+
+      const ckusdcTokenAmount = TokenAmountV2.fromUlps({
+        amount: 100_000_000n,
+        token: mockCkUSDCToken,
+      });
+
+      const store = tokenPriceStore(ckusdcTokenAmount);
+      expect(get(store)).toBe(1.0);
+    });
+
+    it("should return SNS token price when available", () => {
+      setSnsProjects([
+        {
+          rootCanisterId: Principal.fromText(snsRootCanisterIdText),
+          ledgerCanisterId: Principal.fromText(snsLedgerCanisterIdText),
+          tokenMetadata: snsToken,
+        },
+      ]);
+
+      const ckusdcTicker = {
+        ...mockIcpSwapTicker,
+        base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
+        last_price: "12.4",
+      };
+      const snsTicker = {
+        ...mockIcpSwapTicker,
+        base_id: snsLedgerCanisterIdText,
+        last_price: "0.1",
+      };
+      icpSwapTickersStore.set([ckusdcTicker, snsTicker]);
+
+      const snsTokenAmount = TokenAmountV2.fromUlps({
+        amount: 100_000_000n,
+        token: snsToken,
+      });
+
+      const store = tokenPriceStore(snsTokenAmount);
+      expect(get(store)).toBe(124.0); // 12.4 / 0.1
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

#6601 introduced fiat values in transaction forms. The follow-up step in the transaction wizard modal, the Review step, should also display fiat values. This PR extracts a derived store to get the token price and reuse it through all the different components that need this information to render fiat value.

[NNS1-3756](https://dfinity.atlassian.net/browse/NNS1-3756)

# Changes

- New derived store to obtain the token price based on a token's canister ID.

# Tests

- Unit tests for the new store.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3756]: https://dfinity.atlassian.net/browse/NNS1-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ