### PR TITLE
chore(deps): bump ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "3.1.13-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.13-next-2025-07-08.tgz",
-      "integrity": "sha512-/l14Yd4nyMq2ruvRjZ1GNiVraq8A9rRBRTC1wXUAb7bjet3Z4EVEXdKPYXrZad8Lf6j6rRYRIOci49kiQeEZ8Q==",
+      "version": "3.1.13-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.13-next-2025-07-09.tgz",
+      "integrity": "sha512-SDdjs8WbbbX0GKgHMM1np/YI9GBXR7W9mm97QuoAlCpeJfWvFm+QQahtIMPE+I4N1iCheXAPmztukewmMenq9Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "5.0.6-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.6-next-2025-07-08.tgz",
-      "integrity": "sha512-do/A/+GHyQ+xndur1tgJdnpnT2lYhC4fNqy3Z3FLlXKqPUpH8qE+pM4jgpYox4U9NZfpz/9Fv65vFvXAzRTshw==",
+      "version": "5.0.6-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-5.0.6-next-2025-07-09.tgz",
+      "integrity": "sha512-3TBoGnJyMk0UIfEpWQDEwD8fm5ptsQGUGNz56cTp35pDQFIxqTz3q1vuZ6eYTNGTTMdcaYBcS35nTtkxSo5S5w==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "6.2.0-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.2.0-next-2025-07-08.tgz",
-      "integrity": "sha512-kXM+8LAnn9/ESZ3mz/6x+Vw4xGGFP9CQr00PSo3qi6UtpvkGIjW2VAW8zxoDcDpUGpo6SZigAcFAgtdX3E3cBQ==",
+      "version": "6.2.0-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-6.2.0-next-2025-07-09.tgz",
+      "integrity": "sha512-iUVCUbet9WMbzmDfOpoqunfMJidc03LDKtv1l/evZPDfDPJJfq58L1npYu3miqK48kxzHyS6DSOtiH+qgaWNGw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "3.0.0-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-3.0.0-next-2025-07-08.tgz",
-      "integrity": "sha512-WHM3OvYj59rgSXu2Px8pwPG7/bpthY3groZozskFAbDLvcaaA0xs8SJys5hqZY7uiHQFzJl8oA0u2m/GM+2UwQ==",
+      "version": "3.0.0-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-3.0.0-next-2025-07-09.tgz",
+      "integrity": "sha512-pPxdXzh6PcXoV/bI8wty6t/7DP0xHgbM6oTLcERUtgUxf0TnJZQXQupX6KJzMlhKI3J+bpw+vl1Zq2qUgrjMZA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.9.0-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.9.0-next-2025-07-08.tgz",
-      "integrity": "sha512-hbza7qOWlQMhpXvRJvH8lE9f3r/hpfYXtoVTv3DTcePvoI2h0sgubvwPo4rcNy6ujpOU3jwh9Yhlm4CAURmpRg==",
+      "version": "2.9.0-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.9.0-next-2025-07-09.tgz",
+      "integrity": "sha512-dpfvU01V8LClYVQ0GoyI+JXOiGwqDd9Ra2MBK9JxlXlStG14HAL1CdmGVba3QoQHR/ljTAprpQfiy5kWU+tB3A==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -444,9 +444,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "8.5.0-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.5.0-next-2025-07-08.tgz",
-      "integrity": "sha512-5ZEqM0kj6plN3GhKcBOnDQdM6K2pgz0WTiFK1y7N0t7DQuxQdd2mqp9tSZtVqOg7l/HChnWqE+2+db/wxu7bKQ==",
+      "version": "8.5.0-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-8.5.0-next-2025-07-09.tgz",
+      "integrity": "sha512-1qadhZ3sF/vAODzBZN6h8lJn48HgvL+v+hBRzWViziL5gI5IU+HnuCkoujhfLRnbJgNJW1QJJjDd20X9gkWbeQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.7.0-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.7.0-next-2025-07-08.tgz",
-      "integrity": "sha512-Ceisg5xhIQ2MPeLtcpijULTPzO1XcFVl/FyCJFQMqdXIv1ZR6RrbYetLaElxJaOa23Cj5cyOnAXX4nQvODqr+w==",
+      "version": "3.7.0-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.7.0-next-2025-07-09.tgz",
+      "integrity": "sha512-UyR5sRg0uf5YKh3+IjjUxgjnX8IH+8jn7qtvshdFmpVSKDVrvOMt8uKa63hGsqhsdJYrtkUSXPAVbBQp1dSAdA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -486,9 +486,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.13.1-next-2025-07-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.1-next-2025-07-08.tgz",
-      "integrity": "sha512-O24pf0vbzPs14y0ztSbHnfjn2nCF4t05Pt1Q47fnpVDwfPeQ2yAC1FzsBwA0hYly1tj68++ec9HluDFsjmJTRA==",
+      "version": "2.13.1-next-2025-07-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.1-next-2025-07-09.tgz",
+      "integrity": "sha512-OdoXXf+GoPuzrGmr1iwtdf4XSd9imgUOR7E62oBVotbVs9zgeBNnPBcchvDr/gUsvFV/wZEmSw1JDSn4s144Fw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",


### PR DESCRIPTION
# Motivation

#7076 bumped the version of ic-js but this introduced a breaking change in the nns package as a new mandatory field was added before the canister was released. 
This PR bumps one more time ic-js to revert [that change](https://github.com/dfinity/ic-js/pull/984).

# Changes

- Bump ic-js by running `npm run upgrade:next`
- Fix mock by removing field.

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
