### PR TITLE
Add Metrics and RewardEvent derived stores

### DIFF
--- a/frontend/src/lib/derived/sns-metrics.derived.ts
+++ b/frontend/src/lib/derived/sns-metrics.derived.ts
@@ -1,11 +1,12 @@
 import { snsAggregatorDerived } from "$lib/derived/sns-aggregator.derived";
 import type { MetricsDto } from "$lib/types/sns-aggregator";
+import type { CanisterIdString } from "@dfinity/nns";
 import { isNullish } from "@dfinity/utils";
 import { type Readable } from "svelte/store";
 
 export interface SnsMetricsStoreData {
   // Root canister id is the key to identify the metrics for a specific project.
-  [rootCanisterId: string]: MetricsDto | undefined;
+  [rootCanisterId: CanisterIdString]: MetricsDto | undefined;
 }
 
 /**

--- a/frontend/src/lib/derived/sns-metrics.derived.ts
+++ b/frontend/src/lib/derived/sns-metrics.derived.ts
@@ -1,0 +1,19 @@
+import { snsAggregatorDerived } from "$lib/derived/sns-aggregator.derived";
+import type { MetricsDto } from "$lib/types/sns-aggregator";
+import { isNullish } from "@dfinity/utils";
+import { type Readable } from "svelte/store";
+
+export interface SnsMetricsStoreData {
+  // Root canister id is the key to identify the metrics for a specific project.
+  [rootCanisterId: string]: MetricsDto | undefined;
+}
+
+/**
+ * A store that contains the sns metrics for each project.
+ */
+export const snsMetricsStore: Readable<SnsMetricsStoreData> =
+  snsAggregatorDerived((sns) =>
+    isNullish(sns.metrics?.get_metrics_result?.Ok)
+      ? undefined
+      : sns.metrics?.get_metrics_result?.Ok
+  );

--- a/frontend/src/lib/derived/sns-reward-event.derived.ts
+++ b/frontend/src/lib/derived/sns-reward-event.derived.ts
@@ -1,0 +1,20 @@
+import { snsAggregatorDerived } from "$lib/derived/sns-aggregator.derived";
+import { convertDtoRewardEvent } from "$lib/utils/sns-aggregator-converters.utils";
+import type { SnsRewardEvent } from "@dfinity/sns";
+import { isNullish } from "@dfinity/utils";
+import { type Readable } from "svelte/store";
+
+export interface SnsRewardEventStoreData {
+  // Root canister id is the key to identify the reward events for a specific project.
+  [rootCanisterId: string]: SnsRewardEvent | undefined;
+}
+
+/**
+ * A store that contains the sns reward events for each project.
+ */
+export const snsRewardEventStore: Readable<SnsRewardEventStoreData> =
+  snsAggregatorDerived((sns) =>
+    isNullish(sns.latest_reward_event)
+      ? undefined
+      : convertDtoRewardEvent(sns.latest_reward_event)
+  );

--- a/frontend/src/lib/derived/sns-reward-event.derived.ts
+++ b/frontend/src/lib/derived/sns-reward-event.derived.ts
@@ -1,12 +1,13 @@
 import { snsAggregatorDerived } from "$lib/derived/sns-aggregator.derived";
 import { convertDtoRewardEvent } from "$lib/utils/sns-aggregator-converters.utils";
+import type { CanisterIdString } from "@dfinity/nns";
 import type { SnsRewardEvent } from "@dfinity/sns";
 import { isNullish } from "@dfinity/utils";
 import { type Readable } from "svelte/store";
 
 export interface SnsRewardEventStoreData {
   // Root canister id is the key to identify the reward events for a specific project.
-  [rootCanisterId: string]: SnsRewardEvent | undefined;
+  [rootCanisterId: CanisterIdString]: SnsRewardEvent | undefined;
 }
 
 /**

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -25,6 +25,7 @@ import type {
   CachedSwapParamsDto,
   CachedVotingRewardsParametersDto,
   ListTopicsResponseWithUnknown,
+  RewardEventDto,
   TopicInfoDto,
   TopicInfoWithUnknown,
 } from "$lib/types/sns-aggregator";
@@ -42,6 +43,7 @@ import type {
   SnsNervousSystemParameters,
   SnsNeuronsFundParticipationConstraints,
   SnsParams,
+  SnsRewardEvent,
   SnsSwapDerivedState,
   SnsSwapInit,
   SnsVotingRewardsParameters,
@@ -124,7 +126,7 @@ const convertDefaultFollowees = (
   ];
 };
 
-const numberToNullableBigInt = (num?: number): [] | [bigint] =>
+const numberToNullableBigInt = (num?: number | null): [] | [bigint] =>
   toNullable(convertOptionalNumToBigInt(num));
 
 const convertVotingRewardsParameters = (
@@ -574,4 +576,24 @@ export const convertDtoToListTopicsResponse = ({
   uncategorized_functions: toNullable(
     uncategorized_functions.map(convertNervousFunction)
   ),
+});
+
+export const convertDtoRewardEvent = (
+  rewardEvent: RewardEventDto
+): SnsRewardEvent => ({
+  rounds_since_last_distribution: numberToNullableBigInt(
+    rewardEvent.rounds_since_last_distribution
+  ),
+  actual_timestamp_seconds: BigInt(rewardEvent.actual_timestamp_seconds),
+  end_timestamp_seconds: numberToNullableBigInt(
+    rewardEvent.end_timestamp_seconds
+  ),
+  total_available_e8s_equivalent: numberToNullableBigInt(
+    rewardEvent.total_available_e8s_equivalent
+  ),
+  distributed_e8s_equivalent: BigInt(rewardEvent.distributed_e8s_equivalent),
+  round: BigInt(rewardEvent.round),
+  settled_proposals: rewardEvent.settled_proposals.map((proposal) => ({
+    id: BigInt(proposal.id),
+  })),
 });

--- a/frontend/src/tests/lib/derived/sns-metrics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-metrics.derived.spec.ts
@@ -1,0 +1,73 @@
+import { snsMetricsStore } from "$lib/derived/sns-metrics.derived";
+import type { MetricsDto } from "$lib/types/sns-aggregator";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { get } from "svelte/store";
+
+describe("snsMetricsStore", () => {
+  const rootCanisterId = principal(0);
+
+  it("should handle missing data", () => {
+    setSnsProjects([
+      {
+        rootCanisterId,
+      },
+    ]);
+
+    expect(get(snsMetricsStore)[rootCanisterId.toText()]).toEqual(undefined);
+  });
+
+  it("should return data by rootCanisterId", () => {
+    const metrics: MetricsDto = {
+      treasury_metrics: [
+        {
+          name: "TOKEN_ICP",
+          original_amount_e8s: 314100000000,
+          amount_e8s: 314099990000,
+          account: {
+            owner: "7uieb-cx777-77776-qaaaq-cai",
+            subaccount: null,
+          },
+          ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+          treasury: 1,
+          timestamp_seconds: 1752222478,
+        },
+        {
+          name: "TOKEN_SNS_TOKEN",
+          original_amount_e8s: 0,
+          amount_e8s: 293700000000,
+          account: {
+            owner: "7uieb-cx777-77776-qaaaq-cai",
+            subaccount: {
+              subaccount: [
+                246, 230, 97, 166, 146, 227, 55, 186, 137, 156, 240, 185, 163,
+                97, 8, 105, 207, 138, 114, 142, 181, 152, 159, 206, 247, 187,
+                126, 235, 138, 0, 64, 161,
+              ],
+            },
+          },
+          ledger_canister_id: "75lp5-u7777-77776-qaaba-cai",
+          treasury: 2,
+          timestamp_seconds: 1752222478,
+        },
+      ],
+      voting_power_metrics: {
+        governance_total_potential_voting_power: 501746342465693,
+        timestamp_seconds: 1752222478,
+      },
+      last_ledger_block_timestamp: 1752141149,
+      num_recently_executed_proposals: 0,
+      num_recently_submitted_proposals: 0,
+      genesis_timestamp_seconds: 1752074520,
+    };
+
+    setSnsProjects([
+      {
+        rootCanisterId,
+        metrics,
+      },
+    ]);
+
+    expect(get(snsMetricsStore)[rootCanisterId.toText()]).toEqual(metrics);
+  });
+});

--- a/frontend/src/tests/lib/derived/sns-reward-event.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-reward-event.derived.spec.ts
@@ -1,0 +1,54 @@
+import { snsRewardEventStore } from "$lib/derived/sns-reward-event.derived";
+import type { RewardEventDto } from "$lib/types/sns-aggregator";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import type { SnsRewardEvent } from "@dfinity/sns";
+import { get } from "svelte/store";
+
+describe("snsRewardEventStore", () => {
+  const rootCanisterId = principal(0);
+
+  it("should handle missing data", () => {
+    setSnsProjects([
+      {
+        rootCanisterId,
+      },
+    ]);
+
+    expect(get(snsRewardEventStore)[rootCanisterId.toText()]).toEqual(
+      undefined
+    );
+  });
+
+  it("should convert data", () => {
+    const expectedRewardEvent: SnsRewardEvent = {
+      rounds_since_last_distribution: [1n],
+      actual_timestamp_seconds: 1752160922n,
+      end_timestamp_seconds: [1752160920n],
+      total_available_e8s_equivalent: [0n],
+      distributed_e8s_equivalent: 0n,
+      round: 1n,
+      settled_proposals: [{ id: 123n }],
+    };
+    const mockRewardEvent = {
+      rounds_since_last_distribution: 1,
+      actual_timestamp_seconds: 1752160922,
+      end_timestamp_seconds: 1752160920,
+      total_available_e8s_equivalent: 0,
+      distributed_e8s_equivalent: 0,
+      round: 1,
+      settled_proposals: [{ id: 123 }],
+    } as RewardEventDto;
+
+    setSnsProjects([
+      {
+        rootCanisterId,
+        latestRewardEvent: mockRewardEvent,
+      },
+    ]);
+
+    expect(get(snsRewardEventStore)[rootCanisterId.toText()]).toEqual(
+      expectedRewardEvent
+    );
+  });
+});

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "$lib/types/sns-aggregator";
 import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import {
+  convertDtoRewardEvent,
   convertDtoToListTopicsResponse,
   convertDtoToSnsSummary,
   convertDtoTopicInfo,
@@ -21,7 +22,11 @@ import {
 } from "$lib/utils/sns-aggregator-converters.utils";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { Principal } from "@dfinity/principal";
-import type { SnsNervousSystemParameters, SnsTopicInfo } from "@dfinity/sns";
+import type {
+  SnsNervousSystemParameters,
+  SnsRewardEvent,
+  SnsTopicInfo,
+} from "@dfinity/sns";
 
 describe("sns aggregator converters utils", () => {
   describe("convertDtoData", () => {
@@ -104,6 +109,61 @@ describe("sns aggregator converters utils", () => {
         name: "Catalyze",
         description:
           "Catalyze is a one-stop social-fi application for organising your Web3 experience",
+      },
+      metrics: {
+        get_metrics_result: {
+          Ok: {
+            treasury_metrics: [
+              {
+                name: "TOKEN_ICP",
+                original_amount_e8s: 314100000000,
+                amount_e8s: 314099990000,
+                account: {
+                  owner: "7uieb-cx777-77776-qaaaq-cai",
+                  subaccount: null,
+                },
+                ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+                treasury: 1,
+                timestamp_seconds: 1752222478,
+              },
+              {
+                name: "TOKEN_SNS_TOKEN",
+                original_amount_e8s: 0,
+                amount_e8s: 293700000000,
+                account: {
+                  owner: "7uieb-cx777-77776-qaaaq-cai",
+                  subaccount: {
+                    subaccount: [
+                      246, 230, 97, 166, 146, 227, 55, 186, 137, 156, 240, 185,
+                      163, 97, 8, 105, 207, 138, 114, 142, 181, 152, 159, 206,
+                      247, 187, 126, 235, 138, 0, 64, 161,
+                    ],
+                  },
+                },
+                ledger_canister_id: "75lp5-u7777-77776-qaaba-cai",
+                treasury: 2,
+                timestamp_seconds: 1752222478,
+              },
+            ],
+            voting_power_metrics: {
+              governance_total_potential_voting_power: 501746342465693,
+              timestamp_seconds: 1752222478,
+            },
+            last_ledger_block_timestamp: 1752141149,
+            num_recently_executed_proposals: 0,
+            num_recently_submitted_proposals: 0,
+            genesis_timestamp_seconds: 1752074520,
+          },
+        },
+      },
+      latest_reward_event: {
+        rounds_since_last_distribution: 1,
+        actual_timestamp_seconds: 1752160922,
+        end_timestamp_seconds: 1752160920,
+        total_available_e8s_equivalent: 0,
+        distributed_e8s_equivalent: 0,
+        round: 1,
+        settled_proposals: [],
       },
       parameters: {
         reserved_ids: [],
@@ -1160,6 +1220,31 @@ describe("sns aggregator converters utils", () => {
           })
         ).toEqual(expectedTopicsResponse);
         expect(spyOnConsoleError).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("convertDtoRewardEvent", () => {
+      it("converts RewardEvent to ic-js type", () => {
+        const expectedTopicsResponse: SnsRewardEvent = {
+          rounds_since_last_distribution: [1n],
+          actual_timestamp_seconds: 1752160922n,
+          end_timestamp_seconds: [1752160920n],
+          total_available_e8s_equivalent: [0n],
+          distributed_e8s_equivalent: 0n,
+          round: 1n,
+          settled_proposals: [{ id: 123n }],
+        };
+        expect(
+          convertDtoRewardEvent({
+            rounds_since_last_distribution: 1,
+            actual_timestamp_seconds: 1752160922,
+            end_timestamp_seconds: 1752160920,
+            total_available_e8s_equivalent: 0,
+            distributed_e8s_equivalent: 0,
+            round: 1,
+            settled_proposals: [{ id: 123 }],
+          })
+        ).toEqual(expectedTopicsResponse);
       });
     });
   });

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -5,6 +5,8 @@ import type {
   CachedNervousSystemParametersDto,
   CachedSnsDto,
   CachedSnsTokenMetadataDto,
+  MetricsDto,
+  RewardEventDto,
 } from "$lib/types/sns-aggregator";
 import { convertDtoToTokenMetadata } from "$lib/utils/sns-aggregator-converters.utils";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
@@ -94,6 +96,8 @@ export const aggregatorSnsMockWith = ({
   maxAgeBonusPercentage,
   neuronMinimumStakeE8s,
   topics,
+  latestRewardEvent,
+  metrics,
 }: {
   rootCanisterId?: string;
   governanceCanisterId?: string;
@@ -119,6 +123,8 @@ export const aggregatorSnsMockWith = ({
   maxAgeBonusPercentage?: number;
   neuronMinimumStakeE8s?: bigint;
   topics?: CachedListTopicsResponseDto;
+  latestRewardEvent?: RewardEventDto;
+  metrics?: MetricsDto;
 }): CachedSnsDto => ({
   index: index ?? aggregatorSnsMockDto.index,
   ...aggregatorSnsMockDto,
@@ -238,4 +244,12 @@ export const aggregatorSnsMockWith = ({
     lifecycle: lifecycle ?? aggregatorSnsMockDto.lifecycle.lifecycle,
   },
   topics,
+  latest_reward_event: latestRewardEvent,
+  metrics: nonNullish(metrics)
+    ? {
+        get_metrics_result: {
+          Ok: metrics,
+        },
+      }
+    : undefined,
 });

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -6,6 +6,8 @@ import type {
   CachedListTopicsResponseDto,
   CachedNervousSystemParametersDto,
   CachedSnsDto,
+  MetricsDto,
+  RewardEventDto,
 } from "$lib/types/sns-aggregator";
 import { aggregatorSnsMockWith } from "$tests/mocks/sns-aggregator.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
@@ -37,6 +39,8 @@ export const setSnsProjects = (
     maxAgeBonusPercentage?: number;
     neuronMinimumStakeE8s?: bigint;
     topics?: CachedListTopicsResponseDto;
+    latestRewardEvent?: RewardEventDto;
+    metrics?: MetricsDto;
   }[]
 ) => {
   const aggregatorProjects = params.map((params, index) => {
@@ -65,6 +69,8 @@ export const setSnsProjects = (
       maxAgeBonusPercentage: params.maxAgeBonusPercentage,
       neuronMinimumStakeE8s: params.neuronMinimumStakeE8s,
       topics: params.topics,
+      latestRewardEvent: params.latestRewardEvent,
+      metrics: params.metrics,
     });
   });
   snsLifecycleStore.reset();


### PR DESCRIPTION
# Motivation

The aggregator was recently upgraded to expose new SNS-related data:
- SNS metrics
- Latest reward event

These are needed for the updated Launchpad and Portfolio pages. To make this data easily accessible, this PR introduces two new derived stores—one for each of the new data fields.

# Changes

- Add new DTO types matching the updated aggregator response.
- Add `RewardEvent` DTO-to-IC converter.
- Add `snsRewardEventStore` derived store.
- Add `snsMetricsStore` derived store.

# Tests

- Update mock data.
- Add tests for the new stores and the converter.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
