### PR TITLE
feat(store): add viewport size detection

### DIFF
--- a/frontend/src/lib/derived/viewport.derived.ts
+++ b/frontend/src/lib/derived/viewport.derived.ts
@@ -1,0 +1,27 @@
+import { browser } from "$app/environment";
+import { derived, writable, type Readable } from "svelte/store";
+
+// Value from gix
+export const BREAKPOINT_SMALL = 576;
+
+const viewportWidthWritable = writable<number>(
+  browser ? window.innerWidth : BREAKPOINT_SMALL
+);
+
+if (browser) {
+  const handleResize = () => viewportWidthWritable.set(window.innerWidth);
+  window.addEventListener("resize", handleResize);
+}
+
+export const viewportWidthStore: Readable<number> = {
+  subscribe: viewportWidthWritable.subscribe,
+};
+
+export const isMobileViewportStore: Readable<boolean> = derived(
+  viewportWidthStore,
+  ($viewportWidth) => $viewportWidth < BREAKPOINT_SMALL
+);
+
+export const setViewportWidthForTesting = (width: number) => {
+  viewportWidthWritable.set(width);
+};

--- a/frontend/src/lib/derived/viewport.derived.ts
+++ b/frontend/src/lib/derived/viewport.derived.ts
@@ -1,27 +1,22 @@
 import { browser } from "$app/environment";
-import { derived, writable, type Readable } from "svelte/store";
+import { writable, type Readable } from "svelte/store";
 
-// Value from gix
 export const BREAKPOINT_SMALL = 576;
 
-const viewportWidthWritable = writable<number>(
-  browser ? window.innerWidth : BREAKPOINT_SMALL
-);
+const mobileMediaQueryWritable = writable<boolean>(false);
 
 if (browser) {
-  const handleResize = () => viewportWidthWritable.set(window.innerWidth);
-  window.addEventListener("resize", handleResize);
+  const mediaQuery = window.matchMedia(
+    `(max-width: ${BREAKPOINT_SMALL - 1}px)`
+  );
+
+  mobileMediaQueryWritable.set(mediaQuery.matches);
+
+  mediaQuery.addEventListener("change", (event: MediaQueryListEvent) => {
+    mobileMediaQueryWritable.set(event.matches);
+  });
 }
 
-export const viewportWidthStore: Readable<number> = {
-  subscribe: viewportWidthWritable.subscribe,
-};
-
-export const isMobileViewportStore: Readable<boolean> = derived(
-  viewportWidthStore,
-  ($viewportWidth) => $viewportWidth < BREAKPOINT_SMALL
-);
-
-export const setViewportWidthForTesting = (width: number) => {
-  viewportWidthWritable.set(width);
+export const isMobileViewportStore: Readable<boolean> = {
+  subscribe: mobileMediaQueryWritable.subscribe,
 };

--- a/frontend/src/lib/derived/viewport.derived.ts
+++ b/frontend/src/lib/derived/viewport.derived.ts
@@ -6,14 +6,12 @@ export const BREAKPOINT_SMALL = 576;
 const mobileMediaQueryWritable = writable<boolean>(false);
 
 if (browser) {
-  const mediaQuery = window.matchMedia(
-    `(max-width: ${BREAKPOINT_SMALL - 1}px)`
-  );
+  const mediaQuery = window.matchMedia(`(min-width: ${BREAKPOINT_SMALL}px)`);
 
-  mobileMediaQueryWritable.set(mediaQuery.matches);
+  mobileMediaQueryWritable.set(!mediaQuery.matches);
 
   mediaQuery.addEventListener("change", (event: MediaQueryListEvent) => {
-    mobileMediaQueryWritable.set(event.matches);
+    mobileMediaQueryWritable.set(!event.matches);
   });
 }
 

--- a/frontend/src/tests/lib/derived/viewport.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/viewport.derived.spec.ts
@@ -16,7 +16,7 @@ const createMatchMediaMock = (matches: boolean) => {
 
 describe("viewport.derived", () => {
   it("should initialize as mobile when matchMedia matches", async () => {
-    window.matchMedia = createMatchMediaMock(true);
+    window.matchMedia = createMatchMediaMock(false);
 
     const { isMobileViewportStore } = await import(
       "$lib/derived/viewport.derived"
@@ -26,7 +26,7 @@ describe("viewport.derived", () => {
   });
 
   it("should initialize as non-mobile when matchMedia does not match", async () => {
-    window.matchMedia = createMatchMediaMock(false);
+    window.matchMedia = createMatchMediaMock(true);
 
     const { isMobileViewportStore } = await import(
       "$lib/derived/viewport.derived"

--- a/frontend/src/tests/lib/derived/viewport.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/viewport.derived.spec.ts
@@ -1,34 +1,37 @@
-import {
-  BREAKPOINT_SMALL,
-  isMobileViewportStore,
-  setViewportWidthForTesting,
-  viewportWidthStore,
-} from "$lib/derived/viewport.derived";
 import { get } from "svelte/store";
+import { describe, expect, it, vi } from "vitest";
+
+const createMatchMediaMock = (matches: boolean) => {
+  return vi.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+};
 
 describe("viewport.derived", () => {
-  describe("viewportWidthStore", () => {
-    it("should update when viewport width changes", () => {
-      setViewportWidthForTesting(800);
-      expect(get(viewportWidthStore)).toBe(800);
+  it("should initialize as mobile when matchMedia matches", async () => {
+    window.matchMedia = createMatchMediaMock(true);
 
-      setViewportWidthForTesting(400);
-      expect(get(viewportWidthStore)).toBe(400);
-    });
+    const { isMobileViewportStore } = await import(
+      "$lib/derived/viewport.derived"
+    );
+
+    expect(get(isMobileViewportStore)).toBe(true);
   });
 
-  describe("isMobileViewportStore", () => {
-    it("should return true for mobile viewport", () => {
-      setViewportWidthForTesting(BREAKPOINT_SMALL - 1);
-      expect(get(isMobileViewportStore)).toBe(true);
-    });
+  it("should initialize as non-mobile when matchMedia does not match", async () => {
+    window.matchMedia = createMatchMediaMock(false);
 
-    it("should return false for non-mobile viewport", () => {
-      setViewportWidthForTesting(BREAKPOINT_SMALL);
-      expect(get(isMobileViewportStore)).toBe(false);
+    const { isMobileViewportStore } = await import(
+      "$lib/derived/viewport.derived"
+    );
 
-      setViewportWidthForTesting(BREAKPOINT_SMALL + 100);
-      expect(get(isMobileViewportStore)).toBe(false);
-    });
+    expect(get(isMobileViewportStore)).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/derived/viewport.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/viewport.derived.spec.ts
@@ -1,0 +1,34 @@
+import {
+  BREAKPOINT_SMALL,
+  isMobileViewportStore,
+  setViewportWidthForTesting,
+  viewportWidthStore,
+} from "$lib/derived/viewport.derived";
+import { get } from "svelte/store";
+
+describe("viewport.derived", () => {
+  describe("viewportWidthStore", () => {
+    it("should update when viewport width changes", () => {
+      setViewportWidthForTesting(800);
+      expect(get(viewportWidthStore)).toBe(800);
+
+      setViewportWidthForTesting(400);
+      expect(get(viewportWidthStore)).toBe(400);
+    });
+  });
+
+  describe("isMobileViewportStore", () => {
+    it("should return true for mobile viewport", () => {
+      setViewportWidthForTesting(BREAKPOINT_SMALL - 1);
+      expect(get(isMobileViewportStore)).toBe(true);
+    });
+
+    it("should return false for non-mobile viewport", () => {
+      setViewportWidthForTesting(BREAKPOINT_SMALL);
+      expect(get(isMobileViewportStore)).toBe(false);
+
+      setViewportWidthForTesting(BREAKPOINT_SMALL + 100);
+      expect(get(isMobileViewportStore)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

New designs for the nns-dapp define different DOM structures for mobile and non-mobile desktops. Although CSS media queries can handle such cases, they would create too many unnecessary DOM nodes. This PR introduces a new store that exposes the viewport size and a derived store to determine if it is mobile (less than 576px) or not. 

Note: It hardcodes the value of the small breakpoint, but this will be updated to a global constant later.

[NNS1-3922](https://dfinity.atlassian.net/browse/NNS1-3922)

# Changes

- New store for the viewport.

# Tests

- Unit tests.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3922]: https://dfinity.atlassian.net/browse/NNS1-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ