### PR TITLE
fix(sns_aggregator): Call `get_metrics_replicated` instead of `get_metrics`

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1002,8 +1002,8 @@ impl Service {
     pub async fn get_metadata(&self, arg0: GetMetadataArg) -> CallResult<(GetMetadataResponse,)> {
         ic_cdk::call(self.0, "get_metadata", (arg0,)).await
     }
-    pub async fn get_metrics(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
-        ic_cdk::call(self.0, "get_metrics", (arg0,)).await
+    pub async fn get_metrics_replicated(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
+        ic_cdk::call(self.0, "get_metrics_replicated", (arg0,)).await
     }
     pub async fn get_mode(&self, arg0: GetModeArg) -> CallResult<(GetModeResponse,)> {
         ic_cdk::call(self.0, "get_mode", (arg0,)).await

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -131,15 +131,15 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
             })
             .unwrap_or(existing_data.parameters);
 
-    crate::state::log(format!("Getting SNS index {index}... get_metrics"));
+    crate::state::log(format!("Getting SNS index {index}... get_metrics_replicated"));
     let arg: types::GetMetricsRequest = GetMetricsRequest {
         time_window_seconds: Some(TIME_WINDOW_SECONDS),
     };
-    let metrics = ic_cdk::api::call::call(governance_canister_id, "get_metrics", (arg,))
+    let metrics = ic_cdk::api::call::call(governance_canister_id, "get_metrics_replicated", (arg,))
         .await
         .map(|response: (_,)| response.0)
         .map_err(|err| {
-            crate::state::log(format!("Call to SnsGovernance.get_metrics failed: {err:?}"));
+            crate::state::log(format!("Call to SnsGovernance.get_metrics_replicated failed: {err:?}"));
         })
         .unwrap_or(existing_data.metrics);
 


### PR DESCRIPTION
# Motivation

Composite queries are a very nice feature, but unfortunately they cannot be used by canisters. But the SNS Aggregator is a canister. So we circumvent this problem by calling a cousin update method, called `get_metrics_replicated`, to obtain SNS metrics, instead.

# Changes

Call `get_metrics_replicated` instead of `get_metrics`.

# Tests

Manual + CI

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
