### PR TITLE
feat(portfolio): update utils to prioritize ICP in token and project lists

### DIFF
--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -133,14 +133,12 @@
   const topHeldTokens = $derived(
     getTopHeldTokens({
       userTokens: userTokens,
-      isSignedIn: $authSignedInStore,
     })
   );
 
   const topStakedTokens = $derived(
     getTopStakedTokens({
       projects: tableProjects,
-      isSignedIn: $authSignedInStore,
     })
   );
 

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -238,9 +238,10 @@ export const getTableProjects = ({
   });
 };
 
-export const compareIcpFirst = createDescendingComparator(
-  (project: TableProject) => project.universeId === OWN_CANISTER_ID_TEXT
-);
+export const isIcpProject = (project: TableProject) =>
+  project.universeId === OWN_CANISTER_ID_TEXT;
+
+export const compareIcpFirst = createDescendingComparator(isIcpProject);
 
 export const compareNonFailedTokenAmountFirst = createAscendingComparator(
   (project: TableProject) => project.stake instanceof FailedTokenAmount

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -14,9 +14,10 @@ import { TokenAmountV2 } from "@dfinity/utils";
 const getTokenBalanceOrZero = (token: UserToken) =>
   token.balance instanceof TokenAmountV2 ? token.balance.toUlps() : 0n;
 
-export const compareTokensIcpFirst = createDescendingComparator(
-  (token: UserToken) => token.universeId.toText() === OWN_CANISTER_ID_TEXT
-);
+export const isIcpToken = (token: UserToken) =>
+  token.universeId.toText() === OWN_CANISTER_ID_TEXT;
+
+export const compareTokensIcpFirst = createDescendingComparator(isIcpToken);
 
 export const compareFailedTokensLast = createAscendingComparator(
   (token: UserToken) => isUserTokenFailed(token)
@@ -107,8 +108,6 @@ export const compareTokensForTokensTable = ({
 const importantTokensText = IMPORTANT_CK_TOKEN_IDS.map((token) =>
   token.toText()
 );
-const isIcpToken = (token: UserToken) =>
-  token.universeId.toText() === OWN_CANISTER_ID_TEXT;
 const isCkToken = (token: UserToken) =>
   importantTokensText.includes(token.universeId.toText());
 

--- a/frontend/src/tests/lib/pages/Portfolio.spec.ts
+++ b/frontend/src/tests/lib/pages/Portfolio.spec.ts
@@ -138,7 +138,7 @@ describe("Portfolio page", () => {
       expect(await po.getApyFallbackCardPo().isPresent()).toBe(false);
     });
 
-    it("should show empty cards", async () => {
+    it("should show empty cards for top holdings", async () => {
       const po = renderPage({
         tableProjects: mockTableProjects,
         userTokens: mockTokens,
@@ -672,6 +672,7 @@ describe("Portfolio page", () => {
   });
 
   describe("when logged in", () => {
+    const icpToken = createIcpUserToken();
     const token1 = createUserToken({
       balanceInUsd: 100,
       universeId: principal(1),
@@ -820,7 +821,7 @@ describe("Portfolio page", () => {
     describe("HeldTokensCard", () => {
       it("should display the top four tokens by balanceInUsd", async () => {
         const po = renderPage({
-          userTokens: [token1, token2, token3, token4, token5],
+          userTokens: [icpToken, token1, token2, token3, token4, token5],
         });
         const tokensCardPo = po.getHeldTokensCardPo();
 
@@ -832,19 +833,19 @@ describe("Portfolio page", () => {
         expect(await po.getNoHeldTokensCard().isPresent()).toBe(false);
 
         expect(titles.length).toBe(4);
-        expect(titles).toEqual(["Token5", "Token4", "Token3", "Token2"]);
+        expect(titles).toEqual([
+          "Internet Computer",
+          "Token5",
+          "Token4",
+          "Token3",
+        ]);
 
         expect(usdBalances.length).toBe(4);
-        expect(usdBalances).toEqual([
-          "$500.00",
-          "$400.00",
-          "$300.00",
-          "$200.00",
-        ]);
+        expect(usdBalances).toEqual(["$0.00", "$500.00", "$400.00", "$300.00"]);
 
         expect(nativeBalances.length).toBe(4);
         expect(nativeBalances).toEqual([
-          "21.60 TET",
+          "-/- ICP",
           "21.60 TET",
           "21.60 TET",
           "21.60 TET",
@@ -855,7 +856,7 @@ describe("Portfolio page", () => {
 
       it("should display the information row when less then three tokens", async () => {
         const po = renderPage({
-          userTokens: [token1, token2],
+          userTokens: [icpToken, token2],
         });
         const tokensCardPo = po.getHeldTokensCardPo();
 
@@ -867,13 +868,13 @@ describe("Portfolio page", () => {
         expect(await po.getNoHeldTokensCard().isPresent()).toBe(false);
 
         expect(titles.length).toBe(2);
-        expect(titles).toEqual(["Token2", "Token1"]);
+        expect(titles).toEqual(["Internet Computer", "Token2"]);
 
         expect(usdBalances.length).toBe(2);
-        expect(usdBalances).toEqual(["$200.00", "$100.00"]);
+        expect(usdBalances).toEqual(["$0.00", "$200.00"]);
 
         expect(nativeBalances.length).toBe(2);
-        expect(nativeBalances).toEqual(["21.60 TET", "21.60 TET"]);
+        expect(nativeBalances).toEqual(["-/- ICP", "21.60 TET"]);
 
         expect(await tokensCardPo.getInfoRow().isPresent()).toBe(true);
       });
@@ -935,8 +936,8 @@ describe("Portfolio page", () => {
       it("should display the information row when the staked tokens card has less items than the held tokens card", async () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", false);
         const po = renderPage({
-          tableProjects: [tableProject1, tableProject2],
-          userTokens: [token1, token2, token3, token4],
+          tableProjects: [icpProject, tableProject2],
+          userTokens: [icpToken, token2, token3, token4],
         });
         const stakedTokensCardPo = po.getStakedTokensCardPo();
 
@@ -950,16 +951,16 @@ describe("Portfolio page", () => {
         expect(await po.getNoStakedTokensCarPo().isPresent()).toBe(false);
 
         expect(titles.length).toBe(2);
-        expect(titles).toEqual(["Project 2", "Project 1"]);
+        expect(titles).toEqual(["Internet Computer", "Project 2"]);
 
         expect(maturities.length).toBe(2);
-        expect(maturities).toEqual(["0", "0"]);
+        expect(maturities).toEqual(["20.00", "0"]);
 
         expect(stakesInUsd.length).toBe(2);
-        expect(stakesInUsd).toEqual(["$300.00", "$200.00"]);
+        expect(stakesInUsd).toEqual(["$100.00", "$300.00"]);
 
         expect(stakesInNativeCurrency.length).toBe(2);
-        expect(stakesInNativeCurrency).toEqual(["0.01 TET", "0.01 TET"]);
+        expect(stakesInNativeCurrency).toEqual(["0.01 ICP", "0.01 TET"]);
 
         expect(await stakedTokensCardPo.getInfoRow().isPresent()).toBe(true);
       });

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -68,6 +68,21 @@ describe("Portfolio utils", () => {
       expect(result).not.toContainEqual(mockNonUserToken);
     });
 
+    it("should return an empty array if no ICP", () => {
+      const tokens = [
+        mockOtherToken,
+        mockCkUSDCToken,
+        mockCkBTCToken,
+        mockNonUserToken,
+      ];
+
+      const result = getTopHeldTokens({
+        userTokens: tokens,
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
     it("should respect the result limit", () => {
       const tokens: UserToken[] = [
         mockIcpToken,
@@ -197,6 +212,21 @@ describe("Portfolio utils", () => {
         mockProject2,
         mockProject3,
       ]);
+    });
+
+    it("should return an empty array if no ICP", () => {
+      const projects = [
+        mockProject1,
+        mockProject2,
+        mockProject3,
+        mockZeroStakeProject,
+      ];
+
+      const result = getTopStakedTokens({
+        projects,
+      });
+
+      expect(result).toHaveLength(0);
     });
 
     it("should exclude projects with zero stake", () => {

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -29,15 +29,28 @@ import { Principal } from "@dfinity/principal";
 describe("Portfolio utils", () => {
   describe("getTopTokens", () => {
     const mockNonUserToken = createUserTokenLoading();
-    const mockIcpToken = createIcpUserToken();
+    const mockIcpToken = createIcpUserToken({
+      balanceInUsd: 1,
+    });
+
     const mockCkBTCToken = createUserToken({
       universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      balanceInUsd: 10,
     });
+
     const mockCkUSDCToken = createUserToken({
       universeId: CKUSDC_UNIVERSE_CANISTER_ID,
+      balanceInUsd: 1000,
     });
+
     const mockOtherToken = createUserToken({
       universeId: principal(1),
+      balanceInUsd: 2000,
+    });
+
+    const mockZeroBalanceUserTokenData = createUserToken({
+      universeId: principal(2),
+      balanceInUsd: 0,
     });
 
     it("should exclude non-UserTokenData tokens", () => {
@@ -70,120 +83,55 @@ describe("Portfolio utils", () => {
       expect(result).toHaveLength(4);
     });
 
-    it("should order tokens: ICP first, then ckBTC/ckUSDC, then others", () => {
+    it("should exclude tokens with zero balance but not ICP", () => {
+      const mockZeroIcp = createIcpUserToken({
+        balanceInUsd: 0,
+      });
+      const tokens: UserToken[] = [mockZeroBalanceUserTokenData, mockZeroIcp];
+      const result = getTopHeldTokens({
+        userTokens: tokens,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result).not.toContainEqual(mockZeroBalanceUserTokenData);
+      expect(result).toContainEqual(mockZeroIcp);
+    });
+
+    it("should order tokens: ICP first, then by descending USD balance", () => {
       const tokens: UserToken[] = [
         mockOtherToken,
         mockCkUSDCToken,
         mockCkBTCToken,
         mockNonUserToken,
+        mockZeroBalanceUserTokenData,
         mockIcpToken,
       ];
-      const result = getTopHeldTokens({ userTokens: tokens });
+      const result = getTopHeldTokens({
+        userTokens: tokens,
+      });
 
       expect(result).toEqual([
-        mockIcpToken,
-        mockCkBTCToken,
-        mockCkUSDCToken,
-        mockOtherToken,
+        mockIcpToken, // 1$
+        mockOtherToken, // 2000$
+        mockCkUSDCToken, // 1000$
+        mockCkBTCToken, // 10$
       ]);
     });
 
-    describe("when signed in", () => {
-      const mockIcpToken = createIcpUserToken({
-        balanceInUsd: 100,
-      });
-
-      const mockCkBTCToken = createUserToken({
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
-        balanceInUsd: 10,
-      });
-
-      const mockCkUSDCToken = createUserToken({
-        universeId: CKUSDC_UNIVERSE_CANISTER_ID,
-        balanceInUsd: 1000,
-      });
-
-      const mockOtherToken = createUserToken({
-        universeId: principal(1),
-        balanceInUsd: 2000,
-      });
-
-      const mockZeroBalanceUserTokenData = createUserToken({
-        universeId: principal(2),
+    it("should filter CTS token", () => {
+      const mockCSTProject = createUserToken({
+        universeId: Principal.fromText(
+          CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID
+        ),
         balanceInUsd: 0,
       });
-
-      it("should exclude tokens with zero balance", () => {
-        const tokens: UserToken[] = [
-          mockZeroBalanceUserTokenData,
-          mockOtherToken,
-          mockCkUSDCToken,
-          mockCkBTCToken,
-          mockNonUserToken,
-          mockIcpToken,
-        ];
-        const result = getTopHeldTokens({
-          userTokens: tokens,
-          isSignedIn: true,
-        });
-
-        expect(result).toHaveLength(4);
-        expect(result).not.toContainEqual(mockZeroBalanceUserTokenData);
+      const tokens: UserToken[] = [mockCSTProject, mockIcpToken];
+      const result = getTopHeldTokens({
+        userTokens: tokens,
       });
 
-      it("should order tokens: ICP first, then by descending USD balance", () => {
-        const tokens: UserToken[] = [
-          mockOtherToken,
-          mockCkUSDCToken,
-          mockCkBTCToken,
-          mockNonUserToken,
-          mockZeroBalanceUserTokenData,
-          mockIcpToken,
-        ];
-        const result = getTopHeldTokens({
-          userTokens: tokens,
-          isSignedIn: true,
-        });
-
-        expect(result).toEqual([
-          mockIcpToken, // 100$
-          mockOtherToken, // 2000$
-          mockCkUSDCToken, // 1000$
-          mockCkBTCToken, // 10$
-        ]);
-      });
-
-      it("should return empty array when all tokens have zero balance", () => {
-        const mockIcpToken = createIcpUserToken({ balanceInUsd: 0 });
-        const tokens: UserToken[] = [
-          mockZeroBalanceUserTokenData,
-          mockIcpToken,
-        ];
-        const result = getTopHeldTokens({
-          userTokens: tokens,
-          isSignedIn: true,
-        });
-
-        expect(result).toHaveLength(0);
-      });
-
-      it("should filter CTS token", () => {
-        const mockIcpToken = createIcpUserToken({ balanceInUsd: 1000 });
-        const mockCSTProject = createUserToken({
-          universeId: Principal.fromText(
-            CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID
-          ),
-          balanceInUsd: 0,
-        });
-        const tokens: UserToken[] = [mockCSTProject, mockIcpToken];
-        const result = getTopHeldTokens({
-          userTokens: tokens,
-          isSignedIn: true,
-        });
-
-        expect(result).toHaveLength(1);
-        expect(result).not.toContainEqual(mockCSTProject);
-      });
+      expect(result).toHaveLength(1);
+      expect(result).not.toContainEqual(mockCSTProject);
     });
   });
 
@@ -191,38 +139,45 @@ describe("Portfolio utils", () => {
     const mockIcpProject: TableProject = {
       ...mockTableProject,
       title: "Internet Computer",
-      stakeInUsd: 0,
+      stakeInUsd: 1,
     };
 
     const mockProject1: TableProject = {
       ...mockTableProject,
-      title: "A Project",
-      stakeInUsd: 0,
+      title: "Alpha Project",
+      stakeInUsd: 2000,
       universeId: "1",
     };
 
     const mockProject2: TableProject = {
       ...mockTableProject,
-      title: "B Project",
-      stakeInUsd: 0,
+      title: "Beta Project",
+      stakeInUsd: 1000,
       universeId: "2",
     };
 
     const mockProject3: TableProject = {
       ...mockTableProject,
-      title: "C Project",
-      stakeInUsd: 0,
+      title: "Gamma Project",
+      stakeInUsd: 10,
       universeId: "3",
     };
 
     const mockProject4: TableProject = {
       ...mockTableProject,
-      title: "D Project",
+      title: "Gamma Project",
+      stakeInUsd: 1,
+      universeId: "3",
+    };
+
+    const mockZeroStakeProject: TableProject = {
+      ...mockTableProject,
+      title: "Zero Stake Project",
       stakeInUsd: 0,
       universeId: "4",
     };
 
-    it("should respect the result limit of MAX_NUMBER_OF_ITEMS(4)", () => {
+    it("should respect the result limit", () => {
       const projects = [
         mockIcpProject,
         mockProject1,
@@ -244,138 +199,81 @@ describe("Portfolio utils", () => {
       ]);
     });
 
-    it("should order projects: ICP first, then by project title value", () => {
+    it("should exclude projects with zero stake", () => {
       const projects = [
+        mockZeroStakeProject,
+        mockProject1,
         mockProject2,
         mockProject3,
-        mockProject1,
         mockIcpProject,
       ];
 
-      const result = getTopStakedTokens({ projects });
+      const result = getTopStakedTokens({
+        projects,
+      });
+
+      expect(result).toHaveLength(4);
+      expect(result).not.toContainEqual(mockZeroStakeProject);
+    });
+
+    it("should order projects: ICP first, then by descending USD stake", () => {
+      const projects = [
+        mockProject3,
+        mockProject2,
+        mockProject1,
+        mockZeroStakeProject,
+        mockIcpProject,
+      ];
+
+      const result = getTopStakedTokens({
+        projects,
+      });
 
       expect(result).toEqual([
-        mockIcpProject,
-        mockProject1,
-        mockProject2,
-        mockProject3,
+        mockIcpProject, // ICP first, 1$
+        mockProject1, // 2000$
+        mockProject2, // 1000$
+        mockProject3, // 10$
       ]);
     });
 
-    describe("when signed in", () => {
-      const mockIcpProject: TableProject = {
+    it("should exclude projects with zero balance but not ICP", () => {
+      const zeroIcpProject: TableProject = {
         ...mockTableProject,
-        title: "Internet Computer",
-        stakeInUsd: 100,
-      };
-
-      const mockProject1: TableProject = {
-        ...mockTableProject,
-        title: "Alpha Project",
-        stakeInUsd: 2000,
-        universeId: "1",
-      };
-
-      const mockProject2: TableProject = {
-        ...mockTableProject,
-        title: "Beta Project",
-        stakeInUsd: 1000,
-        universeId: "2",
-      };
-
-      const mockProject3: TableProject = {
-        ...mockTableProject,
-        title: "Gamma Project",
-        stakeInUsd: 10,
-        universeId: "3",
-      };
-
-      const mockZeroStakeProject: TableProject = {
-        ...mockTableProject,
-        title: "Zero Stake Project",
         stakeInUsd: 0,
-        universeId: "4",
       };
 
-      it("should exclude projects with zero stake", () => {
-        const projects = [
-          mockZeroStakeProject,
-          mockProject1,
-          mockProject2,
-          mockProject3,
-          mockIcpProject,
-        ];
+      const projects = [mockZeroStakeProject, zeroIcpProject];
 
-        const result = getTopStakedTokens({
-          projects,
-          isSignedIn: true,
-        });
-
-        expect(result).toHaveLength(4);
-        expect(result).not.toContainEqual(mockZeroStakeProject);
+      const result = getTopStakedTokens({
+        projects,
       });
 
-      it("should order projects: ICP first, then by descending USD stake", () => {
-        const projects = [
-          mockProject3,
-          mockProject2,
-          mockProject1,
-          mockZeroStakeProject,
-          mockIcpProject,
-        ];
+      expect(result).toHaveLength(1);
+      expect(result).toContainEqual(zeroIcpProject);
+    });
 
-        const result = getTopStakedTokens({
-          projects,
-          isSignedIn: true,
-        });
+    it("should filter abandoned project", () => {
+      const mockCTSProject: TableProject = {
+        ...mockTableProject,
+        stakeInUsd: 1000,
+        universeId: CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
+      };
+      const mockSeersProject: TableProject = {
+        ...mockTableProject,
+        stakeInUsd: 1000,
+        universeId: SEERS_ROOT_CANISTER_ID,
+      };
 
-        expect(result).toEqual([
-          mockIcpProject, // ICP first, 100$
-          mockProject1, // 2000$
-          mockProject2, // 1000$
-          mockProject3, // 10$
-        ]);
+      const projects = [mockCTSProject, mockSeersProject, mockIcpProject];
+
+      const result = getTopStakedTokens({
+        projects,
       });
 
-      it("should return empty array when all projects have zero stake", () => {
-        const zeroIcpProject: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 0,
-        };
-
-        const projects = [mockZeroStakeProject, zeroIcpProject];
-
-        const result = getTopStakedTokens({
-          projects,
-          isSignedIn: true,
-        });
-
-        expect(result).toHaveLength(0);
-      });
-
-      it("should filter abandoned project", () => {
-        const mockCTSProject: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 1000,
-          universeId: CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
-        };
-        const mockSeersProject: TableProject = {
-          ...mockTableProject,
-          stakeInUsd: 1000,
-          universeId: SEERS_ROOT_CANISTER_ID,
-        };
-
-        const projects = [mockCTSProject, mockSeersProject, mockIcpProject];
-
-        const result = getTopStakedTokens({
-          projects,
-          isSignedIn: true,
-        });
-
-        expect(result).toHaveLength(1);
-        expect(result).not.toContainEqual(mockCTSProject);
-        expect(result).not.toContainEqual(mockSeersProject);
-      });
+      expect(result).toHaveLength(1);
+      expect(result).not.toContainEqual(mockCTSProject);
+      expect(result).not.toContainEqual(mockSeersProject);
     });
   });
 


### PR DESCRIPTION
# Motivation

The Portfolio page now displays tokens and projects only when the user is signed in. Additionally, ICP should always be visible, even if the user has zero tokens or staked. This PR introduces changes to the utility functions without causing any breaking changes in how consumers expect the data.

[NNS1-3999](https://dfinity.atlassian.net/browse/NNS1-3999)

# Changes

- Expose utilities to locate the ICP project and token.  
- Update `getTopHeldTokens` to consistently return ICP and the top three tokens by stake. Additionally, remove the authentication dependency.
- Update `getTopStakedTokens` to consistently return ICP and the top three projects by stake. Additionally, remove the authentication dependency.

Side change: 
- Rename `filterCyclesTransferStation` into `filterAbandonedProjects` for consistency.

# Tests

- Update tests to reflect changes.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-3999]: https://dfinity.atlassian.net/browse/NNS1-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ