### PR TITLE
feat: migrate gix-cmp Collapsible, KeyValuePair and KeyValuePairInfo

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "6.0.0-next-2025-07-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-6.0.0-next-2025-07-11.1.tgz",
-      "integrity": "sha512-q8RvN6GUyEHjLlhxyn/g0prMnJnnS/lop4MKDdIhB1wDmeIqf7cIzmqdJxj1W0DFo7qQGxam/rNfnRoOAUNqeQ==",
+      "version": "7.0.0-next-2025-07-22",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-7.0.0-next-2025-07-22.tgz",
+      "integrity": "sha512-TxLtvnUZxHBBXFVnX8h33hkJpJ//ce6Ut1FiGneUdkQyUUlVKxsMMi4CofFkhwr00DSwC1i219D1dhcQJQH/HQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "decimal.js": "^10.6.0",


### PR DESCRIPTION
# Motivation

We **need** to integrate the latest version of **Gix-cmp**, which includes the migration of `Collapsible`, `KeyInfoPair`, and `KeyInfoPairInfo` to **Svelte v5**. Otherwise, the collapsible element may eventually stop working as expected, as it has become incompatible with the latest version of Svelte.

# Changes in Gix-cmp

- https://github.com/dfinity/gix-components/pull/696
- https://github.com/dfinity/gix-components/pull/698

# Changes

<!-- List the changes that have been developed -->

