### PR TITLE
chore(deps): bump ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.13-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.13-next-2025-07-02.tgz",
-      "integrity": "sha512-K+hoaFY8VFU3CCALudvzsusXuYfMinEPyCVgyhXp70DNWgYjdDlKcHxHqKeFMfWXa35KM8liI+ELeOWPS67Z/g==",
+      "version": "3.1.13-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.13-next-2025-07-08.tgz",
+      "integrity": "sha512-/l14Yd4nyMq2ruvRjZ1GNiVraq8A9rRBRTC1wXUAb7bjet3Z4EVEXdKPYXrZad8Lf6j6rRYRIOci49kiQeEZ8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "5.0.6-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.6-next-2025-07-02.tgz",
-      "integrity": "sha512-BL0smpjwes9Mw22/JC5PnMcAI5FHME+Jl0542gwqBv+GrhFU1WGx6GXEaeGoaJiGuz+Lk2PLV14nVOXvbLjlRw==",
+      "version": "5.0.6-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.6-next-2025-07-08.tgz",
+      "integrity": "sha512-do/A/+GHyQ+xndur1tgJdnpnT2lYhC4fNqy3Z3FLlXKqPUpH8qE+pM4jgpYox4U9NZfpz/9Fv65vFvXAzRTshw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "6.2.0-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.2.0-next-2025-07-02.tgz",
-      "integrity": "sha512-C6z6TvGXntBxwHJyXzWwaGUFyOICcQa+VzOi6mHSR6yvatmdiP5YANhh8pyltN8fUQfGSsXmNKVd1i3f9qE/LA==",
+      "version": "6.2.0-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.2.0-next-2025-07-08.tgz",
+      "integrity": "sha512-kXM+8LAnn9/ESZ3mz/6x+Vw4xGGFP9CQr00PSo3qi6UtpvkGIjW2VAW8zxoDcDpUGpo6SZigAcFAgtdX3E3cBQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "3.0.0-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-3.0.0-next-2025-07-02.tgz",
-      "integrity": "sha512-WAj67pYX4lv4iHJdAfNusxHGxGoilZibin67D8hY7UeYGN6/E/fQQp+MOQfLVZtpW+zi8HRuT8F99EA1C4azTQ==",
+      "version": "3.0.0-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-3.0.0-next-2025-07-08.tgz",
+      "integrity": "sha512-WHM3OvYj59rgSXu2Px8pwPG7/bpthY3groZozskFAbDLvcaaA0xs8SJys5hqZY7uiHQFzJl8oA0u2m/GM+2UwQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.9.0-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.9.0-next-2025-07-02.tgz",
-      "integrity": "sha512-JQgTwaov8kMhiiG77oGJkpxSsrBp2vQ2ud8a4HbD72LZXNizRsbwItwqTBor1OYPEMMUu19+Vijyy6knh1UMXw==",
+      "version": "2.9.0-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.9.0-next-2025-07-08.tgz",
+      "integrity": "sha512-hbza7qOWlQMhpXvRJvH8lE9f3r/hpfYXtoVTv3DTcePvoI2h0sgubvwPo4rcNy6ujpOU3jwh9Yhlm4CAURmpRg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -444,14 +444,13 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "8.5.0-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.5.0-next-2025-07-02.tgz",
-      "integrity": "sha512-KABTw9/8cPS2P+NZoq2EuBZ9tEpVJE/dd19dSDvlEaslCs5UH7Hz2It+WByJJwo6yZJ/FE00iYduL9BH1AG89Q==",
+      "version": "8.5.0-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.5.0-next-2025-07-08.tgz",
+      "integrity": "sha512-5ZEqM0kj6plN3GhKcBOnDQdM6K2pgz0WTiFK1y7N0t7DQuxQdd2mqp9tSZtVqOg7l/HChnWqE+2+db/wxu7bKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "buffer": "^6.0.3",
-        "randombytes": "^2.1.0"
+        "buffer": "^6.0.3"
       },
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -471,9 +470,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.7.0-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.7.0-next-2025-07-02.tgz",
-      "integrity": "sha512-PRKwUYKJMSOzayJPlz/YCDM0nPZNg41oKsmRFXviACDGugzhlPjCB/BDmuh5yTqzzprGPvrkB4qorlcY9/a5rg==",
+      "version": "3.7.0-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.7.0-next-2025-07-08.tgz",
+      "integrity": "sha512-Ceisg5xhIQ2MPeLtcpijULTPzO1XcFVl/FyCJFQMqdXIv1ZR6RrbYetLaElxJaOa23Cj5cyOnAXX4nQvODqr+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -487,9 +486,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.13.1-next-2025-07-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.1-next-2025-07-02.tgz",
-      "integrity": "sha512-k+zEcqrRgUDTK3/VhRhom9ChYe0OgKgcxr7E2CrQyO43hrEhuhSjJSBws/Vs+X4cO54b5q8qsUdU/KGd96+/kA==",
+      "version": "2.13.1-next-2025-07-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.1-next-2025-07-08.tgz",
+      "integrity": "sha512-O24pf0vbzPs14y0ztSbHnfjn2nCF4t05Pt1Q47fnpVDwfPeQ2yAC1FzsBwA0hYly1tj68++ec9HluDFsjmJTRA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -5334,15 +5333,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/rc": {
       "version": "1.2.8",

--- a/frontend/src/tests/mocks/governance-metrics.mock.ts
+++ b/frontend/src/tests/mocks/governance-metrics.mock.ts
@@ -102,4 +102,5 @@ export const mockGovernanceMetrics: GovernanceCachedMetrics = {
   totalStakedMaturityE8sEquivalentSeed: 8n,
   totalSupplyIcp: 1000000n,
   totalVotingPowerNonSelfAuthenticatingController: undefined,
+  spawningNeuronsCount: 2n,
 };


### PR DESCRIPTION
# Motivation

#7075 attempts to upgrade the version of ic-js to include the [new field](https://github.com/dfinity/ic-js/pull/983) `total_potential_voting_power`. However, it fails due to a breaking change in the NNS governance candid, which introduced a new mandatory field in the response of `get_metrics`.

# Changes

- Bump ic-js by running `npm run upgrade:next`
- Fix mock

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
