### PR TITLE
Hide favorite buttons

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -79,7 +79,7 @@
       <h3 data-tid="project-name">{name}</h3>
       <div class="fav-icon">
         <!-- TODO(launchpad2): Should be clickable and toggle favorite state -->
-        <!-- <IconStar size="20px" /> -->
+        <IconStar size="20px" />
       </div>
     </div>
 
@@ -148,9 +148,7 @@
 
     <div class="footer">
       <!-- TODO(launchpad2): Should be clickable and toggle favorite state -->
-      <div>
-        <!-- <button class="ghost with-icon"><IconStar size="20px" /> Watch</button> -->
-      </div>
+      <button class="ghost with-icon"><IconStar size="20px" /> Watch</button>
       <a
         {href}
         class="link"
@@ -196,6 +194,7 @@
       }
 
       .fav-icon {
+        display: none;
         @include media.min-width(medium) {
           display: none;
         }
@@ -275,7 +274,8 @@
 
         color: var(--button-secondary-color);
 
-        display: flex;
+        display: none;
+        // display: flex;
         align-items: center;
         gap: var(--padding-0_5x);
       }


### PR DESCRIPTION
# Motivation

Temporarily hide the fav buttons until the full functionality is implemented.

# Changes

- Hide mobile and desktop fav elements.

# Tests

- Verified manually that they are not visible anymore:

| M | D |
|--------|--------|
| <img width="387" height="410" alt="image" src="https://github.com/user-attachments/assets/8a054113-9610-49f9-b6c6-b4125a0b622e" /> | <img width="910" height="283" alt="image" src="https://github.com/user-attachments/assets/14c98787-2974-469c-8fd5-ce892deef39e" /> |

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
