### PR TITLE
feat(analytics): add project name sluggification util

### DIFF
--- a/frontend/src/lib/utils/analytics.utils.ts
+++ b/frontend/src/lib/utils/analytics.utils.ts
@@ -1,0 +1,8 @@
+export const slugifyTitle = (title: string) =>
+  title
+    .replace(/([a-z])([A-Z])/g, "$1-$2") // Add hyphen before capital letters
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "") // Remove special characters
+    .replace(/[\s_-]+/g, "-") // Replace spaces and underscores with hyphens
+    .replace(/^-+|-+$/g, ""); // Remove leading/trailing hyphens

--- a/frontend/src/tests/lib/utils/analytics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/analytics.utils.spec.ts
@@ -1,0 +1,22 @@
+import {
+  slugifyTitle,
+} from "$lib/utils/analytics.utils";
+describe("analytics.utils", () => {
+  describe("slugifyTitle", () => {
+    it("should convert camelCase to kebab-case", () => {
+      expect(slugifyTitle("ckBTC")).toBe("ck-btc");
+    });
+
+    it("should remove special characters", () => {
+      expect(slugifyTitle("c@#kBTC")).toBe("ck-btc");
+    });
+
+    it("should replace spaces with hyphens", () => {
+      expect(slugifyTitle("Internet Computer")).toBe("internet-computer");
+    });
+
+    it("should remove leading and trailing hyphens", () => {
+      expect(slugifyTitle("-Internet Computer ")).toBe("internet-computer");
+    });
+  });
+});

--- a/frontend/src/tests/lib/utils/analytics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/analytics.utils.spec.ts
@@ -1,6 +1,5 @@
-import {
-  slugifyTitle,
-} from "$lib/utils/analytics.utils";
+import { slugifyTitle } from "$lib/utils/analytics.utils";
+
 describe("analytics.utils", () => {
   describe("slugifyTitle", () => {
     it("should convert camelCase to kebab-case", () => {


### PR DESCRIPTION
# Motivation

Plausible Analytics does not track query parameters. The nns-dapp uses query parameters for nested pages like `projects`, `universes`, and `proposals`.

This PR introduces a utility that sluggifies universe and project names, making them easier to read in the report.

Some examples:
* ckBTC -> ck-btc
* ckUSDC -> ck-usdc
* Internet Computer -> internet-computer

[NNS1-3874](https://dfinity.atlassian.net/browse/NNS1-3874)

# Changes

- New utility to sluggify a project name.

# Tests

- Unit tests for the new util.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3874]: https://dfinity.atlassian.net/browse/NNS1-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ