### PR TITLE
feat(i18n): add translations for new proposal action FulfillSubnetRentalRequest

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -99,7 +99,7 @@ Yet, a proposal of that topic won't be rendered properly until the changes are m
 
 ### How To Update
 
-**Changes in nns-js:**
+**Changes in ic-js:**
 
 - Add to topic entry in the [governance enum](https://github.com/dfinity/ic-js/blob/main/packages/nns/src/enums/governance.enums.ts#L15).
 - Add topic entry in the `Topic` for [protobuf files](https://github.com/dfinity/ic-js/tree/main/packages/nns/proto). You can search for `TOPIC_NEURON_MANAGEMENT` to better see where to add them.

--- a/frontend/src/lib/i18n/en.governance.json
+++ b/frontend/src/lib/i18n/en.governance.json
@@ -93,7 +93,8 @@
     "CreateServiceNervousSystem": "Create Service Nervous System (SNS)",
     "InstallCode": "Install Code",
     "StopOrStartCanister": "Stop or Start Canister",
-    "UpdateCanisterSettings": "Update Canister Settings"
+    "UpdateCanisterSettings": "Update Canister Settings",
+    "FulfillSubnetRentalRequest": "Subnet Rental Agreement"
   },
   "actions_description": {
     "RegisterKnownNeuron": "This proposal registers an existing neuron as a “known neuron,” giving it a name and an optional description, and adding the neuron to the list of known neurons.",
@@ -110,7 +111,8 @@
     "CreateServiceNervousSystem": "Create a new Service Nervous System (SNS).",
     "InstallCode": "Install, reinstall or upgrade the code of a canister that is controlled by the NNS.",
     "StopOrStartCanister": "Stop or start a canister that is controlled by the NNS.",
-    "UpdateCanisterSettings": "Update the settings of a canister that is controlled by the NNS."
+    "UpdateCanisterSettings": "Update the settings of a canister that is controlled by the NNS.",
+    "FulfillSubnetRentalRequest": "A proposal to create a rented subnet with a subnet rental agreement, based on a previously executed Subnet Rental Request proposal. The resulting subnet allows only the user of the rental agreement to create canisters, and canisters are not charged cycles for computation and storage."
   },
   "nns_functions": {
     "Unspecified": "Unspecified",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1534,6 +1534,7 @@ interface I18nActions {
   InstallCode: string;
   StopOrStartCanister: string;
   UpdateCanisterSettings: string;
+  FulfillSubnetRentalRequest: string;
 }
 
 interface I18nActions_description {
@@ -1552,6 +1553,7 @@ interface I18nActions_description {
   InstallCode: string;
   StopOrStartCanister: string;
   UpdateCanisterSettings: string;
+  FulfillSubnetRentalRequest: string;
 }
 
 interface I18nNns_functions {


### PR DESCRIPTION
# Motivation

A new action proposal, `FulfillSubnetRentalRequest`, has been added. This PR introduces support for the i18n aspect of the proposal, allowing it to be rendered in the nns-dapp.

Relevant links:
* https://github.com/dfinity/ic-js/pull/993
* https://github.com/dfinity/nns-dapp/pull/7165
* https://github.com/dfinity/nns-dapp/pull/7113
* https://github.com/dfinity/ic/pull/5835/files#diff-47cb67467f37606a03f7785a62befc6771b11fa71b463741d6fd826c21f05cb4

# Changes

- Add translations to for the new type

# Tests

- Not possible

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
