### PR TITLE
Adjust launchpad banner to different modes

### DIFF
--- a/frontend/src/lib/components/portfolio/LaunchpadBanner.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchpadBanner.svelte
@@ -152,6 +152,8 @@
     min-width: 100%;
     padding: 0;
 
+    box-shadow: var(--box-shadow);
+
     // Extra mode when rendering together with upcoming launches cards.
     &.withUpcomingLaunchesCards {
       @include media.min-width(large) {

--- a/frontend/src/lib/components/portfolio/LaunchpadBanner.svelte
+++ b/frontend/src/lib/components/portfolio/LaunchpadBanner.svelte
@@ -7,11 +7,16 @@
   import { snsProjectsActivePadStore } from "$lib/derived/sns/sns-projects.derived";
   import { isDesktopViewportStore } from "$lib/derived/viewport.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { compactCurrencyNumber } from "$lib/utils/format.utils";
+  import { compactCurrencyNumber, formatNumber } from "$lib/utils/format.utils";
   import { filterProjectsStatus } from "$lib/utils/projects.utils";
   import { IconRight } from "@dfinity/gix-components";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { fade } from "svelte/transition";
+
+  type Props = {
+    withUpcomingLaunchesCards?: boolean;
+  };
+  const { withUpcomingLaunchesCards = false }: Props = $props();
 
   const snsProjects = $derived($snsProjectsActivePadStore);
   const launchedSnsProjects = $derived(
@@ -64,17 +69,19 @@
     </div>
 
     <div class="stats">
-      <div class="stat-item">
+      <div class="stat-item stat-item--a">
         <h6 data-tid="launchpad-banner-raised-by">
           {$i18n.launchpad.banner_raised_by}
         </h6>
         <span class="value" data-tid="launchpad-banner-raised-value">
-          {compactCurrencyNumber(raisedFunds)}
+          {withUpcomingLaunchesCards
+            ? formatNumber(raisedFunds, { minFraction: 0, maxFraction: 0 })
+            : compactCurrencyNumber(raisedFunds)}
           {$i18n.core.icp}
         </span>
       </div>
-      <div class="stat-divider"></div>
-      <div class="stat-item">
+      <div class="stat-divider stat-divider--a"></div>
+      <div class="stat-item stat-item--b">
         <h6 data-tid="launchpad-banner-launched">
           {$i18n.launchpad.banner_launched}
         </h6>
@@ -82,8 +89,8 @@
           >{snsDaoLaunched}</span
         >
       </div>
-      <div class="stat-divider"></div>
-      <div class="stat-item">
+      <div class="stat-divider stat-divider--b"></div>
+      <div class="stat-item stat-item--c">
         <h6 data-tid="launchpad-banner-proposals-executed">
           {$i18n.launchpad.banner_proposals_executed}
         </h6>
@@ -103,6 +110,7 @@
         role="alert"
         aria-live="polite"
         data-tid="launchpad-banner-desktop-component"
+        class:withUpcomingLaunchesCards
       >
         <div class="background">
           {#each logos as logo, index (logo)}
@@ -143,6 +151,58 @@
     border-radius: var(--border-radius-2x);
     min-width: 100%;
     padding: 0;
+
+    // Extra mode when rendering together with upcoming launches cards.
+    &.withUpcomingLaunchesCards {
+      @include media.min-width(large) {
+        .background {
+          --bg-width: 50%;
+        }
+
+        .stats {
+          flex: 2;
+          padding: 30px 52px;
+          gap: var(--padding-2x);
+
+          grid-template-columns: 1fr auto 1fr;
+          grid-template-rows: auto auto;
+          grid-template-areas:
+            "a a a"
+            "b sep c";
+        }
+
+        .stat-item.stat-item--a {
+          grid-area: a;
+
+          .value {
+            font-size: 27px;
+            font-weight: 450;
+            line-height: 31px;
+          }
+        }
+        .stat-item.stat-item--b {
+          grid-area: b;
+        }
+        .stat-item.stat-item--c {
+          grid-area: c;
+        }
+        .stat-divider.stat-divider--a {
+          grid-area: sep;
+        }
+        .stat-divider.stat-divider--b {
+          display: none;
+        }
+
+        .stat-item--b,
+        .stat-item--c {
+          .value {
+            font-size: 18px;
+            font-weight: 450;
+            line-height: 24px;
+          }
+        }
+      }
+    }
   }
   a.launchpad-banner {
     text-decoration: none;
@@ -177,6 +237,7 @@
 
   .info {
     flex: 2;
+    z-index: 1;
 
     display: flex;
     flex-direction: column;
@@ -239,13 +300,19 @@
     gap: var(--padding);
 
     @include media.min-width(large) {
-      justify-content: space-around;
-      gap: var(--padding-3x);
       padding: var(--padding-2x) var(--padding-3x);
+      display: grid;
+      grid-template-columns: 1fr auto 1fr auto 1fr;
+      justify-content: space-around;
+      align-items: center;
+      gap: var(--padding-3x);
 
       border-radius: var(--border-radius);
       background: rgba(#fff, 0.45);
       backdrop-filter: blur(11.5px);
+    }
+    @include media.min-width(xlarge) {
+      flex: 1;
     }
 
     .stat-divider {
@@ -313,6 +380,9 @@
     display: none;
     @include media.min-width(large) {
       display: block;
+    }
+    @include media.min-width(xlarge) {
+      --bg-width: 40%;
     }
 
     .logo {

--- a/frontend/src/lib/pages/Portfolio.svelte
+++ b/frontend/src/lib/pages/Portfolio.svelte
@@ -187,6 +187,7 @@
         })
       : [...launchpadCards, ...openProposalCards, ...adoptedSnsProposalsCards]
   );
+  const withUpcomingLaunchesCards = $derived(cards.length > 0);
 </script>
 
 <main data-tid="portfolio-page-component">
@@ -260,12 +261,12 @@
     {/if}
   </div>
 
-  <div class="sns-section">
+  <div class="sns-section" class:withUpcomingLaunchesCards>
     {#if $ENABLE_LAUNCHPAD_REDESIGN}
-      <LaunchpadBanner />
+      <LaunchpadBanner {withUpcomingLaunchesCards} />
     {/if}
 
-    {#if cards.length > 0}
+    {#if withUpcomingLaunchesCards}
       {#if $ENABLE_LAUNCHPAD_REDESIGN && $ENABLE_APY_PORTFOLIO && $isMobileViewportStore}
         <CardList
           testId="stacked-cards"
@@ -325,7 +326,9 @@
       grid-template-columns: 1fr;
 
       @include media.min-width(large) {
-        grid-template-columns: 2fr 1fr;
+        &.withUpcomingLaunchesCards {
+          grid-template-columns: 2fr 1fr;
+        }
       }
     }
   }


### PR DESCRIPTION
# Motivation

After the latest design iteration (where the SNS launchpad banner was moved to the bottom of the page), layout issues appeared across multiple viewport sizes. This PR addresses those visual inconsistencies.

https://dfinity.atlassian.net/browse/NNS1-4001

# Changes

- Updated styles to improve banner responsiveness and alignment.
- Added shadow to the banner.

# Tests

- Known issue: between 1025px and 1079px, the bottom banner’s height is slightly misaligned. Since this range isn't a focus area and no standard breakpoint covers it in `nns-dapp`, it was intentionally left as-is to reduce complexity and improve maintainability (see screenshots).

| 1024-1079 | 1080+ |
|--------|--------|
| <img width="1762" height="1546" alt="Screenshot 2025-07-28 at 15 54 13" src="https://github.com/user-attachments/assets/580aac30-3567-4858-a974-228f0e8ca62f" /> | <img width="2036" height="1540" alt="Screenshot 2025-07-28 at 15 54 32" src="https://github.com/user-attachments/assets/d3435139-d996-4a7e-91ab-5565b20fa696" /> |

- Verified that the layout looks correct across multiple breakpoints.

**Single banner mode**

<img width="1758" height="1974" alt="Screenshot 2025-07-28 at 15 50 51" src="https://github.com/user-attachments/assets/8b60c998-34f1-479a-bdf6-6e7d4da16a24" />
<img width="1864" height="1974" alt="Screenshot 2025-07-28 at 15 50 43" src="https://github.com/user-attachments/assets/6fc6ef9b-8f6d-40c9-a2be-20d1dd2cab7d" />
<img width="2146" height="1974" alt="Screenshot 2025-07-28 at 15 50 30" src="https://github.com/user-attachments/assets/60a36682-61c0-41d0-9ebd-a55f6493d65c" />
<img width="3104" height="1974" alt="Screenshot 2025-07-28 at 15 50 09" src="https://github.com/user-attachments/assets/22f06292-68a4-4316-8d65-63637078daa3" />
<img width="1830" height="1974" alt="Screenshot 2025-07-28 at 15 52 07" src="https://github.com/user-attachments/assets/8321b8c2-e9a1-49b0-9849-c0458f08a822" />



# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
