### PR TITLE
feat(launchpad2): Fix navigation link visibility

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -279,14 +279,17 @@
         display: flex;
       }
 
+      button {
+        visibility: hidden;
+      }
+
       .link,
       button {
         @include launchpad.text_button;
 
         color: var(--button-secondary-color);
 
-        display: none;
-        // display: flex;
+        display: flex;
         align-items: center;
         gap: var(--padding-0_5x);
       }


### PR DESCRIPTION
# Motivation

This PR restores the link to the project details page, which was mistakenly hidden in [#7126](https://github.com/dfinity/nns-dapp/pull/7126).

# Changes

- Update styles.

# Tests

- Verified manually that the link is there

<img width="829" height="287" alt="image" src="https://github.com/user-attachments/assets/70d245a8-b334-4c9b-8fae-d5fe4a93f2eb" />


# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
