### PR TITLE
feat(portoflio): customize Apy card CTA based on staking power

### DIFF
--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -65,6 +65,12 @@
         ? formatCurrencyNumber(totalAmountUSD)
         : $i18n.core.not_applicable
   );
+
+  const linkText = $derived(
+    stakingPowerUSD > 0
+      ? $i18n.portfolio.apy_card_link_view
+      : $i18n.portfolio.apy_card_link_start
+  );
 </script>
 
 {#snippet content()}
@@ -110,12 +116,7 @@
 
 {#if $isMobileViewportStore}
   <article class="card mobile" data-tid={dataTid}>
-    <a
-      {href}
-      class="link"
-      aria-label={$i18n.portfolio.apy_card_link}
-      data-tid="project-link"
-    >
+    <a {href} class="link" aria-label={linkText} data-tid="project-link">
       {@render content()}
     </a>
   </article>
@@ -124,13 +125,8 @@
     <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
     {@render content()}
 
-    <a
-      {href}
-      class="link"
-      aria-label={$i18n.portfolio.apy_card_link}
-      data-tid="project-link"
-    >
-      <span>{$i18n.portfolio.apy_card_link}</span>
+    <a {href} class="link" aria-label={linkText} data-tid="project-link">
+      <span>{linkText}</span>
       <IconRight />
     </a>
   </article>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1329,7 +1329,8 @@
     "apy_card_title": "Staking Rewards",
     "apy_card_reward_title": "Reward Balance",
     "apy_card_power_title": "Staking Ratio",
-    "apy_card_link": "View Staked",
+    "apy_card_link_view": "View Staked",
+    "apy_card_link_start": "Start Staking",
     "apy_card_estimation": "7d estimate",
     "apy_card_error": "Unable to load rewards",
     "apy_card_tooltip": "Maturity is an attribute of a neuron; it is not a tradable asset. To generate ICP from maturity, users need to trigger a non-deterministic process subject to a changing maturity modulation function. The dollar value reflects an estimate assuming a modulation of 0%."

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1399,7 +1399,8 @@ interface I18nPortfolio {
   apy_card_title: string;
   apy_card_reward_title: string;
   apy_card_power_title: string;
-  apy_card_link: string;
+  apy_card_link_view: string;
+  apy_card_link_start: string;
   apy_card_estimation: string;
   apy_card_error: string;
   apy_card_tooltip: string;

--- a/frontend/src/tests/lib/components/portfolio/ApyCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/ApyCard.spec.ts
@@ -12,7 +12,6 @@ describe("ApyCardPo", () => {
     stakingPower: 0.4567,
     stakingPowerUSD: 9876.54,
     totalAmountUSD: 12345.12,
-    loading: false,
   };
 
   const renderComponent = (props = defaultProps) => {
@@ -59,6 +58,20 @@ describe("ApyCardPo", () => {
     const linkPo = po.getLinkPo();
     expect(await linkPo.isPresent()).toBe(true);
     expect(await linkPo.getHref()).toBe("/staking");
+  });
+
+  it("should show specific label when there is staking power", async () => {
+    const po = renderComponent(defaultProps);
+
+    const linkPo = po.getLinkPo();
+    expect(await linkPo.getText()).contains("View Staked");
+  });
+
+  it("should show specific label when no staking power", async () => {
+    const po = renderComponent({ ...defaultProps, stakingPowerUSD: 0 });
+
+    const linkPo = po.getLinkPo();
+    expect(await linkPo.getText()).contains("Start Staking");
   });
 
   it("should display privacy placeholders when privacy mode is enabled", async () => {


### PR DESCRIPTION
# Motivation

The new APY card can be displayed for users with or without staking power. The CTA in the button should be tailored to each situation.

[NNS1-3922](https://dfinity.atlassian.net/browse/NNS1-3922)

# Changes

- Conditionally display link text based on `stakingPowerUSD`.

# Tests

- Unit test the conditional.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3922]: https://dfinity.atlassian.net/browse/NNS1-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ