### PR TITLE
feat(performance): gate APY calculations behind flag

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -228,16 +228,18 @@
       />
 
       {#if $ENABLE_APY_PORTFOLIO && $isDesktopViewportStore && nonNullish(totalUsdAmount)}
-        {#if isStakingRewardDataReady(stakingRewardData)}
-          <ApyCard
-            rewardBalanceUSD={stakingRewardData.rewardBalanceUSD}
-            rewardEstimateWeekUSD={stakingRewardData.rewardEstimateWeekUSD}
-            stakingPower={stakingRewardData.stakingPower}
-            stakingPowerUSD={stakingRewardData.stakingPowerUSD}
-            totalAmountUSD={totalUsdAmount}
-          />
-        {:else}
-          <ApyFallbackCard {stakingRewardData} />
+        {#if nonNullish(stakingRewardData)}
+          {#if isStakingRewardDataReady(stakingRewardData)}
+            <ApyCard
+              rewardBalanceUSD={stakingRewardData.rewardBalanceUSD}
+              rewardEstimateWeekUSD={stakingRewardData.rewardEstimateWeekUSD}
+              stakingPower={stakingRewardData.stakingPower}
+              stakingPowerUSD={stakingRewardData.stakingPowerUSD}
+              totalAmountUSD={totalUsdAmount}
+            />
+          {:else}
+            <ApyFallbackCard {stakingRewardData} />
+          {/if}
         {/if}
       {/if}
     {/if}
@@ -254,7 +256,7 @@
       {/if}
     {/if}
 
-    {#if $ENABLE_APY_PORTFOLIO && !$isDesktopViewportStore && $authSignedInStore && nonNullish(totalUsdAmount)}
+    {#if $ENABLE_APY_PORTFOLIO && !$isDesktopViewportStore && $authSignedInStore && nonNullish(totalUsdAmount) && nonNullish(stakingRewardData)}
       {#if isStakingRewardDataReady(stakingRewardData)}
         <ApyCard
           rewardBalanceUSD={stakingRewardData.rewardBalanceUSD}

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -49,7 +49,7 @@
     snsProjects: SnsFullProject[];
     openSnsProposals: ProposalInfo[];
     adoptedSnsProposals: SnsFullProject[];
-    stakingRewardData: StakingRewardData;
+    stakingRewardData?: StakingRewardData;
   };
 
   const {
@@ -141,7 +141,7 @@
   );
 
   const tableProjectsWithApy: TableProject[] = $derived(
-    isStakingRewardDataReady(stakingRewardData)
+    nonNullish(stakingRewardData) && isStakingRewardDataReady(stakingRewardData)
       ? tableProjects.map((project) => ({
           ...project,
           apy: stakingRewardData.apy.get(project.universeId) ?? undefined,
@@ -202,7 +202,9 @@
   );
 
   const hasApyCalculationErrored = $derived(
-    !stakingRewardData.loading && "error" in stakingRewardData
+    nonNullish(stakingRewardData) &&
+      !stakingRewardData.loading &&
+      "error" in stakingRewardData
   );
 </script>
 

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -21,6 +21,7 @@
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
   import { loadProposalsSnsCF } from "$lib/services/public/sns.services";
   import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
+  import { ENABLE_APY_PORTFOLIO } from "$lib/stores/feature-flags.store";
   import { governanceMetricsStore } from "$lib/stores/governance-metrics.store";
   import { networkEconomicsStore } from "$lib/stores/network-economics.store";
   import { neuronsStore } from "$lib/stores/neurons.store";
@@ -92,16 +93,18 @@
       projects: $snsProjectsActivePadStore,
     })}
     openSnsProposals={$openSnsProposalsStore}
-    stakingRewardData={getStakingRewardData({
-      auth: $authSignedInStore,
-      tokens: userTokens,
-      snsProjects: $snsAggregatorStore,
-      snsNeurons: $snsNeuronsStore,
-      nnsNeurons: $neuronsStore,
-      nnsEconomics: $networkEconomicsStore,
-      fxRates: $icpSwapUsdPricesStore,
-      governanceMetrics: $governanceMetricsStore,
-      nnsTotalVotingPower: $nnsTotalVotingPowerStore,
-    })}
+    stakingRewardData={$ENABLE_APY_PORTFOLIO
+      ? getStakingRewardData({
+          auth: $authSignedInStore,
+          tokens: userTokens,
+          snsProjects: $snsAggregatorStore,
+          snsNeurons: $snsNeuronsStore,
+          nnsNeurons: $neuronsStore,
+          nnsEconomics: $networkEconomicsStore,
+          fxRates: $icpSwapUsdPricesStore,
+          governanceMetrics: $governanceMetricsStore,
+          nnsTotalVotingPower: $nnsTotalVotingPowerStore,
+        })
+      : undefined}
   /></TestIdWrapper
 >


### PR DESCRIPTION
# Motivation

This PR hides the calculation of APY rewards behind the feature flag to avoid issues with accounts with many neurons and projects.

# Changes

- Hide `getStakingRewardData` behind a feature flag.

# Tests

- Tested in beta that performance of the nns-dapp is not degraded.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
