### PR TITLE
fix(portfolio): restore apy card content visibility on mobile

### DIFF
--- a/frontend/src/lib/components/portfolio/ApyCard.svelte
+++ b/frontend/src/lib/components/portfolio/ApyCard.svelte
@@ -142,7 +142,9 @@
     {#if onStakingPage}
       {@render content()}
     {:else}
-      <a {href} class="link" aria-label={linkText} data-tid="project-link"> </a>
+      <a {href} class="link" aria-label={linkText} data-tid="project-link">
+        {@render content()}
+      </a>
     {/if}
   </article>
 {:else}


### PR DESCRIPTION
# Motivation

#7172 introduced a bug by not rendering the content on mobile devices. This PR fixes it.

# Changes

- Render content inside a link.

# Tests

- Manually tested it.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
