### PR TITLE
Revert "chore: Bump IC types"

### DIFF
--- a/config.json
+++ b/config.json
@@ -118,8 +118,8 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2025-06-25",
-        "IC_COMMIT_FOR_PROPOSALS": "fccfa2c7c7cba9e5485ad0b48823990e24a67f40",
-        "IC_COMMIT_FOR_SNS_AGGREGATOR": "fccfa2c7c7cba9e5485ad0b48823990e24a67f40"
+        "IC_COMMIT_FOR_PROPOSALS": "release-2025-06-26_03-25-base",
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2025-07-03_03-27-base"
       },
       "packtool": ""
     }

--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-06-26_03-25-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -376,7 +376,6 @@ type GovernanceCachedMetrics = record {
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
-  spawning_neurons_count : nat64;
 
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-06-26_03-25-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -73,40 +73,31 @@ type CompleteCanisterMigrationPayload = record {
 type CreateSubnetPayload = record {
   unit_delay_millis : nat64;
   features : SubnetFeatures;
+  gossip_registry_poll_period_ms : nat32;
   max_ingress_bytes_per_message : nat64;
   dkg_dealings_per_block : nat64;
   max_block_payload_size : nat64;
   start_as_nns : bool;
   is_halted : bool;
+  gossip_pfn_evaluation_period_ms : nat32;
   max_ingress_messages_per_block : nat64;
   max_number_of_canisters : nat64;
   chain_key_config : opt InitialChainKeyConfig;
+  gossip_max_artifact_streams_per_peer : nat32;
   replica_version_id : text;
+  gossip_max_duplicity : nat32;
+  gossip_max_chunk_wait_ms : nat32;
   dkg_interval_length : nat64;
   subnet_id_override : opt principal;
   ssh_backup_access : vec text;
+  ingress_bytes_per_block_soft_cap : nat64;
   initial_notary_delay_millis : nat64;
+  gossip_max_chunk_size : nat32;
   subnet_type : SubnetType;
   ssh_readonly_access : vec text;
-  node_ids : vec principal;
-
-  canister_cycles_cost_schedule: opt CanisterCyclesCostSchedule;
-
-  // TODO(NNS1-2444): The fields below are deprecated and they are not read anywhere.
-  ingress_bytes_per_block_soft_cap : nat64;
-  gossip_max_artifact_streams_per_peer : nat32;
-  gossip_max_chunk_size : nat32;
-  gossip_max_chunk_wait_ms : nat32;
-  gossip_max_duplicity : nat32;
-  gossip_pfn_evaluation_period_ms : nat32;
-  gossip_receive_check_cache_size : nat32;
-  gossip_registry_poll_period_ms : nat32;
   gossip_retransmission_request_ms : nat32;
-};
-
-type CanisterCyclesCostSchedule = variant {
-  Normal;
-  Free;
+  gossip_receive_check_cache_size : nat32;
+  node_ids : vec principal;
 };
 
 type DataCenterRecord = record {

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-06-26_03-25-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
+++ b/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-07-03_03-27-base/rs/sns/governance/canister/governance.did>
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -254,43 +254,10 @@ type GetMetricsRequest = record {
   time_window_seconds : opt nat64;
 };
 
-type TreasuryMetrics = record {
-  // Same as, e.g., `TransferSnsTreasuryFunds.from_treasury`.
-  treasury : int32;
-
-  // A human-readable identified for this treasury, e.g., "ICP".
-  name : opt text;
-  
-  // The source of truth for the treasury balance is this ledger canister / account.
-  ledger_canister_id : opt principal;
-  account : opt Account;
-
-  // The regularly updated amount of tokens in this treasury.
-  amount_e8s : opt nat64;
-  // The amount of tokens in this treasury at the end of swap finalization.
-  original_amount_e8s : opt nat64;
-
-  // When the metrics were last updated.
-  timestamp_seconds : opt nat64;
-};
-
-type VotingPowerMetrics = record {
-  governance_total_potential_voting_power : opt nat64; 
-
-  // When the metrics were last updated.
-  timestamp_seconds : opt nat64;
-};
-
 type Metrics = record {
   num_recently_submitted_proposals : opt nat64;
   num_recently_executed_proposals: opt nat64;
-
   last_ledger_block_timestamp : opt nat64;
-
-  // The metrics below are cached (albeit this is an implementation detail).
-  treasury_metrics : opt vec TreasuryMetrics;
-  voting_power_metrics : opt VotingPowerMetrics;
-  genesis_timestamp_seconds : opt nat64;
 };
 
 type GetMetricsResult = variant {
@@ -393,8 +360,6 @@ type GovernanceCachedMetrics = record {
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   timestamp_seconds : nat64;
-  treasury_metrics : vec TreasuryMetrics;
-  voting_power_metrics : opt VotingPowerMetrics;
 };
 
 type GovernanceError = record {
@@ -985,7 +950,6 @@ service : (Governance) -> {
   get_maturity_modulation : (record {}) -> (GetMaturityModulationResponse);
   get_metadata : (record {}) -> (GetMetadataResponse) query;
   get_metrics : (GetMetricsRequest) -> (GetMetricsResponse) composite_query;
-  get_metrics_replicated : (GetMetricsRequest) -> (GetMetricsResponse);
   get_mode : (record {}) -> (GetModeResponse) query;
   get_nervous_system_parameters : (null) -> (NervousSystemParameters) query;
   get_neuron : (GetNeuron) -> (GetNeuronResponse) query;

--- a/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
+++ b/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/ledger_suite/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-07-03_03-27-base/rs/ledger_suite/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/used_by_sns_aggregator/sns_root/sns_root.did
+++ b/declarations/used_by_sns_aggregator/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-07-03_03-27-base/rs/sns/root/canister/root.did>
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
+++ b/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-07-03_03-27-base/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-07-03_03-27-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-06-26_03-25-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -560,7 +560,6 @@ pub struct GovernanceCachedMetrics {
     pub total_voting_power_non_self_authenticating_controller: Option<u64>,
     pub total_staked_maturity_e8s_equivalent: u64,
     pub not_dissolving_neurons_e8s_buckets_ect: Vec<(u64, f64)>,
-    pub spawning_neurons_count: u64,
     pub declining_voting_power_neuron_subset_metrics: Option<NeuronSubsetMetrics>,
     pub total_staked_e8s_ect: u64,
     pub not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: u64,

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-06-26_03-25-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -124,11 +124,6 @@ pub struct SubnetFeatures {
     pub sev_enabled: Option<bool>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub enum CanisterCyclesCostSchedule {
-    Free,
-    Normal,
-}
-#[derive(Serialize, CandidType, Deserialize)]
 pub enum SchnorrAlgorithm {
     #[serde(rename = "ed25519")]
     Ed25519,
@@ -205,7 +200,6 @@ pub struct CreateSubnetPayload {
     pub gossip_pfn_evaluation_period_ms: u32,
     pub max_ingress_messages_per_block: u64,
     pub max_number_of_canisters: u64,
-    pub canister_cycles_cost_schedule: Option<CanisterCyclesCostSchedule>,
     pub gossip_max_artifact_streams_per_peer: u32,
     pub replica_version_id: String,
     pub gossip_max_duplicity: u32,

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-06-26_03-25-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,15 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 1cabf2a85..0e6b6a301 100644
+index 7566582df..00c91ff35 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -1,5 +1,5 @@
- //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
--//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/fccfa2c7c7cba9e5485ad0b48823990e24a67f40/rs/ledger_suite/icrc1/ledger/ledger.did>
-+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2025-07-03_03-27-base/rs/ledger_suite/icrc1/ledger/ledger.did>
- #![allow(clippy::all)]
- #![allow(unused_imports)]
- #![allow(missing_docs)]
-@@ -127,7 +127,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
+@@ -129,7 +129,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
      pub start: BlockIndex,
      pub length: candid::Nat,
  }
@@ -18,7 +11,7 @@ index 1cabf2a85..0e6b6a301 100644
  pub struct GetBlocksResponse {
      pub certificate: Option<serde_bytes::ByteBuf>,
      pub first_index: BlockIndex,
-@@ -203,7 +203,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
+@@ -205,7 +205,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
      pub start: TxIndex,
      pub length: candid::Nat,
  }
@@ -27,7 +20,7 @@ index 1cabf2a85..0e6b6a301 100644
  pub struct GetTransactionsResponse {
      pub first_index: TxIndex,
      pub log_length: candid::Nat,
-@@ -437,7 +437,7 @@ pub struct GetBlocksResultArchivedBlocksItem {
+@@ -339,7 +339,7 @@ pub struct GetBlocksResultArchivedBlocksItem {
      pub args: Vec<GetBlocksArgs>,
      pub callback: GetBlocksResultArchivedBlocksItemCallback,
  }


### PR DESCRIPTION
Reverts dfinity/nns-dapp#7078

Reason: not all required types were updated. We will try another approach after restoring the state to what it was before 7078 got merged.