### PR TITLE
feat(analytics): add path parameter fallbacks

### DIFF
--- a/frontend/src/lib/utils/analytics.utils.ts
+++ b/frontend/src/lib/utils/analytics.utils.ts
@@ -13,6 +13,15 @@ export const slugifyTitle = (title: string) =>
     .replace(/[\s_-]+/g, "-") // Replace spaces and underscores with hyphens
     .replace(/^-+|-+$/g, ""); // Remove leading/trailing hyphens
 
+const buildUrl = (
+  url: string,
+  projectsToSlugMap: Map<string, string>,
+  parameter: string | null
+) =>
+  parameter
+    ? `${url}/${projectsToSlugMap.get(parameter) ?? parameter}`
+    : `${url}/`;
+
 /**
  * Transforms query parameter URLs into clean, readable URLs for analytics tracking
  */
@@ -27,33 +36,25 @@ export const transformUrlForAnalytics = (
     case AppPath.Project + "/":
     case AppPath.Project: {
       const project = searchParams.get(PROJECT_PARAM);
-      return project
-        ? `${AppPath.Project}/${projectsToSlugMap.get(project) ?? project}`
-        : pathname;
+      return buildUrl(AppPath.Project, projectsToSlugMap, project);
     }
 
     case AppPath.Neuron + "/":
     case AppPath.Neuron: {
       const universe = searchParams.get(UNIVERSE_PARAM);
-      return universe
-        ? `${AppPath.Neuron}/${projectsToSlugMap.get(universe) ?? universe}`
-        : pathname;
+      return buildUrl(AppPath.Neuron, projectsToSlugMap, universe);
     }
 
     case AppPath.Neurons + "/":
     case AppPath.Neurons: {
       const universe = searchParams.get(UNIVERSE_PARAM);
-      return universe
-        ? `${AppPath.Neurons}/${projectsToSlugMap.get(universe) ?? universe}`
-        : pathname;
+      return buildUrl(AppPath.Neurons, projectsToSlugMap, universe);
     }
 
     case AppPath.Wallet + "/":
     case AppPath.Wallet: {
       const universe = searchParams.get(UNIVERSE_PARAM);
-      return universe
-        ? `${AppPath.Wallet}/${projectsToSlugMap.get(universe) ?? universe}`
-        : pathname;
+      return buildUrl(AppPath.Wallet, projectsToSlugMap, universe);
     }
 
     default:

--- a/frontend/src/lib/utils/analytics.utils.ts
+++ b/frontend/src/lib/utils/analytics.utils.ts
@@ -28,7 +28,7 @@ export const transformUrlForAnalytics = (
     case AppPath.Project: {
       const project = searchParams.get(PROJECT_PARAM);
       return project
-        ? `${AppPath.Project}/${projectsToSlugMap.get(project)}`
+        ? `${AppPath.Project}/${projectsToSlugMap.get(project) ?? project}`
         : pathname;
     }
 
@@ -36,7 +36,7 @@ export const transformUrlForAnalytics = (
     case AppPath.Neurons: {
       const universe = searchParams.get(UNIVERSE_PARAM);
       return universe
-        ? `${AppPath.Neurons}/${projectsToSlugMap.get(universe)}`
+        ? `${AppPath.Neurons}/${projectsToSlugMap.get(universe) ?? universe}`
         : pathname;
     }
 
@@ -44,7 +44,7 @@ export const transformUrlForAnalytics = (
     case AppPath.Wallet: {
       const universe = searchParams.get(UNIVERSE_PARAM);
       return universe
-        ? `${AppPath.Wallet}/${projectsToSlugMap.get(universe)}`
+        ? `${AppPath.Wallet}/${projectsToSlugMap.get(universe) ?? universe}`
         : pathname;
     }
 

--- a/frontend/src/lib/utils/analytics.utils.ts
+++ b/frontend/src/lib/utils/analytics.utils.ts
@@ -32,6 +32,14 @@ export const transformUrlForAnalytics = (
         : pathname;
     }
 
+    case AppPath.Neuron + "/":
+    case AppPath.Neuron: {
+      const universe = searchParams.get(UNIVERSE_PARAM);
+      return universe
+        ? `${AppPath.Neuron}/${projectsToSlugMap.get(universe) ?? universe}`
+        : pathname;
+    }
+
     case AppPath.Neurons + "/":
     case AppPath.Neurons: {
       const universe = searchParams.get(UNIVERSE_PARAM);

--- a/frontend/src/tests/lib/utils/analytics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/analytics.utils.spec.ts
@@ -61,7 +61,9 @@ describe("analytics.utils", () => {
 
     describe("Neurons page transformations", () => {
       it("should transform universe parameter", () => {
-        const url = new URL("http://localhost:8080/neurons/project-two");
+        const url = new URL(
+          "http://localhost:8080/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai"
+        );
         const result = transformUrlForAnalytics(url, projectsToSlugMap);
         expect(result).toBe("/neurons/project-two");
       });
@@ -106,6 +108,28 @@ describe("analytics.utils", () => {
         const url = new URL("http://localhost:8080/wallet/?u=");
         const result = transformUrlForAnalytics(url, projectsToSlugMap);
         expect(result).toBe("/wallet/");
+      });
+    });
+
+    describe("Unkown projects", () => {
+      it("should transform project parameter", () => {
+        const url = new URL(
+          "http://localhost:8080/project/?project=ajuq4-ruaaa"
+        );
+        const result = transformUrlForAnalytics(url, projectsToSlugMap);
+        expect(result).toBe("/project/ajuq4-ruaaa");
+      });
+
+      it("should transform universe parameter", () => {
+        const url = new URL("http://localhost:8080/neurons/?u=qsgjb-riaaa");
+        const result = transformUrlForAnalytics(url, projectsToSlugMap);
+        expect(result).toBe("/neurons/qsgjb-riaaa");
+      });
+
+      it("should leave the canisterId if universe is not known", () => {
+        const url = new URL("http://localhost:8080/wallet/?u=bd3sg-teaaa");
+        const result = transformUrlForAnalytics(url, projectsToSlugMap);
+        expect(result).toBe("/wallet/bd3sg-teaaa");
       });
     });
 

--- a/frontend/src/tests/lib/utils/analytics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/analytics.utils.spec.ts
@@ -49,7 +49,7 @@ describe("analytics.utils", () => {
         );
         expect(
           transformUrlForAnalytics(urlWithoutTrailingSlash, projectsToSlugMap)
-        ).toBe("/project");
+        ).toBe("/project/");
       });
 
       it("should return original pathname when project parameter is empty", () => {

--- a/frontend/src/tests/lib/utils/analytics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/analytics.utils.spec.ts
@@ -89,6 +89,24 @@ describe("analytics.utils", () => {
       });
     });
 
+    describe("Neuron page transformations", () => {
+      it("should transform universe parameter", () => {
+        const url = new URL(
+          "http://localhost:8080/neuron/?u=qsgjb-riaaa-aaaaa-aaaga-cai"
+        );
+        const result = transformUrlForAnalytics(url, projectsToSlugMap);
+        expect(result).toBe("/neuron/project-two");
+      });
+
+      it("should not track neuron parameter", () => {
+        const url = new URL(
+          "http://localhost:8080/neuron/?u=qsgjb-riaaa-aaaaa-aaaga-cai&neuron=12345"
+        );
+        const result = transformUrlForAnalytics(url, projectsToSlugMap);
+        expect(result).toBe("/neuron/project-two");
+      });
+    });
+
     describe("Wallet page transformations", () => {
       it("should transform universe parameter", () => {
         const url = new URL(


### PR DESCRIPTION
# Motivation

Plausible Analytics does not track query parameters. The nns-dapp uses query parameters for nested pages such as `projects`, `universes`, and `proposals`.

#6974 introduced a utility to "translate" the dapp query parameters into user-friendly paths. This PR adds default values to the conversion, so if the project or universe is unknown to the dapp, we will use the `canisterId` as before.

[NNS1-3874](https://dfinity.atlassian.net/browse/NNS1-3874)

# Changes

- Default conversion to original project/universe value.
- Add conversion for `neuron` page.

# Tests

- New tests to cover the default case.
- New tests to cover the `neuron` page.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3874]: https://dfinity.atlassian.net/browse/NNS1-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ