### PR TITLE
chore: Update Proposals types for potentially any IC commit

### DIFF
--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -23,20 +23,20 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install didc
         run: scripts/install-didc
-      - name: Find newer IC release, if any
+      - name: Find newer IC commit, if any
         id: update
         run: |
-          current_release="$(jq -r .defaults.build.config.IC_COMMIT_FOR_PROPOSALS config.json)"
-          echo "Current IC release: $current_release"
-          latest_release=$(curl -sSL https://api.github.com/repos/dfinity/ic/releases/latest | jq .tag_name -r)
-          echo "Latest IC release:  $latest_release"
+          current_commit="$(jq -r .defaults.build.config.IC_COMMIT_FOR_PROPOSALS config.json)"
+          echo "Current IC commit: $current_commit"
+          latest_commit=$(curl -sSL https://api.github.com/repos/dfinity/ic/commits/master | jq .sha -r)
+          echo "Latest IC commit:  $latest_commit"
           {
-            if [ "$current_release" == "$latest_release" ]
+            if [ "$current_commit" == "$latest_commit" ]
             then
               echo "updated=0"
             else
               echo "updated=1"
-              echo "release=$latest_release"
+              echo "commit=$latest_commit"
             fi
           } >> "$GITHUB_OUTPUT"
       - name: Install sponge
@@ -46,7 +46,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         run: |
           # Update candid files
-          scripts/update_ic_commit --crate proposals --ic_commit "${{ steps.update.outputs.release }}"
+          scripts/update_ic_commit --crate proposals --ic_commit "${{ steps.update.outputs.commit }}"
           # Show changes
           echo "Git status:"
           git status

--- a/config.json
+++ b/config.json
@@ -117,7 +117,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2026-01-08",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2026-01-08_03-31-base",
+        "IC_COMMIT_FOR_PROPOSALS": "4ddc6ed164eb03cbc46af0d194e8ad5d90b1b6b9",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2026-01-08_03-31-base"
       },
       "packtool": ""

--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2026-01-08_03-31-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/4ddc6ed164eb03cbc46af0d194e8ad5d90b1b6b9/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -23,6 +23,8 @@ type Action = variant {
   Motion : Motion;
   FulfillSubnetRentalRequest : FulfillSubnetRentalRequest;
   BlessAlternativeGuestOsVersion : BlessAlternativeGuestOsVersion;
+  TakeCanisterSnapshot : TakeCanisterSnapshot;
+  LoadCanisterSnapshot : LoadCanisterSnapshot;
 };
 
 type AddHotKey = record {
@@ -468,6 +470,11 @@ type LedgerParameters = record {
 
 type ListKnownNeuronsResponse = record {
   known_neurons : vec KnownNeuron;
+};
+
+type LoadCanisterSnapshot = record {
+  canister_id : opt principal;
+  snapshot_id : opt blob;
 };
 
 // Parameters of the list_neurons method.
@@ -1032,6 +1039,8 @@ type ProposalActionRequest = variant {
   Motion : Motion;
   FulfillSubnetRentalRequest : FulfillSubnetRentalRequest;
   BlessAlternativeGuestOsVersion : BlessAlternativeGuestOsVersion;
+  TakeCanisterSnapshot : TakeCanisterSnapshot;
+  LoadCanisterSnapshot : LoadCanisterSnapshot;
 };
 
 // Creates a rented subnet from a rental request (in the Subnet Rental
@@ -1100,6 +1109,10 @@ type GuestLaunchMeasurementMetadata = record {
   kernel_cmdline : opt text;
 };
 
+type TakeCanisterSnapshot = record {
+  canister_id : opt principal;
+  replace_snapshot : opt blob;
+};
 
 type ProposalData = record {
   id : opt ProposalId;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2026-01-08_03-31-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/4ddc6ed164eb03cbc46af0d194e8ad5d90b1b6b9/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2026-01-08_03-31-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/4ddc6ed164eb03cbc46af0d194e8ad5d90b1b6b9/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2026-01-08_03-31-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/4ddc6ed164eb03cbc46af0d194e8ad5d90b1b6b9/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -500,6 +500,11 @@ pub struct ManageNeuronProposal {
     pub neuron_id_or_subaccount: Option<NeuronIdOrSubaccount>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct LoadCanisterSnapshot {
+    pub canister_id: Option<Principal>,
+    pub snapshot_id: Option<serde_bytes::ByteBuf>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct GuestLaunchMeasurementMetadata {
     pub kernel_cmdline: Option<String>,
 }
@@ -548,6 +553,11 @@ pub struct InstallCode {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeregisterKnownNeuron {
     pub id: Option<NeuronId>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct TakeCanisterSnapshot {
+    pub replace_snapshot: Option<serde_bytes::ByteBuf>,
+    pub canister_id: Option<Principal>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct StopOrStartCanister {
@@ -736,10 +746,12 @@ pub enum Action {
     RegisterKnownNeuron(KnownNeuron),
     FulfillSubnetRentalRequest(FulfillSubnetRentalRequest),
     ManageNeuron(ManageNeuronProposal),
+    LoadCanisterSnapshot(LoadCanisterSnapshot),
     BlessAlternativeGuestOsVersion(BlessAlternativeGuestOsVersion),
     UpdateCanisterSettings(UpdateCanisterSettings),
     InstallCode(InstallCode),
     DeregisterKnownNeuron(DeregisterKnownNeuron),
+    TakeCanisterSnapshot(TakeCanisterSnapshot),
     StopOrStartCanister(StopOrStartCanister),
     CreateServiceNervousSystem(CreateServiceNervousSystem),
     ExecuteNnsFunction(ExecuteNnsFunction),
@@ -1103,10 +1115,12 @@ pub enum ProposalActionRequest {
     RegisterKnownNeuron(KnownNeuron),
     FulfillSubnetRentalRequest(FulfillSubnetRentalRequest),
     ManageNeuron(Box<ManageNeuronRequest>),
+    LoadCanisterSnapshot(LoadCanisterSnapshot),
     BlessAlternativeGuestOsVersion(BlessAlternativeGuestOsVersion),
     UpdateCanisterSettings(UpdateCanisterSettings),
     InstallCode(InstallCodeRequest),
     DeregisterKnownNeuron(DeregisterKnownNeuron),
+    TakeCanisterSnapshot(TakeCanisterSnapshot),
     StopOrStartCanister(StopOrStartCanister),
     CreateServiceNervousSystem(CreateServiceNervousSystem),
     ExecuteNnsFunction(ExecuteNnsFunction),

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2026-01-08_03-31-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/4ddc6ed164eb03cbc46af0d194e8ad5d90b1b6b9/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2026-01-08_03-31-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/4ddc6ed164eb03cbc46af0d194e8ad5d90b1b6b9/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation

Like in #7079, this PR updates proposals based on the main branch and not a release

# Changes

- Instead of checking for the latest releases, the `update-aggregator` CI job now checks for any new IC commits.

# Tests

- Tested in []()

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
