### PR TITLE
feat(launchpad2): Filter by all the sns projects

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -197,7 +197,7 @@
   const cards: ComponentWithProps[] = $derived(
     $ENABLE_LAUNCHPAD_REDESIGN && $ENABLE_APY_PORTFOLIO
       ? getUpcomingLaunchesCards({
-          snsProjects,
+          snsProjects: [...snsProjects, ...adoptedSnsProposals],
           openSnsProposals,
         })
       : [...launchpadCards, ...openProposalCards, ...adoptedSnsProposalsCards]

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -647,7 +647,7 @@ describe("Portfolio page", () => {
 
     it("should show first on going swaps, then open proposals, and then adopted proposals", async () => {
       const po = renderPage({
-        snsProjects: mockSnsProjects,
+        snsProjects: mockSnsProjects.slice(0, 1),
         openSnsProposals: mockSnsProposals.slice(0, 1),
         adoptedSnsProposals: mockSnsProjects.slice(1, 2),
       });


### PR DESCRIPTION
# Motivation

There are plans to display redesigned launch cards on the portfolio page.  
The `getUpcomingLaunchesCards` utility, which filters projects for these cards, expects all `snsProjects` as input.  
However, in the Portfolio component, `snsProjects` currently contains only open projects.  

This PR fixes the issue by including adopted projects as well.

# Changes

- Use both open and adopted projects as input for the launch cards utility.

# Tests

- Updated.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
