### PR TITLE
Remove sns topics highlight

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1294,9 +1294,5 @@
     "new_sns_proposal_card_reject": "Reject",
     "next_card": "Next Card",
     "previous_card": "Previous Card"
-  },
-  "highlight": {
-    "topics_feature_title": "New feature ",
-    "topics_feature_description": "As an SNS DAO member, you can now delegate your voting power based on proposal topics. Find the new feature in your SNS neuron detail view."
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1364,11 +1364,6 @@ interface I18nPortfolio {
   previous_card: string;
 }
 
-interface I18nHighlight {
-  topics_feature_title: string;
-  topics_feature_description: string;
-}
-
 interface I18nNeuron_state {
   Unspecified: string;
   Locked: string;
@@ -1663,7 +1658,6 @@ interface I18n {
   tokens: I18nTokens;
   import_token: I18nImport_token;
   portfolio: I18nPortfolio;
-  highlight: I18nHighlight;
   neuron_state: I18nNeuron_state;
   topics: I18nTopics;
   topics_description: I18nTopics_description;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import Alfred from "$lib/components/alfred/Alfred.svelte";
-  import Highlight from "$lib/components/ui/Highlight.svelte";
-  import { authSignedInStore } from "$lib/derived/auth.derived";
   import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
   import { initAnalytics } from "$lib/services/analytics.services";
   import {
@@ -9,8 +7,6 @@
     type AuthWorker,
   } from "$lib/services/worker-auth.services";
   import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
-  import { ENABLE_SNS_TOPICS } from "$lib/stores/feature-flags.store";
-  import { i18n } from "$lib/stores/i18n";
   import { toastsClean } from "$lib/stores/toasts.store";
   import { onMount } from "svelte";
 
@@ -53,16 +49,6 @@
 </script>
 
 <Alfred />
-
-{#if $ENABLE_SNS_TOPICS && $authSignedInStore}
-  <Highlight
-    level="info"
-    title={$i18n.highlight.topics_feature_title}
-    description={$i18n.highlight.topics_feature_description}
-    link="https://internetcomputer.org/docs/building-apps/governing-apps/nns/using-the-nns-dapp/nns-dapp-sns-topic-following"
-    id="topics-feature"
-  />
-{/if}
 
 <slot />
 

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -1,7 +1,6 @@
 import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
 import * as analytics from "$lib/services/analytics.services";
 import { initAuthWorker } from "$lib/services/worker-auth.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import App from "$routes/+layout.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { HighlightPo } from "$tests/page-objects/Highlight.page-object";
@@ -86,19 +85,5 @@ describe("Layout", () => {
     const po = HighlightPo.under(new JestPageObjectElement(container));
 
     expect(await po.isPresent()).toBe(false);
-  });
-
-  it("should show the Highlight component if the user is signed in and the feature is on", async () => {
-    const renderComponent = () => {
-      const { container } = render(App);
-      return HighlightPo.under(new JestPageObjectElement(container));
-    };
-
-    setNoIdentity();
-    expect(await renderComponent().isPresent()).toBe(false);
-
-    resetIdentity();
-    overrideFeatureFlagsStore.setFlag("ENABLE_SNS_TOPICS", true);
-    expect(await renderComponent().isPresent()).toBe(true);
   });
 });


### PR DESCRIPTION
# Motivation

The SNS topics highlight was introduced some time ago ([PR #6766](https://github.com/dfinity/nns-dapp/pull/6766)). At this point, it’s reasonable to assume that most users have seen it, so this PR removes the highlight from the page.

# Changes

- Removed the SNS topics highlight.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
