### PR TITLE
feat(launchpad2): Fix cap.icp source

### DIFF
--- a/frontend/src/tests/lib/components/launchpad/OngoingProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/OngoingProjectCard.spec.ts
@@ -64,9 +64,9 @@ describe("OngoingProjectCard", () => {
     expect(await po.getMinIcpValue()).toEqual("450k");
   });
 
-  it("should current icp value", async () => {
+  it("should max icp value", async () => {
     const summary = createSummary({
-      currentTotalCommitment: 500_000_000_000n,
+      maxDirectParticipation: 500_000_000_000n,
     });
     const po = renderComponent(summary);
 


### PR DESCRIPTION
# Motivation

In the ongoing SNS project card, the "Cap, ICP" field was incorrectly displaying the direct commitment. This PR corrects it by using `max_direct_participation_icp_e8s` instead.

# Changes

- Change the field source.

# Tests

- Updated.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
