### PR TITLE
feat(api): add governance metrics endpoint support

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -6,6 +6,7 @@ import {
   claimOrRefreshNeuronByMemo,
   disburse,
   disburseMaturity,
+  getGovernanceCachedMetrics,
   getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -155,6 +156,9 @@ export const governanceApiService = {
   },
   getNetworkEconomicsParameters(params: ApiQueryParams) {
     return getNetworkEconomicsParameters(params);
+  },
+  getGovernanceCachedMetrics(params: ApiQueryParams) {
+    return getGovernanceCachedMetrics(params);
   },
 
   // Action calls

--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -6,7 +6,7 @@ import {
   claimOrRefreshNeuronByMemo,
   disburse,
   disburseMaturity,
-  getGovernanceCachedMetrics,
+  getGovernanceMetrics,
   getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -157,8 +157,8 @@ export const governanceApiService = {
   getNetworkEconomicsParameters(params: ApiQueryParams) {
     return getNetworkEconomicsParameters(params);
   },
-  getGovernanceCachedMetrics(params: ApiQueryParams) {
-    return getGovernanceCachedMetrics(params);
+  getGovernanceMetrics(params: ApiQueryParams) {
+    return getGovernanceMetrics(params);
   },
 
   // Action calls

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -9,6 +9,7 @@ import type { Agent, Identity } from "@dfinity/agent";
 import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import type {
   E8s,
+  GovernanceCachedMetrics,
   KnownNeuron,
   NetworkEconomics,
   NeuronId,
@@ -631,6 +632,26 @@ export const getNetworkEconomicsParameters = async ({
 
   const { canister: governance } = await governanceCanister({ identity });
   const response = await governance.getNetworkEconomicsParameters({
+    certified,
+  });
+
+  logWithTimestamp(
+    `Getting network economics parameters call certified: ${certified} complete.`
+  );
+
+  return response;
+};
+
+export const getGovernanceCachedMetrics = async ({
+  identity,
+  certified,
+}: ApiQueryParams): Promise<GovernanceCachedMetrics> => {
+  logWithTimestamp(
+    `Getting Governance metrics call certified: ${certified}...`
+  );
+
+  const { canister: governance } = await governanceCanister({ identity });
+  const response = await governance.getMetrics({
     certified,
   });
 

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -656,7 +656,7 @@ export const getGovernanceMetrics = async ({
   });
 
   logWithTimestamp(
-    `Getting network economics parameters call certified: ${certified} complete.`
+    `Getting governance metrics call certified: ${certified} complete.`
   );
 
   return response;

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -642,7 +642,7 @@ export const getNetworkEconomicsParameters = async ({
   return response;
 };
 
-export const getGovernanceCachedMetrics = async ({
+export const getGovernanceMetrics = async ({
   identity,
   certified,
 }: ApiQueryParams): Promise<GovernanceCachedMetrics> => {

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -5,6 +5,7 @@ import {
   claimOrRefreshNeuronByMemo,
   disburse,
   disburseMaturity,
+  getGovernanceCachedMetrics,
   getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -911,6 +912,41 @@ describe("neurons-api", () => {
       expect(
         mockGovernanceCanister.getNetworkEconomicsParameters
       ).toHaveBeenCalledWith({ certified: false });
+    });
+  });
+
+  describe("getGovernanceCachedMetrics", () => {
+    const identity = mockIdentity;
+
+    it("should call the canister to get the governance cached metrics", async () => {
+      const certified = true;
+      await getGovernanceCachedMetrics({
+        certified,
+        identity,
+      });
+      expect(mockGovernanceCanister.getMetrics).toHaveBeenCalledTimes(1);
+      expect(mockGovernanceCanister.getMetrics).toHaveBeenCalledWith({
+        certified,
+      });
+    });
+
+    it("throws error when call fails", async () => {
+      const error = new Error();
+      mockGovernanceCanister.getMetrics.mockImplementation(
+        vi.fn(() => {
+          throw error;
+        })
+      );
+
+      const call = () =>
+        getGovernanceCachedMetrics({
+          certified: false,
+          identity,
+        });
+      await expect(call).rejects.toThrow(error);
+      expect(mockGovernanceCanister.getMetrics).toHaveBeenCalledWith({
+        certified: false,
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -5,7 +5,7 @@ import {
   claimOrRefreshNeuronByMemo,
   disburse,
   disburseMaturity,
-  getGovernanceCachedMetrics,
+  getGovernanceMetrics,
   getNetworkEconomicsParameters,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -915,12 +915,12 @@ describe("neurons-api", () => {
     });
   });
 
-  describe("getGovernanceCachedMetrics", () => {
+  describe("getGovernanceMetrics", () => {
     const identity = mockIdentity;
 
     it("should call the canister to get the governance cached metrics", async () => {
       const certified = true;
-      await getGovernanceCachedMetrics({
+      await getGovernanceMetrics({
         certified,
         identity,
       });
@@ -939,7 +939,7 @@ describe("neurons-api", () => {
       );
 
       const call = () =>
-        getGovernanceCachedMetrics({
+        getGovernanceMetrics({
           certified: false,
           identity,
         });


### PR DESCRIPTION
# Motivation

The nns-dapp will use the [get_metrics](https://github.com/dfinity/ic-js/pull/977) method from the Governance canister to display new information to users. This first PR adds support for this new method in the API layer.

[NNS1-3934](https://dfinity.atlassian.net/browse/NNS1-3934)

# Changes

- New `getGovernanceCachedMetrics` api call and service

# Tests

- Unit tests the new api call

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3935]: https://dfinity.atlassian.net/browse/NNS1-3935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NNS1-3934]: https://dfinity.atlassian.net/browse/NNS1-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ