### PR TITLE
fix(validation): clear stake amount error on valid input

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,6 +28,8 @@ proposal is successful, the changes it released will be moved from this file to
 * Fix an issue where SNS neurons that had been disbursed but still had active maturity disbursements were not displayed in the dapp.
 * Fix disburse maturity disabled button width.
 * Fix proposal card display issues on mobile devices
+* Fix staking form error messages not clearing after correction
+
 
 #### Security
 

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -86,6 +86,8 @@
       errorMessage = $i18n.error.amount_not_enough_stake_neuron;
       return;
     }
+
+    errorMessage = undefined;
   })();
 
   let disableButton: boolean;

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -73,10 +73,9 @@
 
   let errorMessage: string | undefined = undefined;
   $: (() => {
-    if (isNullish(amount) || isNullish(account)) {
-      errorMessage = undefined;
-      return;
-    }
+    errorMessage = undefined;
+
+    if (isNullish(amount) || isNullish(account)) return;
 
     if (amount > max) {
       errorMessage = $i18n.error.insufficient_funds;
@@ -86,8 +85,6 @@
       errorMessage = $i18n.error.amount_not_enough_stake_neuron;
       return;
     }
-
-    errorMessage = undefined;
   })();
 
   let disableButton: boolean;

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -208,6 +208,35 @@ describe("NnsStakeNeuronModal", () => {
       ).toBe(en.error.insufficient_funds);
     });
 
+    it("should clear the error if user corrects amount", async () => {
+      const po = await renderComponent({});
+
+      expect(
+        await po.getNnsStakeNeuronPo().getCreateButtonPo().isDisabled()
+      ).toBe(true);
+      expect(await po.getNnsStakeNeuronPo().getAmountInputPo().hasError()).toBe(
+        false
+      );
+
+      await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(100000000);
+
+      expect(
+        await po.getNnsStakeNeuronPo().getCreateButtonPo().isDisabled()
+      ).toBe(true);
+      expect(await po.getNnsStakeNeuronPo().getAmountInputPo().hasError()).toBe(
+        true
+      );
+      expect(
+        await po.getNnsStakeNeuronPo().getAmountInputPo().getErrorMessage()
+      ).toBe(en.error.insufficient_funds);
+
+      await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(10);
+
+      expect(await po.getNnsStakeNeuronPo().getAmountInputPo().hasError()).toBe(
+        false
+      );
+    });
+
     it("should move to update dissolve delay after creating a neuron", async () => {
       const po = await renderComponent({});
 


### PR DESCRIPTION
# Motivation

The Staking form input validation doesn't reset the error message once the user corrects the provided amount.

Before:

https://github.com/user-attachments/assets/c04cceae-c0be-426c-9fcc-506e9c399dd0

After: 

https://github.com/user-attachments/assets/00c44243-3db9-405f-99eb-cee51a974829

# Changes

- Reset error message if no error condition is met.

# Tests

- Unit test to cover the flow.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
