### PR TITLE
feat(tooltips): add configurable icon size

### DIFF
--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -1,16 +1,26 @@
 <script lang="ts">
   import { IconInfo, Tooltip } from "@dfinity/gix-components";
 
-  export let tooltipId: string | undefined = undefined;
-  export let tooltipIdPrefix = "tooltip-icon";
-  export let text: string | undefined = undefined;
+  type Props = {
+    tooltipId?: string;
+    tooltipIdPrefix?: string;
+    text?: string;
+    iconSize?: number;
+  };
+
+  const {
+    tooltipId,
+    text,
+    iconSize = 20,
+    tooltipIdPrefix = "tooltip-icon",
+  }: Props = $props();
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
-<div class="wrapper" data-tid="tooltip-icon-component" on:click|preventDefault>
+<div class="wrapper" data-tid="tooltip-icon-component">
+  <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
+  <!-- svelte-ignore slot_element_deprecated -->
   <Tooltip id={tooltipId} idPrefix={tooltipIdPrefix} {text}>
-    <IconInfo />
+    <IconInfo size={`${iconSize}px`} />
     <slot slot="tooltip-content" />
   </Tooltip>
 </div>


### PR DESCRIPTION
# Motivation

The nns-dapp displays tooltips with an icon in various parts of the application. The icon has a predefined size of 20px, which is no longer compatible with the new font sizes defined in the app. This PR allows the icon size to be set as a prop, enabling consumers to define it as needed.

[NNS1-3922](https://dfinity.atlassian.net/browse/NNS1-3922)

# Changes

- Expose a new prop to define the icon size, with a default value of 20.

# Tests

- All existing tests should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3922]: https://dfinity.atlassian.net/browse/NNS1-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ