### PR TITLE
feat(staking): add fiat value to neuron set dissolve delay 

### DIFF
--- a/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -1,20 +1,27 @@
 <script lang="ts">
+  import { tokenPriceStore } from "$lib/derived/token-price.derived";
   import { startBusyNeuron } from "$lib/services/busy.services";
   import { updateDelay } from "$lib/services/neurons.services";
   import { stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { formatUsdValue } from "$lib/utils/format.utils";
   import {
     formatVotingPower,
     neuronPotentialVotingPower,
     neuronStake,
   } from "$lib/utils/neuron.utils";
-  import { formatTokenE8s } from "$lib/utils/token.utils";
-  import { valueSpan } from "$lib/utils/utils";
-  import { Html, busy } from "@dfinity/gix-components";
+  import { getUsdValue } from "$lib/utils/token.utils";
+  import { busy } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { secondsToDuration } from "@dfinity/utils";
+  import {
+    ICPToken,
+    isNullish,
+    nonNullish,
+    secondsToDuration,
+    TokenAmountV2,
+  } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
+  import AmountDisplay from "../ic/AmountDisplay.svelte";
 
   type Props = {
     delayInSeconds: bigint;
@@ -23,10 +30,21 @@
   };
   const { delayInSeconds, neuron, confirmButtonText }: Props = $props();
 
-  const neuronICP = $derived(neuronStake(neuron));
+  const stake = $derived(
+    TokenAmountV2.fromUlps({
+      amount: neuronStake(neuron),
+      token: ICPToken,
+    })
+  );
+  const priceStore = $derived(tokenPriceStore(stake));
+  const tokenPrice = $derived($priceStore);
+  const stakeInFiat = $derived.by(() => {
+    if (isNullish(stake) || isNullish(tokenPrice)) return undefined;
+    const fiatValue = getUsdValue({ amount: stake, tokenPrice });
+    return nonNullish(fiatValue) ? formatUsdValue(fiatValue) : undefined;
+  });
 
   const dispatcher = createEventDispatcher();
-
   const updateNeuron = async () => {
     startBusyNeuron({ initiator: "update-delay", neuronId: neuron.neuronId });
 
@@ -39,9 +57,7 @@
 
     stopBusy("update-delay");
 
-    if (neuronId !== undefined) {
-      dispatcher("nnsUpdated");
-    }
+    if (nonNullish(neuronId !== undefined)) dispatcher("nnsUpdated");
   };
 </script>
 
@@ -55,14 +71,16 @@
   </div>
   <div>
     <p class="label">{$i18n.neurons.neuron_balance}</p>
-    <p>
-      <Html
-        text={replacePlaceholders($i18n.neurons.amount_icp_stake, {
-          $amount: valueSpan(
-            formatTokenE8s({ value: neuronICP, detailed: true })
-          ),
-        })}
-      />
+    <p data-tid="neuron-stake" class="value">
+      <AmountDisplay
+        amount={stake}
+        singleLine
+        detailed
+      />{#if nonNullish(stakeInFiat)}
+        <span class="fiat" data-tid="fiat-value">
+          (~{stakeInFiat})
+        </span>
+      {/if}
     </p>
   </div>
   <div class="voting-power">
@@ -111,5 +129,15 @@
 
   .voting-power {
     flex-grow: 1;
+  }
+
+  .value {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+
+    .fiat {
+      color: var(--text-description);
+    }
   }
 </style>

--- a/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { tokenPriceStore } from "$lib/derived/token-price.derived";
   import { startBusyNeuron } from "$lib/services/busy.services";
   import { updateDelay } from "$lib/services/neurons.services";
@@ -21,7 +22,6 @@
     TokenAmountV2,
   } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
-  import AmountDisplay from "../ic/AmountDisplay.svelte";
 
   type Props = {
     delayInSeconds: bigint;

--- a/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
@@ -1,20 +1,27 @@
 <script lang="ts">
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import Hash from "$lib/components/ui/Hash.svelte";
   import { snsParametersStore } from "$lib/derived/sns-parameters.derived";
+  import { tokenPriceStore } from "$lib/derived/token-price.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { formatUsdValue } from "$lib/utils/format.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import {
     getSnsNeuronIdAsHexString,
     getSnsNeuronStake,
     snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
-  import { formatTokenE8s } from "$lib/utils/token.utils";
-  import { valueSpan } from "$lib/utils/utils";
-  import { Html, busy } from "@dfinity/gix-components";
+  import { getUsdValue } from "$lib/utils/token.utils";
+  import { busy } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { nonNullish, secondsToDuration, type Token } from "@dfinity/utils";
+  import {
+    isNullish,
+    nonNullish,
+    secondsToDuration,
+    TokenAmountV2,
+    type Token,
+  } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
   type Props = {
@@ -26,7 +33,12 @@
 
   const { rootCanisterId, neuron, token, delayInSeconds }: Props = $props();
 
-  const neuronStake = $derived(getSnsNeuronStake(neuron));
+  const neuronStake = $derived(
+    TokenAmountV2.fromUlps({
+      amount: getSnsNeuronStake(neuron),
+      token,
+    })
+  );
   const neuronId = $derived(getSnsNeuronIdAsHexString(neuron));
   const snsParameters = $derived(
     $snsParametersStore[rootCanisterId.toText()]?.parameters
@@ -40,6 +52,14 @@
         })
       : undefined
   );
+
+  const priceStore = $derived(tokenPriceStore(neuronStake));
+  const tokenPrice = $derived($priceStore);
+  const neuronStakeInFiat = $derived.by(() => {
+    if (isNullish(neuronStake) || isNullish(tokenPrice)) return undefined;
+    const fiatValue = getUsdValue({ amount: neuronStake, tokenPrice });
+    return nonNullish(fiatValue) ? formatUsdValue(fiatValue) : undefined;
+  });
 
   const dispatcher = createEventDispatcher();
 </script>
@@ -56,15 +76,16 @@
   </div>
   <div>
     <p class="label">{$i18n.neurons.neuron_balance}</p>
-    <p data-tid="neuron-stake">
-      <Html
-        text={replacePlaceholders($i18n.sns_neurons.token_stake, {
-          $amount: valueSpan(
-            formatTokenE8s({ value: neuronStake, detailed: true })
-          ),
-          $token: token.symbol,
-        })}
-      />
+    <p data-tid="neuron-stake" class="value">
+      <AmountDisplay
+        amount={neuronStake}
+        singleLine
+        detailed
+      />{#if nonNullish(neuronStakeInFiat)}
+        <span class="fiat" data-tid="fiat-value">
+          (~{neuronStakeInFiat})
+        </span>
+      {/if}
     </p>
   </div>
   <div class="voting-power">
@@ -111,5 +132,15 @@
 
   .voting-power {
     flex-grow: 1;
+  }
+
+  .value {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+
+    .fiat {
+      color: var(--text-description);
+    }
   }
 </style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -952,7 +952,6 @@
     "stake_sns_neuron": "Stake $tokenSymbol",
     "sns_neuron_destination": "Subaccount of",
     "stake_sns_neuron_success": "$tokenSymbol Neuron created successfully.",
-    "token_stake": "$amount $token",
     "min_dissolve_delay_description": "Voting power is given to neurons with a dissolve delay of at least $duration."
   },
   "responsive_table": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -379,7 +379,7 @@
     "age": "Age",
     "vestion_period": "Remaining vesting period",
     "neuron_id": "Neuron ID",
-    "neuron_balance": "Balance",
+    "neuron_balance": "Staked Balance",
     "current_dissolve_delay": "Current Dissolve Delay",
     "dissolve_delay_title": "Dissolve Delay",
     "no_delay": "0",
@@ -952,7 +952,7 @@
     "stake_sns_neuron": "Stake $tokenSymbol",
     "sns_neuron_destination": "Subaccount of",
     "stake_sns_neuron_success": "$tokenSymbol Neuron created successfully.",
-    "token_stake": "$amount $token Stake",
+    "token_stake": "$amount $token",
     "min_dissolve_delay_description": "Voting power is given to neurons with a dissolve delay of at least $duration."
   },
   "responsive_table": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -990,7 +990,6 @@ interface I18nSns_neurons {
   stake_sns_neuron: string;
   sns_neuron_destination: string;
   stake_sns_neuron_success: string;
-  token_stake: string;
   min_dissolve_delay_description: string;
 }
 

--- a/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
@@ -2,7 +2,7 @@ import ConfirmSnsDissolveDelay from "$lib/components/sns-neurons/ConfirmSnsDisso
 import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { ConfirmSnsDissolveDelayPo } from "$tests/page-objects/ConfirmSnsDissolveDelay.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
@@ -98,17 +98,30 @@ describe("ConfirmSnsDissolveDelay", () => {
   });
 
   it("renders the fiat value together with the neuron stake", async () => {
+    const rootCanisterId = principal(2);
+    const ledgerCanisterId = principal(3);
+    const tokenSymbol = "ZZZ";
+    setSnsProjects([
+      {
+        rootCanisterId,
+        ledgerCanisterId,
+        tokenMetadata: {
+          symbol: tokenSymbol,
+          name: "Token",
+          decimals: 8,
+        },
+      },
+    ]);
     setIcpSwapUsdPrices({
-      [mockPrincipal.toText()]: 10,
+      [ledgerCanisterId.toText()]: 0.1,
     });
 
     const neuron = createMockSnsNeuron({
       stake: 12_300_000_000n,
     });
-    const tokenSymbol = "ZZZ";
     const po = renderComponent({
       props: {
-        rootCanisterId: mockPrincipal,
+        rootCanisterId,
         delayInSeconds,
         neuron,
         token: {
@@ -118,7 +131,7 @@ describe("ConfirmSnsDissolveDelay", () => {
       },
     });
 
-    expect(await po.getNeuronStake()).toBe("123.00 ZZZ(~$123.00)");
+    expect(await po.getNeuronStake()).toBe("123.00 ZZZ(~$12.30)");
   });
 
   it("renders voting power", async () => {

--- a/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
@@ -5,6 +5,7 @@ import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { ConfirmSnsDissolveDelayPo } from "$tests/page-objects/ConfirmSnsDissolveDelay.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import { NeuronState } from "@dfinity/nns";
@@ -93,7 +94,31 @@ describe("ConfirmSnsDissolveDelay", () => {
       },
     });
 
-    expect(await po.getNeuronStake()).toBe("123.00 ZZZ Stake");
+    expect(await po.getNeuronStake()).toBe("123.00 ZZZ");
+  });
+
+  it("renders the fiat value together with the neuron stake", async () => {
+    setIcpSwapUsdPrices({
+      [mockPrincipal.toText()]: 10,
+    });
+
+    const neuron = createMockSnsNeuron({
+      stake: 12_300_000_000n,
+    });
+    const tokenSymbol = "ZZZ";
+    const po = renderComponent({
+      props: {
+        rootCanisterId: mockPrincipal,
+        delayInSeconds,
+        neuron,
+        token: {
+          ...mockSnsToken,
+          symbol: tokenSymbol,
+        },
+      },
+    });
+
+    expect(await po.getNeuronStake()).toBe("123.00 ZZZ(~$123.00)");
   });
 
   it("renders voting power", async () => {

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -294,7 +294,20 @@ describe("NnsStakeNeuronModal", () => {
       await runResolvedPromises();
 
       expect(await po.getSetDissolveDelayPo().getNeuronStake()).toBe(
-        "2.20 ICP Stake"
+        "2.20 ICP"
+      );
+    });
+
+    it("should show the fiat value side to the stake of the new neuron in the dissolve modal", async () => {
+      setIcpPrice(10);
+      const po = await renderComponent({});
+
+      await po.getNnsStakeNeuronPo().getAmountInputPo().enterAmount(2.2);
+      await po.getNnsStakeNeuronPo().clickCreate();
+      await runResolvedPromises();
+
+      expect(await po.getSetDissolveDelayPo().getNeuronStake()).toBe(
+        "2.20 ICP(~$22.00)"
       );
     });
 


### PR DESCRIPTION
# Motivation

To assist users during the neuron stake process, the dapp will display fiat values alongside the token amount. This PR sows the fiat value of the staked amount.

| Before | After |
|--------|--------|
| ![Screenshot 2025-06-17 at 07 56 51](https://github.com/user-attachments/assets/56ae342f-9fee-450a-ba93-d502f9511c42) | <img width="665" alt="Screenshot 2025-06-17 at 13 38 58" src="https://github.com/user-attachments/assets/7be9374b-6226-46bd-b52a-4f45236482da" /> |
| <img width="648" alt="Screenshot 2025-06-17 at 14 39 16" src="https://github.com/user-attachments/assets/9d6ed1ed-eebf-4002-aa24-d09b7c94d96e" /> | <img width="641" alt="Screenshot 2025-06-17 at 14 39 32" src="https://github.com/user-attachments/assets/6b84ca65-a808-4166-8a3d-2d7bbd554e23" /> |

[NNS1-3756](https://dfinity.atlassian.net/browse/NNS1-3756)

# Changes

- Change labels
- Add fiat value neben the token value.

# Tests

- Updated tests for the new value.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3756]: https://dfinity.atlassian.net/browse/NNS1-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ