### PR TITLE
feat(tickers): filter duplicate tickers by volume

### DIFF
--- a/frontend/src/lib/derived/icp-swap.derived.ts
+++ b/frontend/src/lib/derived/icp-swap.derived.ts
@@ -51,8 +51,10 @@ export const icpSwapUsdPricesStore: IcpSwapUsdPricesStore = derived(
             return tickersForPair;
           } else {
             // Multiple tickers for this pair - filter by volume
-            return tickersForPair.filter(
-              (ticker) => Number(ticker.volume_usd_24H) > 0
+            return (
+              tickersForPair.find(
+                (ticker) => Number(ticker.volume_usd_24H) > 0
+              ) ?? []
             );
           }
         }

--- a/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-swap.derived.spec.ts
@@ -121,7 +121,7 @@ describe("icp-swap.derived", () => {
       });
     });
 
-    it("should skip tickers with no volume_usd_24H", () => {
+    it("should skip tickers with no volume_usd_24H when doubled the api response", () => {
       const icpPriceInUsd = 12.4;
 
       const ckusdcTicker = {
@@ -129,15 +129,37 @@ describe("icp-swap.derived", () => {
         base_id: CKUSDC_LEDGER_CANISTER_ID.toText(),
         last_price: `${icpPriceInUsd}`,
       };
+
       const noVolumeTicker = {
         ...mockIcpSwapTicker,
+        base_id: CKETH_LEDGER_CANISTER_ID.toText(),
         volume_usd_24H: "0",
+        last_price: `${icpPriceInUsd}`,
       };
 
       icpSwapTickersStore.set([ckusdcTicker, noVolumeTicker]);
       expect(get(icpSwapUsdPricesStore)).toEqual({
         [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
         [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,
+        [CKETH_LEDGER_CANISTER_ID.toText()]: 1,
+      });
+
+      const sameTickerWithVolume = {
+        ...mockIcpSwapTicker,
+        base_id: CKETH_LEDGER_CANISTER_ID.toText(),
+        volume_usd_24H: "1000",
+        last_price: `${0.5 * icpPriceInUsd}`,
+      };
+
+      icpSwapTickersStore.set([
+        ckusdcTicker,
+        noVolumeTicker,
+        sameTickerWithVolume,
+      ]);
+      expect(get(icpSwapUsdPricesStore)).toEqual({
+        [LEDGER_CANISTER_ID.toText()]: icpPriceInUsd,
+        [CKUSDC_LEDGER_CANISTER_ID.toText()]: 1,
+        [CKETH_LEDGER_CANISTER_ID.toText()]: 2,
       });
     });
 


### PR DESCRIPTION
# Motivation

#7038 introduced a filter for tokens based on their volume over the last 24 hours. This change eliminates unexpected values, such as outdated ones. However, it also removes pairs from tokens with low liquidity. Therefore, this PR applies the filtering only when multiple entries for the same pair are present.

[NNS1-3938](https://dfinity.atlassian.net/browse/NNS1-3938)

# Changes

- Update the derived store to filter duplicate tickers base on `volume_usd_24h`.

# Tests

- Update tests.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3938]: https://dfinity.atlassian.net/browse/NNS1-3938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ