### PR TITLE
style(apy): align fallback card with new design

### DIFF
--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -34,7 +34,6 @@
     <div class="content">
       <div class="subtitle skeleton"></div>
       <div class="main-value skeleton"></div>
-      <div class="secondary-value-single skeleton"></div>
     </div>
   </div>
 {/snippet}
@@ -81,7 +80,6 @@
 
   .content {
     display: flex;
-    justify-content: space-between;
 
     .content {
       display: flex;
@@ -96,11 +94,11 @@
 
       .main-value {
         height: 32px;
-        width: 120px;
+        width: 100px;
 
         @include media.min-width(medium) {
           height: 36px;
-          width: 140px;
+          max-width: 140px;
         }
       }
 
@@ -115,7 +113,7 @@
 
           @include media.min-width(medium) {
             height: 20px;
-            width: 70px;
+            max-width: 70px;
           }
         }
 
@@ -125,18 +123,8 @@
 
           @include media.min-width(medium) {
             height: 20px;
-            width: 100px;
+            max-width: 100px;
           }
-        }
-      }
-
-      .secondary-value-single {
-        height: 16px;
-        width: 90px;
-
-        @include media.min-width(medium) {
-          height: 20px;
-          width: 110px;
         }
       }
     }


### PR DESCRIPTION
# Motivation

#7139 updated the new APY card by removing some values and emphasizing the importance of the staking ratio. The Fallback card is now outdated as it reflects a different design.

| Before | After |
|--------|--------|
| <img width="502" height="229" alt="Screenshot 2025-07-17 at 22 47 48" src="https://github.com/user-attachments/assets/93176fee-0c1f-4141-b932-601cbbbda28b" /> | <img width="397" height="254" alt="Screenshot 2025-07-17 at 22 46 49" src="https://github.com/user-attachments/assets/b41d7e4a-a7fb-4c80-8c53-2e8d3d525e65" /> |

[NNS1-3891](https://dfinity.atlassian.net/browse/NNS1-3891)

# Changes

- Update styles of APY fallback card.

# Tests

- Visually tested

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3891]: https://dfinity.atlassian.net/browse/NNS1-3891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ