### PR TITLE
feat(portfolio): add exchange provider fallback handling

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -7,6 +7,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { i18n } from "$lib/stores/i18n";
+  import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
   import type { UserTokenData } from "$lib/types/tokens-page";
   import { formatNumber } from "$lib/utils/format.utils";
   import { shouldShowInfoRow } from "$lib/utils/portfolio.utils";
@@ -107,10 +108,15 @@
               role="cell"
               aria-label={`${heldToken.title} USD: ${heldToken?.balanceInUsd ?? 0}`}
             >
-              $<PrivacyAwareAmount
-                value={formatNumber(heldToken?.balanceInUsd ?? 0)}
-                length={3}
-              />
+              $
+              {#if $icpSwapTickersStore !== "error"}
+                <PrivacyAwareAmount
+                  value={formatNumber(heldToken?.balanceInUsd ?? 0)}
+                  length={3}
+                />
+              {:else}
+                {PRICE_NOT_AVAILABLE_PLACEHOLDER}
+              {/if}
             </div>
           </svelte:element>
         {/each}

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -8,6 +8,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { i18n } from "$lib/stores/i18n";
+  import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
   import type { TableProject } from "$lib/types/staking";
   import { formatNumber } from "$lib/utils/format.utils";
   import { shouldShowInfoRow } from "$lib/utils/portfolio.utils";
@@ -106,10 +107,15 @@
               role="cell"
               aria-label={`${stakedToken.title} USD: ${stakedToken?.stakeInUsd ?? 0}`}
             >
-              $<PrivacyAwareAmount
-                value={formatNumber(stakedToken?.stakeInUsd ?? 0)}
-                length={3}
-              />
+              $
+              {#if $icpSwapTickersStore !== "error"}
+                <PrivacyAwareAmount
+                  value={formatNumber(stakedToken?.stakeInUsd ?? 0)}
+                  length={3}
+                />
+              {:else}
+                {PRICE_NOT_AVAILABLE_PLACEHOLDER}
+              {/if}
             </div>
             <div
               class="stake-native"

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -2,6 +2,7 @@
   import PrivacyAwareAmount from "$lib/components/ui/PrivacyAwareAmount.svelte";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
   import { formatCurrencyNumber } from "$lib/utils/format.utils";
   import { IconRight } from "@dfinity/gix-components";
   import type { Snippet } from "svelte";
@@ -17,7 +18,7 @@
   const { usdAmount, href, title, linkText, icon }: Props = $props();
 
   const usdAmountFormatted = $derived(
-    $authSignedInStore
+    $authSignedInStore && $icpSwapTickersStore !== "error"
       ? formatCurrencyNumber(usdAmount)
       : PRICE_NOT_AVAILABLE_PLACEHOLDER
   );

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -13,6 +13,7 @@
   import StakedTokensCard from "$lib/components/portfolio/StakedTokensCard.svelte";
   import TotalAssetsCard from "$lib/components/portfolio/TotalAssetsCard.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
   import type { TableProject } from "$lib/types/staking";
   import type { UserToken } from "$lib/types/tokens-page";
@@ -43,6 +44,8 @@
     openSnsProposals,
     adoptedSnsProposals,
   }: Props = $props();
+
+  const isExchangeProviderDown = $derived($icpSwapUsdPricesStore === "error");
 
   const totalTokensBalanceInUsd = $derived(getTotalBalanceInUsd(userTokens));
   const hasUnpricedTokens = $derived(
@@ -82,7 +85,7 @@
     userTokens.some((token) => token.balance === "loading")
   );
   const heldTokensCard: TokensCardType = $derived(
-    !$authSignedInStore
+    !$authSignedInStore || isExchangeProviderDown
       ? "full"
       : areHeldTokensLoading
         ? "skeleton"
@@ -95,7 +98,7 @@
     tableProjects.some((project) => project.isStakeLoading)
   );
   const stakedTokensCard: TokensCardType = $derived(
-    !$authSignedInStore
+    !$authSignedInStore || isExchangeProviderDown
       ? "full"
       : areStakedTokensLoading
         ? "skeleton"
@@ -121,6 +124,7 @@
     getTopHeldTokens({
       userTokens: userTokens,
       isSignedIn: $authSignedInStore,
+      areExchangePairsAvailable: !isExchangeProviderDown,
     })
   );
 
@@ -128,6 +132,7 @@
     getTopStakedTokens({
       projects: tableProjects,
       isSignedIn: $authSignedInStore,
+      areExchangePairsAvailable: !isExchangeProviderDown,
     })
   );
 


### PR DESCRIPTION
# Motivation

The exchange provider for the nns-dapp may experience downtime. If this happens, the Portfolio page will display data based on the available information, such as balance and stake in fiat currency. This PR adds a check for the exchange provider's status and displays basic data accordingly.

| Before | After |
|--------|--------|
| <img width="1473" alt="Screenshot 2025-06-27 at 17 12 00" src="https://github.com/user-attachments/assets/bbf8f31a-1d13-4bd4-9141-d23217bcf582" /> | <img width="1476" alt="Screenshot 2025-06-27 at 17 11 10" src="https://github.com/user-attachments/assets/d5a3c396-87b2-415c-9b7e-e7e2e39c72c8" /> | 

# Changes

- Check the status of the exchange provider.  
- Display default data if the provider is down.  
- Use alternative sorting if the provider is down.

# Tests

- ...

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
