### PR TITLE
feat(launchpad): fix no link for 575-767px

### DIFF
--- a/frontend/src/lib/components/launchpad/CardFrame.svelte
+++ b/frontend/src/lib/components/launchpad/CardFrame.svelte
@@ -61,7 +61,7 @@
     padding: var(--padding-2x) var(--padding-2x)
       var(--card-frame-padding-bottom, var(--padding-2x));
 
-    @include media.min-width(medium) {
+    @include media.min-width(small) {
       height: 230px;
       padding: var(--padding-3x) var(--padding-3x)
         var(--card-frame-padding-bottom, var(--padding-3x));

--- a/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
+++ b/frontend/src/lib/components/launchpad/CreateSnsProposalCard.svelte
@@ -106,7 +106,7 @@
       @include portfolio.card-tag;
 
       --logo-size: var(--padding-4x);
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         --logo-size: 40px;
       }
 
@@ -137,7 +137,7 @@
           font-weight: 450;
           line-height: 20px;
 
-          @include media.min-width(medium) {
+          @include media.min-width(small) {
             font-size: 18px;
             line-height: 24px;
           }
@@ -152,7 +152,7 @@
           padding: 0;
           color: var(--color-text-secondary);
 
-          @include media.min-width(medium) {
+          @include media.min-width(small) {
             display: block;
             // To support -webkit-line-clamp
             display: -webkit-box;
@@ -179,7 +179,7 @@
         color: var(--button-secondary-color);
 
         display: none;
-        @include media.min-width(medium) {
+        @include media.min-width(small) {
           display: flex;
         }
 

--- a/frontend/src/lib/components/launchpad/OngoingProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/OngoingProjectCard.svelte
@@ -145,21 +145,21 @@
     right: -40px;
     bottom: -40px;
 
-    @include media.min-width(medium) {
+    @include media.min-width(small) {
       right: -60px;
       bottom: -60px;
     }
 
     &--mobile {
       display: block;
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         display: none;
       }
     }
 
     &--desktop {
       display: none;
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         display: block;
       }
     }
@@ -176,7 +176,7 @@
       @include portfolio.card-tag;
 
       --logo-size: var(--padding-4x);
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         --logo-size: 40px;
       }
 
@@ -252,7 +252,7 @@
         color: var(--button-secondary-color);
 
         display: none;
-        @include media.min-width(medium) {
+        @include media.min-width(small) {
           display: flex;
         }
 

--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -181,7 +181,7 @@
     // Make the last row always be at the bottom of the card
     grid-template-rows: auto auto 1fr;
 
-    @include media.min-width(medium) {
+    @include media.min-width(small) {
       // Make also the stats row always be at the bottom of the card
       // so they looks aligned horizontally when a project has no/short description.
       grid-template-rows: auto 1fr auto;
@@ -195,7 +195,7 @@
       @include launchpad.card_content_header;
 
       --logo-size: var(--padding-4x);
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         --logo-size: 40px;
       }
 
@@ -208,7 +208,7 @@
 
       .fav-icon {
         display: none;
-        @include media.min-width(medium) {
+        @include media.min-width(small) {
           display: none;
         }
       }
@@ -229,7 +229,7 @@
 
       // margin-bottom: auto;
       margin-top: auto;
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         margin-top: 0;
       }
 
@@ -276,7 +276,7 @@
       justify-content: space-between;
       align-items: end;
 
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         display: flex;
       }
 

--- a/frontend/src/lib/components/launchpad/UpcomingProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/UpcomingProjectCard.svelte
@@ -102,7 +102,7 @@
       // @include portfolio.card-tag;
 
       --logo-size: var(--padding-4x);
-      @include media.min-width(medium) {
+      @include media.min-width(small) {
         --logo-size: 40px;
       }
 
@@ -157,7 +157,7 @@
         color: var(--button-secondary-color);
 
         display: none;
-        @include media.min-width(medium) {
+        @include media.min-width(small) {
           display: flex;
         }
 


### PR DESCRIPTION
# Motivation

The new launchpad cards switch behavior based on the viewport: on mobile (≤575px), the whole card is clickable; on desktop, only a separate link inside the card is clickable. This creates a gap between 576px and 767px where the card contains no clickable link.

Previously, the link was only shown from the medium breakpoint (≥767px), even when `isMobileViewportStore` returned `false`. This PR updates the card styles to ensure the desktop link is visible as soon as `isMobileViewportStore` returns `false`.

# Changes

- Switch to the desktop card styles sooner (replaced `medium` to `small` in all breakpoints)

# Tests

- verified manually

| Before | After |
|--------|--------|
| <img width="592" height="220" alt="image" src="https://github.com/user-attachments/assets/dc3c404a-0369-4626-be35-57c65c5d8cd4" /> | <img width="587" height="245" alt="image" src="https://github.com/user-attachments/assets/2af3c614-6d48-467e-ac38-a86e93f16426" /> | 

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
