### PR TITLE
chore(revert changes): fix leftover differences from prod after the revert

### DIFF
--- a/frontend/src/lib/components/portfolio/NoStakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/NoStakedTokensCard.svelte
@@ -14,6 +14,7 @@
       <IconStakedTokens />
     </div>
     <div class="text">
+      <h5>{$i18n.portfolio.no_neurons_card_title}</h5>
       <p>{$i18n.portfolio.no_neurons_card_description}</p>
     </div>
     <a {href} class={`button ${primaryCard ? "primary" : "secondary"}`}
@@ -50,8 +51,22 @@
     }
     .text {
       color: var(--text-description);
+
+      h5,
       p {
         margin: 0;
+        padding: 0;
+        color: inherit;
+      }
+
+      h5 {
+        font-weight: bold;
+        text-wrap: pretty;
+      }
+
+      p {
+        margin-top: var(--padding);
+        text-wrap: balance;
       }
     }
   }

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -60,6 +60,61 @@
     }
   });
 
+  // Old columns definition if ENABLE_NEW_TABLES is false
+  const oldColumns: ProjectsTableColumn[] = $derived([
+    {
+      id: "title",
+      title: $i18n.staking.nervous_systems,
+      cellComponent: ProjectTitleCell,
+      alignment: "left",
+      templateColumns: ["minmax(min-content, max-content)"],
+      comparator: $authSignedInStore ? compareByProject : undefined,
+    },
+    {
+      title: "",
+      alignment: "left",
+      templateColumns: ["1fr"],
+    },
+    {
+      id: "stake",
+      title: $i18n.neuron_detail.stake,
+      cellComponent: ProjectStakeCell,
+      alignment: "right",
+      templateColumns: ["max-content"],
+      comparator: $authSignedInStore ? compareByStake : undefined,
+    },
+    {
+      title: "",
+      alignment: "left",
+      templateColumns: ["1fr"],
+    },
+    {
+      title: $i18n.neuron_detail.maturity_title,
+      cellComponent: ProjectMaturityCell,
+      alignment: "right",
+      templateColumns: ["max-content"],
+    },
+    {
+      title: "",
+      alignment: "left",
+      templateColumns: ["1fr"],
+    },
+    {
+      id: "neurons",
+      title: $i18n.neurons.title,
+      cellComponent: ProjectNeuronsCell,
+      alignment: "right",
+      templateColumns: ["max-content"],
+      comparator: $authSignedInStore ? compareByNeuron : undefined,
+    },
+    {
+      title: "",
+      cellComponent: ProjectActionsCell,
+      alignment: "right",
+      templateColumns: ["max-content"],
+    },
+  ]);
+
   const commonColumns: ProjectsTableColumn[] = $derived([
     {
       id: "stake",
@@ -102,18 +157,6 @@
       alignment: "right",
       templateColumns: ["1fr"],
     },
-  ]);
-
-  const columns: ProjectsTableColumn[] = $derived([
-    {
-      id: "title",
-      title: $i18n.staking.nervous_systems,
-      cellComponent: ProjectTitleCell,
-      alignment: "left",
-      templateColumns: ["2fr"],
-      comparator: $authSignedInStore ? compareByProject : undefined,
-    },
-    ...commonColumns,
   ]);
 
   const nnsColumns: ProjectsTableColumn[] = $derived([
@@ -276,35 +319,33 @@
 </script>
 
 <div class="wrapper" data-tid="projects-table-component">
-  <div class="top" class:two-card={hasAnyNeurons && apyCardVisible}>
-    {#if $authSignedInStore}
+  {#if $authSignedInStore && (hasAnyNeurons || (apyCardVisible && nonNullish(totalUsdAmount)))}
+    <div class="top" class:two-card={hasAnyNeurons && apyCardVisible}>
       {#if hasAnyNeurons}
         <UsdValueBanner usdAmount={totalStakeInUsd} {hasUnpricedTokens}>
           <IconNeuronsPage slot="icon" />
         </UsdValueBanner>
       {/if}
 
-      {#if apyCardVisible}
-        {#if nonNullish(totalUsdAmount)}
-          {#if isStakingRewardDataReady($stakingRewardsStore)}
-            <ApyCard
-              onStakingPage={true}
-              rewardBalanceUSD={$stakingRewardsStore.rewardBalanceUSD}
-              rewardEstimateWeekUSD={$stakingRewardsStore.rewardEstimateWeekUSD}
-              stakingPower={$stakingRewardsStore.stakingPower}
-              stakingPowerUSD={$stakingRewardsStore.stakingPowerUSD}
-              totalAmountUSD={totalUsdAmount}
-            />
-          {:else}
-            <ApyFallbackCard
-              stakingRewardData={$stakingRewardsStore}
-              onStakingPage={true}
-            />
-          {/if}
+      {#if apyCardVisible && nonNullish(totalUsdAmount)}
+        {#if isStakingRewardDataReady($stakingRewardsStore)}
+          <ApyCard
+            onStakingPage={true}
+            rewardBalanceUSD={$stakingRewardsStore.rewardBalanceUSD}
+            rewardEstimateWeekUSD={$stakingRewardsStore.rewardEstimateWeekUSD}
+            stakingPower={$stakingRewardsStore.stakingPower}
+            stakingPowerUSD={$stakingRewardsStore.stakingPowerUSD}
+            totalAmountUSD={totalUsdAmount}
+          />
+        {:else}
+          <ApyFallbackCard
+            stakingRewardData={$stakingRewardsStore}
+            onStakingPage={true}
+          />
         {/if}
       {/if}
-    {/if}
-  </div>
+    </div>
+  {/if}
 
   {#if $ENABLE_NEW_TABLES}
     {#if !$authSignedInStore}
@@ -384,13 +425,13 @@
   {:else if !$authSignedInStore}
     <ResponsiveTable
       tableData={sortedTableProjects}
-      {columns}
+      columns={oldColumns}
       on:nnsAction={handleAction}
     />
   {:else}
     <ResponsiveTable
       tableData={sortedTableProjects}
-      {columns}
+      columns={oldColumns}
       on:nnsAction={handleAction}
       bind:order={$projectsTableOrderStore}
       displayTableSettings
@@ -444,7 +485,6 @@
 
     @include media.min-width(large) {
       column-gap: var(--padding-2x);
-      row-gap: var(--padding-3x);
     }
   }
 

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -82,7 +82,6 @@
   const closeSettings = () => (settingsPopoverVisible = false);
 
   const hasSubtitles = columns.some((column) => nonNullish(column.subtitle));
-
   // In mobile view, we only show the first column header and it should never be
   // sortable by clicking on it. So depending on whether the first column is
   // sortable we have or don't have separate first column headers for desktop

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1312,9 +1312,10 @@
     "login_title": "Session expired",
     "login_description": "Sign in and start staking to earn voting rewards and participate in the Internet Computer’s onchain governance.",
     "no_tokens_card_title": "Store and transfer tokens securely in the NNS wallet",
-    "no_tokens_card_description": "running 100% on the Internet Computer blockchain — Ready to get started?",
+    "no_tokens_card_description": "running 100% on the Internet Computer blockchain, ready to get started?",
     "no_tokens_card_button": "Buy ICP",
-    "no_neurons_card_description": "Earn voting rewards by staking your tokens in neurons and participating in the Internet Computer’s onchain governance",
+    "no_neurons_card_title": "Earn voting rewards by staking your tokens",
+    "no_neurons_card_description": "create neurons and participate in the Internet Computer's on-chain governance!",
     "no_neurons_card_button": "Start Staking",
     "held_tokens_card_title": "Total Token Balance",
     "held_tokens_card_link": "View tokens",
@@ -1367,8 +1368,5 @@
     "start_staking_card_content": "Stake ICP tokens and participate in NNS governance to earn up to 13% of yearly voting rewards",
     "start_staking_card_link": "Open Staking"
   },
-  "highlight": {
-    "disburse_maturity_title": "Farewell, Spawn Neuron!",
-    "disburse_maturity_description": "Now you can directly disburse your NNS neurons' maturity to the account of your choice."
-  }
+  "highlight": {}
 }

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -149,6 +149,10 @@ const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> => {
 
 const featureFlagsStore = initFeatureFlagsStore();
 
+export const getTestFeatureFlag = (key: FeatureKey): boolean => {
+  return get(featureFlagsStore[key]);
+};
+
 export const {
   ENABLE_CKTESTBTC,
   DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING,

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1385,6 +1385,7 @@ interface I18nPortfolio {
   no_tokens_card_title: string;
   no_tokens_card_description: string;
   no_tokens_card_button: string;
+  no_neurons_card_title: string;
   no_neurons_card_description: string;
   no_neurons_card_button: string;
   held_tokens_card_title: string;
@@ -1439,10 +1440,7 @@ interface I18nPortfolio {
   start_staking_card_link: string;
 }
 
-interface I18nHighlight {
-  disburse_maturity_title: string;
-  disburse_maturity_description: string;
-}
+interface I18nHighlight {}
 
 interface I18nNeuron_state {
   Unspecified: string;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Alfred from "$lib/components/alfred/Alfred.svelte";
-  import Highlight from "$lib/components/ui/Highlight.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
@@ -13,9 +12,7 @@
     type AuthWorker,
   } from "$lib/services/worker-auth.services";
   import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
-  import { ENABLE_DISBURSE_MATURITY } from "$lib/stores/feature-flags.store";
   import { governanceMetricsStore } from "$lib/stores/governance-metrics.store";
-  import { i18n } from "$lib/stores/i18n";
   import { networkEconomicsStore } from "$lib/stores/network-economics.store";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { nnsTotalVotingPowerStore } from "$lib/stores/nns-total-voting-power.store";
@@ -80,16 +77,6 @@
 </script>
 
 <Alfred />
-
-{#if $ENABLE_DISBURSE_MATURITY && $authSignedInStore}
-  <Highlight
-    level="info"
-    title={$i18n.highlight.disburse_maturity_title}
-    description={$i18n.highlight.disburse_maturity_description}
-    link="https://internetcomputer.org/docs/building-apps/governing-apps/nns/using-the-nns-dapp/nns-dapp-advanced-neuron-operations#maturity-disbursements"
-    id="disburse-maturity-feature"
-  />
-{/if}
 
 <slot />
 

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -5,7 +5,10 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import {
+  getTestFeatureFlag,
+  overrideFeatureFlagsStore,
+} from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
@@ -82,8 +85,11 @@ describe("ProjectsTable", () => {
       const po = renderComponent();
       expect(await po.getDesktopColumnHeaders()).toEqual([
         "Nervous Systems",
+        "",
         "Stake",
+        "",
         "Maturity",
+        "",
         "Neurons",
         "", // No header for actions column.
       ]);
@@ -94,8 +100,11 @@ describe("ProjectsTable", () => {
       const rows = await po.getRows();
       expect(await rows[0].getCellAlignments()).toEqual([
         "desktop-align-left", // Nervous Systems
+        "desktop-align-left",
         "desktop-align-right", // Stake
+        "desktop-align-left",
         "desktop-align-right", // Maturity
+        "desktop-align-left",
         "desktop-align-right", // Neurons
         "desktop-align-right", // Actions
       ]);
@@ -105,10 +114,19 @@ describe("ProjectsTable", () => {
       const po = renderComponent();
 
       expect(await po.getDesktopGridTemplateColumns()).toBe(
-        ["2fr", "1fr", "1fr", "1fr", "1fr"].join(" ")
+        [
+          "minmax(min-content, max-content)",
+          "1fr",
+          "max-content",
+          "1fr",
+          "max-content",
+          "1fr",
+          "max-content",
+          "max-content",
+        ].join(" ")
       );
       expect(await po.getMobileGridTemplateAreas()).toBe(
-        '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1" "cell-2 cell-2"'
+        '"first-cell last-cell" "cell-1 cell-1" "cell-3 cell-3" "cell-5 cell-5"'
       );
     });
   });
@@ -117,9 +135,11 @@ describe("ProjectsTable", () => {
     const po = renderComponent();
     expect(await po.getDesktopColumnHeaders()).toEqual([
       "Nervous Systems",
+      "",
       "Stake",
-      "APY (max APY)",
+      "",
       "Maturity",
+      "",
       "Neurons",
       "", // No header for actions column.
     ]);
@@ -138,9 +158,11 @@ describe("ProjectsTable", () => {
     const rows = await po.getRows();
     expect(await rows[0].getCellAlignments()).toEqual([
       "desktop-align-left", // Nervous Systems
+      "desktop-align-left",
       "desktop-align-right", // Stake
-      "desktop-align-right", // APY
+      "desktop-align-left",
       "desktop-align-right", // Maturity
+      "desktop-align-left",
       "desktop-align-right", // Neurons
       "desktop-align-right", // Actions
     ]);
@@ -150,10 +172,19 @@ describe("ProjectsTable", () => {
     const po = renderComponent();
 
     expect(await po.getDesktopGridTemplateColumns()).toBe(
-      ["2fr", "1fr", "1fr", "1fr", "1fr", "1fr"].join(" ")
+      [
+        "minmax(min-content, max-content)",
+        "1fr",
+        "max-content",
+        "1fr",
+        "max-content",
+        "1fr",
+        "max-content",
+        "max-content",
+      ].join(" ")
     );
     expect(await po.getMobileGridTemplateAreas()).toBe(
-      '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1" "cell-2 cell-2" "cell-3 cell-3"'
+      '"first-cell last-cell" "cell-1 cell-1" "cell-3 cell-3" "cell-5 cell-5"'
     );
   });
 
@@ -190,10 +221,16 @@ describe("ProjectsTable", () => {
     expect(await rowPos[1].getStake()).toBe("");
   });
 
-  it("should render apy as -/- when not loaded", async () => {
+  it("should render apy as -/- when not loaded (in new tables)", async () => {
     const po = renderComponent();
     const rowPos = await po.getProjectsTableRowPos();
     expect(rowPos).toHaveLength(2);
+
+    if (getTestFeatureFlag("ENABLE_NEW_TABLES") === false) {
+      expect(await rowPos[0].getProjectApyCellPo().isPresent()).toBe(false);
+      return;
+    }
+
     expect(
       await rowPos[0]
         .getProjectApyCellPo()
@@ -322,7 +359,11 @@ describe("ProjectsTable", () => {
       expect(await rowPos[1].getStake()).toBe("2.00 TOK");
     });
 
-    it("should render apy", async () => {
+    it("should render apy (in new tables)", async () => {
+      if (getTestFeatureFlag("ENABLE_NEW_TABLES") === false) {
+        return;
+      }
+
       neuronsStore.setNeurons({
         neurons: [nnsNeuronWithStake],
         certified: true,

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -360,9 +360,7 @@ describe("ProjectsTable", () => {
     });
 
     it("should render apy (in new tables)", async () => {
-      if (getTestFeatureFlag("ENABLE_NEW_TABLES") === false) {
-        return;
-      }
+      overrideFeatureFlagsStore.setFlag("ENABLE_NEW_TABLES", true);
 
       neuronsStore.setNeurons({
         neurons: [nnsNeuronWithStake],

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -5,10 +5,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { failedActionableSnsesStore } from "$lib/stores/actionable-sns-proposals.store";
-import {
-  getTestFeatureFlag,
-  overrideFeatureFlagsStore,
-} from "$lib/stores/feature-flags.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { projectsTableOrderStore } from "$lib/stores/projects-table.store";
@@ -79,6 +76,14 @@ describe("ProjectsTable", () => {
   describe("table when ENABLE_APY_PORTFOLIO disabled", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_APY_PORTFOLIO", false);
+    });
+
+    it("should not render APY", async () => {
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+
+      expect(await rowPos[0].getProjectApyCellPo().isPresent()).toBe(false);
     });
 
     it("should render desktop headers", async () => {
@@ -222,14 +227,10 @@ describe("ProjectsTable", () => {
   });
 
   it("should render apy as -/- when not loaded (in new tables)", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_NEW_TABLES", true);
     const po = renderComponent();
     const rowPos = await po.getProjectsTableRowPos();
     expect(rowPos).toHaveLength(2);
-
-    if (getTestFeatureFlag("ENABLE_NEW_TABLES") === false) {
-      expect(await rowPos[0].getProjectApyCellPo().isPresent()).toBe(false);
-      return;
-    }
 
     expect(
       await rowPos[0]

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -3,7 +3,6 @@ import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.
 import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
 import * as analytics from "$lib/services/analytics.services";
 import { initAuthWorker } from "$lib/services/worker-auth.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
 import App from "$routes/+layout.svelte";
@@ -102,20 +101,6 @@ describe("Layout", () => {
     const po = HighlightPo.under(new JestPageObjectElement(container));
 
     expect(await po.isPresent()).toBe(false);
-  });
-
-  it("should show the Highlight component if the user is signed in and the feature is on", async () => {
-    const renderComponent = () => {
-      const { container } = render(App);
-      return HighlightPo.under(new JestPageObjectElement(container));
-    };
-
-    setNoIdentity();
-    expect(await renderComponent().isPresent()).toBe(false);
-
-    resetIdentity();
-    overrideFeatureFlagsStore.setFlag("ENABLE_DISBURSE_MATURITY", true);
-    expect(await renderComponent().isPresent()).toBe(true);
   });
 
   it("should load ICP Swap tickers", async () => {

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -153,7 +153,9 @@ export const closeHighlight = async (page: Page) => {
     PlaywrightPageObjectElement.fromPage(page)
   );
 
-  await highlightPo.clickClose();
+  (await highlightPo.isPresent())
+    ? highlightPo.clickClose()
+    : Promise.resolve();
 };
 
 export const disableCssAnimations = async (page: Page) => {


### PR DESCRIPTION
# Motivation

Some minor changes were missing to be reverted, this PR addresses them.

# Changes

Fixed:
- remove the "Farewell, Spawn Neuron!" message
- reinstate the old column layout for the Projects page
- align the design of empty portfolio cards (bold / non-bold)
<img width="1254" height="447" alt="Screenshot 2025-08-04 at 16 53 50" src="https://github.com/user-attachments/assets/afc1cac4-3bef-464b-ac72-c9866a1bae4b" />


# Tests

Tested manually. Updated tests. Tests should pass.

# Todos

- [x] Accessibility (a11y) – any impact? no
- [x] Changelog – is it needed? no
