### PR TITLE
feat(tables): prioritize ICP in token and neuron lists

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Updated and uniformed titles across pages
 * Improved accuracy of proposal voting progress indicators
+* Prioritize ICP in tokens and staking tables
 
 #### Deprecated
 

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -8,6 +8,7 @@
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import UsdValueBanner from "$lib/components/ui/UsdValueBanner.svelte";
+  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
@@ -20,8 +21,8 @@
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { ProjectsTableColumn, TableProject } from "$lib/types/staking";
   import {
-    compareByNeuronCount,
-    compareByProjectTitle,
+    compareByNeuron,
+    compareByProject,
     compareByStake,
     getTableProjects,
     getTotalStakeInUsd,
@@ -42,7 +43,7 @@
       cellComponent: ProjectTitleCell,
       alignment: "left",
       templateColumns: ["minmax(min-content, max-content)"],
-      comparator: compareByProjectTitle,
+      comparator: compareByProject,
     },
     {
       title: "",
@@ -79,7 +80,7 @@
       cellComponent: ProjectNeuronsCell,
       alignment: "right",
       templateColumns: ["max-content"],
-      comparator: compareByNeuronCount,
+      comparator: compareByNeuron,
     },
     {
       title: "",
@@ -105,7 +106,10 @@
 
   let visibleTableProjects: TableProject[] = [];
   $: visibleTableProjects = shouldHideProjectsWithoutNeurons
-    ? tableProjects.filter(({ neuronCount }) => neuronCount ?? 0 > 0)
+    ? tableProjects.filter(
+        ({ neuronCount = 0, universeId }) =>
+          universeId === OWN_CANISTER_ID_TEXT || neuronCount > 0
+      )
     : tableProjects;
 
   let sortedTableProjects: TableProject[];

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -5,11 +5,14 @@
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import type { TokensTableColumn, UserToken } from "$lib/types/tokens-page";
-  import type { TokensTableOrder } from "$lib/types/tokens-page";
+  import type {
+    TokensTableColumn,
+    TokensTableOrder,
+    UserToken,
+  } from "$lib/types/tokens-page";
   import {
-    compareTokensAlphabetically,
     compareTokensByBalance,
+    compareTokensByProject,
   } from "$lib/utils/tokens-table.utils";
 
   export let userTokensData: Array<UserToken>;
@@ -36,7 +39,7 @@
       cellComponent: TokenTitleCell,
       alignment: "left",
       templateColumns: ["1fr"],
-      comparator: enableSorting ? compareTokensAlphabetically : undefined,
+      comparator: enableSorting ? compareTokensByProject : undefined,
     },
     {
       id: "balance",

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -262,9 +262,9 @@ export const compareByProject = mergeComparators([
 // Note that it tries to sort by USD stake but also sorts tokens with neurons
 // above tokens without neurons if there is no exchange rate for that project.
 export const compareByStake = mergeComparators([
+  compareIcpFirst,
   compareByStakeInUsd,
   comparePositiveNeuronsFirst,
-  compareIcpFirst,
 ]);
 
 export const sortTableProjects = (projects: TableProject[]): TableProject[] => {

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -70,6 +70,7 @@ export const compareTokensByProject = mergeComparators([
   compareTokensIcpFirst,
   compareTokensAlphabetically,
 ]);
+
 // This is used when clicking the "Balance" header, but in addition to sorting
 // by balance, it has a number of tie breakers.
 // Note that it tries to sort by USD balance but also sorts tokens with balance
@@ -80,9 +81,9 @@ export const compareTokensByBalance = ({
   importedTokenIds: Set<string>;
 }) =>
   mergeComparators([
+    compareTokensIcpFirst,
     compareTokensByUsdBalance,
     compareTokenHasBalance,
-    compareTokensIcpFirst,
     compareTokensByImportance,
     compareTokensIsImported({ importedTokenIds }),
     compareFailedTokensLast,

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -800,7 +800,7 @@ describe("ProjectsTable", () => {
       vi.advanceTimersByTime(500);
 
       rowPos = await po.getProjectsTableRowPos();
-      expect(rowPos.length).toBe(0);
+      expect(rowPos.length).toBe(1);
       expect(await po.getShowAllButtonPo().isPresent()).toBe(true);
 
       await po.getShowAllButtonPo().click();
@@ -1023,11 +1023,11 @@ describe("ProjectsTable", () => {
     expect(
       await Promise.all(rowPos.map((project) => project.getProjectTitle()))
     ).toEqual([
+      "Internet Computer",
       "D with more USD",
       "C with less USD",
       "B with neurons",
       "Z with neurons",
-      "Internet Computer",
       "A without neurons",
       "X without neurons",
     ]);

--- a/frontend/src/tests/lib/components/tokens/TokensTable.svelte.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.svelte.spec.ts
@@ -503,11 +503,15 @@ describe("TokensTable", () => {
         },
       ]);
       const po = renderTable({
-        userTokensData: [tokenIcp, tokenA],
+        userTokensData: [tokenIcp, tokenB, tokenA],
         orderStore: tokensTableOrderStore,
       });
 
-      expect(await getProjectNames(po)).toEqual(["Internet Computer", "A"]);
+      expect(await getProjectNames(po)).toEqual([
+        "Internet Computer",
+        "B",
+        "A",
+      ]);
 
       tokensTableOrderStore.set([
         {
@@ -516,7 +520,11 @@ describe("TokensTable", () => {
       ]);
       await tick();
 
-      expect(await getProjectNames(po)).toEqual(["A", "Internet Computer"]);
+      expect(await getProjectNames(po)).toEqual([
+        "Internet Computer",
+        "A",
+        "B",
+      ]);
     });
 
     it("should change order store based on clicked header", async () => {

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -199,8 +199,8 @@ describe("Tokens page", () => {
     await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
 
     expect(await po.getTokensTable().getTokenNames()).toEqual([
-      "Positive balance",
       "Internet Computer",
+      "Positive balance",
     ]);
   });
 

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -187,12 +187,12 @@ describe("Tokens page", () => {
     ]);
   });
 
-  it("should not hide ICP even with zero balance", async () => {
+  it("should not hide ICP even with zero balance and should prioritize it", async () => {
     const po = renderPage([icpZeroBalance, positiveBalance]);
 
     expect(await po.getTokensTable().getTokenNames()).toEqual([
-      "Positive balance",
       "Internet Computer",
+      "Positive balance",
     ]);
 
     await po.getSettingsButtonPo().click();

--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -187,11 +187,11 @@ describe("tokens-table.utils", () => {
     const tokenImported = createTokenWithBalance({ id: 5, amount: 0n });
     const tokenNotImported = createTokenWithBalance({ id: 6, amount: 0n });
 
-    it("should compare by balance and tie breaks", () => {
+    it("should compare by ICP, balance and tie breaks", () => {
       const tokens = [
+        tokenIcp,
         tokenWithUsdBalance,
         tokenWithBalanceWithoutUsd,
-        tokenIcp,
         tokenCkbtcWithoutBalance,
         tokenImported,
         failedImportedToken,


### PR DESCRIPTION
# Motivation

The ICP token and ICP neurons should be displayed at the top of the tokens and staking tables. This second PR applies the new comparators and updates the existing ones to always prioritize ICP.

[NNS1-3914](https://dfinity.atlassian.net/browse/NNS1-3914)

# Changes

- Apply new comparators.  
- Refactor existing ones to prioritize ICP.

# Tests

- Update tests.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3914]: https://dfinity.atlassian.net/browse/NNS1-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ