### PR TITLE
feat(staking rewards): create a global store to reuse data across pages

### DIFF
--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -4,7 +4,7 @@
   import { IconError } from "@dfinity/gix-components";
 
   type Props = {
-    stakingRewardData:
+    stakingRewardData?:
       | { loading: true }
       | {
           loading: false;
@@ -15,7 +15,9 @@
   const { stakingRewardData }: Props = $props();
 
   const isError = $derived(
-    !stakingRewardData.loading && "error" in stakingRewardData
+    stakingRewardData &&
+      !stakingRewardData.loading &&
+      "error" in stakingRewardData
   );
   const testId = "apy-fallback-card";
 </script>

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -52,7 +52,7 @@
     snsProjects: SnsFullProject[];
     openSnsProposals: ProposalInfo[];
     adoptedSnsProposals: SnsFullProject[];
-    stakingRewardResult: StakingRewardResult;
+    stakingRewardResult?: StakingRewardResult;
   };
 
   const {

--- a/frontend/src/lib/services/staking-rewards.service.ts
+++ b/frontend/src/lib/services/staking-rewards.service.ts
@@ -4,9 +4,13 @@ import {
   type StakingRewardCalcParams,
 } from "$lib/utils/staking-rewards.utils";
 
+// Encapusaling the variables below in a closure so that they are reset during the different tests
+// Otherwise, this function is supposed to be called only once, in the app root initialization
 export const getRefreshStakingRewards = () => {
   let debounceTimer: ReturnType<typeof setTimeout>;
+  // If the auth state changes, we want to refresh the data immediately to reflect that
   let prevAuthState = false;
+  // We also want to refresh it immediately the first time, in order to set the correct loading state
   let firstTime = true;
 
   return (params: StakingRewardCalcParams) => {

--- a/frontend/src/lib/services/staking-rewards.service.ts
+++ b/frontend/src/lib/services/staking-rewards.service.ts
@@ -1,0 +1,26 @@
+import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
+import {
+  getStakingRewardData,
+  type StakingRewardCalcParams,
+} from "$lib/utils/staking-rewards.utils";
+
+export const getRefreshStakingRewards = () => {
+  let debounceTimer: ReturnType<typeof setTimeout>;
+  let prevAuthState = false;
+  let firstTime = true;
+
+  return (params: StakingRewardCalcParams) => {
+    clearTimeout(debounceTimer);
+    const refreshData = () =>
+      stakingRewardsStore.set(getStakingRewardData(params));
+
+    if (params.auth !== prevAuthState || firstTime) {
+      // No debounce if auth state changes, or if it's the first time: refresh immediately
+      prevAuthState = params.auth;
+      firstTime = false;
+      refreshData();
+    } else {
+      debounceTimer = setTimeout(refreshData, 500);
+    }
+  };
+};

--- a/frontend/src/lib/stores/staking-rewards.store.ts
+++ b/frontend/src/lib/stores/staking-rewards.store.ts
@@ -1,0 +1,6 @@
+import type { StakingRewardResult } from "$lib/utils/staking-rewards.utils";
+import { writable } from "svelte/store";
+
+export const stakingRewardsStore = writable<StakingRewardResult | undefined>(
+  undefined
+);

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -18,28 +18,21 @@
     resetBalanceLoading,
   } from "$lib/services/accounts-balances.services";
   import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
-  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
   import { loadProposalsSnsCF } from "$lib/services/public/sns.services";
   import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
-  import { governanceMetricsStore } from "$lib/stores/governance-metrics.store";
-  import { networkEconomicsStore } from "$lib/stores/network-economics.store";
   import { neuronsStore } from "$lib/stores/neurons.store";
-  import { nnsTotalVotingPowerStore } from "$lib/stores/nns-total-voting-power.store";
-  import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import {
     openSnsProposalsStore,
     snsProposalsStoreIsLoading,
   } from "$lib/stores/sns.store";
+  import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
   import type { UserToken } from "$lib/types/tokens-page";
   import { filterProjectsStatus } from "$lib/utils/projects.utils";
-  import { getStakingRewardData } from "$lib/utils/staking-rewards.utils";
   import { getTableProjects } from "$lib/utils/staking.utils";
   import { SnsSwapLifecycle } from "@dfinity/sns";
-  import { onDestroy } from "svelte";
 
   resetBalanceLoading();
-  loadIcpSwapTickers();
   loadCkBTCTokens();
 
   let userTokens: UserToken[];
@@ -71,48 +64,6 @@
   $: if ($snsProposalsStoreIsLoading) {
     loadProposalsSnsCF({ omitLargeFields: false });
   }
-
-  let stakingRewardData = getStakingRewardData({
-    auth: $authSignedInStore,
-    tokens: userTokens,
-    snsProjects: $snsAggregatorStore,
-    snsNeurons: $snsNeuronsStore,
-    nnsNeurons: $neuronsStore,
-    nnsEconomics: $networkEconomicsStore,
-    fxRates: $icpSwapUsdPricesStore,
-    governanceMetrics: $governanceMetricsStore,
-    nnsTotalVotingPower: $nnsTotalVotingPowerStore,
-  });
-
-  let debounceTimer: ReturnType<typeof setTimeout>;
-  let prevAuthState = $authSignedInStore;
-  $: {
-    clearTimeout(debounceTimer);
-    const refreshData = () =>
-      (stakingRewardData = getStakingRewardData({
-        auth: $authSignedInStore,
-        tokens: userTokens,
-        snsProjects: $snsAggregatorStore,
-        snsNeurons: $snsNeuronsStore,
-        nnsNeurons: $neuronsStore,
-        nnsEconomics: $networkEconomicsStore,
-        fxRates: $icpSwapUsdPricesStore,
-        governanceMetrics: $governanceMetricsStore,
-        nnsTotalVotingPower: $nnsTotalVotingPowerStore,
-      }));
-
-    if ($authSignedInStore !== prevAuthState) {
-      // No debounce if auth state changes, refresh immediately
-      prevAuthState = $authSignedInStore;
-      refreshData();
-    } else {
-      debounceTimer = setTimeout(refreshData, 500);
-    }
-  }
-
-  onDestroy(() => {
-    clearTimeout(debounceTimer);
-  });
 </script>
 
 <TestIdWrapper testId="portfolio-route-component"
@@ -135,6 +86,6 @@
       projects: $snsProjectsActivePadStore,
     })}
     openSnsProposals={$openSnsProposalsStore}
-    stakingRewardResult={stakingRewardData}
+    stakingRewardResult={$stakingRewardsStore}
   /></TestIdWrapper
 >

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,15 +2,25 @@
   import Alfred from "$lib/components/alfred/Alfred.svelte";
   import Highlight from "$lib/components/ui/Highlight.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
   import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
   import { initAnalytics } from "$lib/services/analytics.services";
+  import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
+  import { getRefreshStakingRewards } from "$lib/services/staking-rewards.service";
   import {
     initAuthWorker,
     type AuthWorker,
   } from "$lib/services/worker-auth.services";
   import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
   import { ENABLE_DISBURSE_MATURITY } from "$lib/stores/feature-flags.store";
+  import { governanceMetricsStore } from "$lib/stores/governance-metrics.store";
   import { i18n } from "$lib/stores/i18n";
+  import { networkEconomicsStore } from "$lib/stores/network-economics.store";
+  import { neuronsStore } from "$lib/stores/neurons.store";
+  import { nnsTotalVotingPowerStore } from "$lib/stores/nns-total-voting-power.store";
+  import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+  import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import { toastsClean } from "$lib/stores/toasts.store";
   import { onMount } from "svelte";
 
@@ -50,6 +60,22 @@
   });
 
   $: syncAuth($authStore);
+
+  loadIcpSwapTickers();
+  const refreshStakingRewards = getRefreshStakingRewards();
+  $: {
+    refreshStakingRewards({
+      auth: $authSignedInStore,
+      tokens: $tokensListUserStore,
+      snsProjects: $snsAggregatorStore,
+      snsNeurons: $snsNeuronsStore,
+      nnsNeurons: $neuronsStore,
+      nnsEconomics: $networkEconomicsStore,
+      fxRates: $icpSwapUsdPricesStore,
+      governanceMetrics: $governanceMetricsStore,
+      nnsTotalVotingPower: $nnsTotalVotingPowerStore,
+    });
+  }
 </script>
 
 <Alfred />

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -61,6 +61,7 @@
 
   $: syncAuth($authStore);
 
+  // Load ICP swap tickers for the Staking Rewards
   loadIcpSwapTickers();
   const refreshStakingRewards = getRefreshStakingRewards();
   $: {


### PR DESCRIPTION
# Motivation

The calculation for the Staking Rewards was triggered on any page change. This avoids it, and recalculates it only when a dependency really changes.

# Changes

Introduced a reusable store. Update the tests.

# Tests

Tested manually + tests should pass.

# Todos

- [x] Accessibility (a11y) – any impact? no
- [x] Changelog – is it needed? no
