### PR TITLE
feat(launchpad2): getUpcomingLaunchesCards util

### DIFF
--- a/frontend/src/lib/utils/launchpad.utils.ts
+++ b/frontend/src/lib/utils/launchpad.utils.ts
@@ -1,0 +1,56 @@
+import AdoptedProposalCard from "$lib/components/portfolio/AdoptedProposalCard.svelte";
+import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
+import NewSnsProposalCard from "$lib/components/portfolio/NewSnsProposalCard.svelte";
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import type { ComponentWithProps } from "$lib/types/svelte";
+import { compareProposalInfoByDeadlineTimestampSeconds } from "$lib/utils/portfolio.utils";
+import {
+  comparesByDecentralizationSaleOpenTimestampDesc,
+  filterProjectsStatus,
+} from "$lib/utils/projects.utils";
+import type { ProposalInfo } from "@dfinity/nns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import type { Component } from "svelte";
+
+export const getUpcomingLaunchesCards = ({
+  snsProjects,
+  openSnsProposals,
+}: {
+  snsProjects: SnsFullProject[];
+  openSnsProposals: ProposalInfo[];
+}): ComponentWithProps[] => {
+  const launchedSnsCards: ComponentWithProps[] = filterProjectsStatus({
+    swapLifecycle: SnsSwapLifecycle.Open,
+    projects: snsProjects,
+  })
+    .sort(comparesByDecentralizationSaleOpenTimestampDesc)
+    .reverse()
+    .map<ComponentWithProps>(({ summary }) => ({
+      Component: LaunchProjectCard as unknown as Component,
+      props: { summary },
+    }));
+
+  const adoptedSnsProposalCards = filterProjectsStatus({
+    swapLifecycle: SnsSwapLifecycle.Adopted,
+    projects: snsProjects,
+  })
+    .sort(comparesByDecentralizationSaleOpenTimestampDesc)
+    .reverse()
+    .map<ComponentWithProps>(({ summary }) => ({
+      Component: AdoptedProposalCard as unknown as Component,
+      props: { summary },
+    }));
+
+  const openProposalCards: ComponentWithProps[] = [...openSnsProposals]
+    .sort(compareProposalInfoByDeadlineTimestampSeconds)
+    .map((proposalInfo) => ({
+      Component: NewSnsProposalCard as unknown as Component,
+      props: { proposalInfo },
+    }));
+
+  return [
+    ...launchedSnsCards,
+    ...openProposalCards,
+    ...adoptedSnsProposalCards,
+  ];
+};

--- a/frontend/src/tests/lib/utils/launchpad.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/launchpad.utils.spec.ts
@@ -1,0 +1,177 @@
+import AdoptedProposalCard from "$lib/components/portfolio/AdoptedProposalCard.svelte";
+import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
+import NewSnsProposalCard from "$lib/components/portfolio/NewSnsProposalCard.svelte";
+import { getUpcomingLaunchesCards } from "$lib/utils/launchpad.utils";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import {
+  createMockSnsFullProject,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
+import { ProposalStatus, Topic, type ProposalInfo } from "@dfinity/nns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+
+describe("Launchpad utils", () => {
+  describe("getUpcomingLaunchesCards", () => {
+    it('ignores not "Open" or "Adopted" sns projects', () => {
+      const abortedSnsProject = createMockSnsFullProject({
+        rootCanisterId: principal(1),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Aborted,
+        },
+      });
+      const committedSnsProject = createMockSnsFullProject({
+        rootCanisterId: principal(2),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Committed,
+        },
+      });
+      const pendingSnsProject = createMockSnsFullProject({
+        rootCanisterId: principal(3),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Pending,
+        },
+      });
+      const cards = getUpcomingLaunchesCards({
+        snsProjects: [
+          abortedSnsProject,
+          committedSnsProject,
+          pendingSnsProject,
+        ],
+        openSnsProposals: [],
+      });
+
+      expect(cards).toEqual([]);
+    });
+
+    it("returns all type of cards", () => {
+      const openSnsProject1 = createMockSnsFullProject({
+        rootCanisterId: principal(1),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Open,
+          swapOpenTimestampSeconds: BigInt(168_000_000),
+          projectName: "Project 1",
+        },
+      });
+      const adoptedSnsProject1 = createMockSnsFullProject({
+        rootCanisterId: principal(2),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Adopted,
+          swapOpenTimestampSeconds: BigInt(168_000_000),
+          projectName: "Project 2",
+        },
+      });
+      const openProposal1: ProposalInfo = {
+        ...mockProposalInfo,
+        deadlineTimestampSeconds: 168_000_000n,
+        topic: Topic.SnsAndCommunityFund,
+        status: ProposalStatus.Open,
+      };
+
+      const cards = getUpcomingLaunchesCards({
+        snsProjects: [openSnsProject1, adoptedSnsProject1],
+        openSnsProposals: [openProposal1],
+      });
+
+      expect(cards.length).toBe(3);
+      expect(cards).toEqual([
+        {
+          Component: LaunchProjectCard,
+          props: { summary: openSnsProject1.summary },
+        },
+        {
+          Component: NewSnsProposalCard,
+          props: { proposalInfo: openProposal1 },
+        },
+        {
+          Component: AdoptedProposalCard,
+          props: { summary: adoptedSnsProject1.summary },
+        },
+      ]);
+    });
+
+    it("returns cards in the correct order", () => {
+      const openSnsProject1 = createMockSnsFullProject({
+        rootCanisterId: principal(1),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Open,
+          swapOpenTimestampSeconds: BigInt(200_000_000),
+          projectName: "Project 1",
+        },
+      });
+      const openSnsProject2 = createMockSnsFullProject({
+        rootCanisterId: principal(1),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Open,
+          swapOpenTimestampSeconds: BigInt(100_000_000),
+          projectName: "Project 2",
+        },
+      });
+      const adoptedSnsProject1 = createMockSnsFullProject({
+        rootCanisterId: principal(2),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Adopted,
+          swapOpenTimestampSeconds: BigInt(200_000_000),
+          projectName: "Project 2",
+        },
+      });
+      const adoptedSnsProject2 = createMockSnsFullProject({
+        rootCanisterId: principal(2),
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Adopted,
+          swapOpenTimestampSeconds: BigInt(100_000_000),
+          projectName: "Project 3",
+        },
+      });
+      const openProposal1: ProposalInfo = {
+        ...mockProposalInfo,
+        deadlineTimestampSeconds: 200_000_000n,
+        topic: Topic.SnsAndCommunityFund,
+        status: ProposalStatus.Open,
+      };
+      const openProposal2: ProposalInfo = {
+        ...mockProposalInfo,
+        deadlineTimestampSeconds: 100_000_000n,
+        topic: Topic.SnsAndCommunityFund,
+        status: ProposalStatus.Open,
+      };
+
+      const cards = getUpcomingLaunchesCards({
+        snsProjects: [
+          adoptedSnsProject1,
+          adoptedSnsProject2,
+          openSnsProject1,
+          openSnsProject2,
+        ],
+        openSnsProposals: [openProposal1, openProposal2],
+      });
+
+      expect(cards.length).toBe(6);
+      expect(cards).toEqual([
+        {
+          Component: LaunchProjectCard,
+          props: { summary: openSnsProject2.summary },
+        },
+        {
+          Component: LaunchProjectCard,
+          props: { summary: openSnsProject1.summary },
+        },
+        {
+          Component: NewSnsProposalCard,
+          props: { proposalInfo: openProposal2 },
+        },
+        {
+          Component: NewSnsProposalCard,
+          props: { proposalInfo: openProposal1 },
+        },
+        {
+          Component: AdoptedProposalCard,
+          props: { summary: adoptedSnsProject2.summary },
+        },
+        {
+          Component: AdoptedProposalCard,
+          props: { summary: adoptedSnsProject1.summary },
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

For the Launchpad redesign, the first block should display the upcoming launch cards (similar to portfolio page). This PR adds a function that provides these cards in the correct order.

https://dfinity.atlassian.net/browse/NNS1-3906

# Changes

- Add getUpcomingLaunchesCards util.

# Tests

- Added.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
