### PR TITLE
fix(tooltip): prevent navigation on icon click

### DIFF
--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -14,9 +14,15 @@
     iconSize = 20,
     tooltipIdPrefix = "tooltip-icon",
   }: Props = $props();
+  const handleOnClick = (event: MouseEvent) => {
+    // Prevents the click event from propagating to the parent elements
+    event.preventDefault();
+  };
 </script>
 
-<div class="wrapper" data-tid="tooltip-icon-component">
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="wrapper" data-tid="tooltip-icon-component" onclick={handleOnClick}>
   <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
   <!-- svelte-ignore slot_element_deprecated -->
   <Tooltip id={tooltipId} idPrefix={tooltipIdPrefix} {text}>

--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -15,7 +15,6 @@
     tooltipIdPrefix = "tooltip-icon",
   }: Props = $props();
   const handleOnClick = (event: MouseEvent) => {
-    // Prevents the click event from propagating to the parent elements
     event.preventDefault();
   };
 </script>


### PR DESCRIPTION
# Motivation

The `TooltipIcon` is used in clickable cards to allow users to open the tooltips without navigating away. The element needs to block the default behavior.

# Changes

- Add a `preventDefault` event to the wrapper of the Tooltip.

# Tests

- Manually tested.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
