### PR TITLE
feat(launchpad2): Display redesigned launchpad

### DIFF
--- a/frontend/src/lib/utils/launchpad.utils.ts
+++ b/frontend/src/lib/utils/launchpad.utils.ts
@@ -1,6 +1,6 @@
-import AdoptedProposalCard from "$lib/components/portfolio/AdoptedProposalCard.svelte";
-import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
-import NewSnsProposalCard from "$lib/components/portfolio/NewSnsProposalCard.svelte";
+import CreateSnsProposalCard from "$lib/components/launchpad/CreateSnsProposalCard.svelte";
+import OngoingProjectCard from "$lib/components/launchpad/OngoingProjectCard.svelte";
+import UpcomingProjectCard from "$lib/components/launchpad/UpcomingProjectCard.svelte";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type { ComponentWithProps } from "$lib/types/svelte";
 import { compareProposalInfoByDeadlineTimestampSeconds } from "$lib/utils/portfolio.utils";
@@ -26,7 +26,7 @@ export const getUpcomingLaunchesCards = ({
     .sort(comparesByDecentralizationSaleOpenTimestampDesc)
     .reverse()
     .map<ComponentWithProps>(({ summary }) => ({
-      Component: LaunchProjectCard as unknown as Component,
+      Component: OngoingProjectCard as unknown as Component,
       props: { summary },
     }));
 
@@ -37,14 +37,14 @@ export const getUpcomingLaunchesCards = ({
     .sort(comparesByDecentralizationSaleOpenTimestampDesc)
     .reverse()
     .map<ComponentWithProps>(({ summary }) => ({
-      Component: AdoptedProposalCard as unknown as Component,
+      Component: UpcomingProjectCard as unknown as Component,
       props: { summary },
     }));
 
   const openProposalCards: ComponentWithProps[] = [...openSnsProposals]
     .sort(compareProposalInfoByDeadlineTimestampSeconds)
     .map((proposalInfo) => ({
-      Component: NewSnsProposalCard as unknown as Component,
+      Component: CreateSnsProposalCard as unknown as Component,
       props: { proposalInfo },
     }));
 

--- a/frontend/src/routes/(app)/(nns)/launchpad/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/launchpad/+page.svelte
@@ -1,5 +1,42 @@
 <script lang="ts">
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { snsProjectsActivePadStore } from "$lib/derived/sns/sns-projects.derived";
   import Launchpad from "$lib/pages/Launchpad.svelte";
+  import Launchpad2 from "$lib/pages/Launchpad2.svelte";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { loadProposalsSnsCF } from "$lib/services/public/sns.services";
+  import { loadSnsSwapCommitments } from "$lib/services/sns.services";
+  import { ENABLE_LAUNCHPAD_REDESIGN } from "$lib/stores/feature-flags.store";
+  import {
+    openSnsProposalsStore,
+    snsProposalsStoreIsLoading,
+  } from "$lib/stores/sns.store";
+  import { isLoadingSnsProjectsStore } from "$lib/stores/sns.store";
+
+  if ($ENABLE_LAUNCHPAD_REDESIGN) {
+    loadIcpSwapTickers();
+  }
+  $effect(() => {
+    if ($ENABLE_LAUNCHPAD_REDESIGN && $authSignedInStore) {
+      loadSnsSwapCommitments();
+    }
+  });
+  $effect(() => {
+    if ($ENABLE_LAUNCHPAD_REDESIGN && $snsProposalsStoreIsLoading) {
+      loadProposalsSnsCF({ omitLargeFields: false });
+    }
+  });
+
+  const snsProjects = $derived($snsProjectsActivePadStore);
+  const openSnsProposals = $derived($openSnsProposalsStore);
 </script>
 
-<Launchpad />
+{#if $ENABLE_LAUNCHPAD_REDESIGN}
+  <Launchpad2
+    {snsProjects}
+    {openSnsProposals}
+    isLoading={$isLoadingSnsProjectsStore}
+  />
+{:else}
+  <Launchpad />
+{/if}

--- a/frontend/src/tests/lib/utils/launchpad.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/launchpad.utils.spec.ts
@@ -1,6 +1,6 @@
-import AdoptedProposalCard from "$lib/components/portfolio/AdoptedProposalCard.svelte";
-import LaunchProjectCard from "$lib/components/portfolio/LaunchProjectCard.svelte";
-import NewSnsProposalCard from "$lib/components/portfolio/NewSnsProposalCard.svelte";
+import CreateSnsProposalCard from "$lib/components/launchpad/CreateSnsProposalCard.svelte";
+import OngoingProjectCard from "$lib/components/launchpad/OngoingProjectCard.svelte";
+import UpcomingProjectCard from "$lib/components/launchpad/UpcomingProjectCard.svelte";
 import { getUpcomingLaunchesCards } from "$lib/utils/launchpad.utils";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import {
@@ -75,15 +75,15 @@ describe("Launchpad utils", () => {
       expect(cards.length).toBe(3);
       expect(cards).toEqual([
         {
-          Component: LaunchProjectCard,
+          Component: OngoingProjectCard,
           props: { summary: openSnsProject1.summary },
         },
         {
-          Component: NewSnsProposalCard,
+          Component: CreateSnsProposalCard,
           props: { proposalInfo: openProposal1 },
         },
         {
-          Component: AdoptedProposalCard,
+          Component: UpcomingProjectCard,
           props: { summary: adoptedSnsProject1.summary },
         },
       ]);
@@ -148,27 +148,27 @@ describe("Launchpad utils", () => {
       expect(cards.length).toBe(6);
       expect(cards).toEqual([
         {
-          Component: LaunchProjectCard,
+          Component: OngoingProjectCard,
           props: { summary: openSnsProject2.summary },
         },
         {
-          Component: LaunchProjectCard,
+          Component: OngoingProjectCard,
           props: { summary: openSnsProject1.summary },
         },
         {
-          Component: NewSnsProposalCard,
+          Component: CreateSnsProposalCard,
           props: { proposalInfo: openProposal2 },
         },
         {
-          Component: NewSnsProposalCard,
+          Component: CreateSnsProposalCard,
           props: { proposalInfo: openProposal1 },
         },
         {
-          Component: AdoptedProposalCard,
+          Component: UpcomingProjectCard,
           props: { summary: adoptedSnsProject2.summary },
         },
         {
-          Component: AdoptedProposalCard,
+          Component: UpcomingProjectCard,
           props: { summary: adoptedSnsProject1.summary },
         },
       ]);

--- a/frontend/src/tests/routes/app/launchpad/page.spec.ts
+++ b/frontend/src/tests/routes/app/launchpad/page.spec.ts
@@ -1,0 +1,127 @@
+import * as icpSwapApi from "$lib/api/icp-swap.api";
+import * as proposalsApi from "$lib/api/proposals.api";
+import * as snsApi from "$lib/api/sns.api";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import LaunchpadPage from "$routes/(app)/(nns)/launchpad/+page.svelte";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
+import {
+  createMockSnsFullProject,
+  mockSnsSwapCommitment,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Launchpad2Po } from "$tests/page-objects/Launchpad2.page-object";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { AnonymousIdentity } from "@dfinity/agent";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+
+describe("Launchpad page", () => {
+  const renderPage = async () => {
+    const { container } = render(LaunchpadPage);
+    await runResolvedPromises();
+    await tick();
+    return Launchpad2Po.under(new JestPageObjectElement(container));
+  };
+
+  const tickers = [
+    {
+      ...mockIcpSwapTicker,
+      base_id: CKUSDC_UNIVERSE_CANISTER_ID.toText(),
+      last_price: "10.00",
+    },
+  ];
+
+  beforeEach(() => {
+    // Test only the redesign of the Launchpad, since the old one contains no logic on this level (and is deprecated).
+    overrideFeatureFlagsStore.setFlag("ENABLE_LAUNCHPAD_REDESIGN", true);
+
+    vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue(tickers);
+    vi.spyOn(proposalsApi, "queryProposals").mockResolvedValue([]);
+  });
+
+  it("should load ICP Swap tickers", async () => {
+    expect(get(icpSwapTickersStore)).toBeUndefined();
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(0);
+
+    await renderPage();
+
+    expect(get(icpSwapTickersStore)).toEqual(tickers);
+    expect(icpSwapApi.queryIcpSwapTickers).toBeCalledTimes(1);
+  });
+
+  it("should load Swap commitments after login", async () => {
+    const sns1RootCanisterId = principal(1);
+    const sns2RootCanisterId = principal(2);
+    const sns1 = createMockSnsFullProject({
+      rootCanisterId: sns1RootCanisterId,
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Open,
+      },
+    });
+    const sns2 = createMockSnsFullProject({
+      rootCanisterId: sns2RootCanisterId,
+      summaryParams: {
+        lifecycle: SnsSwapLifecycle.Adopted,
+      },
+    });
+    setSnsProjects([sns1, sns2]);
+
+    const querySnsSwapCommitmentSpy = vi
+      .spyOn(snsApi, "querySnsSwapCommitment")
+      .mockResolvedValue(mockSnsSwapCommitment(principal(1)));
+
+    await renderPage();
+
+    expect(querySnsSwapCommitmentSpy).toBeCalledTimes(0);
+
+    resetIdentity();
+    await runResolvedPromises();
+
+    expect(querySnsSwapCommitmentSpy).toBeCalledTimes(4);
+    expect(querySnsSwapCommitmentSpy).toHaveBeenCalledWith({
+      certified: false,
+      identity: mockIdentity,
+      rootCanisterId: sns1RootCanisterId.toText(),
+    });
+    expect(querySnsSwapCommitmentSpy).toHaveBeenCalledWith({
+      certified: true,
+      identity: mockIdentity,
+      rootCanisterId: sns1RootCanisterId.toText(),
+    });
+    expect(querySnsSwapCommitmentSpy).toHaveBeenCalledWith({
+      certified: false,
+      identity: mockIdentity,
+      rootCanisterId: sns2RootCanisterId.toText(),
+    });
+    expect(querySnsSwapCommitmentSpy).toHaveBeenCalledWith({
+      certified: true,
+      identity: mockIdentity,
+      rootCanisterId: sns2RootCanisterId.toText(),
+    });
+  });
+
+  it("should load sns proposals", async () => {
+    await renderPage();
+
+    expect(proposalsApi.queryProposals).toBeCalledTimes(1);
+    expect(proposalsApi.queryProposals).toHaveBeenCalledWith({
+      certified: false,
+      identity: new AnonymousIdentity(),
+      beforeProposal: undefined,
+      includeStatus: [1],
+      includeTopics: [14],
+      omitLargeFields: false,
+    });
+  });
+
+  it("displays sns projects", async () => {
+    // TODO(launchpad2): Add more tests for the Launchpad2 component.
+  });
+});


### PR DESCRIPTION
# Motivation

This PR enables the newly implemented `Launchpad2` component (from the redesign) behind a feature flag, replacing the old one.

# Changes

- Now that all cards are merged, the old ones have been replaced in the [Launchpad utils](https://github.com/dfinity/nns-dapp/pull/7092/files#diff-a0d1fb112de70a1db4d133cb87a1e8a8e8029e52f60cc2fc531946933ef78e7fR29).
- Preload necessary data and conditionally render the redesigned Launchpad content component depending on the feature flag.

# Tests

- Added tests for the required data loading.
- Tested manually.
- Additional content related tests will be added in the cleanup phase (https://dfinity.atlassian.net/browse/NNS1-3919)

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
