### PR TITLE
fix(tooltips): constrain icon wrapper to specified size

### DIFF
--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -14,6 +14,8 @@
     iconSize = 20,
     tooltipIdPrefix = "tooltip-icon",
   }: Props = $props();
+  const iconSizePx = $derived(`${iconSize}px`);
+
   const handleOnClick = (event: MouseEvent) => {
     event.preventDefault();
   };
@@ -21,11 +23,16 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="wrapper" data-tid="tooltip-icon-component" onclick={handleOnClick}>
+<div
+  class="wrapper"
+  data-tid="tooltip-icon-component"
+  onclick={handleOnClick}
+  style="--icon-size: {iconSizePx};"
+>
   <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -->
   <!-- svelte-ignore slot_element_deprecated -->
   <Tooltip id={tooltipId} idPrefix={tooltipIdPrefix} {text}>
-    <IconInfo size={`${iconSize}px`} />
+    <IconInfo size={iconSizePx} />
     <slot slot="tooltip-content" />
   </Tooltip>
 </div>


### PR DESCRIPTION
# Motivation

The `TooltipIcon` component exposes a prop to define the icon size, but it is not sufficient to ensure that the container does not exceed the specified size. This PR reuses the value to set the size of the icon's wrapper, ensuring consistency.

Note: The issue becomes apparent when one table has the icon while the other does not, as the former occupies a few more pixels of space.

| Before | After |
|--------|--------|
| <img width="1472" height="830" alt="Screenshot 2025-07-28 at 16 23 54" src="https://github.com/user-attachments/assets/879773e3-d942-490f-bf47-e7569998c57c" /> | <img width="1469" height="834" alt="Screenshot 2025-07-28 at 16 23 31" src="https://github.com/user-attachments/assets/ff2c72a4-4f4c-4759-986c-116aebf92451" /> | 

# Changes

- Use the icon size to determine the container size.

# Tests

- Visually tested

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?