### PR TITLE
feat(launchpad2): Project card

### DIFF
--- a/frontend/src/lib/components/launchpad/UpcomingProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/UpcomingProjectCard.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import CardFrame from "$lib/components/launchpad/CardFrame.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { i18n } from "$lib/stores/i18n";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
+  import { durationTillSwapStart } from "$lib/utils/projects.utils";
+  import {
+    IconClockNoFill,
+    IconOpenInNew,
+    IconRight,
+    IconRocketLaunch,
+    Tag,
+  } from "@dfinity/gix-components";
+  import { secondsToDuration } from "@dfinity/utils";
+
+  type Props = {
+    summary: SnsSummaryWrapper;
+  };
+
+  const { summary }: Props = $props();
+
+  const projectUrl = $derived(summary.metadata.url);
+
+  const durationTillStart = $derived(durationTillSwapStart(summary.swap) ?? 0n);
+  const href = $derived(
+    `${AppPath.Project}/?project=${summary.rootCanisterId.toText()}`
+  );
+</script>
+
+<CardFrame testId="upcoming-project-card-component" mobileHref={href}>
+  <div class="card-content">
+    <div class="header">
+      <Logo
+        src={summary.metadata.logo}
+        alt={summary.metadata.name}
+        size="medium"
+      />
+      <h3 data-tid="project-name">{summary.metadata.name}</h3>
+      <Tag size="medium">
+        <span>{$i18n.launchpad_cards.upcoming_tag_upcoming}</span>
+        <IconRocketLaunch size="14px" />
+      </Tag>
+    </div>
+
+    <div class="content">
+      <p class="description" data-tid="project-description"
+        >{summary.metadata.description}</p
+      >
+      <a
+        data-tid="project-site-link"
+        href={projectUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="link"
+        aria-label={$i18n.launchpad_cards.upcoming_link}
+      >
+        <span class="text">{$i18n.launchpad_cards.upcoming_link}</span>
+        <IconOpenInNew />
+      </a>
+    </div>
+
+    <div class="footer">
+      <div class="time-remaining">
+        <IconClockNoFill size="20px" />
+        <span>{$i18n.launchpad_cards.upcoming_sale_starts}</span>
+        <span data-tid="time-remaining">
+          {secondsToDuration({
+            seconds: durationTillStart,
+            i18n: $i18n.time,
+          })}
+        </span>
+      </div>
+      <a
+        {href}
+        class="link"
+        aria-label={$i18n.core.view}
+        data-tid="project-link"
+      >
+        <span>{$i18n.core.view}</span>
+        <IconRight />
+      </a>
+    </div>
+  </div>
+</CardFrame>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "../../themes/mixins/launchpad";
+
+  .card-content {
+    @include launchpad.card_content();
+
+    background-color: var(--card-background-tint);
+    // Make the last row always be at the bottom of the card
+    grid-template-rows: auto auto 1fr;
+
+    .header {
+      @include launchpad.card_content_header();
+      // @include portfolio.card-tag;
+
+      --logo-size: var(--padding-4x);
+      @include media.min-width(medium) {
+        --logo-size: 40px;
+      }
+
+      h3 {
+        @include launchpad.text_h3;
+        // TODO(launchpad2): think about moving to _launchpad mixin
+        @include text.truncate;
+
+        margin: 0;
+        padding: 0;
+      }
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding);
+
+      .description {
+        @include launchpad.text_h5;
+        @include text.clamp(5);
+
+        margin: 0;
+        color: var(--color-text-secondary);
+      }
+
+      .link {
+        @include launchpad.text_button;
+
+        display: flex;
+        align-items: center;
+        gap: var(--padding);
+        color: var(--button-primary);
+      }
+    }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: end;
+
+      .time-remaining {
+        @include launchpad.text_body;
+
+        display: flex;
+        align-items: center;
+        gap: var(--padding);
+      }
+
+      .link {
+        @include launchpad.text_button;
+        color: var(--button-secondary-color);
+
+        display: none;
+        @include media.min-width(medium) {
+          display: flex;
+        }
+
+        align-items: center;
+        gap: var(--padding-0_5x);
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -904,7 +904,10 @@
     "project_card_token_price": "Token Price",
     "project_card_icp_in_treasury": "ICP in Treasury",
     "project_card_my_participation": "My Participation",
-    "project_card_proposal_activity": "Proposal Activity"
+    "project_card_proposal_activity": "Proposal Activity",
+    "upcoming_tag_upcoming": "Upcoming",
+    "upcoming_link": "Link to project",
+    "upcoming_sale_starts": "Sale starts in"
   },
   "sns_project_detail": {
     "swap_proposal": "Swap Proposal",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -941,6 +941,9 @@ interface I18nLaunchpad_cards {
   project_card_icp_in_treasury: string;
   project_card_my_participation: string;
   project_card_proposal_activity: string;
+  upcoming_tag_upcoming: string;
+  upcoming_link: string;
+  upcoming_sale_starts: string;
 }
 
 interface I18nSns_project_detail {

--- a/frontend/src/tests/lib/components/launchpad/UpcomingProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/UpcomingProjectCard.spec.ts
@@ -1,0 +1,70 @@
+import UpcomingProjectCard from "$lib/components/launchpad/UpcomingProjectCard.svelte";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
+import { createSummary } from "$tests/mocks/sns-projects.mock";
+import { UpcomingProjectCardPo } from "$tests/page-objects/UpcomingProjectCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Principal } from "@dfinity/principal";
+import { render } from "@testing-library/svelte";
+
+describe("UpcomingProjectCard", () => {
+  const renderComponent = (summary: SnsSummaryWrapper) => {
+    const { container } = render(UpcomingProjectCard, {
+      props: {
+        summary,
+      },
+    });
+
+    return UpcomingProjectCardPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should display project name and description", async () => {
+    const projectName = "Test Project";
+    const projectDescription = "This is a test project description";
+    const summary = createSummary({
+      projectName,
+      projectDescription,
+    });
+    const po = renderComponent(summary);
+
+    expect(await po.getTitle()).toBe(projectName);
+    expect(await po.getDescription()).toBe(projectDescription);
+  });
+
+  it("should display link to project page", async () => {
+    const projectUrl = "https://testproject.com";
+    const summary = createSummary({
+      projectUrl,
+    });
+    const po = renderComponent(summary);
+
+    expect(await po.getProjectSiteLinkPo().getHref()).toBe(projectUrl);
+  });
+
+  it("should display time remaining until swap start", async () => {
+    const mockDate = new Date("2025-03-11T00:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+
+    // 3 days from now
+    const swapOpenTimestampSeconds = BigInt(Date.now()) / 1000n + 3n * 86400n;
+    const summary = createSummary({
+      swapOpenTimestampSeconds,
+    });
+
+    const po = renderComponent(summary);
+
+    const timeRemaining = await po.getTimeRemaining();
+    expect(timeRemaining).toEqual("3 days");
+  });
+
+  it("should have link to project page", async () => {
+    const rootCanisterId = Principal.fromText("aaaaa-aa");
+    const summary = createSummary({
+      rootCanisterId,
+    });
+    const po = renderComponent(summary);
+    const expectedHref = `/project/?project=${rootCanisterId.toText()}`;
+
+    expect(await po.getProjectLinkPo().getHref()).toBe(expectedHref);
+  });
+});

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -345,6 +345,7 @@ type SnsSummaryParams = {
   rootCanisterId?: Principal;
   projectName?: string;
   projectDescription?: string;
+  projectUrl?: string;
   logo?: string;
 };
 
@@ -372,6 +373,7 @@ export const createSummary = ({
   rootCanisterId,
   projectName,
   projectDescription,
+  projectUrl,
   logo,
 }: SnsSummaryParams): SnsSummaryWrapper => {
   const init: SnsSwapInit = {
@@ -423,6 +425,7 @@ export const createSummary = ({
     name: projectName ?? mockMetadata.name,
     logo: logo ?? mockMetadata.logo,
     description: projectDescription ?? mockMetadata.description,
+    url: projectUrl ?? mockMetadata.url,
   };
   const summary = summaryForLifecycle(lifecycle);
   return summary.override({

--- a/frontend/src/tests/page-objects/UpcomingProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/UpcomingProjectCard.page-object.ts
@@ -1,0 +1,39 @@
+import { CardFramePo } from "$tests/page-objects/CardFrame.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class UpcomingProjectCardPo extends CardFramePo {
+  private static readonly TID = "upcoming-project-card-component";
+
+  static under(element: PageObjectElement): UpcomingProjectCardPo {
+    return new UpcomingProjectCardPo(
+      element.byTestId(UpcomingProjectCardPo.TID)
+    );
+  }
+
+  getTitle(): Promise<string> {
+    return this.getText("project-name");
+  }
+
+  getDescription(): Promise<string> {
+    return this.getText("project-description");
+  }
+
+  getProjectSiteLinkPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "project-site-link",
+    });
+  }
+
+  getTimeRemaining(): Promise<string> {
+    return this.getText("time-remaining");
+  }
+
+  getProjectLinkPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "project-link",
+    });
+  }
+}


### PR DESCRIPTION
# Motivation

As part of the Launchpad redesign, the launched project card needs to be updated. This PR introduces a new ProjectCard component.

**Out of scope:**
- Fav projects.
- Assets in Treasury field.
- Proposal Activity field.

https://dfinity.atlassian.net/browse/NNS1-3904

# Changes

- Add ProjectCard2 component (will be renamed later)

# Tests

- Added.
- Tested locally:

| M | D |
|--------|--------|
| <img width="329" alt="image" src="https://github.com/user-attachments/assets/4de682c6-59f9-426d-b1ed-03dac6505a15" /> | <img width="1165" alt="image" src="https://github.com/user-attachments/assets/09502ae3-2685-4e98-a961-38b0fb9e18fc" /> | 

Version with participation:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/48686c82-92b5-46a4-842e-60e55df82359" />


# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
