### PR TITLE
Display staking-rewards card on staking page

### DIFF
--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -123,7 +123,7 @@
           )}
         />
       </span>
-      <span class="main-value bigger" data-tid="staking-power"
+      <span class="main-value" data-tid="staking-power"
         >{stakingPowerPercentage}</span
       >
     </div>
@@ -178,19 +178,8 @@
         font-weight: 450;
         line-height: 32px;
 
-        &.bigger {
-          font-size: 30px;
-          line-height: 30px;
-          font-weight: 400;
-        }
-
         @include media.min-width(medium) {
           font-size: 27px;
-
-          &.bigger {
-            font-size: 40px;
-            line-height: 40px;
-          }
         }
       }
 
@@ -225,7 +214,7 @@
   .card {
     height: 100%;
     box-sizing: border-box;
-    background-color: var(--background);
+    background-color: var(--card-background-tint);
 
     box-shadow: var(--box-shadow);
 

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -19,6 +19,8 @@
     stakingPower: number;
     stakingPowerUSD: number;
     totalAmountUSD: number;
+    /// Whether to render the link and the header.
+    simpleMode?: boolean;
   };
   const {
     rewardBalanceUSD,
@@ -26,6 +28,7 @@
     stakingPower,
     stakingPowerUSD,
     totalAmountUSD,
+    simpleMode = false,
   }: Props = $props();
 
   const href = AppPath.Staking;
@@ -132,19 +135,26 @@
 
 {#if $isMobileViewportStore}
   <article class="card mobile" data-tid={dataTid}>
-    <a {href} class="link" aria-label={linkText} data-tid="project-link">
+    {#if simpleMode}
       {@render content()}
-    </a>
+    {:else}
+      <a {href} class="link" aria-label={linkText} data-tid="project-link"> </a>
+    {/if}
   </article>
 {:else}
-  <article class="card desktop" data-tid={dataTid}>
-    <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
+  <article class="card desktop" data-tid={dataTid} class:simpleMode>
+    {#if !simpleMode}
+      <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
+    {/if}
+
     {@render content()}
 
-    <a {href} class="link" aria-label={linkText} data-tid="project-link">
-      <span>{linkText}</span>
-      <IconRight />
-    </a>
+    {#if !simpleMode}
+      <a {href} class="link" aria-label={linkText} data-tid="project-link">
+        <span>{linkText}</span>
+        <IconRight />
+      </a>
+    {/if}
   </article>
 {/if}
 
@@ -238,6 +248,10 @@
     grid-template-rows: auto auto 1fr;
     padding: 24px;
     grid-gap: 16px;
+
+    &.simpleMode {
+      grid-template-rows: auto;
+    }
 
     .title {
       font-size: 18px;

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -20,7 +20,7 @@
     stakingPowerUSD: number;
     totalAmountUSD: number;
     /// Whether to render the link and the header.
-    simpleMode?: boolean;
+    onStakingPage?: boolean;
   };
   const {
     rewardBalanceUSD,
@@ -28,7 +28,7 @@
     stakingPower,
     stakingPowerUSD,
     totalAmountUSD,
-    simpleMode = false,
+    onStakingPage = false,
   }: Props = $props();
 
   const href = AppPath.Staking;
@@ -135,19 +135,19 @@
 
 {#if $isMobileViewportStore}
   <article class="card mobile" data-tid={dataTid}>
-    {#if simpleMode}
+    {#if onStakingPage}
       {@render content()}
     {:else}
       <a {href} class="link" aria-label={linkText} data-tid="project-link"> </a>
     {/if}
   </article>
 {:else}
-  <article class="card desktop" data-tid={dataTid} class:simpleMode>
+  <article class="card desktop" data-tid={dataTid} class:onStakingPage>
     <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
 
     {@render content()}
 
-    {#if !simpleMode}
+    {#if !onStakingPage}
       <a {href} class="link" aria-label={linkText} data-tid="project-link">
         <span>{linkText}</span>
         <IconRight />
@@ -231,7 +231,7 @@
     border-radius: 12px;
     overflow: hidden;
 
-    &.simpleMode {
+    &.onStakingPage {
       box-shadow: none;
       border-radius: var(--padding);
     }
@@ -251,7 +251,7 @@
     padding: 24px;
     grid-gap: 16px;
 
-    &.simpleMode {
+    &.onStakingPage {
       grid-template-rows: auto;
     }
 

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -143,9 +143,7 @@
   </article>
 {:else}
   <article class="card desktop" data-tid={dataTid} class:simpleMode>
-    {#if !simpleMode}
-      <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
-    {/if}
+    <h5 class="title">{$i18n.portfolio.apy_card_title}</h5>
 
     {@render content()}
 
@@ -227,12 +225,16 @@
     background-color: var(--card-background-tint);
 
     box-shadow: var(--box-shadow);
-
     transition:
       color var(--animation-time-normal),
       box-shadow var(--animation-time-normal);
     border-radius: 12px;
     overflow: hidden;
+
+    &.simpleMode {
+      box-shadow: none;
+      border-radius: var(--padding);
+    }
   }
 
   .card.mobile {

--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -37,7 +37,8 @@
   const rewardBalanceUSDFormatted = $derived(
     $isBalancePrivacyOptionStore
       ? renderPrivacyModeBalance(5)
-      : nonNullish(rewardBalanceUSD)
+      : // TODO: nonNullish check looks redundant
+        nonNullish(rewardBalanceUSD)
         ? formatCurrencyNumber(rewardBalanceUSD)
         : $i18n.core.not_applicable
   );
@@ -45,7 +46,8 @@
   const totalAmountUSDFormatted = $derived(
     $isBalancePrivacyOptionStore
       ? renderPrivacyModeBalance(3)
-      : nonNullish(totalAmountUSD)
+      : // TODO: nonNullish check looks redundant
+        nonNullish(totalAmountUSD)
         ? formatCurrencyNumber(totalAmountUSD)
         : $i18n.core.not_applicable
   );
@@ -53,7 +55,8 @@
   const stakingPowerUSDFormatted = $derived(
     $isBalancePrivacyOptionStore
       ? renderPrivacyModeBalance(3)
-      : nonNullish(stakingPowerUSD)
+      : // TODO: nonNullish check looks redundant
+        nonNullish(stakingPowerUSD)
         ? formatCurrencyNumber(stakingPowerUSD)
         : $i18n.core.not_applicable
   );
@@ -61,7 +64,8 @@
   const rewardEstimateWeekUSDFormatted = $derived(
     $isBalancePrivacyOptionStore
       ? renderPrivacyModeBalance(3)
-      : nonNullish(rewardEstimateWeekUSD)
+      : // TODO: looks redundant
+        nonNullish(rewardEstimateWeekUSD)
         ? formatCurrencyNumber(rewardEstimateWeekUSD)
         : $i18n.core.not_applicable
   );

--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -10,10 +10,10 @@
           loading: false;
           error: string;
         };
-    onStakingPage: boolean;
+    onStakingPage?: boolean;
   };
 
-  const { stakingRewardData, onStakingPage }: Props = $props();
+  const { stakingRewardData, onStakingPage = false }: Props = $props();
 
   const isError = $derived(
     stakingRewardData &&

--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -97,7 +97,6 @@
         width: 100px;
 
         @include media.min-width(medium) {
-          height: 36px;
           max-width: 140px;
         }
       }
@@ -156,7 +155,7 @@
   .card {
     height: 100%;
     box-sizing: border-box;
-    background-color: var(--background);
+    background-color: var(--card-background-tint);
     box-shadow: var(--box-shadow);
     border-radius: 12px;
     overflow: hidden;

--- a/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyFallbackCard.svelte
@@ -10,9 +10,10 @@
           loading: false;
           error: string;
         };
+    onStakingPage: boolean;
   };
 
-  const { stakingRewardData }: Props = $props();
+  const { stakingRewardData, onStakingPage }: Props = $props();
 
   const isError = $derived(
     stakingRewardData &&
@@ -68,7 +69,9 @@
     {:else}
       <div class="title skeleton"></div>
       {@render loadingContent()}
-      <div class="link skeleton"></div>
+      {#if !onStakingPage}
+        <div class="link skeleton"></div>
+      {/if}
     {/if}
   </article>
 {/if}

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -281,24 +281,26 @@
 
 <div class="wrapper" data-tid="projects-table-component">
   <div class="top">
-    {#if $authSignedInStore && hasAnyNeurons}
-      <UsdValueBanner usdAmount={totalStakeInUsd} {hasUnpricedTokens}>
-        <IconNeuronsPage slot="icon" />
-      </UsdValueBanner>
-    {/if}
+    {#if $authSignedInStore}
+      {#if hasAnyNeurons}
+        <UsdValueBanner usdAmount={totalStakeInUsd} {hasUnpricedTokens}>
+          <IconNeuronsPage slot="icon" />
+        </UsdValueBanner>
+      {/if}
 
-    {#if $ENABLE_APY_PORTFOLIO && nonNullish(totalUsdAmount)}
-      {#if isStakingRewardDataReady(stakingRewardData)}
-        <ApyCard
-          simpleMode={true}
-          rewardBalanceUSD={stakingRewardData.rewardBalanceUSD}
-          rewardEstimateWeekUSD={stakingRewardData.rewardEstimateWeekUSD}
-          stakingPower={stakingRewardData.stakingPower}
-          stakingPowerUSD={stakingRewardData.stakingPowerUSD}
-          totalAmountUSD={totalUsdAmount}
-        />
-      {:else}
-        <ApyFallbackCard {stakingRewardData} />
+      {#if $ENABLE_APY_PORTFOLIO && nonNullish(totalUsdAmount)}
+        {#if isStakingRewardDataReady(stakingRewardData)}
+          <ApyCard
+            onStakingPage={true}
+            rewardBalanceUSD={stakingRewardData.rewardBalanceUSD}
+            rewardEstimateWeekUSD={stakingRewardData.rewardEstimateWeekUSD}
+            stakingPower={stakingRewardData.stakingPower}
+            stakingPowerUSD={stakingRewardData.stakingPowerUSD}
+            totalAmountUSD={totalUsdAmount}
+          />
+        {:else}
+          <ApyFallbackCard {stakingRewardData} />
+        {/if}
       {/if}
     {/if}
   </div>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -15,9 +15,16 @@
     OWN_CANISTER_ID_TEXT,
   } from "$lib/constants/canister-ids.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
+  import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
   import { tokensListVisitorsStore } from "$lib/derived/tokens-list-visitors.derived";
+  import {
+    loadAccountsBalances,
+    loadSnsAccountsBalances,
+  } from "$lib/services/accounts-balances.services";
   import { loadIcpSwapTickers } from "$lib/services/icp-swap.services";
   import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
   import {
@@ -29,6 +36,7 @@
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+  import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
   import type { ProjectsTableColumn, TableProject } from "$lib/types/staking";
   import { isStakingRewardDataReady } from "$lib/utils/staking-rewards.utils";
   import {
@@ -43,14 +51,6 @@
   import { IconNeuronsPage } from "@dfinity/gix-components";
   import { isNullish, nonNullish, TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
-  import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
-  import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
-  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
-  import {
-    loadAccountsBalances,
-    loadSnsAccountsBalances,
-  } from "$lib/services/accounts-balances.services";
-  import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
 
   $effect(() => {
     if ($authSignedInStore) {

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -216,7 +216,6 @@
   // ==================================
   // Staking Rewards/APY related logic
   // ==================================
-  const stakingRewardData = $derived($stakingRewardsStore);
   const totalUsdAmount = $derived.by(() => {
     const userTokens = $tokensListVisitorsStore;
     const totalTokensBalanceInUsd = getTotalBalanceInUsd(userTokens);
@@ -250,16 +249,15 @@
     }
   });
 
-  const usdValueBannerVisible = $derived(hasAnyNeurons);
   const apyCardVisible = $derived(
     $ENABLE_APY_PORTFOLIO && nonNullish(totalUsdAmount)
   );
 </script>
 
 <div class="wrapper" data-tid="projects-table-component">
-  <div class="top" class:two-card={usdValueBannerVisible && apyCardVisible}>
+  <div class="top" class:two-card={hasAnyNeurons && apyCardVisible}>
     {#if $authSignedInStore}
-      {#if usdValueBannerVisible}
+      {#if hasAnyNeurons}
         <UsdValueBanner usdAmount={totalStakeInUsd} {hasUnpricedTokens}>
           <IconNeuronsPage slot="icon" />
         </UsdValueBanner>
@@ -267,17 +265,20 @@
 
       {#if apyCardVisible}
         {#if nonNullish(totalUsdAmount)}
-          {#if isStakingRewardDataReady(stakingRewardData)}
+          {#if isStakingRewardDataReady($stakingRewardsStore)}
             <ApyCard
               onStakingPage={true}
-              rewardBalanceUSD={stakingRewardData.rewardBalanceUSD}
-              rewardEstimateWeekUSD={stakingRewardData.rewardEstimateWeekUSD}
-              stakingPower={stakingRewardData.stakingPower}
-              stakingPowerUSD={stakingRewardData.stakingPowerUSD}
+              rewardBalanceUSD={$stakingRewardsStore.rewardBalanceUSD}
+              rewardEstimateWeekUSD={$stakingRewardsStore.rewardEstimateWeekUSD}
+              stakingPower={$stakingRewardsStore.stakingPower}
+              stakingPowerUSD={$stakingRewardsStore.stakingPowerUSD}
               totalAmountUSD={totalUsdAmount}
             />
           {:else}
-            <ApyFallbackCard {stakingRewardData} onStakingPage={true} />
+            <ApyFallbackCard
+              stakingRewardData={$stakingRewardsStore}
+              onStakingPage={true}
+            />
           {/if}
         {/if}
       {/if}

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import ApyCard from "$lib/components/portfolio/ApyCard.svelte";
+  import ApyFallbackCard from "$lib/components/portfolio/ApyFallbackCard.svelte";
   import HideZeroNeuronsToggle from "$lib/components/staking/HideZeroNeuronsToggle.svelte";
   import ProjectActionsCell from "$lib/components/staking/ProjectActionsCell.svelte";
   import ProjectMaturityCell from "$lib/components/staking/ProjectMaturityCell.svelte";
@@ -34,7 +36,9 @@
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+  import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
   import type { ProjectsTableColumn, TableProject } from "$lib/types/staking";
+  import { isStakingRewardDataReady } from "$lib/utils/staking-rewards.utils";
   import {
     compareByNeuron,
     compareByProject,
@@ -47,10 +51,6 @@
   import { IconNeuronsPage } from "@dfinity/gix-components";
   import { isNullish, nonNullish, TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
-  import { isStakingRewardDataReady } from "../../utils/staking-rewards.utils";
-  import { stakingRewardsStore } from "../../stores/staking-rewards.store";
-  import ApyCard from "../portfolio/ApyCard.svelte";
-  import ApyFallbackCard from "../portfolio/ApyFallbackCard.svelte";
 
   $: if ($authSignedInStore) {
     loadIcpSwapTickers();

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -326,7 +326,7 @@
               <button
                 data-tid="show-all-button"
                 class="ghost show-all"
-                on:click={showAll}
+                onclick={showAll}
               >
                 {$i18n.staking.show_all}</button
               >
@@ -385,7 +385,7 @@
             <button
               data-tid="show-all-button"
               class="ghost show-all"
-              on:click={showAll}
+              onclick={showAll}
             >
               {$i18n.staking.show_all}</button
             >

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -277,7 +277,7 @@
               totalAmountUSD={totalUsdAmount}
             />
           {:else}
-            <ApyFallbackCard {stakingRewardData} />
+            <ApyFallbackCard {stakingRewardData} onStakingPage={true} />
           {/if}
         {/if}
       {/if}

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -1,4 +1,5 @@
 import * as icpSwapApi from "$lib/api/icp-swap.api";
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import ProjectsTable from "$lib/components/staking/ProjectsTable.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
@@ -9,13 +10,18 @@ import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
+import {
+  mockSnsToken,
+  mockToken,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
 import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
@@ -45,8 +51,6 @@ describe("ProjectsTable", () => {
   };
 
   beforeEach(() => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", false);
-
     vi.useFakeTimers();
     resetIdentity();
 
@@ -65,6 +69,8 @@ describe("ProjectsTable", () => {
       },
     ]);
     vi.spyOn(icpSwapApi, "queryIcpSwapTickers").mockResolvedValue([]);
+    vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(0n);
+    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockToken);
   });
 
   it("should render desktop headers", async () => {
@@ -1024,5 +1030,38 @@ describe("ProjectsTable", () => {
   it("should display settings button", async () => {
     const po = renderComponent();
     expect(await po.getOpenSettingsButtonPo().isPresent()).toBe(true);
+  });
+
+  it("should display Staking Rewards banner", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", true);
+    stakingRewardsStore.set({
+      loading: false,
+      rewardBalanceUSD: 100,
+      rewardEstimateWeekUSD: 10,
+      stakingPower: 1,
+      stakingPowerUSD: 1,
+      apy: new Map(),
+    });
+
+    const po = renderComponent();
+    const apyCardPo = po.getApyCardPo();
+    expect(await apyCardPo.isPresent()).toBe(true);
+    // Check that the link is not present
+    expect(await apyCardPo.getLinkPo().isPresent()).toBe(false);
+  });
+
+  it("should not display Staking Rewards banner w/o the feature flag", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", false);
+    stakingRewardsStore.set({
+      loading: false,
+      rewardBalanceUSD: 100,
+      rewardEstimateWeekUSD: 10,
+      stakingPower: 1,
+      stakingPowerUSD: 1,
+      apy: new Map(),
+    });
+
+    const po = renderComponent();
+    expect(await po.getApyCardPo().isPresent()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -4,6 +4,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
@@ -44,6 +45,8 @@ describe("ProjectsTable", () => {
   };
 
   beforeEach(() => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", false);
+
     vi.useFakeTimers();
     resetIdentity();
 

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -37,6 +37,7 @@ import { fromNullable } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
+
 describe("Staking", () => {
   const snsTitle = "SNS-1";
   const snsCanisterId = principal(1112);
@@ -52,6 +53,9 @@ describe("Staking", () => {
     setIcpSwapUsdPrices({
       [snsLedgerId.toText()]: 10,
     });
+
+    vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(0n);
+    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockToken);
   });
 
   const renderComponent = () => {

--- a/frontend/src/tests/lib/routes/Staking.spec.ts
+++ b/frontend/src/tests/lib/routes/Staking.spec.ts
@@ -37,7 +37,6 @@ import { fromNullable } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-
 describe("Staking", () => {
   const snsTitle = "SNS-1";
   const snsCanisterId = principal(1112);

--- a/frontend/src/tests/page-objects/ProjectsTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTable.page-object.ts
@@ -1,3 +1,4 @@
+import { ApyCardPo } from "$tests/page-objects/ApyCard.page-object";
 import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { HideZeroNeuronsTogglePo } from "$tests/page-objects/HideZeroNeuronsToggle.page-object";
@@ -52,5 +53,9 @@ export class ProjectsTablePo extends ResponsiveTablePo {
 
   getBackdropPo(): BackdropPo {
     return BackdropPo.under(this.root);
+  }
+
+  getApyCardPo(): ApyCardPo {
+    return ApyCardPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

To make users aware of their current staking rewards, this PR adds new cards to the Staking page.

[Jira task → NNS1-3993](https://dfinity.atlassian.net/browse/NNS1-3993)

# Changes

- Migrated `ProjectsTable` to svelte5.
- Loaded the necessary data for staking rewards calculation inside `ProjectsTable`.
- Added `onStakingPage` mode to `ApyCard` and `ApyFallbackCard` (disables link rendering).
- Rendered `ApyCard` on the Staking page.

# Tests

- Added unit tests for card visibility.
- Tested manually.
 
| M | D |
|--------|--------|
| <img width="352" height="472" alt="image" src="https://github.com/user-attachments/assets/0d45e73f-8ff7-49d6-9034-f4e18350b106" /> | <img width="1066" height="798" alt="image" src="https://github.com/user-attachments/assets/44110a1c-aebc-4494-bb7a-6754dcb04594" /> | 



# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
