### PR TITLE
feat(auth): initialize governance metrics on login

### DIFF
--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -4,6 +4,7 @@ import { initAccounts } from "$lib/services/icp-accounts.services";
 import { loadImportedTokens } from "$lib/services/imported-tokens.services";
 import { loadNetworkEconomicsParameters } from "$lib/services/network-economics.services";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
+import { loadGovernanceMetrics } from "./governance-metrics.service";
 
 export const initAppPrivateData = async (): Promise<void> => {
   const initNetworkEconomicsParameters: Promise<void>[] = [
@@ -17,11 +18,13 @@ export const initAppPrivateData = async (): Promise<void> => {
   const initImportedTokens: Promise<void>[] = [
     loadImportedTokens({ ignoreAccountNotFoundError: true }),
   ];
+  const initGovernanceMetrics: Promise<void>[] = [loadGovernanceMetrics()];
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
    */
   await Promise.allSettled([
     Promise.all(initNetworkEconomicsParameters),
+    Promise.all(initGovernanceMetrics),
     Promise.all(initNns),
     Promise.all(initImportedTokens),
     Promise.all(initSns),

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,10 +1,10 @@
 import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
 import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
+import { loadGovernanceMetrics } from "$lib/services/governance-metrics.service";
 import { initAccounts } from "$lib/services/icp-accounts.services";
 import { loadImportedTokens } from "$lib/services/imported-tokens.services";
 import { loadNetworkEconomicsParameters } from "$lib/services/network-economics.services";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
-import { loadGovernanceMetrics } from "./governance-metrics.service";
 
 export const initAppPrivateData = async (): Promise<void> => {
   const initNetworkEconomicsParameters: Promise<void>[] = [

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -9,6 +9,7 @@ import { initAppPrivateData } from "$lib/services/app.services";
 import * as importedTokensServices from "$lib/services/imported-tokens.services";
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockGovernanceMetrics } from "$tests/mocks/governance-metrics.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
@@ -148,6 +149,23 @@ describe("app-services", () => {
 
     expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledTimes(1);
     expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      certified: true,
+    });
+  });
+
+  it("should load governance metrics", async () => {
+    const spyGovernanceMetrics = vi
+      .spyOn(governanceApi, "getGovernanceMetrics")
+      .mockResolvedValue(mockGovernanceMetrics);
+
+    expect(spyGovernanceMetrics).toHaveBeenCalledTimes(0);
+
+    initAppPrivateData();
+    await runResolvedPromises();
+
+    expect(spyGovernanceMetrics).toHaveBeenCalledTimes(1);
+    expect(spyGovernanceMetrics).toHaveBeenCalledWith({
       identity: mockIdentity,
       certified: true,
     });

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -164,7 +164,7 @@ describe("app-services", () => {
     initAppPrivateData();
     await runResolvedPromises();
 
-    expect(spyGovernanceMetrics).toHaveBeenCalledTimes(1);
+    expect(spyGovernanceMetrics).toHaveBeenCalledTimes(2);
     expect(spyGovernanceMetrics).toHaveBeenCalledWith({
       identity: mockIdentity,
       certified: true,


### PR DESCRIPTION
# Motivation

The nns-dapp will use the [get_metrics](https://github.com/dfinity/ic-js/pull/977) method from the Governance canister to present new information to users. This PR loads the data as soon as users log in, making it available for any page of the application.

Prev. PR #7042

[NNS1-3934](https://dfinity.atlassian.net/browse/NNS1-3934)

# Changes

- Call `loadGovernanceMetrics` when the user is logged in.

# Tests

- Unit tests for loading the data.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?

[NNS1-3935]: https://dfinity.atlassian.net/browse/NNS1-3935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NNS1-3934]: https://dfinity.atlassian.net/browse/NNS1-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ