### PR TITLE
feat(launchpad2): Display ICP in treasury

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -7,7 +7,10 @@
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
   import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
   import { i18n } from "$lib/stores/i18n";
-  import { formatNumber, formatUsdValue } from "$lib/utils/format.utils";
+  import {
+    formatCurrencyNumber,
+    formatPercentage,
+  } from "$lib/utils/format.utils";
   import {
     snsProjectIcpInTreasuryPercentage,
     snsProjectWeeklyProposalActivity,
@@ -103,10 +106,10 @@
           <IconAccountBalance size="16px" />
           {#if nonNullish(icpInTreasury)}
             <span data-tid="icp-in-treasury-value"
-              >{formatNumber(icpInTreasury, {
+              >{formatPercentage(icpInTreasury, {
                 minFraction: 0,
                 maxFraction: 2,
-              })}%</span
+              })}</span
             >
           {:else}
             <span data-tid="icp-in-treasury-not-applicable"

--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -109,7 +109,7 @@
               })}%</span
             >
           {:else}
-            <span data-tid="icp-in-treasury-not-available"
+            <span data-tid="icp-in-treasury-not-applicable"
               >{$i18n.core.not_applicable}</span
             >
           {/if}

--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -7,10 +7,7 @@
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
   import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
   import { i18n } from "$lib/stores/i18n";
-  import {
-    formatCurrencyNumber,
-    formatPercentage,
-  } from "$lib/utils/format.utils";
+  import { formatUsdValue, formatPercentage } from "$lib/utils/format.utils";
   import {
     snsProjectIcpInTreasuryPercentage,
     snsProjectWeeklyProposalActivity,

--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -7,8 +7,11 @@
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
   import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
   import { i18n } from "$lib/stores/i18n";
-  import { formatUsdValue } from "$lib/utils/format.utils";
-  import { snsProjectWeeklyProposalActivity } from "$lib/utils/projects.utils";
+  import { formatNumber, formatUsdValue } from "$lib/utils/format.utils";
+  import {
+    snsProjectIcpInTreasuryPercentage,
+    snsProjectWeeklyProposalActivity,
+  } from "$lib/utils/projects.utils";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import {
     IconAccountBalance,
@@ -47,10 +50,7 @@
     }
     return formatUsdValue(tokenPriceUsd);
   });
-  const icpInTreasury = $derived.by(() => {
-    // TODO(launchpad2): should be available after aggregator upgrade
-    return "-/-%";
-  });
+  const icpInTreasury = $derived(snsProjectIcpInTreasuryPercentage(project));
   const userCommitmentIcp = $derived.by(() => {
     const myCommitment = getCommitmentE8s(swapCommitment);
     if (isNullish(myCommitment)) {
@@ -101,7 +101,18 @@
         >
         <div class="stat-value">
           <IconAccountBalance size="16px" />
-          <span data-tid="icp-in-treasury-value">{icpInTreasury}</span>
+          {#if nonNullish(icpInTreasury)}
+            <span data-tid="icp-in-treasury-value"
+              >{formatNumber(icpInTreasury, {
+                minFraction: 0,
+                maxFraction: 2,
+              })}%</span
+            >
+          {:else}
+            <span data-tid="icp-in-treasury-not-available"
+              >{$i18n.core.not_applicable}</span
+            >
+          {/if}
         </div>
       </li>
       <li class="stat-item">

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -480,3 +480,21 @@ export const snsProjectWeeklyProposalActivity = (
 
   return Math.round(numRecentProposals / weeks);
 };
+
+export const snsProjectIcpInTreasuryPercentage = (
+  sns: SnsFullProject
+): number | undefined => {
+  const ICP_TREASURY_ID = 1;
+  const icpInTreasuryMetrics = sns.metrics?.treasury_metrics?.find(
+    ({ treasury }) => treasury === ICP_TREASURY_ID
+  );
+
+  if (!icpInTreasuryMetrics) return undefined;
+
+  const currentAmount = icpInTreasuryMetrics.amount_e8s;
+  const originalAmount = icpInTreasuryMetrics.original_amount_e8s;
+  if (isNullish(currentAmount) || isNullish(originalAmount)) return undefined;
+  if (originalAmount === 0) return 0;
+
+  return (currentAmount / originalAmount) * 100;
+};

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -481,6 +481,8 @@ export const snsProjectWeeklyProposalActivity = (
   return Math.round(numRecentProposals / weeks);
 };
 
+// Returns the percentage [0..1] of ICP in the treasury compared to the original amount.
+// Returns undefined if the metrics are not available.
 export const snsProjectIcpInTreasuryPercentage = (
   sns: SnsFullProject
 ): number | undefined => {
@@ -496,5 +498,5 @@ export const snsProjectIcpInTreasuryPercentage = (
   if (isNullish(currentAmount) || isNullish(originalAmount)) return undefined;
   if (originalAmount === 0) return 0;
 
-  return (currentAmount / originalAmount) * 100;
+  return currentAmount / originalAmount;
 };

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard2.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard2.spec.ts
@@ -2,6 +2,7 @@ import * as saleApi from "$lib/api/sns-sale.api";
 import ProjectCard2 from "$lib/components/launchpad/ProjectCard2.svelte";
 import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import type { TreasuryMetricsDto } from "$lib/types/sns-aggregator";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { createFinalizationStatusMock } from "$tests/mocks/sns-finalization-status.mock";
 import {
@@ -203,17 +204,61 @@ describe("ProjectCard2", () => {
     });
 
     it("should display ICP in treasury", async () => {
+      const icpInTreasuryMetrics: TreasuryMetricsDto = {
+        name: "TOKEN_ICP",
+        original_amount_e8s: 314100000000,
+        amount_e8s: 314099990000,
+        account: {
+          owner: "7uieb-cx777-77776-qaaaq-cai",
+          subaccount: null,
+        },
+        ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+        treasury: 1,
+        timestamp_seconds: 1752222478,
+      };
       const project = createMockSnsFullProject({
         rootCanisterId,
         summaryParams: {
           lifecycle: SnsSwapLifecycle.Open,
         },
         icpCommitment: undefined,
+        metrics: {
+          ...mockSnsMetrics,
+          treasury_metrics: [
+            {
+              ...icpInTreasuryMetrics,
+              amount_e8s: 2_571_600_000,
+              original_amount_e8s: 10_000_000_000,
+            },
+          ],
+        },
       });
       const po = await renderCard(project);
 
-      // TODO(launchpad2): Update this test when ICP in treasury is implemented.
-      expect(await po.getIcpInTreasuryValue()).toEqual("-/-%");
+      expect(await po.getIcpInTreasuryValueText()).toEqual("25.72%");
+      expect(await po.getIcpInTreasuryValueNotApplicable().isPresent()).toEqual(
+        false
+      );
+    });
+
+    it("should display N/A when no ICP in treasury available", async () => {
+      const project = createMockSnsFullProject({
+        rootCanisterId,
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Open,
+        },
+        icpCommitment: undefined,
+        metrics: {
+          ...mockSnsMetrics,
+          treasury_metrics: [],
+        },
+      });
+      const po = await renderCard(project);
+
+      expect(await po.getIcpInTreasuryValue().isPresent()).toEqual(false);
+      expect(await po.getIcpInTreasuryValueNotApplicable().isPresent()).toEqual(
+        true
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1551,7 +1551,7 @@ describe("snsProjectIcpInTreasuryPercentage", () => {
       },
     });
 
-    expect(snsProjectIcpInTreasuryPercentage(testProject)).toBe(20);
+    expect(snsProjectIcpInTreasuryPercentage(testProject)).toBe(0.2);
   });
 
   it("should use icp treasury metrics for calculation", () => {
@@ -1572,7 +1572,7 @@ describe("snsProjectIcpInTreasuryPercentage", () => {
       },
     });
 
-    expect(snsProjectIcpInTreasuryPercentage(testProject)).toBe(20);
+    expect(snsProjectIcpInTreasuryPercentage(testProject)).toBe(0.2);
   });
 
   it("should return undefined when no treasury metrics fields available", () => {

--- a/frontend/src/tests/page-objects/ProjectCard2.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCard2.page-object.ts
@@ -32,8 +32,16 @@ export class ProjectCard2Po extends CardPo {
     return this.getText("token-price-value");
   }
 
-  getIcpInTreasuryValue(): Promise<string> {
-    return this.getText("icp-in-treasury-value");
+  getIcpInTreasuryValue(): PageObjectElement {
+    return this.root.byTestId("icp-in-treasury-value");
+  }
+
+  getIcpInTreasuryValueText(): Promise<string> {
+    return this.getIcpInTreasuryValue().getText();
+  }
+
+  getIcpInTreasuryValueNotApplicable(): PageObjectElement {
+    return this.root.byTestId("icp-in-treasury-not-applicable");
   }
 
   getUserCommitmentIcp(): AmountDisplayPo {


### PR DESCRIPTION
# Motivation

In the redesigned project cards, the ICP in treasury should be displayed.  
This PR replaces the placeholder with the real value based on the aggregator metrics.

# Changes

- Add new utility: `snsProjectIcpInTreasuryPercentage`.
- Display actual ICP treasury value.

# Tests

- Updated.
- Tested manually.

<img width="937" height="535" alt="image" src="https://github.com/user-attachments/assets/1fe3133e-0c88-4668-895d-efcc68d41db9" />


# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
