### PR TITLE
chore(deps): upgrade ic-js 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.13-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.13-next-2025-07-01.tgz",
-      "integrity": "sha512-WRRrTvO2ohOOAg7Rr4/3u/EFacsZVqRU5OCNgRaQxBjrqWzCLkLKAzNgXi0NY5PfWBI39f7dmmbAOqwi/MlAfw==",
+      "version": "3.1.13-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.13-next-2025-07-02.tgz",
+      "integrity": "sha512-K+hoaFY8VFU3CCALudvzsusXuYfMinEPyCVgyhXp70DNWgYjdDlKcHxHqKeFMfWXa35KM8liI+ELeOWPS67Z/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "5.0.6-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.6-next-2025-07-01.tgz",
-      "integrity": "sha512-mHEC6Y5XyqOUR7cCQYp3RTplpBxTqfODXleV5qlRlzWmVI+M3tuDaLCyhWbAhiNhlEMlnHiLo2wQzcM4Se13Wg==",
+      "version": "5.0.6-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.6-next-2025-07-02.tgz",
+      "integrity": "sha512-BL0smpjwes9Mw22/JC5PnMcAI5FHME+Jl0542gwqBv+GrhFU1WGx6GXEaeGoaJiGuz+Lk2PLV14nVOXvbLjlRw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "6.2.0-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.2.0-next-2025-07-01.tgz",
-      "integrity": "sha512-9yrshx50dS79rFommBwVWJDMLBooQ22W3hcHBar7TomDHZ0/O3vRHFNKL7SFjB0Ns1Hhf9u+4RqOZD2eMnYs1Q==",
+      "version": "6.2.0-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.2.0-next-2025-07-02.tgz",
+      "integrity": "sha512-C6z6TvGXntBxwHJyXzWwaGUFyOICcQa+VzOi6mHSR6yvatmdiP5YANhh8pyltN8fUQfGSsXmNKVd1i3f9qE/LA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "3.0.0-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-3.0.0-next-2025-07-01.tgz",
-      "integrity": "sha512-uoamRZHNKRnABtKkWQubu6NdA+PAmBUOdah72FbPiHVwGQLBb3fm27gFb+x2QQfEZc2WX4lwZJGIZkMl8V/4+g==",
+      "version": "3.0.0-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-3.0.0-next-2025-07-02.tgz",
+      "integrity": "sha512-WAj67pYX4lv4iHJdAfNusxHGxGoilZibin67D8hY7UeYGN6/E/fQQp+MOQfLVZtpW+zi8HRuT8F99EA1C4azTQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.9.0-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.9.0-next-2025-07-01.tgz",
-      "integrity": "sha512-4JedBiMFuU5Gla0lVgG8AKf065W28xmE+6GXN1AtmnaV8xlLgmoD7CQDWR7NNQqc6Pi+mht821/Qba8tARLGWA==",
+      "version": "2.9.0-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.9.0-next-2025-07-02.tgz",
+      "integrity": "sha512-JQgTwaov8kMhiiG77oGJkpxSsrBp2vQ2ud8a4HbD72LZXNizRsbwItwqTBor1OYPEMMUu19+Vijyy6knh1UMXw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -444,9 +444,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "8.5.0-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.5.0-next-2025-07-01.tgz",
-      "integrity": "sha512-6gOswrdB0+p/6oxne+RLomGf2/WVgXKie79ktCsRAP25xmo5/MxaUR0wMnAMVbM3FX36eyMeWSbTcnbShNdXjA==",
+      "version": "8.5.0-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.5.0-next-2025-07-02.tgz",
+      "integrity": "sha512-KABTw9/8cPS2P+NZoq2EuBZ9tEpVJE/dd19dSDvlEaslCs5UH7Hz2It+WByJJwo6yZJ/FE00iYduL9BH1AG89Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.7.0-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.7.0-next-2025-07-01.tgz",
-      "integrity": "sha512-nWipAn1oKa3KY2d9VYQDb+g2BwcprX9bZfecMw91Le5cYyBmJQ8JTDVD7uT9cIrfgi/h1wGEH8Ju9qyn7aQ9tQ==",
+      "version": "3.7.0-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.7.0-next-2025-07-02.tgz",
+      "integrity": "sha512-PRKwUYKJMSOzayJPlz/YCDM0nPZNg41oKsmRFXviACDGugzhlPjCB/BDmuh5yTqzzprGPvrkB4qorlcY9/a5rg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.13.1-next-2025-07-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.1-next-2025-07-01.tgz",
-      "integrity": "sha512-VsHDM03rxpVNjlzFXpBiEGz3Nl3Rze83sMPaFVkZfDNn6DldqUeknMF/tNTda4qhms4v/IF00tRcgNAYtEEMvw==",
+      "version": "2.13.1-next-2025-07-02",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.1-next-2025-07-02.tgz",
+      "integrity": "sha512-k+zEcqrRgUDTK3/VhRhom9ChYe0OgKgcxr7E2CrQyO43hrEhuhSjJSBws/Vs+X4cO54b5q8qsUdU/KGd96+/kA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -560,7 +560,7 @@ export const queryLastestRewardEvent = async ({
   const { canister: governance } = await governanceCanister({ identity });
 
   try {
-    return governance.getLastestRewardEvent(certified);
+    return governance.getLatestRewardEvent(certified);
   } finally {
     logWithTimestamp(
       `Getting latest reward event call certified: ${certified} complete.`

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -762,10 +762,10 @@ describe("neurons-api", () => {
         certified,
         identity,
       });
-      expect(
-        mockGovernanceCanister.getLastestRewardEvent
-      ).toHaveBeenCalledTimes(1);
-      expect(mockGovernanceCanister.getLastestRewardEvent).toHaveBeenCalledWith(
+      expect(mockGovernanceCanister.getLatestRewardEvent).toHaveBeenCalledTimes(
+        1
+      );
+      expect(mockGovernanceCanister.getLatestRewardEvent).toHaveBeenCalledWith(
         certified
       );
     });


### PR DESCRIPTION
# Motivation

Upgrade the nns-dapp to the latest version of ic-js, which includes the `getMetrics` method. 

Note: The latest version introduces a breaking change due to a method being renamed to correct a typo.

[NNS1-3935](https://dfinity.atlassian.net/browse/NNS1-3935)

# Changes

- Run `npm run upgrade:next`
- Rename `getLastestRewardEvent` into `getLatestRewardEvent`

# Tests

- CI should pass as it did before since no changes were introduced.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3935]: https://dfinity.atlassian.net/browse/NNS1-3935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ