### PR TITLE
Bump next ic js

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,8 +14,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Support for a new SNS action type: `RegisterExtension`.
-
 #### Changed
 
 * Updated and uniformed titles across pages


### PR DESCRIPTION
# Motivation

We want to pull in the latest changes to make new NNS api `setFollowing` available and add  support for a new SNS action type: `RegisterExtension`.

# Changes

* Ran `npm run upgrade:next`

# Tests

* CI should pass
* Tested locally that nns-dapp builds and works.