### PR TITLE
feat(launchpad2): Launchpad2 component

### DIFF
--- a/frontend/src/lib/components/launchpad/CardList.svelte
+++ b/frontend/src/lib/components/launchpad/CardList.svelte
@@ -3,11 +3,12 @@
 
   type Props = {
     cards: ComponentWithProps[];
+    testId?: string;
   };
-  const { cards }: Props = $props();
+  const { cards, testId }: Props = $props();
 </script>
 
-<ul data-tid="card-list-component">
+<ul data-tid={testId ?? "card-list-component"}>
   {#each cards as { Component, props }}
     <li data-tid="card-entry">
       <Component {...props} />

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -889,6 +889,12 @@
     "project_logo": "project logo",
     "no_proposals": "There are no decentralisation swap proposals open at the moment."
   },
+  "launchpad": {
+    "headline": "Discover SNS Projects",
+    "subheadline": "See upcoming and available SNS projects",
+    "upcoming_launches": "New Launches and Proposals",
+    "launched_projects": "Launched Projects"
+  },
   "sns_project_detail": {
     "swap_proposal": "Swap Proposal",
     "link_to_dashboard": "ICP Dashboard",

--- a/frontend/src/lib/pages/Launchpad2.svelte
+++ b/frontend/src/lib/pages/Launchpad2.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import CardList from "$lib/components/launchpad/CardList.svelte";
+  import ProjectCard from "$lib/components/launchpad/ProjectCard.svelte";
+  import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import type { ComponentWithProps } from "$lib/types/svelte";
+  import { getUpcomingLaunchesCards } from "$lib/utils/launchpad.utils";
+  import {
+    comparesByDecentralizationSaleOpenTimestampDesc,
+    filterProjectsStatus,
+  } from "$lib/utils/projects.utils";
+  import { getCommitmentE8s } from "$lib/utils/sns.utils";
+  import type { ProposalInfo } from "@dfinity/nns";
+  import { SnsSwapLifecycle } from "@dfinity/sns";
+  import type { Component } from "svelte";
+
+  type Props = {
+    snsProjects: SnsFullProject[];
+    openSnsProposals: ProposalInfo[];
+  };
+
+  const { snsProjects, openSnsProposals }: Props = $props();
+
+  // TODO(launchpad2): add skeletons on loading.
+
+  const upcomingLaunchesCards = $derived(
+    getUpcomingLaunchesCards({
+      snsProjects,
+      openSnsProposals,
+    })
+  );
+  const launchedSnsProjects = $derived(
+    filterProjectsStatus({
+      swapLifecycle: SnsSwapLifecycle.Committed,
+      projects: snsProjects,
+    }).sort(comparesByDecentralizationSaleOpenTimestampDesc)
+  );
+  const userCommittedSnsProjects = $derived(
+    launchedSnsProjects.filter(
+      ({ swapCommitment }) => getCommitmentE8s(swapCommitment) ?? 0n > 0n
+    )
+  );
+  const notCommittedSnsProjects = $derived(
+    launchedSnsProjects.filter(
+      ({ swapCommitment }) => !getCommitmentE8s(swapCommitment)
+    )
+  );
+  const launchedSnsProjectsCards: ComponentWithProps[] = $derived(
+    [...userCommittedSnsProjects, ...notCommittedSnsProjects].map(
+      (project) => ({
+        Component: ProjectCard as unknown as Component,
+        props: { project },
+      })
+    )
+  );
+</script>
+
+<main data-tid="launchpad2-component">
+  <div class="header">
+    <h3>{$i18n.launchpad.headline}</h3>
+    <p>{$i18n.launchpad.subheadline}</p>
+  </div>
+  {#if upcomingLaunchesCards.length > 0}
+    <section>
+      <h4>{$i18n.launchpad.upcoming_launches}</h4>
+      <CardList testId="upcoming-launches-list" cards={upcomingLaunchesCards} />
+    </section>
+  {/if}
+  {#if launchedSnsProjectsCards.length > 0}
+    <section>
+      <h4>{$i18n.launchpad.launched_projects}</h4>
+      <CardList
+        testId="launched-projects-list"
+        cards={launchedSnsProjectsCards}
+      />
+    </section>
+  {/if}
+</main>
+
+<style lang="scss">
+  main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-3x);
+  }
+
+  h3 {
+    font-family: "CircularXX TT";
+    font-size: 24px;
+    font-weight: 500;
+    line-height: 32px;
+  }
+
+  section {
+    margin: 0;
+    padding: 0;
+    max-width: none;
+  }
+
+  h4 {
+    font-size: 16px;
+    font-weight: 450;
+    line-height: 20px;
+  }
+
+  p {
+    margin: 0;
+
+    font-family: "CircularXX TT";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 24px;
+    color: var(--text-description);
+  }
+</style>

--- a/frontend/src/lib/pages/Launchpad2.svelte
+++ b/frontend/src/lib/pages/Launchpad2.svelte
@@ -12,6 +12,7 @@
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import type { ProposalInfo } from "@dfinity/nns";
   import { SnsSwapLifecycle } from "@dfinity/sns";
+  import { isNullish } from "@dfinity/utils";
   import type { Component } from "svelte";
 
   type Props = {
@@ -29,30 +30,29 @@
       openSnsProposals,
     })
   );
-  const launchedSnsProjects = $derived(
-    filterProjectsStatus({
+
+  const launchedSnsProjectsCards: ComponentWithProps[] = $derived.by(() => {
+    const launchedSnsProjects = filterProjectsStatus({
       swapLifecycle: SnsSwapLifecycle.Committed,
       projects: snsProjects,
-    }).sort(comparesByDecentralizationSaleOpenTimestampDesc)
-  );
-  const userCommittedSnsProjects = $derived(
-    launchedSnsProjects.filter(
-      ({ swapCommitment }) => getCommitmentE8s(swapCommitment) ?? 0n > 0n
-    )
-  );
-  const notCommittedSnsProjects = $derived(
-    launchedSnsProjects.filter(
-      ({ swapCommitment }) => !getCommitmentE8s(swapCommitment)
-    )
-  );
-  const launchedSnsProjectsCards: ComponentWithProps[] = $derived(
-    [...userCommittedSnsProjects, ...notCommittedSnsProjects].map(
+    })
+      .sort(comparesByDecentralizationSaleOpenTimestampDesc)
+      .map(({ swapCommitment }) => swapCommitment);
+    const userCommittedSnsProjects = launchedSnsProjects.filter(
+      (swapCommitment) => getCommitmentE8s(swapCommitment) ?? 0n > 0n
+    );
+    const notCommittedSnsProjects = launchedSnsProjects.filter(
+      (swapCommitment) =>
+        isNullish(getCommitmentE8s(swapCommitment)) ||
+        getCommitmentE8s(swapCommitment) === 0n
+    );
+    return [...userCommittedSnsProjects, ...notCommittedSnsProjects].map(
       (project) => ({
         Component: ProjectCard as unknown as Component,
         props: { project },
       })
-    )
-  );
+    );
+  });
 </script>
 
 <main data-tid="launchpad2-component">

--- a/frontend/src/lib/pages/Launchpad2.svelte
+++ b/frontend/src/lib/pages/Launchpad2.svelte
@@ -35,14 +35,12 @@
     const launchedSnsProjects = filterProjectsStatus({
       swapLifecycle: SnsSwapLifecycle.Committed,
       projects: snsProjects,
-    })
-      .sort(comparesByDecentralizationSaleOpenTimestampDesc)
-      .map(({ swapCommitment }) => swapCommitment);
+    }).sort(comparesByDecentralizationSaleOpenTimestampDesc);
     const userCommittedSnsProjects = launchedSnsProjects.filter(
-      (swapCommitment) => getCommitmentE8s(swapCommitment) ?? 0n > 0n
+      ({ swapCommitment }) => getCommitmentE8s(swapCommitment) ?? 0n > 0n
     );
     const notCommittedSnsProjects = launchedSnsProjects.filter(
-      (swapCommitment) =>
+      ({ swapCommitment }) =>
         isNullish(getCommitmentE8s(swapCommitment)) ||
         getCommitmentE8s(swapCommitment) === 0n
     );

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -924,6 +924,13 @@ interface I18nSns_launchpad {
   no_proposals: string;
 }
 
+interface I18nLaunchpad {
+  headline: string;
+  subheadline: string;
+  upcoming_launches: string;
+  launched_projects: string;
+}
+
 interface I18nSns_project_detail {
   swap_proposal: string;
   link_to_dashboard: string;
@@ -1633,6 +1640,7 @@ interface I18n {
   proposal_detail__ineligible: I18nProposal_detail__ineligible;
   neuron_detail: I18nNeuron_detail;
   sns_launchpad: I18nSns_launchpad;
+  launchpad: I18nLaunchpad;
   sns_project_detail: I18nSns_project_detail;
   sns_sale: I18nSns_sale;
   sns_neuron_detail: I18nSns_neuron_detail;

--- a/frontend/src/tests/lib/components/launchpad/CardList.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/CardList.spec.ts
@@ -10,7 +10,9 @@ import { render } from "@testing-library/svelte";
 describe("CardList", () => {
   const renderComponent = (props: { cards: ComponentWithProps[] }) => {
     const { container } = render(CardList, { props });
-    return CardListPo.under(new JestPageObjectElement(container));
+    return CardListPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   it("should render cards", async () => {

--- a/frontend/src/tests/lib/pages/Launchpad2.spec.ts
+++ b/frontend/src/tests/lib/pages/Launchpad2.spec.ts
@@ -1,0 +1,121 @@
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import Launchpad2 from "$lib/pages/Launchpad2.svelte";
+import {
+  createMockProposalActionCreateServiceNervousSystem,
+  createMockProposalInfo,
+} from "$tests/mocks/proposal.mock";
+import {
+  createMockSnsFullProject,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Launchpad2Po } from "$tests/page-objects/Launchpad2.page-object";
+import { type ProposalInfo } from "@dfinity/nns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("Launchpad2", () => {
+  const renderComponent = (props: {
+    snsProjects: SnsFullProject[];
+    openSnsProposals: ProposalInfo[];
+  }) => {
+    const { container } = render(Launchpad2, { props });
+    return Launchpad2Po.under(new JestPageObjectElement(container));
+  };
+
+  it("doesn't display cards if no data available", async () => {
+    const po = renderComponent({
+      snsProjects: [],
+      openSnsProposals: [],
+    });
+
+    expect(await po.getUpcomingLaunchesCardListPo().isPresent()).toBe(false);
+    // TODO(launchpad2): to replace with skeletons
+    expect(await po.getLaunchedProjectsCardListPo().isPresent()).toBe(false);
+  });
+
+  it("displays upcoming launch cards", async () => {
+    const openSnsProject1 = createMockSnsFullProject({
+      rootCanisterId: principal(1),
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Open,
+        swapOpenTimestampSeconds: BigInt(168_000_000),
+        projectName: "Project 1",
+      },
+    });
+    const adoptedSnsProject1 = createMockSnsFullProject({
+      rootCanisterId: principal(2),
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Adopted,
+        swapOpenTimestampSeconds: BigInt(168_000_000),
+        projectName: "Project 2",
+      },
+    });
+    const openProposal1: ProposalInfo = createMockProposalInfo({
+      action: createMockProposalActionCreateServiceNervousSystem({
+        name: "SNS Proposal Title",
+      }),
+    });
+
+    const po = renderComponent({
+      snsProjects: [openSnsProject1, adoptedSnsProject1],
+      openSnsProposals: [openProposal1],
+    });
+
+    const upcomingLaunchesCards = po.getUpcomingLaunchesCardListPo();
+    const upcomingLaunchesCardsEntryPos =
+      await upcomingLaunchesCards.getCardEntries();
+
+    expect(await upcomingLaunchesCards.isPresent()).toBe(true);
+    expect(upcomingLaunchesCardsEntryPos.length).toBe(3);
+
+    expect(await upcomingLaunchesCardsEntryPos[0].getCardTitle()).toEqual(
+      "Project 1"
+    );
+    expect(await upcomingLaunchesCardsEntryPos[1].getCardTitle()).toEqual(
+      "SNS Proposal Title"
+    );
+    expect(await upcomingLaunchesCardsEntryPos[2].getCardTitle()).toEqual(
+      "Project 2"
+    );
+  });
+
+  it("displays launched cards in correct order", async () => {
+    const project1 = createMockSnsFullProject({
+      rootCanisterId: principal(1),
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Committed,
+        swapOpenTimestampSeconds: BigInt(168_000_000),
+        projectName: "Not Committed Project",
+      },
+    });
+    const project2 = createMockSnsFullProject({
+      rootCanisterId: principal(1),
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Committed,
+        swapOpenTimestampSeconds: BigInt(168_000_000),
+        projectName: "Committed Project",
+      },
+      icpCommitment: 10_000_000n,
+    });
+
+    const po = renderComponent({
+      snsProjects: [project1, project2],
+      openSnsProposals: [],
+    });
+
+    const launchedProjectsCards = po.getLaunchedProjectsCardListPo();
+    const launchedProjectsCardsEntryPos =
+      await launchedProjectsCards.getCardEntries();
+
+    expect(await launchedProjectsCards.isPresent()).toBe(true);
+    expect(launchedProjectsCardsEntryPos.length).toBe(2);
+
+    expect(await launchedProjectsCardsEntryPos[0].getCardTitle()).toEqual(
+      "Committed Project"
+    );
+    expect(await launchedProjectsCardsEntryPos[1].getCardTitle()).toEqual(
+      "Not Committed Project"
+    );
+  });
+});

--- a/frontend/src/tests/mocks/proposal.mock.ts
+++ b/frontend/src/tests/mocks/proposal.mock.ts
@@ -1,6 +1,11 @@
 import type { VoteRegistrationStoreEntry } from "$lib/stores/vote-registration.store";
 import { deadlineTimestampSeconds } from "$tests/mocks/proposals.store.mock";
-import { Vote, type Action, type ProposalInfo } from "@dfinity/nns";
+import {
+  Vote,
+  type Action,
+  type CreateServiceNervousSystem,
+  type ProposalInfo,
+} from "@dfinity/nns";
 
 /**
  * Generate mock proposals with autoincremented "id".
@@ -97,3 +102,23 @@ export const mockVoteRegistration = {
   vote: Vote.No,
   status: "vote-registration",
 } as VoteRegistrationStoreEntry;
+
+export const createMockProposalActionCreateServiceNervousSystem = ({
+  name,
+}: {
+  name: string;
+}) =>
+  ({
+    CreateServiceNervousSystem: {
+      name,
+      governanceParameters: {},
+      fallbackControllerPrincipalIds: [],
+      logo: {},
+      url: "url",
+      ledgerParameters: {},
+      description: "Test DAO description",
+      dappCanisters: [],
+      swapParameters: {},
+      initialTokenDistribution: {},
+    } as CreateServiceNervousSystem,
+  }) as Action;

--- a/frontend/src/tests/page-objects/CardList.page-object.ts
+++ b/frontend/src/tests/page-objects/CardList.page-object.ts
@@ -4,8 +4,14 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class CardListPo extends BasePageObject {
   static readonly TID = "card-list-component";
 
-  static under(element: PageObjectElement): CardListPo {
-    return new CardListPo(element.byTestId(CardListPo.TID));
+  static under({
+    element,
+    testId = CardListPo.TID,
+  }: {
+    element: PageObjectElement;
+    testId?: string;
+  }): CardListPo {
+    return new CardListPo(element.byTestId(testId));
   }
 
   static async allUnder(element: PageObjectElement): Promise<CardListPo[]> {
@@ -31,6 +37,14 @@ export class CardListEntryPo extends BasePageObject {
   ): Promise<CardListEntryPo[]> {
     return Array.from(await element.allByTestId(CardListEntryPo.TID)).map(
       (el) => new CardListEntryPo(el)
+    );
+  }
+
+  async getCardTitle(): Promise<string> {
+    return (
+      (await this.getText("project-name")) ??
+      (await this.getText("proposal-title")) ??
+      "getCardTitle: not found"
     );
   }
 }

--- a/frontend/src/tests/page-objects/Launchpad2.page-object.ts
+++ b/frontend/src/tests/page-objects/Launchpad2.page-object.ts
@@ -1,0 +1,25 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { CardListPo } from "$tests/page-objects/CardList.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class Launchpad2Po extends BasePageObject {
+  private static readonly TID = "launchpad2-component";
+
+  static under(element: PageObjectElement): Launchpad2Po {
+    return new Launchpad2Po(element.byTestId(Launchpad2Po.TID));
+  }
+
+  getUpcomingLaunchesCardListPo(): CardListPo {
+    return CardListPo.under({
+      element: this.root,
+      testId: "upcoming-launches-list",
+    });
+  }
+
+  getLaunchedProjectsCardListPo(): CardListPo {
+    return CardListPo.under({
+      element: this.root,
+      testId: "launched-projects-list",
+    });
+  }
+}


### PR DESCRIPTION
# Motivation

As part of the Launchpad redesign, a new component is needed to implement the updated layout. In its basic view, it displays upcoming launch cards (similar to the Portfolio page) alongside launched SNS projects. 

This PR introduces that new component, which will replace the current Launchpad component later.

**Out of scope for this PR:**
- Loading states (e.g., skeletons)
- Mobile-specific layouts

https://dfinity.atlassian.net/browse/NNS1-3906

# Changes

- New Launchpad2 component.

# Tests

- Added.

# Todos

- [x] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
