### PR TITLE
feat(launchpad2): CardList component

### DIFF
--- a/frontend/src/lib/components/launchpad/CardList.svelte
+++ b/frontend/src/lib/components/launchpad/CardList.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { ComponentWithProps } from "$lib/types/svelte";
+
+  type Props = {
+    cards: ComponentWithProps[];
+  };
+  const { cards }: Props = $props();
+</script>
+
+<ul data-tid="card-list-component">
+  {#each cards as { Component, props }}
+    <li data-tid="card-entry">
+      <Component {...props} />
+    </li>
+  {/each}
+</ul>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .card-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+  }
+
+  ul {
+    // reset default styles
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--padding);
+
+    @include media.min-width(medium) {
+      grid-template-columns: repeat(2, 1fr);
+      gap: var(--padding-2x);
+    }
+
+    @include media.min-width(large) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+</style>

--- a/frontend/src/lib/types/svelte.ts
+++ b/frontend/src/lib/types/svelte.ts
@@ -1,0 +1,6 @@
+import type { Component } from "svelte";
+
+export type ComponentWithProps = {
+  Component: Component;
+  props?: Record<string, unknown>;
+};

--- a/frontend/src/tests/lib/components/launchpad/CardList.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/CardList.spec.ts
@@ -1,0 +1,49 @@
+import CardList from "$lib/components/launchpad/CardList.svelte";
+import AdoptedProposalCard from "$lib/components/portfolio/AdoptedProposalCard.svelte";
+import type { ComponentWithProps } from "$lib/types/svelte";
+import { createSummary } from "$tests/mocks/sns-projects.mock";
+import { AdoptedProposalCardPo } from "$tests/page-objects/AdoptedProposalCard.page-object";
+import { CardListPo } from "$tests/page-objects/CardList.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("CardList", () => {
+  const renderComponent = (props: { cards: ComponentWithProps[] }) => {
+    const { container } = render(CardList, { props });
+    return CardListPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render cards", async () => {
+    const projectName1 = "Project 1";
+    const projectName2 = "Project 2";
+    const po = renderComponent({
+      cards: [
+        {
+          Component: AdoptedProposalCard,
+          props: {
+            summary: createSummary({
+              projectName: projectName1,
+            }),
+          },
+        },
+        {
+          Component: AdoptedProposalCard,
+          props: {
+            summary: createSummary({
+              projectName: projectName2,
+            }),
+          },
+        },
+      ],
+    });
+
+    const cardEntries = await po.getCardEntries();
+    expect(cardEntries.length).toBe(2);
+    expect(
+      await AdoptedProposalCardPo.under(cardEntries[0].root).getTitle()
+    ).toBe(projectName1);
+    expect(
+      await AdoptedProposalCardPo.under(cardEntries[1].root).getTitle()
+    ).toBe(projectName2);
+  });
+});

--- a/frontend/src/tests/page-objects/CardList.page-object.ts
+++ b/frontend/src/tests/page-objects/CardList.page-object.ts
@@ -1,0 +1,36 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class CardListPo extends BasePageObject {
+  static readonly TID = "card-list-component";
+
+  static under(element: PageObjectElement): CardListPo {
+    return new CardListPo(element.byTestId(CardListPo.TID));
+  }
+
+  static async allUnder(element: PageObjectElement): Promise<CardListPo[]> {
+    return Array.from(await element.allByTestId(CardListPo.TID)).map(
+      (el) => new CardListPo(el)
+    );
+  }
+
+  getCardEntries(): Promise<CardListEntryPo[]> {
+    return CardListEntryPo.allUnder(this.root);
+  }
+}
+
+export class CardListEntryPo extends BasePageObject {
+  private static readonly TID = "card-entry";
+
+  static under(element: PageObjectElement): CardListEntryPo {
+    return new CardListEntryPo(element.byTestId(CardListEntryPo.TID));
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<CardListEntryPo[]> {
+    return Array.from(await element.allByTestId(CardListEntryPo.TID)).map(
+      (el) => new CardListEntryPo(el)
+    );
+  }
+}


### PR DESCRIPTION
# Motivation

For the Launchpad redesign, a new card list component is required. This PR adds a basic version of the component, which will later be extended with optional horizontal scrolling on mobile.

https://dfinity.atlassian.net/browse/NNS1-3906

# Changes

- New component.

# Tests

- Added.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
