### PR TITLE
refactor(copy): migrate to custom tooltip component

### DIFF
--- a/frontend/src/lib/components/ui/Copy.svelte
+++ b/frontend/src/lib/components/ui/Copy.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { IconCheck, IconCopy } from "@dfinity/gix-components";
+  import { IconCheck, IconCopy, Tooltip } from "@dfinity/gix-components";
 
   type Props = {
     value: string;
@@ -25,20 +25,21 @@
   };
 </script>
 
-<button
-  data-tid="copy-component"
-  onclick={copyToClipboard}
-  aria-label={`${copied ? $i18n.core.copied : $i18n.core.copy}: ${value}`}
-  class:copied
-  disabled={copied}
-  title={copied ? $i18n.core.copied : $i18n.core.copy}
->
-  {#if copied}
-    <IconCheck size="20" />
-  {:else}
-    <IconCopy size="20" />
-  {/if}
-</button>
+<Tooltip text={copied ? $i18n.core.copied : $i18n.core.copy}>
+  <button
+    data-tid="copy-component"
+    onclick={copyToClipboard}
+    aria-label={`${copied ? $i18n.core.copied : $i18n.core.copy}: ${value}`}
+    class:copied
+    disabled={copied}
+  >
+    {#if copied}
+      <IconCheck size="20" />
+    {:else}
+      <IconCopy size="20" />
+    {/if}
+  </button>
+</Tooltip>
 
 <style lang="scss">
   button {


### PR DESCRIPTION
# Motivation

#6901 introduces a new `Copy` component that displays a checkmark in place. This custom component relied on the native tooltip to show text to the user. This PR replaces that tooltip with the project's custom one.

Before:

https://github.com/user-attachments/assets/000a924c-54e8-4224-8d6f-aba395737708

After:

https://github.com/user-attachments/assets/60f374ba-5001-4676-be15-15d00bd6f7be

# Changes

- Replace native tooltip with custom one for consistency.

# Tests

- Manually tested.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
