### PR TITLE
style(portfolio): fix banner width and button alignment

### DIFF
--- a/frontend/src/lib/components/portfolio/StartStakingCard.svelte
+++ b/frontend/src/lib/components/portfolio/StartStakingCard.svelte
@@ -50,6 +50,7 @@
   .wrapper {
     height: 100%;
     background-color: var(--card-background-tint);
+    box-sizing: border-box;
 
     h2,
     p {
@@ -88,6 +89,7 @@
       align-items: center;
       text-decoration: none;
       align-self: flex-end;
+      margin-top: auto;
       font-weight: var(--font-weight-bold);
 
       color: var(--button-secondary-color);

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -260,7 +260,7 @@
     {/if}
   </div>
 
-  <div class="sns-section" class:withCards={cards.length > 0}>
+  <div class="sns-section" class:with-cards={cards.length > 0}>
     {#if $ENABLE_LAUNCHPAD_REDESIGN}
       <LaunchpadBanner />
     {/if}
@@ -324,8 +324,8 @@
       gap: 16px;
       grid-template-columns: 1fr;
 
-      @include media.min-width(large) {
-        &.with-cards {
+      &.with-cards {
+        @include media.min-width(large) {
           grid-template-columns: 2fr 1fr;
         }
       }

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -260,7 +260,7 @@
     {/if}
   </div>
 
-  <div class="sns-section">
+  <div class="sns-section" class:withCards={cards.length > 0}>
     {#if $ENABLE_LAUNCHPAD_REDESIGN}
       <LaunchpadBanner />
     {/if}
@@ -325,7 +325,9 @@
       grid-template-columns: 1fr;
 
       @include media.min-width(large) {
-        grid-template-columns: 2fr 1fr;
+        &.with-cards {
+          grid-template-columns: 2fr 1fr;
+        }
       }
     }
   }


### PR DESCRIPTION
# Motivation

Fix some visual issues in the Portfolio page.

| Before | After |
|--------|--------|
| <img width="1472" height="852" alt="Screenshot 2025-07-28 at 12 36 52" src="https://github.com/user-attachments/assets/d3f4be6f-9cfa-4ded-82ff-f5bbc58f6efe" /> | <img width="1474" height="851" alt="Screenshot 2025-07-28 at 12 37 35" src="https://github.com/user-attachments/assets/f8aa83a5-34cc-4755-970d-7ca06e2559fd" /> | 

# Changes

- Make the SNS banner span the full width when there are no ongoing proposals.  
-  Align the button on the `StartStakingCard` to the bottom.

# Tests

- Visual tests.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
