### PR TITLE
style(portfolio): update start staking card layout

### DIFF
--- a/frontend/src/lib/components/portfolio/StartStakingCard.svelte
+++ b/frontend/src/lib/components/portfolio/StartStakingCard.svelte
@@ -13,7 +13,7 @@
 
 {#snippet backgroundIcon()}
   <div class="background-icon-container" aria-hidden="true">
-    <div class="icon icon--mobile"><IconNeurons size="180px" /></div>
+    <div class="icon icon--mobile"><IconNeurons size="150px" /></div>
     <div class="icon icon--desktop"><IconNeurons size="200px" /></div>
   </div>
 {/snippet}


### PR DESCRIPTION
# Motivation

The design of the Start Staking card has been updated by removing the button on mobile devices. This change prevents the display of too many buttons alongside the new empty state tables.

<img width="451" height="747" alt="Screenshot 2025-07-25 at 00 51 01" src="https://github.com/user-attachments/assets/68caabfe-37a7-40de-a6cb-b94501408628" />

[NNS1-3989](https://dfinity.atlassian.net/browse/NNS1-3989)

# Changes

- Remove the icon link on small viewports.  
- Adjust the background icon according to the new card size.

# Tests

- Visually tested.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3989]: https://dfinity.atlassian.net/browse/NNS1-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ