### PR TITLE
debounce call to calculate staking rewards

### DIFF
--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -42,6 +42,11 @@
   loadIcpSwapTickers();
   loadCkBTCTokens();
 
+  let stakingRewardData: ReturnType<typeof getStakingRewardData> = {
+    loading: true,
+  };
+  let debounceTimer: number;
+
   let userTokens: UserToken[];
   $: userTokens = $tokensListVisitorsStore;
 
@@ -71,6 +76,26 @@
   $: if ($snsProposalsStoreIsLoading) {
     loadProposalsSnsCF({ omitLargeFields: false });
   }
+  $: {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      if ($ENABLE_APY_PORTFOLIO) {
+        stakingRewardData = getStakingRewardData({
+          auth: $authSignedInStore,
+          tokens: userTokens,
+          snsProjects: $snsAggregatorStore,
+          snsNeurons: $snsNeuronsStore,
+          nnsNeurons: $neuronsStore,
+          nnsEconomics: $networkEconomicsStore,
+          fxRates: $icpSwapUsdPricesStore,
+          governanceMetrics: $governanceMetricsStore,
+          nnsTotalVotingPower: $nnsTotalVotingPowerStore,
+        });
+      } else {
+        stakingRewardData = { loading: true };
+      }
+    }, 700) as unknown as number;
+  }
 </script>
 
 <TestIdWrapper testId="portfolio-route-component"
@@ -93,18 +118,6 @@
       projects: $snsProjectsActivePadStore,
     })}
     openSnsProposals={$openSnsProposalsStore}
-    stakingRewardData={$ENABLE_APY_PORTFOLIO
-      ? getStakingRewardData({
-          auth: $authSignedInStore,
-          tokens: userTokens,
-          snsProjects: $snsAggregatorStore,
-          snsNeurons: $snsNeuronsStore,
-          nnsNeurons: $neuronsStore,
-          nnsEconomics: $networkEconomicsStore,
-          fxRates: $icpSwapUsdPricesStore,
-          governanceMetrics: $governanceMetricsStore,
-          nnsTotalVotingPower: $nnsTotalVotingPowerStore,
-        })
-      : undefined}
+    {stakingRewardData}
   /></TestIdWrapper
 >


### PR DESCRIPTION
# Motivation

The new APY card estimates rewards based on a simulation of potential earnings over a year. This simulation must be conducted for each project and neuron. The more projects and neurons a user has, the longer the simulation will take. The calculation is triggered as data sources become available, leading to multiple executions in a cascading effect. This PR minimizes this effect by debouncing the function call until the data sources are ready.

[NNS1-3922](https://dfinity.atlassian.net/browse/NNS1-3922)

# Changes

- Debounce call to `getStakingRewardData`.
- ...

# Tests

- ...

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3922]: https://dfinity.atlassian.net/browse/NNS1-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ