### PR TITLE
feat(apy): hide card for accounts without assets

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -260,7 +260,7 @@
     {/if}
 
     {#if $ENABLE_APY_PORTFOLIO && !$isDesktopViewportStore && $authSignedInStore && nonNullish(totalUsdAmount) && nonNullish(stakingRewardResult)}
-      {#if isStakingRewardDataReady(stakingRewardResult)}
+      {#if isStakingRewardDataReady(stakingRewardResult) && totalUsdAmount > 0}
         <ApyCard
           rewardBalanceUSD={stakingRewardResult.rewardBalanceUSD}
           rewardEstimateWeekUSD={stakingRewardResult.rewardEstimateWeekUSD}
@@ -268,7 +268,7 @@
           stakingPowerUSD={stakingRewardResult.stakingPowerUSD}
           totalAmountUSD={totalUsdAmount}
         />
-      {:else}
+      {:else if isStakingRewardDataError(stakingRewardResult) || isStakingRewardDataLoading(stakingRewardResult)}
         <ApyFallbackCard stakingRewardData={stakingRewardResult} />
       {/if}
     {/if}

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -202,6 +202,13 @@
         })
       : [...launchpadCards, ...openProposalCards, ...adoptedSnsProposalsCards]
   );
+
+  const showAnyApyCard = $derived(
+    (isStakingRewardDataReady(stakingRewardResult) &&
+      (totalUsdAmount ?? 0) > 0) ||
+      isStakingRewardDataError(stakingRewardResult) ||
+      isStakingRewardDataLoading(stakingRewardResult)
+  );
 </script>
 
 <main data-tid="portfolio-page-component">
@@ -209,7 +216,7 @@
     class="top"
     class:signed-in={$authSignedInStore}
     class:launchpad={cards.length > 0}
-    class:apy-card={$ENABLE_APY_PORTFOLIO}
+    class:apy-card={$ENABLE_APY_PORTFOLIO && showAnyApyCard}
   >
     {#if !$authSignedInStore}
       <div class="login-card">
@@ -220,11 +227,13 @@
         usdAmount={totalUsdAmount}
         hasUnpricedTokens={hasUnpricedTokensOrStake}
         isLoading={isSomethingLoading}
-        isFullWidth={cards.length === 0 && !$ENABLE_APY_PORTFOLIO}
+        isFullWidth={cards.length === 0 &&
+          !$ENABLE_APY_PORTFOLIO &&
+          !showAnyApyCard}
       />
 
       {#if $ENABLE_APY_PORTFOLIO && $isDesktopViewportStore && nonNullish(totalUsdAmount)}
-        {#if isStakingRewardDataReady(stakingRewardResult)}
+        {#if isStakingRewardDataReady(stakingRewardResult) && totalUsdAmount > 0}
           <ApyCard
             rewardBalanceUSD={stakingRewardResult.rewardBalanceUSD}
             rewardEstimateWeekUSD={stakingRewardResult.rewardEstimateWeekUSD}
@@ -232,7 +241,7 @@
             stakingPowerUSD={stakingRewardResult.stakingPowerUSD}
             totalAmountUSD={totalUsdAmount}
           />
-        {:else}
+        {:else if isStakingRewardDataError(stakingRewardResult) || isStakingRewardDataLoading(stakingRewardResult)}
           <ApyFallbackCard stakingRewardData={stakingRewardResult} />
         {/if}
       {/if}

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -228,8 +228,7 @@
         hasUnpricedTokens={hasUnpricedTokensOrStake}
         isLoading={isSomethingLoading}
         isFullWidth={cards.length === 0 &&
-          !$ENABLE_APY_PORTFOLIO &&
-          !showAnyApyCard}
+          (!$ENABLE_APY_PORTFOLIO || !showAnyApyCard)}
       />
 
       {#if $ENABLE_APY_PORTFOLIO && $isDesktopViewportStore && nonNullish(totalUsdAmount)}

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -495,11 +495,25 @@ describe("Portfolio page", () => {
     });
 
     it("should not show a full width TotalAssetsCard when no stacked cards but APY FF is on", async () => {
-      const po = renderPage();
+      const po = renderPage({
+        stakingRewardResult: {
+          loading: true,
+        },
+      });
       const totalAssetsCardPo = po.getTotalAssetsCardPo();
 
       expect(await totalAssetsCardPo.isPresent()).toBe(true);
       expect(await totalAssetsCardPo.isFullWidth()).toBe(false);
+      expect(await po.getApyFallbackCardPo().isPresent()).toBe(true);
+    });
+
+    it("should show a full width TotalAssetsCard when no stacked cards, APY FF is on but no assets ", async () => {
+      const po = renderPage({ stakingRewardResult: null });
+      const totalAssetsCardPo = po.getTotalAssetsCardPo();
+
+      expect(await totalAssetsCardPo.isPresent()).toBe(true);
+      expect(await totalAssetsCardPo.isFullWidth()).toBe(true);
+      expect(await po.getApyCardPo().isPresent()).toBe(false);
     });
 
     it("should show a not full width TotalAssetsCard when stacked cards is not empty", async () => {


### PR DESCRIPTION
# Motivation

The new APY card should not be displayed for empty accounts with no assets.

[NNS1-3891](https://dfinity.atlassian.net/browse/NNS1-3891)

# Changes

- Hide `ApyCard` when calculation has finished and there are no total assets.

# Tests

- Add new tests to cover case

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3891]: https://dfinity.atlassian.net/browse/NNS1-3891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ