### PR TITLE
feat(launchpad2): Add new fields to SnsFullProject

### DIFF
--- a/frontend/src/lib/derived/sns-latest-reward-event.derived.ts
+++ b/frontend/src/lib/derived/sns-latest-reward-event.derived.ts
@@ -5,15 +5,15 @@ import type { SnsRewardEvent } from "@dfinity/sns";
 import { isNullish } from "@dfinity/utils";
 import { type Readable } from "svelte/store";
 
-export interface SnsRewardEventStoreData {
-  // Root canister id is the key to identify the reward events for a specific project.
+export interface SnsLatestRewardEventStoreData {
+  // Root canister id is the key to identify the latest reward events for a specific project.
   [rootCanisterId: CanisterIdString]: SnsRewardEvent | undefined;
 }
 
 /**
- * A store that contains the sns reward events for each project.
+ * A store that contains the latest sns reward events for each project.
  */
-export const snsRewardEventStore: Readable<SnsRewardEventStoreData> =
+export const snsLatestRewardEventStore: Readable<SnsLatestRewardEventStoreData> =
   snsAggregatorDerived((sns) =>
     isNullish(sns.latest_reward_event)
       ? undefined

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -185,6 +185,8 @@
             rootCanisterId: summary.rootCanisterId,
             summary,
             swapCommitment,
+            metrics: undefined,
+            latestRewardEvent: undefined,
           },
           amount: tokenAmount,
         });

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,4 +1,3 @@
-import { AGGREGATOR_METRICS_TIME_WINDOW_SECONDS } from "$lib/constants/sns.constants";
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import {

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,3 +1,4 @@
+import { AGGREGATOR_METRICS_TIME_WINDOW_SECONDS } from "$lib/constants/sns.constants";
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import {

--- a/frontend/src/tests/lib/derived/sns-latest-reward-event.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-latest-reward-event.derived.spec.ts
@@ -1,11 +1,11 @@
-import { snsRewardEventStore } from "$lib/derived/sns-reward-event.derived";
+import { snsLatestRewardEventStore } from "$lib/derived/sns-latest-reward-event.derived";
 import type { RewardEventDto } from "$lib/types/sns-aggregator";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { SnsRewardEvent } from "@dfinity/sns";
 import { get } from "svelte/store";
 
-describe("snsRewardEventStore", () => {
+describe("snsLatestRewardEventStore", () => {
   const rootCanisterId = principal(0);
 
   it("should handle missing data", () => {
@@ -15,7 +15,7 @@ describe("snsRewardEventStore", () => {
       },
     ]);
 
-    expect(get(snsRewardEventStore)[rootCanisterId.toText()]).toEqual(
+    expect(get(snsLatestRewardEventStore)[rootCanisterId.toText()]).toEqual(
       undefined
     );
   });
@@ -47,7 +47,7 @@ describe("snsRewardEventStore", () => {
       },
     ]);
 
-    expect(get(snsRewardEventStore)[rootCanisterId.toText()]).toEqual(
+    expect(get(snsLatestRewardEventStore)[rootCanisterId.toText()]).toEqual(
       expectedRewardEvent
     );
   });

--- a/frontend/src/tests/lib/derived/sns-metrics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-metrics.derived.spec.ts
@@ -1,6 +1,5 @@
 import { snsMetricsStore } from "$lib/derived/sns-metrics.derived";
-import type { MetricsDto } from "$lib/types/sns-aggregator";
-import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockSnsMetrics, principal } from "$tests/mocks/sns-projects.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
 
@@ -18,56 +17,15 @@ describe("snsMetricsStore", () => {
   });
 
   it("should return data by rootCanisterId", () => {
-    const metrics: MetricsDto = {
-      treasury_metrics: [
-        {
-          name: "TOKEN_ICP",
-          original_amount_e8s: 314100000000,
-          amount_e8s: 314099990000,
-          account: {
-            owner: "7uieb-cx777-77776-qaaaq-cai",
-            subaccount: null,
-          },
-          ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
-          treasury: 1,
-          timestamp_seconds: 1752222478,
-        },
-        {
-          name: "TOKEN_SNS_TOKEN",
-          original_amount_e8s: 0,
-          amount_e8s: 293700000000,
-          account: {
-            owner: "7uieb-cx777-77776-qaaaq-cai",
-            subaccount: {
-              subaccount: [
-                246, 230, 97, 166, 146, 227, 55, 186, 137, 156, 240, 185, 163,
-                97, 8, 105, 207, 138, 114, 142, 181, 152, 159, 206, 247, 187,
-                126, 235, 138, 0, 64, 161,
-              ],
-            },
-          },
-          ledger_canister_id: "75lp5-u7777-77776-qaaba-cai",
-          treasury: 2,
-          timestamp_seconds: 1752222478,
-        },
-      ],
-      voting_power_metrics: {
-        governance_total_potential_voting_power: 501746342465693,
-        timestamp_seconds: 1752222478,
-      },
-      last_ledger_block_timestamp: 1752141149,
-      num_recently_executed_proposals: 0,
-      num_recently_submitted_proposals: 0,
-      genesis_timestamp_seconds: 1752074520,
-    };
-
     setSnsProjects([
       {
         rootCanisterId,
-        metrics,
+        metrics: mockSnsMetrics,
       },
     ]);
 
-    expect(get(snsMetricsStore)[rootCanisterId.toText()]).toEqual(metrics);
+    expect(get(snsMetricsStore)[rootCanisterId.toText()]).toEqual(
+      mockSnsMetrics
+    );
   });
 });

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -5,6 +5,11 @@ import {
   snsProjectsRecordStore,
   snsProjectsStore,
 } from "$lib/derived/sns/sns-projects.derived";
+import {
+  mockSnsMetrics,
+  mockSnsRewardEvent,
+  mockSnsRewardEventDto,
+} from "$tests/mocks/sns-projects.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
@@ -18,6 +23,33 @@ describe("projects.derived", () => {
       ]);
       const projects = get(snsProjectsStore);
       expect(projects).toHaveLength(2);
+    });
+
+    it("should include project metrics", () => {
+      setSnsProjects([
+        { lifecycle: SnsSwapLifecycle.Open, metrics: undefined },
+        { lifecycle: SnsSwapLifecycle.Committed, metrics: mockSnsMetrics },
+      ]);
+      const projects = get(snsProjectsStore);
+      expect(projects).toHaveLength(2);
+
+      expect(projects[0].metrics).toBeUndefined();
+      expect(projects[1].metrics).toEqual(mockSnsMetrics);
+    });
+
+    it("should include project last reward event", () => {
+      setSnsProjects([
+        { lifecycle: SnsSwapLifecycle.Open, latestRewardEvent: undefined },
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          latestRewardEvent: mockSnsRewardEventDto,
+        },
+      ]);
+      const projects = get(snsProjectsStore);
+      expect(projects).toHaveLength(2);
+
+      expect(projects[0].latestRewardEvent).toBeUndefined();
+      expect(projects[1].latestRewardEvent).toEqual(mockSnsRewardEvent);
     });
   });
 

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -5,6 +5,7 @@ import type {
   SnsSummarySwap,
   SnsSwapCommitment,
 } from "$lib/types/sns";
+import type { MetricsDto, RewardEventDto } from "$lib/types/sns-aggregator";
 import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { QuerySnsMetadata } from "$lib/types/sns.query";
 import type { Universe } from "$lib/types/universe";
@@ -19,6 +20,7 @@ import {
   type SnsGetLifecycleResponse,
   type SnsGetMetadataResponse,
   type SnsParams,
+  type SnsRewardEvent,
   type SnsSwap,
   type SnsSwapBuyerState,
   type SnsSwapDerivedState,
@@ -307,6 +309,69 @@ export const mockSnsSummaryList: SnsSummaryWrapper[] = [
 
 export const mockSummary = mockSnsSummaryList[0];
 
+export const mockSnsMetrics: MetricsDto = {
+  treasury_metrics: [
+    {
+      name: "TOKEN_ICP",
+      original_amount_e8s: 314100000000,
+      amount_e8s: 314099990000,
+      account: {
+        owner: "7uieb-cx777-77776-qaaaq-cai",
+        subaccount: null,
+      },
+      ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+      treasury: 1,
+      timestamp_seconds: 1752222478,
+    },
+    {
+      name: "TOKEN_SNS_TOKEN",
+      original_amount_e8s: 0,
+      amount_e8s: 293700000000,
+      account: {
+        owner: "7uieb-cx777-77776-qaaaq-cai",
+        subaccount: {
+          subaccount: [
+            246, 230, 97, 166, 146, 227, 55, 186, 137, 156, 240, 185, 163, 97,
+            8, 105, 207, 138, 114, 142, 181, 152, 159, 206, 247, 187, 126, 235,
+            138, 0, 64, 161,
+          ],
+        },
+      },
+      ledger_canister_id: "75lp5-u7777-77776-qaaba-cai",
+      treasury: 2,
+      timestamp_seconds: 1752222478,
+    },
+  ],
+  voting_power_metrics: {
+    governance_total_potential_voting_power: 501746342465693,
+    timestamp_seconds: 1752222478,
+  },
+  last_ledger_block_timestamp: 1752141149,
+  num_recently_executed_proposals: 0,
+  num_recently_submitted_proposals: 0,
+  genesis_timestamp_seconds: 1752074520,
+};
+
+export const mockSnsRewardEventDto: RewardEventDto = {
+  rounds_since_last_distribution: 1,
+  actual_timestamp_seconds: 1752160922,
+  end_timestamp_seconds: 1752160920,
+  total_available_e8s_equivalent: 0,
+  distributed_e8s_equivalent: 0,
+  round: 1,
+  settled_proposals: [{ id: 123 }],
+};
+
+export const mockSnsRewardEvent: SnsRewardEvent = {
+  rounds_since_last_distribution: [1n],
+  actual_timestamp_seconds: 1752160922n,
+  end_timestamp_seconds: [1752160920n],
+  total_available_e8s_equivalent: [0n],
+  distributed_e8s_equivalent: 0n,
+  round: 1n,
+  settled_proposals: [{ id: 123n }],
+};
+
 export const mockSwapCommitment = mockSnsSwapCommitment(
   principal(0)
 ) as SnsSwapCommitment;
@@ -315,6 +380,8 @@ export const mockSnsFullProject: SnsFullProject = {
   rootCanisterId: principal(0),
   summary: mockSummary,
   swapCommitment: mockSwapCommitment,
+  metrics: mockSnsMetrics,
+  latestRewardEvent: mockSnsRewardEvent,
 };
 
 export const summaryForLifecycle = (
@@ -446,10 +513,14 @@ export const createMockSnsFullProject = ({
   summaryParams,
   rootCanisterId,
   icpCommitment,
+  metrics = mockSnsMetrics,
+  latestRewardEvent = mockSnsRewardEvent,
 }: {
   rootCanisterId: Principal;
   summaryParams: SnsSummaryParams;
   icpCommitment?: bigint;
+  metrics?: MetricsDto | undefined;
+  latestRewardEvent?: SnsRewardEvent | undefined;
 }): SnsFullProject => ({
   rootCanisterId,
   summary: createSummary(summaryParams),
@@ -459,6 +530,8 @@ export const createMockSnsFullProject = ({
       ? createBuyersState(icpCommitment)
       : undefined,
   },
+  metrics,
+  latestRewardEvent,
 });
 
 export const mockQueryMetadataResponse: SnsGetMetadataResponse = {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -5,7 +5,7 @@ import type {
   SnsSummarySwap,
   SnsSwapCommitment,
 } from "$lib/types/sns";
-import type { MetricsDto } from "$lib/types/sns-aggregator";
+import type { MetricsDto, RewardEventDto } from "$lib/types/sns-aggregator";
 import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { QuerySnsMetadata } from "$lib/types/sns.query";
 import type { Universe } from "$lib/types/universe";
@@ -350,6 +350,16 @@ export const mockSnsMetrics: MetricsDto = {
   num_recently_executed_proposals: 0,
   num_recently_submitted_proposals: 0,
   genesis_timestamp_seconds: 1752074520,
+};
+
+export const mockSnsRewardEventDto: RewardEventDto = {
+  rounds_since_last_distribution: 1,
+  actual_timestamp_seconds: 1752160922,
+  end_timestamp_seconds: 1752160920,
+  total_available_e8s_equivalent: 0,
+  distributed_e8s_equivalent: 0,
+  round: 1,
+  settled_proposals: [{ id: 123 }],
 };
 
 export const mockSnsRewardEvent: SnsRewardEvent = {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -5,7 +5,7 @@ import type {
   SnsSummarySwap,
   SnsSwapCommitment,
 } from "$lib/types/sns";
-import type { MetricsDto, RewardEventDto } from "$lib/types/sns-aggregator";
+import type { MetricsDto } from "$lib/types/sns-aggregator";
 import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { QuerySnsMetadata } from "$lib/types/sns.query";
 import type { Universe } from "$lib/types/universe";
@@ -350,16 +350,6 @@ export const mockSnsMetrics: MetricsDto = {
   num_recently_executed_proposals: 0,
   num_recently_submitted_proposals: 0,
   genesis_timestamp_seconds: 1752074520,
-};
-
-export const mockSnsRewardEventDto: RewardEventDto = {
-  rounds_since_last_distribution: 1,
-  actual_timestamp_seconds: 1752160922,
-  end_timestamp_seconds: 1752160920,
-  total_available_e8s_equivalent: 0,
-  distributed_e8s_equivalent: 0,
-  round: 1,
-  settled_proposals: [{ id: 123 }],
 };
 
 export const mockSnsRewardEvent: SnsRewardEvent = {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -513,14 +513,14 @@ export const createMockSnsFullProject = ({
   summaryParams,
   rootCanisterId,
   icpCommitment,
-  metrics = mockSnsMetrics,
-  latestRewardEvent = mockSnsRewardEvent,
+  metrics,
+  latestRewardEvent,
 }: {
   rootCanisterId: Principal;
   summaryParams: SnsSummaryParams;
   icpCommitment?: bigint;
-  metrics?: MetricsDto | undefined;
-  latestRewardEvent?: SnsRewardEvent | undefined;
+  metrics?: MetricsDto;
+  latestRewardEvent?: SnsRewardEvent;
 }): SnsFullProject => ({
   rootCanisterId,
   summary: createSummary(summaryParams),

--- a/frontend/src/tests/routes/app/launchpad/page.spec.ts
+++ b/frontend/src/tests/routes/app/launchpad/page.spec.ts
@@ -8,7 +8,6 @@ import LaunchpadPage from "$routes/(app)/(nns)/launchpad/+page.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import {
-  createMockSnsFullProject,
   mockSnsSwapCommitment,
   principal,
 } from "$tests/mocks/sns-projects.mock";
@@ -59,19 +58,16 @@ describe("Launchpad page", () => {
   it("should load Swap commitments after login", async () => {
     const sns1RootCanisterId = principal(1);
     const sns2RootCanisterId = principal(2);
-    const sns1 = createMockSnsFullProject({
-      rootCanisterId: sns1RootCanisterId,
-      summaryParams: {
+    setSnsProjects([
+      {
+        rootCanisterId: sns1RootCanisterId,
         lifecycle: SnsSwapLifecycle.Open,
       },
-    });
-    const sns2 = createMockSnsFullProject({
-      rootCanisterId: sns2RootCanisterId,
-      summaryParams: {
+      {
+        rootCanisterId: sns2RootCanisterId,
         lifecycle: SnsSwapLifecycle.Adopted,
       },
-    });
-    setSnsProjects([sns1, sns2]);
+    ]);
 
     const querySnsSwapCommitmentSpy = vi
       .spyOn(snsApi, "querySnsSwapCommitment")


### PR DESCRIPTION
# Motivation

Recently, the new aggregator data was integrated into the nns-dapp ([#7109](https://github.com/dfinity/nns-dapp/pull/7109)).  

This follow-up PR adds the new data to the `SnsFullProject` type, which should simplify access to the `metrics` and `latestRewardEvent` fields.

# Changes

- Extend SnsFullProject with new fields: `metrics` and `latestRewardEvent`.

**(drive-by refactoring):** rename SnsRewardEventStore to LatestSnsRewardEventStore.

# Tests

- Updated

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
