### PR TITLE
fix(modal): resolve close button callback issue

### DIFF
--- a/frontend/src/lib/modals/neurons/FollowNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/FollowNeuronsModal.svelte
@@ -13,7 +13,7 @@
 
 <Modal
   testId="follow-neurons-modal-component"
-  on:nnsClose
+  on:nnsClose={onClose}
   --modal-content-overflow-y="scroll"
 >
   <svelte:fragment slot="title"


### PR DESCRIPTION
# Motivation

#6987 introduced a bug when closing the modal using the X icon. This PR resolves the issue by providing the callback to Gix Modal.

# Changes

- Provide callback to `nnsClose` event emitter.

# Tests

- Manually tested

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
