### PR TITLE
feat(analytics): expose manual page view tracking method

### DIFF
--- a/frontend/src/lib/services/analytics.services.ts
+++ b/frontend/src/lib/services/analytics.services.ts
@@ -27,4 +27,11 @@ export const analytics = {
       console.error("plausible event:", error);
     }
   },
+  pageView: (url: string) => {
+    try {
+      tracker?.trackPageview({ url });
+    } catch (error) {
+      console.error("plausible pageview:", error);
+    }
+  },
 };

--- a/frontend/src/tests/lib/services/analytics.services.spec.ts
+++ b/frontend/src/tests/lib/services/analytics.services.spec.ts
@@ -4,12 +4,14 @@ vi.mock("plausible-tracker", () => {
   const enableAutoPageviews = vi.fn(() => () => {});
   const enableAutoOutboundTracking = vi.fn(() => () => {});
   const trackEvent = vi.fn();
+  const trackPageview = vi.fn();
 
   return {
     default: vi.fn(() => ({
       enableAutoPageviews,
       enableAutoOutboundTracking,
       trackEvent,
+      trackPageview,
     })),
   };
 });
@@ -92,6 +94,25 @@ describe("analytics service", () => {
     analytics.event("test-event-with-props", eventProps);
     expect(tracker.trackEvent).toHaveBeenCalledWith("test-event-with-props", {
       props: eventProps,
+    });
+  });
+
+  it("should track custom page views", async () => {
+    vi.doMock("$lib/utils/env-vars.utils", () => ({
+      getEnvVars: getEnvVarsFactory("some-domain"),
+    }));
+
+    const { initAnalytics, analytics } = await import(
+      "$lib/services/analytics.services"
+    );
+
+    const tracker = Plausible();
+    initAnalytics();
+    const pageToTrack = "/test-page";
+
+    analytics.pageView(pageToTrack);
+    expect(tracker.trackPageview).toHaveBeenCalledWith({
+      url: pageToTrack,
     });
   });
 });


### PR DESCRIPTION
# Motivation

Plausible Analytics does not track query parameters. The nns-dapp uses query parameters for nested pages like `projects`, `universes`, and `proposals`.

This PR introduces a new method in the analytics object to manually track page views by calling [TrackPageview](https://plausible-tracker.netlify.app/globals#trackpageview).

[NNS1-3874](https://dfinity.atlassian.net/browse/NNS1-3874)

# Changes

- Method to track page views

# Tests

- Unit test for the new method.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3874]: https://dfinity.atlassian.net/browse/NNS1-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ