### PR TITLE
chore(test-e2e): add utility to disable css animations on the page

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
   await page.goto("/accounts");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await expect(page).toHaveTitle("Account | Network Nervous System");
 
   await signInWithNewUser({ page, context });

--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
   await page.goto("/accounts");
+  disableCssAnimations(page);
   await expect(page).toHaveTitle("Account | Network Nervous System");
 
   await signInWithNewUser({ page, context });

--- a/frontend/src/tests/e2e/canisters.spec.ts
+++ b/frontend/src/tests/e2e/canisters.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test canisters", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/canisters.spec.ts
+++ b/frontend/src/tests/e2e/canisters.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test canisters", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/ckbtc.spec.ts
+++ b/frontend/src/tests/e2e/ckbtc.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
   await page.goto("/tokens");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/ckbtc.spec.ts
+++ b/frontend/src/tests/e2e/ckbtc.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
   await page.goto("/tokens");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/design.spec.ts
+++ b/frontend/src/tests/e2e/design.spec.ts
@@ -1,11 +1,16 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { replaceContent, signInWithNewUser } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  replaceContent,
+  signInWithNewUser,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test, type Page } from "@playwright/test";
 
 test.describe("Design", () => {
   test("Login", async ({ page }) => {
     await page.goto("/accounts");
+    disableCssAnimations(page);
     await expect(page).toHaveTitle("Account | Network Nervous System");
     // Wait for balance in the first row of the table to make sure the screenshot is taken after the app is loaded.
     const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -23,6 +28,7 @@ test.describe("Design", () => {
 
   test("App loading spinner is removed", async ({ page }) => {
     await page.goto("/");
+    disableCssAnimations(page);
     await expect(page).toHaveTitle("Portfolio | Network Nervous System");
 
     // Wait for the button to make sure the app is loaded
@@ -41,6 +47,7 @@ test.describe("Design", () => {
     test.beforeAll(async ({ browser }) => {
       page = await browser.newPage();
       await page.goto("/tokens");
+      disableCssAnimations(page);
 
       await signInWithNewUser({ page, context: browser.contexts()[0] });
     });

--- a/frontend/src/tests/e2e/design.spec.ts
+++ b/frontend/src/tests/e2e/design.spec.ts
@@ -10,7 +10,7 @@ import { expect, test, type Page } from "@playwright/test";
 test.describe("Design", () => {
   test("Login", async ({ page }) => {
     await page.goto("/accounts");
-    disableCssAnimations(page);
+    await disableCssAnimations(page);
     await expect(page).toHaveTitle("Account | Network Nervous System");
     // Wait for balance in the first row of the table to make sure the screenshot is taken after the app is loaded.
     const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -28,7 +28,7 @@ test.describe("Design", () => {
 
   test("App loading spinner is removed", async ({ page }) => {
     await page.goto("/");
-    disableCssAnimations(page);
+    await disableCssAnimations(page);
     await expect(page).toHaveTitle("Portfolio | Network Nervous System");
 
     // Wait for the button to make sure the app is loaded
@@ -47,7 +47,7 @@ test.describe("Design", () => {
     test.beforeAll(async ({ browser }) => {
       page = await browser.newPage();
       await page.goto("/tokens");
-      disableCssAnimations(page);
+      await disableCssAnimations(page);
 
       await signInWithNewUser({ page, context: browser.contexts()[0] });
     });

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test disburse neuron", async ({ page, context }) => {
   await page.goto("/");
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test disburse neuron", async ({ page, context }) => {
   await page.goto("/");
-  await disableCssAnimations(page);
+  await await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/following.spec.ts
+++ b/frontend/src/tests/e2e/following.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron following", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/following.spec.ts
+++ b/frontend/src/tests/e2e/following.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test neuron following", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/import-token.spec.ts
+++ b/frontend/src/tests/e2e/import-token.spec.ts
@@ -2,6 +2,7 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
   dfxCanisterId,
+  disableCssAnimations,
   signInWithNewUser,
   step,
 } from "$tests/utils/e2e.test-utils";
@@ -14,6 +15,7 @@ test("Test imported tokens", async ({ page, context }) => {
   const testIndexCanisterId = await dfxCanisterId("ckred_index");
 
   await page.goto("/tokens");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/import-token.spec.ts
+++ b/frontend/src/tests/e2e/import-token.spec.ts
@@ -15,7 +15,7 @@ test("Test imported tokens", async ({ page, context }) => {
   const testIndexCanisterId = await dfxCanisterId("ckred_index");
 
   await page.goto("/tokens");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test merge neurons", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -93,7 +93,7 @@ test("Test merge neurons", async ({ page, context }) => {
   // Reload the page in case we would only know the neuron because it was still
   // in the store from before.
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await appPo.goToNnsMainAccountWallet();
   const transactionList = appPo
     .getWalletPo()

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test merge neurons", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -88,6 +93,7 @@ test("Test merge neurons", async ({ page, context }) => {
   // Reload the page in case we would only know the neuron because it was still
   // in the store from before.
   await page.goto("/");
+  disableCssAnimations(page);
   await appPo.goToNnsMainAccountWallet();
   const transactionList = appPo
     .getWalletPo()

--- a/frontend/src/tests/e2e/neuron-details.spec.ts
+++ b/frontend/src/tests/e2e/neuron-details.spec.ts
@@ -11,7 +11,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test neuron details", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neuron-details.spec.ts
+++ b/frontend/src/tests/e2e/neuron-details.spec.ts
@@ -2,6 +2,7 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
 import {
+  disableCssAnimations,
   replaceContent,
   signInWithNewUser,
   step,
@@ -10,6 +11,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test neuron details", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -10,7 +10,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test neuron increase stake", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -1,11 +1,16 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron increase stake", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neurons-table.spec.ts
+++ b/frontend/src/tests/e2e/neurons-table.spec.ts
@@ -66,6 +66,7 @@ const createHotkeyNeuronsInOtherAccount = async ({
 
 test("Test neurons table", async ({ page, context, browser }) => {
   await page.goto("/canisters");
+  disableCssAnimations(page);
   await expect(page).toHaveTitle("Canisters | Network Nervous System");
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));

--- a/frontend/src/tests/e2e/neurons-table.spec.ts
+++ b/frontend/src/tests/e2e/neurons-table.spec.ts
@@ -26,7 +26,7 @@ const createHotkeyNeuronsInOtherAccount = async ({
   const page = await context.newPage();
 
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
@@ -66,7 +66,7 @@ const createHotkeyNeuronsInOtherAccount = async ({
 
 test("Test neurons table", async ({ page, context, browser }) => {
   await page.goto("/canisters");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await expect(page).toHaveTitle("Canisters | Network Nervous System");
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));

--- a/frontend/src/tests/e2e/neurons-table.spec.ts
+++ b/frontend/src/tests/e2e/neurons-table.spec.ts
@@ -1,6 +1,7 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
+  disableCssAnimations,
   replaceContent,
   signInWithNewUser,
   step,
@@ -25,6 +26,7 @@ const createHotkeyNeuronsInOtherAccount = async ({
   const page = await context.newPage();
 
   await page.goto("/");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -2,11 +2,16 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -11,7 +11,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/periodic.spec.ts
+++ b/frontend/src/tests/e2e/periodic.spec.ts
@@ -15,7 +15,7 @@ test("Test periodic confirmation", async ({ page, context }) => {
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
 
   await page.goto("/tokens");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await expect(page).toHaveTitle("Tokens | Network Nervous System");
 
   step("Sign in");

--- a/frontend/src/tests/e2e/periodic.spec.ts
+++ b/frontend/src/tests/e2e/periodic.spec.ts
@@ -1,6 +1,10 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 const SECONDS_IN_DAY = 24 * 60 * 60;
@@ -11,6 +15,7 @@ test("Test periodic confirmation", async ({ page, context }) => {
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
 
   await page.goto("/tokens");
+  disableCssAnimations(page);
   await expect(page).toHaveTitle("Tokens | Network Nervous System");
 
   step("Sign in");

--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -27,7 +27,7 @@ test.skip("Visual test Landing Page", async ({ page, browser }) => {
   const portfolioPo = appPo.getPortfolioPo();
 
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await expect(page).toHaveTitle("Portfolio | Network Nervous System");
 
   await page.setViewportSize(VIEWPORT_SIZES.desktop);
@@ -80,7 +80,7 @@ test.skip("Visual test Landing Page", async ({ page, browser }) => {
 
   step("Get some ICP and BTC");
   await page.goto("/tokens");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await appPo.getIcpTokens(41);
   const ckBTCRow = await appPo
     .getTokensPo()
@@ -105,7 +105,7 @@ test.skip("Visual test Landing Page", async ({ page, browser }) => {
 
   step("Total Assets");
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
 
   await portfolioPo.getPortfolioPagePo().getHeldTokensCardPo().waitFor();
   await portfolioPo.getPortfolioPagePo().getStakedTokensCardPo().waitFor();

--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -1,6 +1,7 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
+  disableCssAnimations,
   replaceContent,
   signInWithNewUser,
   step,
@@ -26,6 +27,7 @@ test.skip("Visual test Landing Page", async ({ page, browser }) => {
   const portfolioPo = appPo.getPortfolioPo();
 
   await page.goto("/");
+  disableCssAnimations(page);
   await expect(page).toHaveTitle("Portfolio | Network Nervous System");
 
   await page.setViewportSize(VIEWPORT_SIZES.desktop);
@@ -78,6 +80,7 @@ test.skip("Visual test Landing Page", async ({ page, browser }) => {
 
   step("Get some ICP and BTC");
   await page.goto("/tokens");
+  disableCssAnimations(page);
   await appPo.getIcpTokens(41);
   const ckBTCRow = await appPo
     .getTokensPo()
@@ -102,6 +105,7 @@ test.skip("Visual test Landing Page", async ({ page, browser }) => {
 
   step("Total Assets");
   await page.goto("/");
+  disableCssAnimations(page);
 
   await portfolioPo.getPortfolioPagePo().getHeldTokensCardPo().waitFor();
   await portfolioPo.getPortfolioPagePo().getStakedTokensCardPo().waitFor();

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -12,7 +12,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test proposals", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await expect(page).toHaveTitle("Portfolio | Network Nervous System");
 
   await signInWithNewUser({ page, context });

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -2,12 +2,17 @@ import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { ProposalStatus, Topic } from "@dfinity/nns";
 import { expect, test } from "@playwright/test";
 
 test("Test proposals", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
   await expect(page).toHaveTitle("Portfolio | Network Nervous System");
 
   await signInWithNewUser({ page, context });

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test SNS governance", async ({ page, context }) => {
   await page.goto("/tokens");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS governance", async ({ page, context }) => {
   await page.goto("/tokens");
+  disableCssAnimations(page);
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from "@playwright/test";
 
 test("Test SNS participation", async ({ page, context }) => {
   await page.goto("/");
-  disableCssAnimations(page);
+  await disableCssAnimations(page);
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -1,10 +1,15 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS participation", async ({ page, context }) => {
   await page.goto("/");
+  disableCssAnimations(page);
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -155,3 +155,18 @@ export const closeHighlight = async (page: Page) => {
 
   await highlightPo.clickClose();
 };
+
+export const disableCssAnimations = async (page: Page) => {
+  await page.addStyleTag({
+    content: `
+      *, ::before, ::after {
+        animation-duration: 0s !important;
+        transition-duration: 0s !important;
+        animation-delay: 0s !important;
+        animation-play-state: paused !important;
+        transition-property: none !important;
+        caret-color: transparent !important;
+      }
+    `,
+  });
+};

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -160,11 +160,8 @@ export const disableCssAnimations = async (page: Page) => {
   await page.addStyleTag({
     content: `
       *, ::before, ::after {
-        animation-duration: 0s !important;
-        transition-duration: 0s !important;
-        animation-delay: 0s !important;
-        animation-play-state: paused !important;
-        transition-property: none !important;
+        animation: none !important;
+        transition: none !important;
         caret-color: transparent !important;
       }
     `,


### PR DESCRIPTION
# Motivation

CSS animation may be non-deterministic in screenshot taking, this adds a utility to force disabling them for the page.

# Changes

Added utility to disable css animations

# Tests

Tests should pass.

# Todos

- [x] Accessibility (a11y) – any impact? no
- [x] Changelog – is it needed? no
