### PR TITLE
style(portfolio): refine token list visual components

### DIFF
--- a/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/SkeletonTokensCard.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
 
-  export let testId: string;
+  type Props = {
+    testId?: string;
+  };
+  const { testId }: Props = $props();
 </script>
 
 <Card {testId}>
@@ -19,13 +22,37 @@
 
     <div class="body">
       <div class="header">
-        <span class="skeleton"></span>
-        <span class="skeleton justify-end"></span>
-        <span class="skeleton justify-end tablet-up"></span>
+        <span class="title skeleton"></span>
+        <div class="columnheaders">
+          <span class="skeleton"></span>
+          <span class="skeleton"></span>
+          <span class="skeleton"></span>
+        </div>
       </div>
 
       <div class="list">
-        {#each Array(4) as _, i (i)}
+        <div class="row">
+          <div class="info">
+            <div class="logo-skeleton skeleton"></div>
+            <div class="title-skeleton skeleton"></div>
+          </div>
+
+          <div class="balance-native skeleton"></div>
+          <div class="balance-usd skeleton"></div>
+        </div>
+      </div>
+
+      <div class="header">
+        <span class="title skeleton"></span>
+        <div class="columnheaders">
+          <span class="skeleton"></span>
+          <span class="skeleton"></span>
+          <span class="skeleton"></span>
+        </div>
+      </div>
+
+      <div class="list grow">
+        {#each Array(3) as _}
           <div class="row">
             <div class="info">
               <div class="logo-skeleton skeleton"></div>
@@ -54,12 +81,12 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: var(--padding-3x) var(--padding-2x);
+      padding: var(--padding-2x);
 
       .header-wrapper {
         display: flex;
         align-items: flex-start;
-        gap: var(--padding-2x);
+        gap: var(--padding);
 
         .icon {
           width: 50px;
@@ -73,14 +100,14 @@
           gap: var(--padding-0_5x);
 
           .title {
-            height: 20px;
+            height: 14px;
             width: 120px;
             border-radius: 4px;
           }
 
           .amount {
-            height: 42px;
-            width: 100px;
+            height: 32px;
+            width: 80px;
             border-radius: 4px;
           }
         }
@@ -102,27 +129,52 @@
     .body {
       display: flex;
       flex-direction: column;
-      gap: var(--padding);
       flex-grow: 1;
 
       .header {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        padding: 0 var(--padding-2x);
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: var(--padding-2x);
+        padding-bottom: var(--padding);
+        gap: var(--padding);
+        border-top: 4px solid var(--elements-divider);
 
-        span {
-          height: 14px;
-          border-radius: 4px;
-          &:first-child {
-            width: 80px;
-          }
-          &:not(:first-child) {
-            width: 60px;
-          }
+        .title {
+          height: 20px;
+          width: 90px;
         }
 
-        @include media.min-width(medium) {
-          grid-template-columns: 1fr 1fr 1fr;
+        .columnheaders {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          width: 100%;
+
+          @include media.min-width(medium) {
+            grid-template-columns: 1fr 1fr 1fr;
+          }
+
+          span {
+            height: 16px;
+            border-radius: 4px;
+
+            &:first-child {
+              width: 80px;
+            }
+
+            &:not(:first-child) {
+              width: 60px;
+              justify-self: flex-end;
+            }
+
+            &:last-child {
+              display: none;
+
+              @include media.min-width(medium) {
+                display: block;
+              }
+            }
+          }
         }
       }
 
@@ -130,7 +182,6 @@
         display: flex;
         flex-direction: column;
         background-color: var(--card-background);
-        flex-grow: 1;
 
         .row {
           display: grid;
@@ -144,7 +195,7 @@
           }
 
           align-items: center;
-          padding: var(--padding-3x) var(--padding-2x);
+          padding: var(--padding-2x);
           border-top: 1px solid var(--elements-divider);
 
           .info {
@@ -183,6 +234,10 @@
           }
         }
       }
+
+      .grow {
+        flex-grow: 1;
+      }
     }
 
     .tablet-up {
@@ -193,10 +248,6 @@
       .tablet-up {
         display: block !important;
       }
-    }
-
-    .justify-end {
-      justify-self: end;
     }
   }
 </style>

--- a/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
+++ b/frontend/src/lib/components/portfolio/TokensCardHeader.svelte
@@ -69,7 +69,7 @@
     .header-wrapper {
       display: flex;
       align-items: flex-start;
-      gap: var(--padding);
+      gap: var(--padding-2x);
 
       .icon {
         width: 50px;
@@ -79,22 +79,28 @@
       .text-content {
         display: flex;
         flex-direction: column;
-        gap: var(--padding-0_5x);
 
         .title {
           margin: 0;
           padding: 0;
-          font-size: 0.875rem;
+          font-size: 12px;
           font-weight: bold;
           color: var(--text-description);
-          margin: 0;
-          padding: 0;
+
+          @include media.min-width(medium) {
+            font-size: 14px;
+          }
         }
 
         .amount {
           margin: 0;
           padding: 0;
-          font-size: 1.5rem;
+          font-size: 24px;
+          line-height: 32px;
+
+          @include media.min-width(medium) {
+            font-size: 27px;
+          }
         }
       }
     }

--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -42,5 +42,8 @@
     display: inline-flex;
     align-items: center;
     color: var(--tooltip-icon-color, var(--elements-icons));
+
+    height: var(--icon-size);
+    width: var(--icon-size);
   }
 </style>

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -120,7 +120,7 @@ export const shouldShowInfoRow = ({
   return (
     otherCardNumberOfTokens > currentCardNumberOfTokens ||
     (otherCardNumberOfTokens === 0 && currentCardNumberOfTokens < 4) ||
-    (currentCardNumberOfTokens < 3 && otherCardNumberOfTokens < 3)
+    (currentCardNumberOfTokens < 4 && otherCardNumberOfTokens < 4)
   );
 };
 

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -366,8 +366,8 @@ describe("Portfolio utils", () => {
     it("should not show info row when both cards have 3 or more tokens", () => {
       expect(
         shouldShowInfoRow({
-          currentCardNumberOfTokens: 3,
-          otherCardNumberOfTokens: 3,
+          currentCardNumberOfTokens: 4,
+          otherCardNumberOfTokens: 4,
         })
       ).toBe(false);
 


### PR DESCRIPTION
# Motivation

This PR enhances the visuals of the new design by:  
* introducing a new skeleton shape based on the updated tables  
* updating the typography styles of the `TokensCardHeader` to align with the design changes  
* adding the missing wrapper sizing from #7196  
* modifying `shouldShowInfoRow` to display the info row in the tables when the user has fewer than 4 items.

https://github.com/user-attachments/assets/0402953a-9537-4204-885e-c1d9d0f60961


[NNS1-4005](https://dfinity.atlassian.net/browse/NNS1-4005)

# Changes

- Update the skeleton for the new design.  
- Adjust the TooltipIcon container to fit the size.  
- Apply new styles to the table headers.  
- Display the InfoRow when there are fewer than 4 items.  

# Tests

- Update utility tests to verify that the info row displays up to four items.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
