### PR TITLE
feat(launchpad2): 

### DIFF
--- a/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
+++ b/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import CardFrame from "$lib/components/launchpad/CardFrame.svelte";
+  import VotesResult from "$lib/components/portfolio/VotesResult.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import VoteLogo from "$lib/components/universe/VoteLogo.svelte";
+  import { pageStore } from "$lib/derived/page.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import { buildProposalUrl } from "$lib/utils/navigation.utils";
+  import { mapProposalInfoToCard } from "$lib/utils/portfolio.utils";
+  import {
+    IconClockNoFill,
+    IconRight,
+    IconVote,
+    Tag,
+  } from "@dfinity/gix-components";
+  import type { ProposalInfo } from "@dfinity/nns";
+  import { nonNullish, secondsToDuration } from "@dfinity/utils";
+
+  type Props = {
+    proposalInfo: ProposalInfo;
+  };
+  const { proposalInfo }: Props = $props();
+
+  const proposal = $derived(mapProposalInfoToCard(proposalInfo));
+  const universe = $derived($pageStore.universe);
+  const href = $derived(
+    nonNullish(proposal)
+      ? buildProposalUrl({
+          universe,
+          proposalId: proposal.id,
+          actionable: false,
+        })
+      : "#"
+  );
+</script>
+
+{#if nonNullish(proposal)}
+  <CardFrame testId="create-sns-proposal-card-component" mobileHref={href}>
+    <div class="card-content">
+      <div class="header">
+        {#if nonNullish(proposal?.logo) && nonNullish(proposal?.name)}
+          <Logo src={proposal?.logo} alt={proposal?.name} size="medium" />
+        {:else}
+          <VoteLogo size="medium" />
+        {/if}
+        <h3 data-tid="project-name">{proposal.name}</h3>
+        <Tag size="medium">
+          <span>{$i18n.portfolio.project_status_proposal}</span>
+          <IconVote size="14px" />
+        </Tag>
+      </div>
+
+      <div class="content">
+        <div class="description-wrapper">
+          <h3 class="title"
+            >{$i18n.launchpad_cards.create_sns_proposal_title}</h3
+          >
+          <p class="description" data-tid="proposal-title">{proposal.title}</p>
+        </div>
+        <VotesResult
+          yes={Number(proposalInfo.latestTally?.yes)}
+          no={Number(proposalInfo.latestTally?.no)}
+          total={Number(proposalInfo.latestTally?.total)}
+        />
+      </div>
+
+      <div class="footer">
+        <div class="time-remaining">
+          <IconClockNoFill size="20px" />
+          <span data-tid="time-remaining">
+            {secondsToDuration({
+              seconds: proposal.durationTillDeadline,
+              i18n: $i18n.time,
+            })}
+          </span>
+        </div>
+        <a
+          {href}
+          class="link"
+          aria-label={$i18n.core.view}
+          data-tid="proposal-link"
+        >
+          <span>{$i18n.launchpad_cards.create_sns_proposal_vote}</span>
+          <IconRight />
+        </a>
+      </div>
+    </div>
+  </CardFrame>
+{/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "../../themes/mixins/launchpad";
+  @use "../../themes/mixins/portfolio";
+
+  .card-content {
+    @include launchpad.card_content;
+
+    // Make the last row always be at the bottom of the card
+    grid-template-rows: auto auto 1fr;
+
+    .header {
+      @include launchpad.card_content_header;
+      @include portfolio.card-tag;
+
+      --logo-size: var(--padding-4x);
+      @include media.min-width(medium) {
+        --logo-size: 40px;
+      }
+
+      h3 {
+        margin: 0;
+        padding: 0;
+        @include launchpad.text_h3;
+        @include text.truncate;
+      }
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-2x);
+      height: 124px;
+
+      .description-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: var(--padding-0_5x);
+
+        h3 {
+          @include launchpad.text_h3;
+          @include text.clamp(1);
+
+          margin: 0;
+          padding: 0;
+        }
+
+        .description {
+          @include launchpad.text_body;
+          @include text.clamp(1);
+
+          margin: 0;
+          padding: 0;
+          color: var(--color-text-secondary);
+        }
+      }
+    }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: end;
+
+      .time-remaining {
+        @include launchpad.text_body;
+
+        display: flex;
+        align-items: center;
+        gap: var(--padding);
+      }
+
+      .link {
+        @include launchpad.text_button;
+        color: var(--button-secondary-color);
+
+        display: none;
+        @include media.min-width(medium) {
+          display: flex;
+        }
+
+        align-items: center;
+        gap: var(--padding-0_5x);
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -903,7 +903,9 @@
 
     "upcoming_tag_upcoming": "Upcoming",
     "upcoming_link": "Link to project",
-    "upcoming_sale_starts": "Sale starts in"
+    "upcoming_sale_starts": "Sale starts in",
+    "create_sns_proposal_title": "Create Service Nervous System (SNS)",
+    "create_sns_proposal_vote": "Vote"
   },
   "sns_project_detail": {
     "swap_proposal": "Swap Proposal",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -939,6 +939,8 @@ interface I18nLaunchpad_cards {
   upcoming_tag_upcoming: string;
   upcoming_link: string;
   upcoming_sale_starts: string;
+  create_sns_proposal_title: string;
+  create_sns_proposal_vote: string;
 }
 
 interface I18nSns_project_detail {

--- a/frontend/src/tests/lib/components/launchpad/CreateSnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/CreateSnsProposalCard.spec.ts
@@ -1,0 +1,99 @@
+import CreateSnsProposalCard from "$lib/components/launchpad/CreateSnsProposalCard.svelte";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { CreateSnsProposalCardPo } from "$tests/page-objects/CreateSnsProposalCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  type CreateServiceNervousSystem,
+  type ProposalInfo,
+} from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+
+describe("CreateSnsProposalCard", () => {
+  const mockProposal = {
+    proposal: {
+      title: "Proposal to create new SNS",
+      summary: "",
+      url: "url",
+      action: {
+        CreateServiceNervousSystem: {
+          name: "TestDAO",
+          governanceParameters: {},
+          fallbackControllerPrincipalIds: [],
+          logo: {},
+          url: "url",
+          ledgerParameters: {},
+          description: "",
+          dappCanisters: [],
+          swapParameters: {},
+          initialTokenDistribution: {},
+        },
+      },
+    },
+  } as ProposalInfo;
+
+  const renderComponent = (proposalInfo: ProposalInfo) => {
+    const { container } = render(CreateSnsProposalCard, {
+      props: {
+        proposalInfo,
+      },
+    });
+
+    return CreateSnsProposalCardPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should display project name and description", async () => {
+    const po = renderComponent(mockProposal);
+    const expectedProjectName = (
+      mockProposal.proposal.action as {
+        CreateServiceNervousSystem: CreateServiceNervousSystem;
+      }
+    ).CreateServiceNervousSystem.name;
+    const expectedProposalTitle = mockProposal.proposal.title;
+
+    expect(await po.getTitle()).toBe(expectedProjectName);
+    expect(await po.getProposalTitle()).toBe(expectedProposalTitle);
+  });
+
+  it("should display percentage of yes/no", async () => {
+    const po = renderComponent({
+      ...mockProposal,
+      latestTally: {
+        yes: 100_000_000n,
+        no: 200_000_000n,
+        total: 300_000_000n,
+        timestampSeconds: 10000000n,
+      },
+    });
+
+    expect(await po.getAdoptPercentage()).toBe("33.33%");
+    expect(await po.getRejectPercentage()).toBe("66.67%");
+  });
+
+  it("should display time remaining until deadline", async () => {
+    const mockDate = new Date("2025-03-11T00:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+
+    const oneDayLater = new Date(mockDate.getTime() + 24 * 60 * 60 * 1000);
+    const deadlineTimestampSeconds = BigInt(
+      Math.floor(oneDayLater.getTime() / 1000)
+    );
+
+    const po = renderComponent({
+      ...mockProposal,
+      deadlineTimestampSeconds,
+    });
+
+    expect(await po.getTimeRemaining()).toEqual("1 day");
+  });
+
+  it("should have proper link to project page", async () => {
+    const po = renderComponent({
+      ...mockProposal,
+      id: 1n,
+    });
+    const expectedHref = `/proposal/?u=${OWN_CANISTER_ID_TEXT}&proposal=1`;
+
+    expect(await po.getLinkPo().getHref()).toBe(expectedHref);
+  });
+});

--- a/frontend/src/tests/page-objects/CreateSnsProposalCard.page-object.ts
+++ b/frontend/src/tests/page-objects/CreateSnsProposalCard.page-object.ts
@@ -1,0 +1,40 @@
+import { CardFramePo } from "$tests/page-objects/CardFrame.page-object";
+import { LinkPo } from "$tests/page-objects/Link.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class CreateSnsProposalCardPo extends CardFramePo {
+  private static readonly TID = "create-sns-proposal-card-component";
+
+  static under(element: PageObjectElement): CreateSnsProposalCardPo {
+    return new CreateSnsProposalCardPo(
+      element.byTestId(CreateSnsProposalCardPo.TID)
+    );
+  }
+
+  getTitle(): Promise<string> {
+    return this.getText("project-name");
+  }
+
+  getProposalTitle(): Promise<string> {
+    return this.getText("proposal-title");
+  }
+
+  getAdoptPercentage(): Promise<string> {
+    return this.getText("adopt-percentage");
+  }
+
+  getRejectPercentage(): Promise<string> {
+    return this.getText("reject-percentage");
+  }
+
+  getTimeRemaining(): Promise<string> {
+    return this.getText("time-remaining");
+  }
+
+  getLinkPo(): LinkPo {
+    return LinkPo.under({
+      element: this.root,
+      testId: "proposal-link",
+    });
+  }
+}


### PR DESCRIPTION
# Motivation

As part of the Launchpad redesign, the create Sns proposal card needs to be updated. This PR introduces a new CreateSnsProposalCard component.

Out of scope of this pr:
- desktop voting result redesign.

# Changes

- New CreateSnsProposalCard component.

# Tests

- Added.
- Tested manually:

| M | D |
|--------|--------|
| <img width="407" alt="image" src="https://github.com/user-attachments/assets/a562d4ad-1a12-4f03-9121-e204f38319e1" /> | <img width="452" alt="image" src="https://github.com/user-attachments/assets/b7eec1ea-7a40-413a-b26b-8e242b8c7105" /> | 


# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
