### PR TITLE
chore(scripts): remove snapshot script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,6 @@
     "update:agent": "npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/nns @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/nns@next @dfinity/cmc@next @dfinity/sns@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
     "update:gix": "npm update @dfinity/gix-components",
     "upgrade:next": "npm rm @dfinity/nns @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/nns@next @dfinity/cmc@next @dfinity/sns@next @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
-    "start:snapshot": "../scripts/dfx-snapshot-start --snapshot ~/snapshot.tar.xz ",
     "sync-node-version": "./scripts/sync-node-version"
   },
   "engines": {


### PR DESCRIPTION
# Motivation

The snapshot script is not very useful because it assumes a snapshot is called in a specific way, which is not typically the case.

# Changes

- Remove script.

# Tests

- Not necessary.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
