### PR TITLE
feat(launchpad2): Cards mobileHorizontalScroll style

### DIFF
--- a/frontend/src/lib/components/launchpad/CardList.svelte
+++ b/frontend/src/lib/components/launchpad/CardList.svelte
@@ -3,11 +3,13 @@
 
   type Props = {
     cards: ComponentWithProps[];
+    testId?: string;
+    mobileHorizontalScroll?: boolean;
   };
-  const { cards }: Props = $props();
+  const { cards, testId, mobileHorizontalScroll = false }: Props = $props();
 </script>
 
-<ul data-tid="card-list-component">
+<ul data-tid={testId ?? "card-list-component"} class:mobileHorizontalScroll>
   {#each cards as { Component, props }}
     <li data-tid="card-entry">
       <Component {...props} />
@@ -19,7 +21,7 @@
   @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   ul {
-    // reset default styles
+    // reset default list styles
     list-style: none;
     margin: 0;
     padding: 0;
@@ -28,9 +30,52 @@
     grid-template-columns: 1fr;
     gap: var(--padding);
 
+    &.mobileHorizontalScroll {
+      display: flex;
+      overflow-x: auto;
+      scroll-snap-type: x mandatory;
+      gap: var(--padding);
+
+      // Expand visible area to the full width
+      padding: 0 var(--padding);
+      margin: 0 calc(-1 * var(--padding));
+      width: auto;
+
+      li {
+        flex: 0 0 90%;
+        scroll-snap-align: center;
+
+        &:first-child {
+          scroll-snap-align: start;
+          padding-left: var(--padding);
+        }
+        &:last-child {
+          scroll-snap-align: end;
+          padding-right: var(--padding);
+        }
+      }
+    }
+  }
+
+  ul,
+  // Explicitly set to override mobile styles of `mobileHorizontalScroll`.
+  ul.mobileHorizontalScroll {
     @include media.min-width(medium) {
+      margin: 0;
+      padding: 0;
+      display: grid;
       grid-template-columns: repeat(2, 1fr);
       gap: var(--padding-2x);
+
+      li {
+        flex: unset;
+        scroll-snap-type: none;
+        scroll-snap-align: none;
+      }
+      li:first-child,
+      li:last-child {
+        padding: 0;
+      }
     }
 
     @include media.min-width(large) {

--- a/frontend/src/lib/pages/Launchpad2.svelte
+++ b/frontend/src/lib/pages/Launchpad2.svelte
@@ -61,7 +61,11 @@
   {#if upcomingLaunchesCards.length > 0}
     <section>
       <h4>{$i18n.launchpad.upcoming_launches}</h4>
-      <CardList testId="upcoming-launches-list" cards={upcomingLaunchesCards} />
+      <CardList
+        testId="upcoming-launches-list"
+        cards={upcomingLaunchesCards}
+        mobileHorizontalScroll
+      />
     </section>
   {/if}
   {#if launchedSnsProjectsCards.length > 0}


### PR DESCRIPTION
# Motivation

As part of the Launchpad redesign, the upcoming launch cards should be displayed in a slider style on mobile (single row, horizontal scrolling). This PR introduces a new property to CardList component `mobileHorizontalScroll`, that enables the required styles.

# Changes

CardList:
  - New `mobileHorizontalScroll` prop.
  - Styles for optional horizontal scrolling.

# Tests

- Tested locally:

[mobile-slider.webm](https://github.com/user-attachments/assets/76d2d3d9-9cc7-415d-af19-356bab661ef5)


# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
