### PR TITLE
feat(scripts): add SNS executed proposals script

### DIFF
--- a/scripts/nns-dapp/num_proposals.sh
+++ b/scripts/nns-dapp/num_proposals.sh
@@ -18,7 +18,7 @@ total_entries=${#ENTRIES[@]}
 echo "► Found $total_entries committed SNS projects."
 echo
 
-echo "name,executed_proposals" > "$OUTPUT_FILE"
+echo "name,executed_proposals" >"$OUTPUT_FILE"
 total_sum=0
 index=0
 
@@ -30,44 +30,44 @@ for entry in "${ENTRIES[@]}"; do
   printf "[%02d/%d] %-30s " "$index" "$total_entries" "$name"
 
   # Governance canister ID
-  gov=$(curl -s "https://sns-api.internetcomputer.org/api/v1/snses/$root_id" \
-        | jq -r '.governance_canister_id')
+  gov=$(curl -s "https://sns-api.internetcomputer.org/api/v1/snses/$root_id" |
+    jq -r '.governance_canister_id')
 
   if [[ -z "$gov" || "$gov" == "null" ]]; then
     echo "⛔  no governance_id"
-    echo "$name,ERROR_NO_GOV_ID" >> "$OUTPUT_FILE"
+    echo "$name,ERROR_NO_GOV_ID" >>"$OUTPUT_FILE"
     continue
   fi
 
   printf "→ get_metrics … "
   if ! raw=$(dfx canister --ic call "$gov" \
-            get_metrics "(record { time_window_seconds = opt ($MAX_NAT64) })" 2>/dev/null); then
+    get_metrics "(record { time_window_seconds = opt ($MAX_NAT64) })" 2>/dev/null); then
     echo "⛔  call failed"
-    echo "$name,ERROR_CALL_FAILED" >> "$OUTPUT_FILE"
+    echo "$name,ERROR_CALL_FAILED" >>"$OUTPUT_FILE"
     continue
   fi
 
   if ! json=$(echo "$raw" | idl2json 2>/dev/null); then
     echo "⛔  idl2json failed"
-    echo "$name,ERROR_JSON_FAILED" >> "$OUTPUT_FILE"
+    echo "$name,ERROR_JSON_FAILED" >>"$OUTPUT_FILE"
     continue
   fi
 
-  num=$(echo "$json" \
-        | jq -r '.get_metrics_result[0].Ok.num_recently_executed_proposals[0]' 2>/dev/null)
+  num=$(echo "$json" |
+    jq -r '.get_metrics_result[0].Ok.num_recently_executed_proposals[0]' 2>/dev/null)
 
   if [[ -z "$num" || "$num" == "null" ]]; then
     echo "⛔  parse failed"
-    echo "$name,ERROR_PARSE_FAILED" >> "$OUTPUT_FILE"
+    echo "$name,ERROR_PARSE_FAILED" >>"$OUTPUT_FILE"
     continue
   fi
 
   echo "✅  $num"
-  echo "$name,$num" >> "$OUTPUT_FILE"
+  echo "$name,$num" >>"$OUTPUT_FILE"
   total_sum=$((total_sum + num))
 done
 
-echo "Total,$total_sum" >> "$OUTPUT_FILE"
+echo "Total,$total_sum" >>"$OUTPUT_FILE"
 
 echo
 echo "============================================"

--- a/scripts/nns-dapp/num_proposals.sh
+++ b/scripts/nns-dapp/num_proposals.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OUTPUT_FILE="executed_proposals.csv"
+export DFX_WARNING="-mainnet_plaintext_identity"
+MAX_NAT64="18446744073709551615 : nat64"
+
+echo "============================================"
+echo "Fetching SNS list (single request)…"
+echo "============================================"
+
+response=$(curl -s "https://sns-api.internetcomputer.org/api/v1/snses?max_sns_index=999&offset=0&limit=100&include_swap_lifecycle=LIFECYCLE_COMMITTED")
+
+mapfile -t ENTRIES < <(echo "$response" | jq -c '.data[] | {root: .root_canister_id, name: .name}')
+
+total_entries=${#ENTRIES[@]}
+echo "► Found $total_entries committed SNS projects."
+echo
+
+echo "name,executed_proposals" > "$OUTPUT_FILE"
+total_sum=0
+index=0
+
+for entry in "${ENTRIES[@]}"; do
+  index=$((index + 1))
+  root_id=$(jq -r '.root' <<<"$entry")
+  name=$(jq -r '.name' <<<"$entry")
+
+  printf "[%02d/%d] %-30s " "$index" "$total_entries" "$name"
+
+  # Governance canister ID
+  gov=$(curl -s "https://sns-api.internetcomputer.org/api/v1/snses/$root_id" \
+        | jq -r '.governance_canister_id')
+
+  if [[ -z "$gov" || "$gov" == "null" ]]; then
+    echo "⛔  no governance_id"
+    echo "$name,ERROR_NO_GOV_ID" >> "$OUTPUT_FILE"
+    continue
+  fi
+
+  printf "→ get_metrics … "
+  if ! raw=$(dfx canister --ic call "$gov" \
+            get_metrics "(record { time_window_seconds = opt ($MAX_NAT64) })" 2>/dev/null); then
+    echo "⛔  call failed"
+    echo "$name,ERROR_CALL_FAILED" >> "$OUTPUT_FILE"
+    continue
+  fi
+
+  if ! json=$(echo "$raw" | idl2json 2>/dev/null); then
+    echo "⛔  idl2json failed"
+    echo "$name,ERROR_JSON_FAILED" >> "$OUTPUT_FILE"
+    continue
+  fi
+
+  num=$(echo "$json" \
+        | jq -r '.get_metrics_result[0].Ok.num_recently_executed_proposals[0]' 2>/dev/null)
+
+  if [[ -z "$num" || "$num" == "null" ]]; then
+    echo "⛔  parse failed"
+    echo "$name,ERROR_PARSE_FAILED" >> "$OUTPUT_FILE"
+    continue
+  fi
+
+  echo "✅  $num"
+  echo "$name,$num" >> "$OUTPUT_FILE"
+  total_sum=$((total_sum + num))
+done
+
+echo "Total,$total_sum" >> "$OUTPUT_FILE"
+
+echo
+echo "============================================"
+echo "Finished ✔  CSV written to $OUTPUT_FILE"
+echo "Total num_recently_executed_proposals = $total_sum"
+echo "============================================"


### PR DESCRIPTION
# Motivation

#7153 introduced a new banner on the home page that displays general information about the SNS projects. One of the values shown is "Proposals Executed." This script calculates those proposals. For example:

<img width="601" height="742" alt="Screenshot 2025-07-21 at 13 03 21" src="https://github.com/user-attachments/assets/2d991ba6-cb68-459f-b09e-7fa0829bb259" />

Based on script by @aterga, modified by @mstrasinskis.

[NNS1-3841](https://dfinity.atlassian.net/browse/NNS1-3841)

# Changes

- Add script

# Tests

- Run it locally.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3841]: https://dfinity.atlassian.net/browse/NNS1-3841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ