### PR TITLE
test(api): verify query and update call certification for network economics and governance metrics

### DIFF
--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -148,7 +148,12 @@ describe("app-services", () => {
     await runResolvedPromises();
 
     expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledTimes(2);
-    expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledWith({
+
+    expect(spyGetNetworkEconomicsParameters).toHaveBeenNthCalledWith(1, {
+      identity: mockIdentity,
+      certified: false,
+    });
+    expect(spyGetNetworkEconomicsParameters).toHaveBeenNthCalledWith(2, {
       identity: mockIdentity,
       certified: true,
     });
@@ -165,7 +170,11 @@ describe("app-services", () => {
     await runResolvedPromises();
 
     expect(spyGovernanceMetrics).toHaveBeenCalledTimes(2);
-    expect(spyGovernanceMetrics).toHaveBeenCalledWith({
+    expect(spyGovernanceMetrics).toHaveBeenNthCalledWith(1, {
+      identity: mockIdentity,
+      certified: false,
+    });
+    expect(spyGovernanceMetrics).toHaveBeenNthCalledWith(2, {
       identity: mockIdentity,
       certified: true,
     });

--- a/frontend/src/tests/lib/services/governance-metrics.services.spec.ts
+++ b/frontend/src/tests/lib/services/governance-metrics.services.spec.ts
@@ -30,7 +30,11 @@ describe("governance-metrics-services", () => {
       await loadGovernanceMetrics();
 
       expect(spyGetGovernanceMetrics).toHaveBeenCalledTimes(2);
-      expect(spyGetGovernanceMetrics).toHaveBeenCalledWith({
+      expect(spyGetGovernanceMetrics).toHaveBeenNthCalledWith(1, {
+        identity: mockIdentity,
+        certified: false,
+      });
+      expect(spyGetGovernanceMetrics).toHaveBeenNthCalledWith(2, {
         identity: mockIdentity,
         certified: true,
       });

--- a/frontend/src/tests/lib/services/network-economics.services.spec.ts
+++ b/frontend/src/tests/lib/services/network-economics.services.spec.ts
@@ -20,7 +20,11 @@ describe("network-economics-services", () => {
       await loadNetworkEconomicsParameters();
 
       expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledTimes(2);
-      expect(spyGetNetworkEconomicsParameters).toHaveBeenCalledWith({
+      expect(spyGetNetworkEconomicsParameters).toHaveBeenNthCalledWith(1, {
+        identity: mockIdentity,
+        certified: false,
+      });
+      expect(spyGetNetworkEconomicsParameters).toHaveBeenNthCalledWith(2, {
         identity: mockIdentity,
         certified: true,
       });


### PR DESCRIPTION
# Motivation

#7047 and #7042 introduced query and update calls for governance metrics and network economics. This PR enhances their tests by verifying that when two calls are expected, the first is not certified and the second is certified.

[NNS1-3934](https://dfinity.atlassian.net/browse/NNS1-3934)

# Changes

- Improve assertions by explicitly checking both calls: query and update, each time.

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3934]: https://dfinity.atlassian.net/browse/NNS1-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ