### PR TITLE
feat(portfolio): reorganize cards for APY prominence

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -13,6 +13,7 @@
   import SkeletonTokensCard from "$lib/components/portfolio/SkeletonTokensCard.svelte";
   import StackedCards from "$lib/components/portfolio/StackedCards.svelte";
   import StakedTokensCard from "$lib/components/portfolio/StakedTokensCard.svelte";
+  import StartStakingCard from "$lib/components/portfolio/StartStakingCard.svelte";
   import TotalAssetsCard from "$lib/components/portfolio/TotalAssetsCard.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
@@ -209,13 +210,11 @@
   <div
     class="top"
     class:signed-in={$authSignedInStore}
-    class:launchpad={cards.length > 0}
     class:apy-card={$ENABLE_APY_PORTFOLIO}
   >
     {#if !$authSignedInStore}
-      <div class="login-card">
-        <LoginCard />
-      </div>
+      <LoginCard />
+      <StartStakingCard />
     {:else}
       <TotalAssetsCard
         usdAmount={totalUsdAmount}
@@ -236,18 +235,6 @@
         {:else}
           <ApyFallbackCard stakingRewardData={stakingRewardResult} />
         {/if}
-      {/if}
-    {/if}
-
-    {#if cards.length > 0}
-      {#if $ENABLE_LAUNCHPAD_REDESIGN && $ENABLE_APY_PORTFOLIO && $isMobileViewportStore}
-        <CardList
-          testId="stacked-cards"
-          {cards}
-          mobileHorizontalScroll={cards.length > 1}
-        />
-      {:else}
-        <StackedCards {cards} />
       {/if}
     {/if}
 
@@ -294,9 +281,23 @@
     {/if}
   </div>
 
-  {#if $ENABLE_LAUNCHPAD_REDESIGN}
-    <LaunchpadBanner />
-  {/if}
+  <div class="sns-section">
+    {#if $ENABLE_LAUNCHPAD_REDESIGN}
+      <LaunchpadBanner />
+    {/if}
+
+    {#if cards.length > 0}
+      {#if $ENABLE_LAUNCHPAD_REDESIGN && $ENABLE_APY_PORTFOLIO && $isMobileViewportStore}
+        <CardList
+          testId="stacked-cards"
+          {cards}
+          mobileHorizontalScroll={cards.length > 1}
+        />
+      {:else}
+        <StackedCards {cards} />
+      {/if}
+    {/if}
+  </div>
 </main>
 
 <style lang="scss">
@@ -326,18 +327,9 @@
       @include media.min-width(large) {
         grid-template-columns: 1fr 2fr;
 
-        .login-card {
-          height: 100%;
-        }
-
-        // Case: not signed in, with projects
-        &:not(.signed-in).launchpad {
+        // Case: not signed in, login card and start-staking card
+        &:not(.signed-in) {
           grid-template-columns: 2fr 1fr;
-        }
-
-        // Case: not signed in, with no projects
-        &:not(.signed-in):not(.launchpad) {
-          grid-template-columns: 1fr;
         }
 
         // Case: signed in, no projects
@@ -370,6 +362,15 @@
       @include media.min-width(large) {
         grid-template-columns: repeat(2, 1fr);
         grid-auto-rows: minmax(345px, min-content);
+      }
+    }
+    .sns-section {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: 1fr;
+
+      @include media.min-width(large) {
+        grid-template-columns: 2fr 1fr;
       }
     }
   }

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -207,11 +207,7 @@
 </script>
 
 <main data-tid="portfolio-page-component">
-  <div
-    class="top"
-    class:signed-in={$authSignedInStore}
-    class:apy-card={$ENABLE_APY_PORTFOLIO}
-  >
+  <div class="top" class:apy-card={$ENABLE_APY_PORTFOLIO}>
     {#if !$authSignedInStore}
       <LoginCard />
       <StartStakingCard />
@@ -220,7 +216,7 @@
         usdAmount={totalUsdAmount}
         hasUnpricedTokens={hasUnpricedTokensOrStake}
         isLoading={isSomethingLoading}
-        isFullWidth={cards.length === 0 && !$ENABLE_APY_PORTFOLIO}
+        isFullWidth={!$ENABLE_APY_PORTFOLIO}
       />
 
       {#if $ENABLE_APY_PORTFOLIO && $isDesktopViewportStore && nonNullish(totalUsdAmount)}
@@ -325,32 +321,7 @@
       gap: var(--padding-2x);
 
       @include media.min-width(large) {
-        grid-template-columns: 1fr 2fr;
-
-        // Case: not signed in, login card and start-staking card
-        &:not(.signed-in) {
-          grid-template-columns: 2fr 1fr;
-        }
-
-        // Case: signed in, no projects
-        &.signed-in {
-          grid-template-columns: 3fr;
-        }
-
-        // Case: signed in, with projects
-        &.signed-in.launchpad {
-          grid-template-columns: 2fr 1fr;
-        }
-
-        // Case: signed in, with APY card
-        &.signed-in.apy-card {
-          grid-template-columns: 2fr 1fr;
-        }
-
-        // Case: signed in, with APY card and projects
-        &.signed-in.apy-card.launchpad {
-          grid-template-columns: 1fr 1fr 1fr;
-        }
+        grid-template-columns: 2fr 1fr;
       }
     }
 

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -119,6 +119,12 @@ describe("Portfolio page", () => {
       expect(await po.getLoginCard().isPresent()).toBe(true);
     });
 
+    it("should display the StartStakingCard", async () => {
+      const po = renderPage();
+
+      expect(await po.getStartStakingCard().isPresent()).toBe(true);
+    });
+
     it("should not show TotalAssetsCard", async () => {
       const po = renderPage();
 
@@ -130,16 +136,6 @@ describe("Portfolio page", () => {
       const po = renderPage();
 
       expect(await po.getApyFallbackCardPo().isPresent()).toBe(false);
-    });
-
-    it("should show StackedCards when snsProjects is not empty", async () => {
-      const mockSnsProjects: SnsFullProject[] = [mockSnsFullProject];
-      const po = renderPage({ snsProjects: mockSnsProjects });
-      const stackedCardsPo = po.getStackedCardsPo();
-      const cardWrappers = await stackedCardsPo.getCardWrappers();
-
-      expect(await stackedCardsPo.isPresent()).toBe(true);
-      expect(cardWrappers.length).toBe(1);
     });
 
     it("should show both cards with default data", async () => {
@@ -170,6 +166,16 @@ describe("Portfolio page", () => {
       expect(await po.getTotalAssetsCardPo().hasSpinner()).toEqual(false);
       expect(await po.getHeldTokensSkeletonCard().isPresent()).toEqual(false);
       expect(await po.getStakedTokensSkeletonCard().isPresent()).toEqual(false);
+    });
+
+    it("should show StackedCards when snsProjects is not empty", async () => {
+      const mockSnsProjects: SnsFullProject[] = [mockSnsFullProject];
+      const po = renderPage({ snsProjects: mockSnsProjects });
+      const stackedCardsPo = po.getStackedCardsPo();
+      const cardWrappers = await stackedCardsPo.getCardWrappers();
+
+      expect(await stackedCardsPo.isPresent()).toBe(true);
+      expect(cardWrappers.length).toBe(1);
     });
   });
 
@@ -242,25 +248,6 @@ describe("Portfolio page", () => {
       const stackedCardsPo = po.getStackedCardsPo();
 
       expect(await stackedCardsPo.isPresent()).toBe(false);
-    });
-
-    it("should show a full width TotalAssetsCard when no stacked cards", async () => {
-      const po = renderPage();
-      const totalAssetsCardPo = po.getTotalAssetsCardPo();
-      overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", false);
-
-      expect(await totalAssetsCardPo.isPresent()).toBe(true);
-      expect(await totalAssetsCardPo.isFullWidth()).toBe(true);
-    });
-
-    it("should show a not full width TotalAssetsCard when stacked cards is not empty", async () => {
-      const po = renderPage({ openSnsProposals: mockSnsProposals });
-      const totalAssetsCardPo = po.getTotalAssetsCardPo();
-      const stackedCardsPo = po.getStackedCardsPo();
-
-      expect(await stackedCardsPo.isPresent()).toBe(true);
-      expect(await totalAssetsCardPo.isPresent()).toBe(true);
-      expect(await totalAssetsCardPo.isFullWidth()).toBe(false);
     });
 
     it("should display StackedCards when snsProjects is not empty", async () => {
@@ -488,29 +475,28 @@ describe("Portfolio page", () => {
       resetIdentity();
     });
 
+    it("should show a full width TotalAssetsCard by default", async () => {
+      const po = renderPage();
+      const totalAssetsCardPo = po.getTotalAssetsCardPo();
+      overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", false);
+
+      expect(await totalAssetsCardPo.isPresent()).toBe(true);
+      expect(await totalAssetsCardPo.isFullWidth()).toBe(true);
+    });
+
+    it("should not show a full width TotalAssetsCard when APY FF is on", async () => {
+      const po = renderPage();
+      const totalAssetsCardPo = po.getTotalAssetsCardPo();
+
+      expect(await totalAssetsCardPo.isPresent()).toBe(true);
+      expect(await totalAssetsCardPo.isFullWidth()).toBe(false);
+    });
+
     it("should not display StackedCards if no snsProjects nor proposals for new sns", async () => {
       const po = renderPage();
       const stackedCardsPo = po.getStackedCardsPo();
 
       expect(await stackedCardsPo.isPresent()).toBe(false);
-    });
-
-    it("should not show a full width TotalAssetsCard when no stacked cards but APY FF is on", async () => {
-      const po = renderPage();
-      const totalAssetsCardPo = po.getTotalAssetsCardPo();
-
-      expect(await totalAssetsCardPo.isPresent()).toBe(true);
-      expect(await totalAssetsCardPo.isFullWidth()).toBe(false);
-    });
-
-    it("should show a not full width TotalAssetsCard when stacked cards is not empty", async () => {
-      const po = renderPage({ openSnsProposals: mockSnsProposals });
-      const totalAssetsCardPo = po.getTotalAssetsCardPo();
-      const stackedCardsPo = po.getStackedCardsPo();
-
-      expect(await stackedCardsPo.isPresent()).toBe(true);
-      expect(await totalAssetsCardPo.isPresent()).toBe(true);
-      expect(await totalAssetsCardPo.isFullWidth()).toBe(false);
     });
 
     it("should display StackedCards when snsProjects is not empty", async () => {
@@ -800,6 +786,12 @@ describe("Portfolio page", () => {
       const po = renderPage();
 
       expect(await po.getLoginCard().isPresent()).toBe(false);
+    });
+
+    it("should not display the StartStakingCard when the user is logged in", async () => {
+      const po = renderPage();
+
+      expect(await po.getStartStakingCard().isPresent()).toBe(false);
     });
 
     describe("NoHeldTokensCard", () => {

--- a/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
+++ b/frontend/src/tests/page-objects/PortfolioPage.page-object.ts
@@ -19,6 +19,10 @@ export class PortfolioPagePo extends BasePageObject {
     return this.getElement("portfolio-login-card");
   }
 
+  getStartStakingCard(): PageObjectElement {
+    return this.getElement("start-staking-card");
+  }
+
   getNoHeldTokensCard(): PageObjectElement {
     return this.getElement("no-held-tokens-card");
   }


### PR DESCRIPTION
# Motivation

Give more visibility to the new APY card before and after login. This PR introduces the new card from #7173 on the Portfolio page and moves the Upcoming Projects card down to the new SNS section, along with the SNS banner.


| M | D |
|--------|--------|
| <img width="419" height="799" alt="Screenshot 2025-07-24 at 16 17 31" src="https://github.com/user-attachments/assets/6ba84f65-3aaa-4ea9-89de-062d3ae798e3" /> | <img width="1481" height="855" alt="Screenshot 2025-07-24 at 16 16 48" src="https://github.com/user-attachments/assets/8e3f89b5-4540-43fe-901b-88abf3647277" /> |
| <img width="520" height="701" alt="Screenshot 2025-07-24 at 16 17 17" src="https://github.com/user-attachments/assets/6859c310-35b6-4039-bd73-c04cfa791abd" /> | <img width="1467" height="858" alt="Screenshot 2025-07-24 at 16 18 16" src="https://github.com/user-attachments/assets/f3b26c9f-755c-42c4-acb4-76e068950dc9" /> |

[NNS1-3989](https://dfinity.atlassian.net/browse/NNS1-3989)

# Changes

- Move Upcoming projects card from top row to the sns-section together with the new sns-banner.
- Added Start Staking card to the sign-out state.

# Tests

- Updated Portfolio page tests
- Tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3989]: https://dfinity.atlassian.net/browse/NNS1-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ