### PR TITLE
feat(store): add project slug derived store

### DIFF
--- a/frontend/src/lib/derived/analytics.derived.ts
+++ b/frontend/src/lib/derived/analytics.derived.ts
@@ -3,7 +3,11 @@ import { universesStore } from "$lib/derived/universes.derived";
 import { slugifyTitle } from "$lib/utils/analytics.utils";
 import { derived } from "svelte/store";
 
-export const getMapOfUniversesToProjectSlug = derived(
+/**
+ * This derived store creates a mapping of projects and universe canister IDs to slugs.
+ * As the universeStore contains some of the projects, we ensure that a universe doesn't already exist on the map before adding it.
+ */
+export const projectSlugMapStore = derived(
   [universesStore, snsProjectsActivePadStore],
   ([$universesStore, $snsProjectsActivePadStore]) => {
     const universeToProjectSlugMap = new Map<string, string>();

--- a/frontend/src/lib/derived/analytics.derived.ts
+++ b/frontend/src/lib/derived/analytics.derived.ts
@@ -1,0 +1,29 @@
+import { snsProjectsActivePadStore } from "$lib/derived/sns/sns-projects.derived";
+import { universesStore } from "$lib/derived/universes.derived";
+import { slugifyTitle } from "$lib/utils/analytics.utils";
+import { derived } from "svelte/store";
+
+export const getMapOfUniversesToProjectSlug = derived(
+  [universesStore, snsProjectsActivePadStore],
+  ([$universesStore, $snsProjectsActivePadStore]) => {
+    const universeToProjectSlugMap = new Map<string, string>();
+
+    $snsProjectsActivePadStore.forEach((project) => {
+      universeToProjectSlugMap.set(
+        project.rootCanisterId.toText(),
+        slugifyTitle(project.summary.metadata.name)
+      );
+    });
+
+    $universesStore.forEach((universe) => {
+      if (universeToProjectSlugMap.has(universe.canisterId)) return;
+
+      universeToProjectSlugMap.set(
+        universe.canisterId,
+        slugifyTitle(universe.title)
+      );
+    });
+
+    return universeToProjectSlugMap;
+  }
+);

--- a/frontend/src/tests/lib/derived/analytics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/analytics.derived.spec.ts
@@ -1,0 +1,40 @@
+import {
+  CKBTC_LEDGER_CANISTER_ID,
+  CKTESTBTC_LEDGER_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
+import { getMapOfUniversesToProjectSlug } from "$lib/derived/analytics.derived";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { get } from "svelte/store";
+import { describe, expect, it } from "vitest";
+
+describe("getMapOfUniversesToProjectSlug", () => {
+  it("should have base universes", () => {
+    const map = get(getMapOfUniversesToProjectSlug);
+
+    // IC universe Id
+    expect(map.get("qhbym-qaaaa-aaaaa-aaafq-cai")).toBe("internet-computer");
+    expect(map.get(CKBTC_LEDGER_CANISTER_ID.toText())).toBe("ck-btc");
+    expect(map.get(CKTESTBTC_LEDGER_CANISTER_ID.toText())).toBe("ck-testbtc");
+  });
+
+  it("should map SNS projects' root canister IDs to slugified names", () => {
+    const rootCanisterId1 = principal(1);
+    const rootCanisterId2 = principal(2);
+
+    setSnsProjects([
+      {
+        rootCanisterId: rootCanisterId1,
+        projectName: "Project One",
+      },
+      {
+        rootCanisterId: rootCanisterId2,
+        projectName: "Project Two",
+      },
+    ]);
+    const map = get(getMapOfUniversesToProjectSlug);
+
+    expect(map.get(rootCanisterId1.toText())).toBe("project-one");
+    expect(map.get(rootCanisterId2.toText())).toBe("project-two");
+  });
+});

--- a/frontend/src/tests/lib/derived/analytics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/analytics.derived.spec.ts
@@ -2,7 +2,7 @@ import {
   CKBTC_LEDGER_CANISTER_ID,
   CKTESTBTC_LEDGER_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import { getMapOfUniversesToProjectSlug } from "$lib/derived/analytics.derived";
+import { projectSlugMapStore } from "$lib/derived/analytics.derived";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 
 describe("getMapOfUniversesToProjectSlug", () => {
   it("should have base universes", () => {
-    const map = get(getMapOfUniversesToProjectSlug);
+    const map = get(projectSlugMapStore);
 
     // IC universe Id
     expect(map.get("qhbym-qaaaa-aaaaa-aaafq-cai")).toBe("internet-computer");
@@ -32,7 +32,7 @@ describe("getMapOfUniversesToProjectSlug", () => {
         projectName: "Project Two",
       },
     ]);
-    const map = get(getMapOfUniversesToProjectSlug);
+    const map = get(projectSlugMapStore);
 
     expect(map.get(rootCanisterId1.toText())).toBe("project-one");
     expect(map.get(rootCanisterId2.toText())).toBe("project-two");


### PR DESCRIPTION
# Motivation

Plausible Analytics does not track query parameters. The nns-dapp uses query parameters for nested pages like `projects`, `universes`, and `proposals`.

This PR introduces a new derived store to get a map of universes/projects and slugs.

[NNS1-3874](https://dfinity.atlassian.net/browse/NNS1-3874)

# Changes

- New derived store.

# Tests

- Unit tests for the new store.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3874]: https://dfinity.atlassian.net/browse/NNS1-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ