### PR TITLE
fix(projects): prioritize responsive projects in table

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Improved disburse button feedback when neuron has insufficient stake
+* Improved project list organization by moving unresponsive projects to bottom
+
 
 #### Security
 

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -231,8 +231,8 @@ export const compareIcpFirst = createDescendingComparator(
   (project: TableProject) => project.universeId === OWN_CANISTER_ID_TEXT
 );
 
-export const compareNonFailedTokenAmountFirst = createDescendingComparator(
-  (project: TableProject) => !(project.stake instanceof FailedTokenAmount)
+export const compareNonFailedTokenAmountFirst = createAscendingComparator(
+  (project: TableProject) => project.stake instanceof FailedTokenAmount
 );
 
 const comparePositiveNeuronsFirst = createDescendingComparator(

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -231,6 +231,10 @@ export const compareIcpFirst = createDescendingComparator(
   (project: TableProject) => project.universeId === OWN_CANISTER_ID_TEXT
 );
 
+export const compareNonFailedTokenAmountFirst = createDescendingComparator(
+  (project: TableProject) => !(project.stake instanceof FailedTokenAmount)
+);
+
 const comparePositiveNeuronsFirst = createDescendingComparator(
   (project: TableProject) => (project.neuronCount ?? 0) > 0
 );
@@ -249,11 +253,13 @@ export const compareByStakeInUsd = createDescendingComparator(
 
 export const compareByNeuron = mergeComparators([
   compareIcpFirst,
+  compareNonFailedTokenAmountFirst,
   compareByNeuronCount,
 ]);
 
 export const compareByProject = mergeComparators([
   compareIcpFirst,
+  compareNonFailedTokenAmountFirst,
   compareByProjectTitle,
 ]);
 
@@ -264,6 +270,7 @@ export const compareByProject = mergeComparators([
 export const compareByStake = mergeComparators([
   compareIcpFirst,
   compareByStakeInUsd,
+  compareNonFailedTokenAmountFirst,
   comparePositiveNeuronsFirst,
 ]);
 
@@ -271,6 +278,7 @@ export const sortTableProjects = (projects: TableProject[]): TableProject[] => {
   return [...projects].sort(
     mergeComparators([
       compareIcpFirst,
+      compareNonFailedTokenAmountFirst,
       comparePositiveNeuronsFirst,
       compareByProjectTitle,
     ])

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -750,6 +750,24 @@ describe("staking.utils", () => {
 
       expect(compareByStake(project1, project2)).toEqual(1);
     });
+
+    it("should push unavailable projects to the bottom", () => {
+      const failedProject = {
+        ...mockTableProject,
+        stake: new FailedTokenAmount(mockSnsToken),
+      };
+      const nonFailedProject = {
+        ...mockTableProject,
+        stake: TokenAmountV2.fromUlps({
+          amount: 100_000_000n,
+          token: ICPToken,
+        }),
+      };
+      expect(sortTableProjects([failedProject, nonFailedProject])).toEqual([
+        nonFailedProject,
+        failedProject,
+      ]);
+    });
   });
 
   describe("compareByNeuron", () => {
@@ -781,6 +799,26 @@ describe("staking.utils", () => {
       };
 
       expect(compareByNeuron(project1, project2)).toEqual(-1);
+    });
+
+    it("should push unavailable projects to the bottom", () => {
+      const failedProject = {
+        ...mockTableProject,
+        neuronCount: 10,
+        stake: new FailedTokenAmount(mockSnsToken),
+      };
+      const nonFailedProject = {
+        ...mockTableProject,
+        neuronCount: 0,
+        stake: TokenAmountV2.fromUlps({
+          amount: 100_000_000n,
+          token: ICPToken,
+        }),
+      };
+      expect(sortTableProjects([failedProject, nonFailedProject])).toEqual([
+        nonFailedProject,
+        failedProject,
+      ]);
     });
   });
 
@@ -818,6 +856,27 @@ describe("staking.utils", () => {
 
       expect(compareByNeuron(project1, project2)).toEqual(-1);
     });
+
+    it("should push unavailable projects to the bottom", () => {
+      const failedProject = {
+        ...mockTableProject,
+        title: "ZZZ",
+        stake: new FailedTokenAmount(mockSnsToken),
+      };
+      const nonFailedProject = {
+        ...mockTableProject,
+        title: "AAA",
+        stake: TokenAmountV2.fromUlps({
+          amount: 100_000_000n,
+          token: ICPToken,
+        }),
+      };
+
+      expect(sortTableProjects([failedProject, nonFailedProject])).toEqual([
+        nonFailedProject,
+        failedProject,
+      ]);
+    });
   });
 
   describe("sortTableProjects", () => {
@@ -853,6 +912,28 @@ describe("staking.utils", () => {
       expect(sortTableProjects([icpProject, snsProject])).toEqual([
         icpProject,
         snsProject,
+      ]);
+    });
+
+    it("should push unavailable projects to the bottom", () => {
+      const failedProject = {
+        ...defaultProject,
+        title: "ZZZ",
+        stake: new FailedTokenAmount(mockSnsToken),
+        neuronCount: 1,
+      };
+      const nonFailedProject = {
+        ...defaultProject,
+        title: "AAA",
+        stake: TokenAmountV2.fromUlps({
+          amount: 100_000_000n,
+          token: ICPToken,
+        }),
+        neuronCount: 0,
+      };
+      expect(sortTableProjects([failedProject, nonFailedProject])).toEqual([
+        nonFailedProject,
+        failedProject,
       ]);
     });
 


### PR DESCRIPTION
# Motivation

Unresponsive projects should be moved to the bottom of the projects table unless a special sorting has been applied.

| Before | After |
|--------|--------|
| <img width="423" alt="Screenshot 2025-07-03 at 13 58 08" src="https://github.com/user-attachments/assets/7372a2ca-1080-48ab-80b4-430519ae7c00" /> | <img width="419" alt="Screenshot 2025-07-03 at 13 57 46" src="https://github.com/user-attachments/assets/613ab851-3fa1-4781-a188-7a9178a40e63" /> | 

[NNS1-3941](https://dfinity.atlassian.net/browse/NNS1-3941)

# Changes

- New comparator to check for unresponsive projects based on the staked amount.

# Tests

- Tests to existing sorting rules with new comparator.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3941]: https://dfinity.atlassian.net/browse/NNS1-3941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ