### PR TITLE
feat(tokens): add token type filtering utility

### DIFF
--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -112,11 +112,15 @@ const isIcpToken = (token: UserToken) =>
 const isCkToken = (token: UserToken) =>
   importantTokensText.includes(token.universeId.toText());
 
-export const filterTokensByType = (
-  tokens: UserToken[],
-  type: "icp" | "ck" | "sns" | "imported",
-  importedTokens: ImportedTokenData[] = []
-) => {
+export const filterTokensByType = ({
+  tokens,
+  type,
+  importedTokens = [],
+}: {
+  tokens: UserToken[];
+  type: "icp" | "ck" | "sns" | "imported";
+  importedTokens?: ImportedTokenData[];
+}) => {
   if (type === "icp") return tokens.filter(isIcpToken);
   if (type === "ck") return tokens.filter(isCkToken);
   if (type === "imported")

--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -410,40 +410,43 @@ describe("tokens-table.utils", () => {
     ];
 
     it("should filter ICP tokens", () => {
-      const result = filterTokensByType(allTokens, "icp");
+      const result = filterTokensByType({ tokens: allTokens, type: "icp" });
       expect(result).toEqual([icpToken]);
     });
 
     it("should filter ckTokens (important ck tokens)", () => {
-      const result = filterTokensByType(allTokens, "ck");
+      const result = filterTokensByType({ tokens: allTokens, type: "ck" });
       expect(result).toEqual([ckBTCToken, ckETHTToken, ckUSDCToken]);
     });
 
     it("should filter imported tokens", () => {
-      const result = filterTokensByType(
-        allTokens,
-        "imported",
-        mockImportedTokensData
-      );
+      const result = filterTokensByType({
+        tokens: allTokens,
+        type: "imported",
+        importedTokens: mockImportedTokensData,
+      });
       expect(result).toEqual([importedToken1, importedToken2]);
     });
 
     it("should filter imported tokens without providing importedTokens parameter", () => {
-      const result = filterTokensByType(allTokens, "imported");
+      const result = filterTokensByType({
+        tokens: allTokens,
+        type: "imported",
+      });
       expect(result).toEqual([]);
     });
 
     it("should filter SNS tokens (excluding ICP, ck, and imported)", () => {
-      const result = filterTokensByType(
-        allTokens,
-        "sns",
-        mockImportedTokensData
-      );
+      const result = filterTokensByType({
+        tokens: allTokens,
+        type: "sns",
+        importedTokens: mockImportedTokensData,
+      });
       expect(result).toEqual([snsToken1, snsToken2]);
     });
 
     it("should filter SNS tokens when no imported tokens are provided", () => {
-      const result = filterTokensByType(allTokens, "sns");
+      const result = filterTokensByType({ tokens: allTokens, type: "sns" });
       // Without imported tokens data, importedToken1 and importedToken2 should be classified as SNS
       expect(result).toEqual([
         snsToken1,
@@ -451,19 +454,6 @@ describe("tokens-table.utils", () => {
         importedToken1,
         importedToken2,
       ]);
-    });
-
-    it("should handle mixed token types correctly", () => {
-      const mixedTokens = [icpToken, ckBTCToken, snsToken1, importedToken1];
-
-      expect(filterTokensByType(mixedTokens, "icp")).toEqual([icpToken]);
-      expect(filterTokensByType(mixedTokens, "ck")).toEqual([ckBTCToken]);
-      expect(
-        filterTokensByType(mixedTokens, "sns", mockImportedTokensData)
-      ).toEqual([snsToken1]);
-      expect(
-        filterTokensByType(mixedTokens, "imported", mockImportedTokensData)
-      ).toEqual([importedToken1]);
     });
   });
 });


### PR DESCRIPTION
# Motivation

The Tokens and Neurons tables will be divided into multiple tables to distinguish ICP from other assets. This PR creates a new util to filter tokens by type so different tables can be created with each type of token.

[NNS1-3966](https://dfinity.atlassian.net/browse/NNS1-3966)

# Changes

- New utility to filter tokens by type. Since we lack a specific method for filtering SNS tokens, these will include any tokens that do not belong to the other types.

# Tests

- Unit tests for the new utility.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3966]: https://dfinity.atlassian.net/browse/NNS1-3966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ