### PR TITLE
feat(launchpad2): Create Sns proposal card styles

### DIFF
--- a/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
+++ b/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
@@ -130,20 +130,34 @@
         gap: var(--padding-0_5x);
 
         h3 {
-          @include launchpad.text_h3;
           @include text.clamp(1);
 
           margin: 0;
           padding: 0;
+
+          font-family: CircularXX;
+          font-size: 16px;
+          font-weight: 450;
+          line-height: 20px;
+
+          @include media.min-width(medium) {
+            font-size: 18px;
+            line-height: 24px;
+          }
         }
 
         .description {
           @include launchpad.text_body;
           @include text.clamp(1);
 
+          display: none;
           margin: 0;
           padding: 0;
           color: var(--color-text-secondary);
+
+          @include media.min-width(medium) {
+            display: block;
+          }
         }
       }
     }

--- a/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
+++ b/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
@@ -135,7 +135,6 @@
           margin: 0;
           padding: 0;
 
-          font-family: CircularXX;
           font-size: 16px;
           font-weight: 450;
           line-height: 20px;

--- a/frontend/src/lib/components/portfolio/VotesResult.svelte
+++ b/frontend/src/lib/components/portfolio/VotesResult.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { formatPercentage } from "$lib/utils/format.utils";
+  import { IconThumbDown, IconThumbUp } from "@dfinity/gix-components";
 
   type Props = {
     yes: number;
@@ -15,8 +16,9 @@
 </script>
 
 <div class="votes-info">
-  <div class="yes yes-percent">
+  <div class="yes yes-percent percentage-container">
     <span class="caption">{$i18n.portfolio.new_sns_proposal_card_adopt}</span>
+    <span class="icon"><IconThumbUp size="20px" /></span>
     <span class="percentage" data-tid="adopt-percentage"
       >{formatPercentage(yesProportion, {
         minFraction: 2,
@@ -24,8 +26,9 @@
       })}</span
     >
   </div>
-  <div class="no no-percent">
+  <div class="no no-percent percentage-container">
     <span class="caption">{$i18n.portfolio.new_sns_proposal_card_reject}</span>
+    <span class="icon"><IconThumbDown size="20px" /></span>
     <span class="percentage" data-tid="reject-percentage"
       >{formatPercentage(noProportion, {
         minFraction: 2,
@@ -86,12 +89,49 @@
       @include fonts.small;
     }
 
-    .yes .percentage {
-      color: var(--positive-emphasis);
+    .yes {
+      .percentage,
+      .icon {
+        color: var(--positive-emphasis);
+      }
     }
 
-    .no .percentage {
-      color: var(--negative-emphasis);
+    .no {
+      .percentage,
+      .icon {
+        color: var(--negative-emphasis);
+      }
+    }
+
+    .percentage-container {
+      .icon {
+        display: none;
+      }
+
+      @include media.min-width(medium) {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: var(--padding-0_5x);
+
+        .caption {
+          display: none;
+        }
+        &.no {
+          justify-self: end;
+        }
+
+        .icon {
+          display: flex;
+          align-items: center;
+        }
+        .percentage {
+          font-family: CircularXX;
+          font-size: 24px;
+          font-weight: 450;
+          line-height: 32px;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# Motivation

In the new design, the voting results block displays icons instead of labels on desktop. This PR updates the styles of the voting results component accordingly.

# Changes

- Display icons only on desktop.
- Hide description on mobile.
- Update text styles.

# Tests

- Tested manually:

| M | D |
|--------|--------|
| <img width="395" alt="image" src="https://github.com/user-attachments/assets/1dc68b38-9b47-487d-9c45-a3a1a44dbf44" /> | ![Screenshot 2025-07-09 at 17 24 00](https://github.com/user-attachments/assets/8fbd5408-942d-462a-97e0-5060c432b86d) | 




# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
