### PR TITLE
feat(sns_aggregator): Scrape latest reward events from SNS Governance

### DIFF
--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -1,6 +1,6 @@
 //! Slowly changing information about an SNS
 use crate::types::ic_sns_governance::{
-    ListNervousSystemFunctionsResponse, ListTopicsResponse, NervousSystemParameters,
+    ListNervousSystemFunctionsResponse, ListTopicsResponse, NervousSystemParameters, RewardEvent,
 };
 use crate::types::ic_sns_root::ListSnsCanistersResponse;
 use crate::types::ic_sns_swap::{
@@ -30,6 +30,8 @@ pub struct SlowSnsData {
     /// Governance metrics such as the last ledger block timestamp and
     /// number of recently submitted proposals.
     pub metrics: Option<GetMetricsResponse>,
+    /// Latest voting reward distribution data.
+    pub latest_reward_event: Option<RewardEvent>,
     /// Governance functions.
     pub parameters: ListNervousSystemFunctionsResponse,
     /// Governance parameters such as tokenomics.
@@ -63,6 +65,7 @@ impl From<&UpstreamData> for SlowSnsData {
             list_sns_canisters,
             meta: _,
             metrics,
+            latest_reward_event,
             parameters,
             nervous_system_parameters,
             swap_state,
@@ -81,6 +84,7 @@ impl From<&UpstreamData> for SlowSnsData {
             list_sns_canisters: list_sns_canisters.clone(),
             meta: SlowMetadata::from(upstream),
             metrics: metrics.clone(),
+            latest_reward_event: latest_reward_event.clone(),
             parameters: parameters.clone(),
             nervous_system_parameters: nervous_system_parameters.clone(),
             swap_state: SlowSwapState::from(swap_state),

--- a/rs/sns_aggregator/src/types/upstream.rs
+++ b/rs/sns_aggregator/src/types/upstream.rs
@@ -7,7 +7,7 @@ use super::ic_sns_root::ListSnsCanistersResponse;
 use super::ic_sns_swap::{GetSaleParametersResponse, GetStateResponse};
 use super::ic_sns_wasm::DeployedSns;
 use super::{CandidType, Deserialize};
-use crate::types::ic_sns_governance::GetMetricsResponse;
+use crate::types::ic_sns_governance::{GetMetricsResponse, RewardEvent};
 use crate::types::ic_sns_swap::{GetDerivedStateResponse, GetInitResponse, GetLifecycleResponse};
 use candid::Nat;
 use ic_cdk::api::management_canister::provisional::CanisterId;
@@ -35,7 +35,7 @@ pub struct SnsCache {
 pub type SnsIndex = u64;
 
 /// Information about an SNS that changes relatively slowly and that is common, i.e. not user specific.
-#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
 pub struct UpstreamData {
     /// Index of the SNS in the SNS wasms canister
     pub index: u64,
@@ -48,6 +48,8 @@ pub struct UpstreamData {
     /// Governance metrics such as the last ledger block timestamp and
     /// number of recently submitted proposals.
     pub metrics: Option<GetMetricsResponse>,
+    /// Latest voting reward distribution data.
+    pub latest_reward_event: Option<RewardEvent>,
     /// Governance functions.
     pub parameters: ListNervousSystemFunctionsResponse,
     /// Governance parameters such as tokenomics.
@@ -70,29 +72,4 @@ pub struct UpstreamData {
     pub lifecycle: Option<GetLifecycleResponse>,
     /// The topics and the corresponding proposal types of this SNS.
     pub topics: Option<ListTopicsResponse>,
-}
-
-impl Default for UpstreamData {
-    fn default() -> Self {
-        Self {
-            index: u64::default(),
-            canister_ids: DeployedSns::default(),
-            list_sns_canisters: ListSnsCanistersResponse::default(),
-            meta: GetMetadataResponse::default(),
-            metrics: Some(GetMetricsResponse {
-                get_metrics_result: None,
-            }),
-            parameters: ListNervousSystemFunctionsResponse::default(),
-            nervous_system_parameters: None,
-            swap_state: GetStateResponse::default(),
-            icrc1_metadata: Vec::default(),
-            icrc1_fee: Nat::default(),
-            icrc1_total_supply: Nat::default(),
-            swap_params: None,
-            init: None,
-            derived_state: None,
-            lifecycle: None,
-            topics: None,
-        }
-    }
 }

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -143,6 +143,7 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
         })
         .unwrap_or(existing_data.metrics);
 
+    crate::state::log(format!("Getting SNS index {index}... get_latest_reward_event"));
     let latest_reward_event = get_latest_reward_event(governance_canister_id)
         .await
         .map_err(|err| crate::state::log(format!("Call to SnsGovernance.get_latest_reward_event failed: {err:?}")))


### PR DESCRIPTION
# Motivation

The latest reward event of an SNS contains data that is useful for computing metrics that are relevant to end users / NNS dapp users, e.g., the DAO's voting activity. 

# Changes

Call and aggregate the responses from `SnsGov.get_latest_reward_event`.

# Tests

Manual + CI.

# Todos

- [x] Manual testing.
- [x] Changelog.
