### PR TITLE
chore(deps): update snsdemo to release-2025-07-09

### DIFF
--- a/config.json
+++ b/config.json
@@ -118,7 +118,7 @@
         "DIDC_VERSION": "didc 0.4.0",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2025-06-25",
+        "SNSDEMO_RELEASE": "release-2025-07-09",
         "IC_COMMIT_FOR_PROPOSALS": "release-2025-07-31_03-32-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "fccfa2c7c7cba9e5485ad0b48823990e24a67f40"
       },

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.25.1",
+  "dfx": "0.27.0",
   "canisters": {
     "nns-governance": {
       "type": "custom",


### PR DESCRIPTION
# Motivation

We would like to keep the testing environment, provided by snsdemo, up to date.

Note: This PR was spun off from #7143

# Changes
* Updated `snsdemo` version in `config.json`.
* Ensured that the `dfx` version in `dfx.json` matches `snsdemo`.

# Tests
CI should pass.