### PR TITLE
fix(responsive): resolve card overflow on mobile devices

### DIFF
--- a/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
+++ b/frontend/src/lib/components/portfolio/NewSnsProposalCard.svelte
@@ -158,9 +158,8 @@
           margin: 0;
           padding: 0;
           color: var(--color-text-secondary);
-          max-width: 95%;
 
-          @include text.truncate;
+          @include text.clamp(1);
         }
       }
     }


### PR DESCRIPTION
# Motivation

There is a bug on the Portfolio page that causes the card to overflow the available space when displaying NNS proposals for new SNS on small devices.

Before:

![Screenshot 2025-06-12 at 10 04 29](https://github.com/user-attachments/assets/f6061f7f-8cab-48c3-9f1d-83dcf680d2f4)

After:

![Screenshot 2025-06-12 at 10 01 15](https://github.com/user-attachments/assets/1c2b799f-d285-47d9-aad0-ce19905a817f)

# Changes

- Replaces truncate with clump as it behaves better for this case.

# Tests

- Manually tested.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
