### PR TITLE
fix(proposals): use precise threshold for vote calculations

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Updated and uniformed titles across pages
+* Improved accuracy of proposal voting progress indicators
 
 #### Deprecated
 

--- a/frontend/src/lib/components/proposal-detail/VotesResults.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResults.svelte
@@ -46,7 +46,9 @@
     if (immediateNoMajority) return "failed";
     if (canStillVote) return "default";
 
-    const majority = isCriticalProposalMode ? yes > 2 * no : yes > no;
+    const majority = isCriticalProposalMode
+      ? castVotesYes > immediateMajorityPercent
+      : yes > no;
     return majority ? "success" : "failed";
   };
 

--- a/frontend/src/tests/lib/components/proposal-detail/VotesResults.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotesResults.spec.ts
@@ -310,7 +310,7 @@ describe("VotesResults", () => {
           expect(await po.getMajorityStatus()).toBe("failed");
         });
 
-        it("should render majority success when yes votes are more than double the no votes -> Critical proposal", async () => {
+        it("should render majority 'success' when yes votes exceed immediateMajorityPercent of exercised voting power in critical proposal", async () => {
           const po = renderComponent({
             immediateMajorityPercent: 67,
             standardMajorityPercent: 20,
@@ -320,21 +320,25 @@ describe("VotesResults", () => {
             deadlineTimestampSeconds,
           });
 
-          // yes is 61% and no votes are 30% for a critical proposal
+          // Total exercised votes = 6.1 + 3 = 9.1
+          // Yes percentage = (6.1 / 9.1) * 100 ≈ 67.03%
+          // 67.03% > 67%, so it should return "success"
           expect(await po.getMajorityStatus()).toBe("success");
         });
 
-        it("should render majority success when yes votes are more than double the no votes -> Critical proposal", async () => {
+        it("should render majority 'failed' when yes votes do not exceed immediateMajorityPercent in critical proposal", async () => {
           const po = renderComponent({
             immediateMajorityPercent: 67,
             standardMajorityPercent: 20,
-            yes: 6,
+            yes: 6.02,
             no: 3,
             total: 10,
             deadlineTimestampSeconds,
           });
 
-          // yes is 60% and no votes are 30% for a critical proposal
+          // Total exercised votes = 6.05 + 3 = 9.05
+          // Yes percentage = (6.05 / 9.05) * 100 = 66.85%
+          // 66.85% < 67%, so it should return "failed"
           expect(await po.getMajorityStatus()).toBe("failed");
         });
       });

--- a/frontend/src/tests/lib/components/proposal-detail/VotesResults.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotesResults.spec.ts
@@ -330,7 +330,7 @@ describe("VotesResults", () => {
           const po = renderComponent({
             immediateMajorityPercent: 67,
             standardMajorityPercent: 20,
-            yes: 6.02,
+            yes: 6.05,
             no: 3,
             total: 10,
             deadlineTimestampSeconds,


### PR DESCRIPTION
# Motivation

#6892 introduced an alternative method for displaying voting progression in proposals. It relies on the 2/3 rule, but this is not precise enough. This PR updates the logic to utilize `minimum_yes_proportion_of_exercised`.

[NNS1-3753](https://dfinity.atlassian.net/browse/NNS1-3753)

# Changes

- Update logic.

# Tests

- Improve tests descriptions
- New test case for `2/3 < x < 0.67`

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3753]: https://dfinity.atlassian.net/browse/NNS1-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ