### PR TITLE
feat(staking): add APY card fallback states

### DIFF
--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -12,18 +12,16 @@
   import { nonNullish } from "@dfinity/utils";
 
   type Props = {
-    rewardBalanceUSD?: number;
-    rewardEstimateWeekUSD?: number;
-    stakingPower?: number;
-    stakingPowerUSD?: number;
-    loading: boolean;
+    rewardBalanceUSD: number;
+    rewardEstimateWeekUSD: number;
+    stakingPower: number;
+    stakingPowerUSD: number;
   };
-
   const {
-    rewardBalanceUSD = 0,
-    rewardEstimateWeekUSD = 0,
-    stakingPower = 0,
-    stakingPowerUSD = 0,
+    rewardBalanceUSD,
+    rewardEstimateWeekUSD,
+    stakingPower,
+    stakingPowerUSD,
   }: Props = $props();
 
   const href = AppPath.Staking;
@@ -200,8 +198,6 @@
   }
 
   .card.desktop {
-    height: 270px;
-
     display: grid;
     grid-template-rows: auto auto 1fr;
     padding: 24px;

--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  import { isMobileViewportStore } from "$lib/derived/viewport.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import { IconError } from "@dfinity/gix-components";
+
+  type Props = {
+    stakingRewardData:
+      | { loading: true }
+      | {
+          loading: false;
+          error: string;
+        };
+  };
+
+  const { stakingRewardData }: Props = $props();
+
+  const isError = $derived(
+    !stakingRewardData.loading && "error" in stakingRewardData
+  );
+  const testId = "apy-fallback-card";
+</script>
+
+{#snippet loadingContent()}
+  <div class="content" data-tid="loading-content">
+    <div class="content">
+      <div class="subtitle skeleton"></div>
+      <div class="main-value skeleton"></div>
+      <div class="secondary-value">
+        <div class="projection-skeleton skeleton"></div>
+        <div class="estimation-skeleton skeleton"></div>
+      </div>
+    </div>
+
+    <div class="content">
+      <div class="subtitle skeleton"></div>
+      <div class="main-value skeleton"></div>
+      <div class="secondary-value-single skeleton"></div>
+    </div>
+  </div>
+{/snippet}
+
+{#snippet errorContent()}
+  <div class="error-content" data-tid="error-content">
+    <div class="error-icon">
+      <IconError size="20" />
+    </div>
+    <div class="error-text">
+      {$i18n.portfolio.apy_card_error}
+    </div>
+  </div>
+{/snippet}
+
+{#if $isMobileViewportStore}
+  <article class="card mobile" data-tid={testId}>
+    {#if isError}
+      {@render errorContent()}
+    {:else}
+      {@render loadingContent()}
+    {/if}
+  </article>
+{:else}
+  <article class="card desktop" data-tid={testId}>
+    {#if isError}
+      <div class="title-text">{$i18n.portfolio.apy_card_title}</div>
+      {@render errorContent()}
+      <div class="link-area"></div>
+    {:else}
+      <div class="title skeleton"></div>
+      {@render loadingContent()}
+    {/if}
+  </article>
+{/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  @keyframes shimmer {
+    0% {
+      background-position: -1000px 0;
+    }
+    100% {
+      background-position: 1000px 0;
+    }
+  }
+
+  .skeleton {
+    background: linear-gradient(
+      90deg,
+      var(--card-background) 0px,
+      var(--elements-divider) 50%,
+      var(--card-background) 100%
+    );
+    background-size: 1000px 100%;
+    animation: shimmer 2s infinite linear;
+    border-radius: 4px;
+  }
+
+  .content {
+    display: flex;
+    justify-content: space-between;
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      gap: 4px;
+
+      .subtitle {
+        height: 16px;
+        width: 80px;
+      }
+
+      .main-value {
+        height: 32px;
+        width: 120px;
+
+        @include media.min-width(medium) {
+          height: 36px;
+          width: 140px;
+        }
+      }
+
+      .secondary-value {
+        display: flex;
+        gap: 4px;
+        align-items: center;
+
+        .projection-skeleton {
+          height: 16px;
+          width: 60px;
+
+          @include media.min-width(medium) {
+            height: 20px;
+            width: 70px;
+          }
+        }
+
+        .estimation-skeleton {
+          height: 16px;
+          width: 80px;
+
+          @include media.min-width(medium) {
+            height: 20px;
+            width: 100px;
+          }
+        }
+      }
+
+      .secondary-value-single {
+        height: 16px;
+        width: 90px;
+
+        @include media.min-width(medium) {
+          height: 20px;
+          width: 110px;
+        }
+      }
+    }
+  }
+
+  .error-content {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+
+    @include media.min-width(medium) {
+      margin-top: 32px;
+    }
+
+    .error-icon {
+      display: flex;
+      align-items: center;
+      color: var(--negative-emphasis);
+    }
+
+    .error-text {
+      font-size: 16px;
+      font-weight: 450;
+      color: var(--text-primary);
+    }
+  }
+
+  .card {
+    height: 100%;
+    box-sizing: border-box;
+    background-color: var(--background);
+    box-shadow: var(--box-shadow);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .card.mobile {
+    padding: 20px 16px;
+  }
+
+  .card.desktop {
+    height: 270px;
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+    padding: 24px;
+    grid-gap: 16px;
+
+    .title {
+      height: 24px;
+      width: 60px;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -67,6 +67,7 @@
     {:else}
       <div class="title skeleton"></div>
       {@render loadingContent()}
+      <div class="link skeleton"></div>
     {/if}
   </article>
 {/if}
@@ -201,9 +202,15 @@
     padding: 24px;
     grid-gap: 16px;
 
+    .link,
     .title {
       height: 24px;
-      width: 60px;
+      width: 120px;
+    }
+
+    .link {
+      align-self: end;
+      justify-self: end;
     }
   }
 </style>

--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -202,6 +202,13 @@
     padding: 24px;
     grid-gap: 16px;
 
+    .title-text {
+      font-size: 18px;
+      font-style: normal;
+      font-weight: 450;
+      line-height: 24px;
+    }
+
     .link,
     .title {
       height: 24px;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1330,7 +1330,8 @@
     "apy_card_reward_title": "Reward Balance",
     "apy_card_power_title": "Staking Power Used",
     "apy_card_link": "View Staked",
-    "apy_card_estimation": "7d estimate"
+    "apy_card_estimation": "7d estimate",
+    "apy_card_error": "Unable to load rewards"
   },
   "highlight": {
     "disburse_maturity_title": "Farewell, Spawn Neuron!",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1401,6 +1401,7 @@ interface I18nPortfolio {
   apy_card_power_title: string;
   apy_card_link: string;
   apy_card_estimation: string;
+  apy_card_error: string;
 }
 
 interface I18nHighlight {

--- a/frontend/src/tests/lib/components/portfolio/ApyFallbackCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/ApyFallbackCard.spec.ts
@@ -1,0 +1,42 @@
+import ApyFallbackCard from "$lib/components/portfolio/ApyFallbackCard.svelte";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { ApyFallbackCardPo } from "$tests/page-objects/ApyFallbackCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("ApyFallbackCard", () => {
+  const loadingProps = {
+    stakingRewardData: { loading: true } as const,
+  };
+
+  const errorProps = {
+    stakingRewardData: {
+      loading: false,
+      error: "Failed to load staking data",
+    } as const,
+  };
+
+  const renderComponent = (props) => {
+    const { container } = render(ApyFallbackCard, { props });
+
+    return ApyFallbackCardPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    resetIdentity();
+  });
+
+  it("should display loading content when loading is true", async () => {
+    const po = renderComponent(loadingProps);
+
+    expect(await po.getLoadingContent().isPresent()).toBe(true);
+    expect(await po.getErrorContent().isPresent()).toBe(false);
+  });
+
+  it("should display error content when there is an error", async () => {
+    const po = renderComponent(errorProps);
+
+    expect(await po.getLoadingContent().isPresent()).toBe(false);
+    expect(await po.getErrorContent().isPresent()).toBe(true);
+  });
+});

--- a/frontend/src/tests/page-objects/ApyFallbackCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ApyFallbackCard.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ApyFallbackCardPo extends BasePageObject {
+  private static readonly TID = "apy-fallback-card";
+
+  static under(element: PageObjectElement): ApyFallbackCardPo {
+    return new ApyFallbackCardPo(element.byTestId(ApyFallbackCardPo.TID));
+  }
+
+  getErrorContent(): PageObjectElement {
+    return this.getElement("error-content");
+  }
+
+  getLoadingContent(): PageObjectElement {
+    return this.getElement("loading-content");
+  }
+}


### PR DESCRIPTION
# Motivation

The nns-dapp will display information about staking power on the portfolio page using the new ApyCard. However, this requires a significant amount of data to load, and issues may arise. This PR introduces a new component to be shown in case of an error or loading state.

| Mobile | Desktop |
|--------|--------|
| <img width="570" alt="Screenshot 2025-07-09 at 11 53 05" src="https://github.com/user-attachments/assets/75463976-1c71-4189-8c1c-12421a494d7c" /> | <img width="1685" alt="Screenshot 2025-07-09 at 12 00 08" src="https://github.com/user-attachments/assets/4b640ff7-ec0b-4371-9d83-da22600abeff" /> |
| <img width="554" alt="Screenshot 2025-07-09 at 11 58 52" src="https://github.com/user-attachments/assets/0ab9a505-2857-476b-b8e5-1419acbddef0" /> | <img width="1648" alt="Screenshot 2025-07-09 at 11 58 35" src="https://github.com/user-attachments/assets/d390be7e-5658-44d6-8803-61512e14b2a4" /> |  

# Changes

- New fallback component  
- Updated `ApyCard` height to adapt to containers and removed the optionality of props, as it will only render when the data is available.

# Tests

- Unit tests for the new component.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
