### PR TITLE
feat(analytics): add fiat values to participation events

### DIFF
--- a/frontend/src/lib/constants/constants.ts
+++ b/frontend/src/lib/constants/constants.ts
@@ -25,3 +25,4 @@ export const NANO_SECONDS_IN_MILLISECOND = 1_000_000;
 export const NANO_SECONDS_IN_MINUTE = NANO_SECONDS_IN_MILLISECOND * 1_000 * 60;
 
 export const PRICE_NOT_AVAILABLE_PLACEHOLDER = "-/-";
+export const PRICE_NOT_AVAILABLE = "price-not-available";

--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -65,7 +65,7 @@
       });
 
       const usdAmount = nonNullish($tokenPrice)
-        ? ($tokenPrice * amount).toFixed(2)
+        ? ($tokenPrice * amount).toFixed(1)
         : PRICE_NOT_AVAILABLE;
 
       analytics.event("sns-stake-topup-neuron", {

--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -64,8 +64,8 @@
         },
       });
 
-      const fiatAmount = nonNullish($tokenPrice)
-        ? ($tokenPrice * amount).toFixed(1)
+      const usdAmount = nonNullish($tokenPrice)
+        ? ($tokenPrice * amount).toFixed(2)
         : PRICE_NOT_AVAILABLE;
 
       analytics.event("sns-stake-topup-neuron", {
@@ -73,7 +73,7 @@
         project:
           $projectSlugMapStore.get(rootCanisterId.toText()) ??
           rootCanisterId.toText(),
-        fiatAmount,
+        usdAmount,
       });
 
       dispatcher("nnsClose");

--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { PRICE_NOT_AVAILABLE } from "$lib/constants/constants";
   import { projectSlugMapStore } from "$lib/derived/analytics.derived";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
@@ -64,14 +65,15 @@
       });
 
       const fiatAmount = nonNullish($tokenPrice)
-        ? $tokenPrice * amount
-        : undefined;
+        ? ($tokenPrice * amount).toFixed(1)
+        : PRICE_NOT_AVAILABLE;
+
       analytics.event("sns-stake-topup-neuron", {
         tokenAmount: amount.toString(),
         project:
           $projectSlugMapStore.get(rootCanisterId.toText()) ??
           rootCanisterId.toText(),
-        ...(nonNullish(fiatAmount) && { fiatAmount: fiatAmount.toFixed(2) }),
+        fiatAmount,
       });
 
       dispatcher("nnsClose");

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { PRICE_NOT_AVAILABLE } from "$lib/constants/constants";
   import { E8S_PER_ICP } from "$lib/constants/icp.constants";
   import { projectSlugMapStore } from "$lib/derived/analytics.derived";
   import { snsParametersStore } from "$lib/derived/sns-parameters.derived";
@@ -98,14 +99,15 @@
       });
 
       const fiatAmount = nonNullish($tokenPrice)
-        ? $tokenPrice * detail.amount
-        : undefined;
+        ? ($tokenPrice * detail.amount).toFixed(1)
+        : PRICE_NOT_AVAILABLE;
+
       analytics.event("sns-stake-new-neuron", {
         tokenAmount: detail.amount.toString(),
         project:
           $projectSlugMapStore.get(rootCanisterId.toText()) ??
           rootCanisterId.toText(),
-        ...(nonNullish(fiatAmount) && { fiatAmount: fiatAmount.toFixed(2) }),
+        fiatAmount,
       });
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -99,7 +99,7 @@
       });
 
       const usdAmount = nonNullish($tokenPrice)
-        ? ($tokenPrice * detail.amount).toFixed(2)
+        ? ($tokenPrice * detail.amount).toFixed(1)
         : PRICE_NOT_AVAILABLE;
 
       analytics.event("sns-stake-new-neuron", {

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -98,8 +98,8 @@
         },
       });
 
-      const fiatAmount = nonNullish($tokenPrice)
-        ? ($tokenPrice * detail.amount).toFixed(1)
+      const usdAmount = nonNullish($tokenPrice)
+        ? ($tokenPrice * detail.amount).toFixed(2)
         : PRICE_NOT_AVAILABLE;
 
       analytics.event("sns-stake-new-neuron", {
@@ -107,7 +107,7 @@
         project:
           $projectSlugMapStore.get(rootCanisterId.toText()) ??
           rootCanisterId.toText(),
-        fiatAmount,
+        usdAmount,
       });
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -2,6 +2,7 @@
   import { E8S_PER_ICP } from "$lib/constants/icp.constants";
   import { projectSlugMapStore } from "$lib/derived/analytics.derived";
   import { snsParametersStore } from "$lib/derived/sns-parameters.derived";
+  import { tokenPriceStore } from "$lib/derived/token-price.derived";
   import SnsNeuronTransactionModal from "$lib/modals/sns/neurons/SnsNeuronTransactionModal.svelte";
   import { analytics } from "$lib/services/analytics.services";
   import { stakeNeuron } from "$lib/services/sns-neurons.services";
@@ -23,6 +24,7 @@
     type TokenAmountV2,
   } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
+  import type { Readable } from "svelte/store";
 
   export let token: Token;
   export let rootCanisterId: Principal;
@@ -69,6 +71,8 @@
     }
     return undefined;
   };
+  let tokenPrice: Readable<number | undefined>;
+  $: tokenPrice = tokenPriceStore(token);
 
   const dispatcher = createEventDispatcher();
   const stake = async ({ detail }: CustomEvent<NewTransaction>) => {
@@ -93,11 +97,15 @@
         },
       });
 
+      const fiatAmount = nonNullish($tokenPrice)
+        ? $tokenPrice * detail.amount
+        : undefined;
       analytics.event("sns-stake-new-neuron", {
         tokenAmount: detail.amount.toString(),
         project:
           $projectSlugMapStore.get(rootCanisterId.toText()) ??
           rootCanisterId.toText(),
+        ...(nonNullish(fiatAmount) && { fiatAmount: fiatAmount.toFixed(2) }),
       });
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -3,6 +3,7 @@
   import AdditionalInfoReview from "$lib/components/sale/AdditionalInfoReview.svelte";
   import SaleInProgress from "$lib/components/sale/SaleInProgress.svelte";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { PRICE_NOT_AVAILABLE } from "$lib/constants/constants";
   import { projectSlugMapStore } from "$lib/derived/analytics.derived";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import { tokenPriceStore } from "$lib/derived/token-price.derived";
@@ -151,14 +152,15 @@
       }
 
       const fiatAmount = nonNullish($tokenPrice)
-        ? $tokenPrice * amount
-        : undefined;
+        ? ($tokenPrice * amount).toFixed(1)
+        : PRICE_NOT_AVAILABLE;
+
       analytics.event("sns-swap-participation", {
         tokenAmount: amount.toString(),
         project:
           $projectSlugMapStore.get(rootCanisterId.toText()) ??
           rootCanisterId.toText(),
-        ...(nonNullish(fiatAmount) && { fiatAmount: fiatAmount.toFixed(2) }),
+        fiatAmount,
       });
 
       // We defer the closing of the modal a bit to let the user notice the last step was successful

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -152,7 +152,7 @@
       }
 
       const usdAmount = nonNullish($tokenPrice)
-        ? ($tokenPrice * amount).toFixed(2)
+        ? ($tokenPrice * amount).toFixed(1)
         : PRICE_NOT_AVAILABLE;
 
       analytics.event("sns-swap-participation", {

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -151,8 +151,8 @@
         return;
       }
 
-      const fiatAmount = nonNullish($tokenPrice)
-        ? ($tokenPrice * amount).toFixed(1)
+      const usdAmount = nonNullish($tokenPrice)
+        ? ($tokenPrice * amount).toFixed(2)
         : PRICE_NOT_AVAILABLE;
 
       analytics.event("sns-swap-participation", {
@@ -160,7 +160,7 @@
         project:
           $projectSlugMapStore.get(rootCanisterId.toText()) ??
           rootCanisterId.toText(),
-        fiatAmount,
+        usdAmount,
       });
 
       // We defer the closing of the modal a bit to let the user notice the last step was successful


### PR DESCRIPTION
# Motivation

#6985 introduces events for SNS participation flows. This PR adds a `fiatAmount` parameter to these events based on the conversion at that specific time.

Note: If the conversion is unavailable, the property will not be provided.

[NNS1-3874](https://dfinity.atlassian.net/browse/NNS1-3874)

# Changes

- Add `fiatAmount` property to custom events.

# Tests

- Manually tested.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3874]: https://dfinity.atlassian.net/browse/NNS1-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ