### PR TITLE
fix(transactions): resolve duplicate content rendering

### DIFF
--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -189,8 +189,9 @@
         <slot name="description" />
       {/snippet}
       {#snippet receivedAmount()}
-        <slot name="received-amount" />
-        <TransactionReceivedAmount amount={amount!} {token} />
+        <slot name="received-amount">
+          <TransactionReceivedAmount amount={amount!} {token} />
+        </slot>
       {/snippet}
     </TransactionReview>
   {/if}


### PR DESCRIPTION
# Motivation

#6946 introduced a [bug](https://github.com/dfinity/nns-dapp/pull/6946/files#diff-935873ba23201df42a1b8c0aa09851f9e7898c3b7c6d8f199740b353be690789L185) by migrating a slot with a default value into a snippet was rendering both the slot and a default value. 

[NNS1-3756](https://dfinity.atlassian.net/browse/NNS1-3756)

| Before | After |
|--------|--------|
| <img width="643" alt="Screenshot 2025-06-16 at 18 26 52" src="https://github.com/user-attachments/assets/12b9b35d-78e8-410f-b0c5-a8571a97578b" /> |  <img width="639" alt="Screenshot 2025-06-16 at 18 26 26" src="https://github.com/user-attachments/assets/9ddf7725-9294-4df3-abc6-1fcbc68d9c96" /> |

# Changes

- Fix slot rendering with a default value.

# Tests

- Manually tested.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3756]: https://dfinity.atlassian.net/browse/NNS1-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ