### PR TITLE
chore(staking rewards): expose calculation of APY per single neuron

### DIFF
--- a/frontend/src/lib/utils/agnostic-neuron.utils.ts
+++ b/frontend/src/lib/utils/agnostic-neuron.utils.ts
@@ -8,6 +8,7 @@ import {
 import {
   getSnsDissolvingTimeInSeconds,
   getSnsLockedTimeInSeconds,
+  getSnsNeuronIdAsHexString,
   getSnsNeuronState,
   hasAutoStakeMaturityOn as hasAutoStakeMaturityOnSns,
 } from "$lib/utils/sns-neuron.utils";
@@ -25,6 +26,14 @@ export const isNnsNeuron = (neuron: AgnosticNeuron): neuron is NeuronInfo => {
 
 export const isSnsNeuron = (neuron: AgnosticNeuron): neuron is SnsNeuron => {
   return !isNnsNeuron(neuron);
+};
+
+export const getNeuronId = (neuron: AgnosticNeuron): string => {
+  if (isNnsNeuron(neuron)) {
+    return String(neuron.neuronId);
+  } else {
+    return getSnsNeuronIdAsHexString(neuron);
+  }
 };
 
 export const getNeuronFreeMaturityE8s = (neuron: AgnosticNeuron): bigint => {


### PR DESCRIPTION
# Motivation

In some of the new pages, we need to display the APY related to a single neuron instead of the overall project.

# Changes

Tweaked calculations to also include single neurons. Added unit tests.

# Tests

Added unit tests. Tests should pass.

# Todos

- [x] Accessibility (a11y) – any impact? no
- [x] Changelog – is it needed? no
