### PR TITLE
feat(staking): add rewards information card

### DIFF
--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -34,7 +34,7 @@
       ? renderPrivacyModeBalance(5)
       : nonNullish(rewardBalanceUSD)
         ? formatCurrencyNumber(rewardBalanceUSD)
-        : "N/A"
+        : $i18n.core.not_applicable
   );
 
   const rewardEstimateWeekUSDFormatted = $derived(
@@ -42,7 +42,7 @@
       ? renderPrivacyModeBalance(3)
       : nonNullish(rewardEstimateWeekUSD)
         ? formatCurrencyNumber(rewardEstimateWeekUSD)
-        : "N/A"
+        : $i18n.core.not_applicable
   );
   const stakingPowerPercentage = $derived(
     formatPercentage(stakingPower, {
@@ -55,13 +55,13 @@
       ? renderPrivacyModeBalance(3)
       : nonNullish(stakingPowerUSD)
         ? formatCurrencyNumber(stakingPowerUSD)
-        : "N/A"
+        : $i18n.core.not_applicable
   );
 </script>
 
 {#snippet content()}
   <div class="content">
-    <div class="left">
+    <div class="content">
       <span class="subtitle">{$i18n.portfolio.apy_card_reward_title}</span>
       <span class="main-value" data-tid="reward"
         >${rewardBalanceUSDFormatted}</span
@@ -84,7 +84,7 @@
       >
     </div>
 
-    <div class="right">
+    <div class="content">
       <span class="subtitle">{$i18n.portfolio.apy_card_power_title}</span>
       <span class="main-value" data-tid="staking-power"
         >{stakingPowerPercentage}</span
@@ -131,8 +131,7 @@
     display: flex;
     justify-content: space-between;
 
-    .left,
-    .right {
+    .content {
       display: flex;
       flex-direction: column;
       flex-grow: 1;

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -159,22 +159,22 @@
         font-weight: 450;
         line-height: 16px;
 
+        display: flex;
+
         @include media.min-width(medium) {
           font-size: 16px;
           font-weight: 400;
           line-height: 20px;
         }
-
-        display: flex;
-
-        .projection {
-          display: flex;
-          align-items: center;
-
-          color: #29a079;
-          padding-right: 4px;
-        }
       }
+    }
+
+    .projection {
+      display: flex;
+      align-items: center;
+
+      color: #29a079;
+      padding-right: 4px;
     }
   }
 

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -12,19 +12,35 @@
   import { nonNullish } from "@dfinity/utils";
 
   type Props = {
-    rewardBalance: number;
-    stakingPower: number;
+    rewardBalanceUSD?: number;
+    rewardEstimateWeekUSD?: number;
+    stakingPower?: number;
+    stakingPowerUSD?: number;
+    loading: boolean;
   };
 
-  const { rewardBalance = 3260.21, stakingPower = 0.7845 }: Props = $props();
+  const {
+    rewardBalanceUSD = 3260.21,
+    rewardEstimateWeekUSD = 50.12,
+    stakingPower = 0.7845,
+    stakingPowerUSD = 16606,
+  }: Props = $props();
 
   const href = AppPath.Staking;
 
-  const rewardBalanceFormatted = $derived(
+  const rewardBalanceUSDFormatted = $derived(
     $isBalancePrivacyOptionStore
       ? renderPrivacyModeBalance(5)
-      : nonNullish(rewardBalance)
-        ? formatCurrencyNumber(rewardBalance)
+      : nonNullish(rewardBalanceUSD)
+        ? formatCurrencyNumber(rewardBalanceUSD)
+        : "N/A"
+  );
+
+  const rewardEstimateWeekUSDFormatted = $derived(
+    $isBalancePrivacyOptionStore
+      ? renderPrivacyModeBalance(3)
+      : nonNullish(rewardEstimateWeekUSD)
+        ? formatCurrencyNumber(rewardEstimateWeekUSD)
         : "N/A"
   );
   const stakingPowerFormatted = $derived(
@@ -33,13 +49,20 @@
       maxFraction: 2,
     })
   );
+  const stakingPowerUSDFormatted = $derived(
+    $isBalancePrivacyOptionStore
+      ? renderPrivacyModeBalance(3)
+      : nonNullish(stakingPowerUSD)
+        ? formatCurrencyNumber(stakingPowerUSD)
+        : "N/A"
+  );
 </script>
 
 {#snippet content()}
   <div class="content">
     <div class="left">
       <span class="subtitle">{$i18n.portfolio.apy_card_reward_title}</span>
-      <span class="main-value">~${rewardBalanceFormatted}</span>
+      <span class="main-value">~${rewardBalanceUSDFormatted}</span>
       <span class="secondary-value"
         ><span>
           <svg
@@ -53,7 +76,7 @@
               d="M4.5 0.5L8.39711 7.25H0.602886L4.5 0.5Z"
               fill="currentColor"
             />
-          </svg>$85.03</span
+          </svg>${rewardEstimateWeekUSDFormatted}</span
         >{$i18n.portfolio.apy_card_estimation}</span
       >
     </div>
@@ -61,7 +84,7 @@
     <div class="right">
       <span class="subtitle">{$i18n.portfolio.apy_card_power_title}</span>
       <span class="main-value">~{stakingPowerFormatted}</span>
-      <span class="secondary-value">~$16606</span>
+      <span class="secondary-value">~${stakingPowerUSDFormatted}</span>
     </div>
   </div>
 {/snippet}

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -20,13 +20,14 @@
   };
 
   const {
-    rewardBalanceUSD = 3260.21,
-    rewardEstimateWeekUSD = 50.12,
-    stakingPower = 0.7845,
-    stakingPowerUSD = 16606,
+    rewardBalanceUSD = 0,
+    rewardEstimateWeekUSD = 0,
+    stakingPower = 0,
+    stakingPowerUSD = 0,
   }: Props = $props();
 
   const href = AppPath.Staking;
+  const dataTid = "apy-card-component";
 
   const rewardBalanceUSDFormatted = $derived(
     $isBalancePrivacyOptionStore
@@ -43,7 +44,7 @@
         ? formatCurrencyNumber(rewardEstimateWeekUSD)
         : "N/A"
   );
-  const stakingPowerFormatted = $derived(
+  const stakingPowerPercentage = $derived(
     formatPercentage(stakingPower, {
       minFraction: 2,
       maxFraction: 2,
@@ -62,9 +63,11 @@
   <div class="content">
     <div class="left">
       <span class="subtitle">{$i18n.portfolio.apy_card_reward_title}</span>
-      <span class="main-value">~${rewardBalanceUSDFormatted}</span>
+      <span class="main-value" data-tid="reward"
+        >${rewardBalanceUSDFormatted}</span
+      >
       <span class="secondary-value"
-        ><span>
+        ><span class="projection" data-tid="projection">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="9"
@@ -83,18 +86,29 @@
 
     <div class="right">
       <span class="subtitle">{$i18n.portfolio.apy_card_power_title}</span>
-      <span class="main-value">~{stakingPowerFormatted}</span>
-      <span class="secondary-value">~${stakingPowerUSDFormatted}</span>
+      <span class="main-value" data-tid="staking-power"
+        >{stakingPowerPercentage}</span
+      >
+      <span class="secondary-value" data-tid="total-staking-power"
+        >${stakingPowerUSDFormatted}</span
+      >
     </div>
   </div>
 {/snippet}
 
 {#if $isMobileViewportStore}
-  <a class="card mobile" {href}>
-    {@render content()}
-  </a>
+  <article class="card mobile" data-tid={dataTid}>
+    <a
+      {href}
+      class="link"
+      aria-label={$i18n.portfolio.apy_card_link}
+      data-tid="project-link"
+    >
+      {@render content()}
+    </a>
+  </article>
 {:else}
-  <article class="card desktop">
+  <article class="card desktop" data-tid={dataTid}>
     <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
     {@render content()}
 
@@ -153,7 +167,7 @@
 
         display: flex;
 
-        span {
+        .projection {
           display: flex;
           align-items: center;
 
@@ -180,7 +194,10 @@
 
   .card.mobile {
     padding: 20px 16px;
-    text-decoration: none;
+
+    .link {
+      text-decoration: none;
+    }
   }
 
   .card.desktop {

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { isBalancePrivacyOptionStore } from "$lib/derived/balance-privacy-active.derived";
+  import { isMobileViewportStore } from "$lib/derived/viewport.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import {
+    formatCurrencyNumber,
+    formatPercentage,
+    renderPrivacyModeBalance,
+  } from "$lib/utils/format.utils";
+  import { IconRight } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
+
+  type Props = {
+    rewardBalance: number;
+    stakingPower: number;
+  };
+
+  const { rewardBalance = 3260.21, stakingPower = 0.7845 }: Props = $props();
+
+  const href = AppPath.Staking;
+
+  const rewardBalanceFormatted = $derived(
+    $isBalancePrivacyOptionStore
+      ? renderPrivacyModeBalance(5)
+      : nonNullish(rewardBalance)
+        ? formatCurrencyNumber(rewardBalance)
+        : "N/A"
+  );
+  const stakingPowerFormatted = $derived(
+    formatPercentage(stakingPower, {
+      minFraction: 2,
+      maxFraction: 2,
+    })
+  );
+</script>
+
+{#snippet content()}
+  <div class="content">
+    <div class="left">
+      <span class="subtitle">{$i18n.portfolio.apy_card_reward_title}</span>
+      <span class="main-value">~${rewardBalanceFormatted}</span>
+      <span class="secondary-value"
+        ><span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="9"
+            height="8"
+            viewBox="0 0 9 8"
+            fill="none"
+          >
+            <path
+              d="M4.5 0.5L8.39711 7.25H0.602886L4.5 0.5Z"
+              fill="currentColor"
+            />
+          </svg>$85.03</span
+        >{$i18n.portfolio.apy_card_estimation}</span
+      >
+    </div>
+
+    <div class="right">
+      <span class="subtitle">{$i18n.portfolio.apy_card_power_title}</span>
+      <span class="main-value">~{stakingPowerFormatted}</span>
+      <span class="secondary-value">~$16606</span>
+    </div>
+  </div>
+{/snippet}
+
+{#if $isMobileViewportStore}
+  <a class="card mobile" {href}>
+    {@render content()}
+  </a>
+{:else}
+  <article class="card desktop">
+    <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
+    {@render content()}
+
+    <a
+      {href}
+      class="link"
+      aria-label={$i18n.portfolio.apy_card_link}
+      data-tid="project-link"
+    >
+      <span>{$i18n.portfolio.apy_card_link}</span>
+      <IconRight />
+    </a>
+  </article>
+{/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .content {
+    display: flex;
+    justify-content: space-between;
+
+    .left,
+    .right {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      gap: 4px;
+
+      .subtitle {
+        font-size: 12px;
+        font-weight: 700;
+        color: var(--text-description);
+      }
+
+      .main-value {
+        font-size: 24px;
+        font-weight: 450;
+        line-height: 32px;
+
+        @include media.min-width(medium) {
+          font-size: 27px;
+        }
+      }
+
+      .secondary-value {
+        font-size: 12px;
+        font-weight: 450;
+        line-height: 16px;
+
+        @include media.min-width(medium) {
+          font-size: 16px;
+          font-weight: 400;
+          line-height: 20px;
+        }
+
+        display: flex;
+
+        span {
+          display: flex;
+          align-items: center;
+
+          color: #29a079;
+          padding-right: 4px;
+        }
+      }
+    }
+  }
+
+  .card {
+    height: 100%;
+    box-sizing: border-box;
+    background-color: var(--background);
+
+    box-shadow: var(--box-shadow);
+
+    transition:
+      color var(--animation-time-normal),
+      box-shadow var(--animation-time-normal);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .card.mobile {
+    padding: 20px 16px;
+    text-decoration: none;
+  }
+
+  .card.desktop {
+    height: 270px;
+
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+    padding: 24px;
+    grid-gap: 16px;
+
+    .title {
+      font-size: 18px;
+      font-style: normal;
+      font-weight: 450;
+      line-height: 24px;
+    }
+
+    .link {
+      align-self: end;
+      justify-self: end;
+
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      color: var(--button-secondary-color);
+      font-weight: var(--font-weight-bold);
+      text-decoration: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1309,7 +1309,12 @@
     "new_sns_proposal_card_adopt": "Adopt",
     "new_sns_proposal_card_reject": "Reject",
     "next_card": "Next Card",
-    "previous_card": "Previous Card"
+    "previous_card": "Previous Card",
+    "apy_card_title": "Staking Rewards",
+    "apy_card_reward_title": "Reward Balance",
+    "apy_card_power_title": "Staking Power Used",
+    "apy_card_link": "View Staked",
+    "apy_card_estimation": "7d estimate"
   },
   "highlight": {
     "disburse_maturity_title": "Farewell, Spawn Neuron!",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1380,6 +1380,11 @@ interface I18nPortfolio {
   new_sns_proposal_card_reject: string;
   next_card: string;
   previous_card: string;
+  apy_card_title: string;
+  apy_card_reward_title: string;
+  apy_card_power_title: string;
+  apy_card_link: string;
+  apy_card_estimation: string;
 }
 
 interface I18nHighlight {

--- a/frontend/src/tests/lib/components/portfolio/ApyCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/ApyCard.spec.ts
@@ -1,0 +1,75 @@
+import ApyCard from "$lib/components/portfolio/ApyCard.svelte";
+import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { ApyCardPo } from "$tests/page-objects/ApyCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("ApyCardPo", () => {
+  const defaultProps = {
+    rewardBalanceUSD: 1234.56,
+    rewardEstimateWeekUSD: 78.9,
+    stakingPower: 0.4567,
+    stakingPowerUSD: 9876.54,
+    loading: false,
+  };
+
+  const renderComponent = (props = defaultProps) => {
+    const { container } = render(ApyCard, { props });
+
+    return ApyCardPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    resetIdentity();
+  });
+
+  it("should display reward amount", async () => {
+    const po = renderComponent(defaultProps);
+
+    const rewardAmount = await po.getRewardAmount();
+    expect(rewardAmount).toEqual("$1’235");
+  });
+
+  it("should display projection amount", async () => {
+    const po = renderComponent(defaultProps);
+
+    const projectionAmount = await po.getProjectionAmount();
+    expect(projectionAmount).toEqual("$78.90");
+  });
+
+  it("should display staking power percentage", async () => {
+    const po = renderComponent(defaultProps);
+
+    const stakingPower = await po.getStakingPowerPercentage();
+    expect(stakingPower).toEqual("45.67%");
+  });
+
+  it("should display total staking power USD", async () => {
+    const po = renderComponent(defaultProps);
+
+    const totalStakingPower = await po.getTotalStakingPowerUSD();
+    expect(totalStakingPower).toEqual("$9’877");
+  });
+
+  it("should have project link", async () => {
+    const po = renderComponent(defaultProps);
+
+    const linkPo = po.getLinkPo();
+    expect(await linkPo.isPresent()).toBe(true);
+    expect(await linkPo.getHref()).toBe("/staking");
+  });
+
+  it("should display privacy placeholders when privacy mode is enabled", async () => {
+    balancePrivacyOptionStore.set("hide");
+    const po = renderComponent(defaultProps);
+
+    const rewardAmount = await po.getRewardAmount();
+    const totalStakingPower = await po.getTotalStakingPowerUSD();
+    const projectionAmount = await po.getProjectionAmount();
+
+    expect(rewardAmount).toEqual("$•••••");
+    expect(totalStakingPower).toEqual("$•••");
+    expect(projectionAmount).toEqual("$•••");
+  });
+});

--- a/frontend/src/tests/page-objects/ApyCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ApyCard.page-object.ts
@@ -1,0 +1,34 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ApyCardPo extends BasePageObject {
+  private static readonly TID = "apy-card-component";
+
+  static under(element: PageObjectElement): ApyCardPo {
+    return new ApyCardPo(element.byTestId(ApyCardPo.TID));
+  }
+
+  getRewardAmount(): Promise<string> {
+    return this.getText("reward");
+  }
+
+  getProjectionAmount(): Promise<string> {
+    return this.getText("projection");
+  }
+
+  getStakingPowerPercentage(): Promise<string> {
+    return this.getText("staking-power");
+  }
+
+  getTotalStakingPowerUSD(): Promise<string> {
+    return this.getText("total-staking-power");
+  }
+
+  getLinkPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "project-link",
+    });
+  }
+}


### PR DESCRIPTION
# Motivation

The nns-dapp will display information to users about their staking power and exploitation. This PR introduces new cards based on the API defined in #7065.

| Narrow | Mobile | Desktop |
|--------|--------|--------|
| ![Screenshot 2025-07-08 at 01 46 49](https://github.com/user-attachments/assets/d6b5c42b-a03e-4f26-b5ad-8a5cb2c1a7e6) | ![Screenshot 2025-07-08 at 01 47 12](https://github.com/user-attachments/assets/89b02c4a-a459-4aa6-b65f-ac13078bcd3b) | ![Screenshot 2025-07-08 at 01 47 32](https://github.com/user-attachments/assets/48246e86-073d-4372-aa68-154ff8f33b49) | 

Note: This PR does not add the new card to the portfolio page where all the cars are displayed. This will be addressed in a follow-up.

[NNS1-3922](https://dfinity.atlassian.net/browse/NNS1-3922)

# Changes

- New card with information about the staking rewards.

# Tests

- Unit tests new card.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3922]: https://dfinity.atlassian.net/browse/NNS1-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ