### PR TITLE
fix(errors): improve canister error detection

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Improved project list organization by moving unresponsive projects to bottom
+* Ledger and index canister errors
 
 #### Security
 

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -223,6 +223,7 @@ export const loadAccounts = async ({
       });
 
       if (isCanisterOutOfCycles) {
+        // TODO: Rename store to be generic
         outOfCyclesCanistersStore.add(ledgerCanisterId.toString());
       }
 

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -205,16 +205,17 @@ const isUpdateCallRejectedError = (
   "type" in error &&
   error.type === "update";
 
+// TOOD: Rename the function for generic errors
 export const isCanisterOutOfCyclesError = (error: unknown): boolean => {
   // https://github.com/dfinity/ic/blob/6e327863fd0e72d8cf9c5c46fc1263f548fad4f5/rs/protobuf/src/gen/state/state.ingress.v1.rs#L146
-  const outOfCyclesCanisterErrorCode = "IC0207";
+  const errorPrefix = "IC0";
 
   if (isQueryCallRejectedError(error)) {
-    return error.result.error_code === outOfCyclesCanisterErrorCode;
+    return error.result.error_code.startsWith(errorPrefix);
   }
 
   if (isUpdateCallRejectedError(error)) {
-    return error.error_code === outOfCyclesCanisterErrorCode;
+    return error.error_code?.startsWith(errorPrefix) ?? false;
   }
 
   return false;

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -132,7 +132,7 @@ describe("error-utils", () => {
   });
 
   describe("isCanisterOutOfCycles", () => {
-    it("should return true for query error with IC0207 code", () => {
+    it("should return true for query error with IC0 codes", () => {
       const queryError = {
         type: "query",
         result: {
@@ -140,32 +140,41 @@ describe("error-utils", () => {
         },
       } as QueryCallRejectedError;
       expect(isCanisterOutOfCyclesError(queryError)).toBe(true);
-    });
 
-    it("should return false for query error with different error code", () => {
-      const queryError = {
-        type: "query",
-        result: {
-          error_code: "IC0503",
-        },
-      } as QueryCallRejectedError;
-      expect(isCanisterOutOfCyclesError(queryError)).toBe(false);
+      queryError.result.error_code = "IC0503";
+      expect(isCanisterOutOfCyclesError(queryError)).toBe(true);
+
+      queryError.result.error_code = "IC0";
+      expect(isCanisterOutOfCyclesError(queryError)).toBe(true);
+
+      queryError.result.error_code = "IC0999";
+      expect(isCanisterOutOfCyclesError(queryError)).toBe(true);
     });
 
     it("should return true for update error with IC0207 code", () => {
-      const updateError = {
+      let updateError = {
         type: "update",
         error_code: "IC0207",
       } as UpdateCallRejectedError;
       expect(isCanisterOutOfCyclesError(updateError)).toBe(true);
-    });
 
-    it("should return false for update error with different error code", () => {
-      const updateError = {
+      updateError = {
         type: "update",
         error_code: "IC0503",
       } as UpdateCallRejectedError;
-      expect(isCanisterOutOfCyclesError(updateError)).toBe(false);
+      expect(isCanisterOutOfCyclesError(updateError)).toBe(true);
+
+      updateError = {
+        type: "update",
+        error_code: "IC0",
+      } as UpdateCallRejectedError;
+      expect(isCanisterOutOfCyclesError(updateError)).toBe(true);
+
+      updateError = {
+        type: "update",
+        error_code: "IC0999",
+      } as UpdateCallRejectedError;
+      expect(isCanisterOutOfCyclesError(updateError)).toBe(true);
     });
 
     it("should return false for invalid inputs", () => {


### PR DESCRIPTION
# Motivation

The nns-dapp fails to process errors when canisters are uninstalled. This leads to incorrect loading states in the UI and a poor user experience as users wait for something to happen. This change will be applied to the ledger and index canisters.

# Changes

- Treat all canister errors the same when loading transactions and accounts.

# Tests

- Update unit tests to check util against different error codes.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
