### PR TITLE
style(launchpad2): Update project card background

### DIFF
--- a/frontend/src/lib/components/launchpad/CardFrame.svelte
+++ b/frontend/src/lib/components/launchpad/CardFrame.svelte
@@ -8,6 +8,7 @@
     children: Snippet;
     backgroundIcon?: Snippet;
     highlighted?: boolean;
+    dimmed?: boolean;
     mobileHref?: string;
   };
 
@@ -16,6 +17,7 @@
     children,
     backgroundIcon,
     highlighted = false,
+    dimmed = false,
     mobileHref,
   }: Props = $props();
 
@@ -23,7 +25,7 @@
 </script>
 
 {#snippet content()}
-  <article data-tid={testId} class:highlighted>
+  <article data-tid={testId} class:highlighted class:dimmed>
     {#if nonNullish(backgroundIcon)}
       <div class="background-icon-container" data-tid="background-icon">
         {@render backgroundIcon()}
@@ -65,6 +67,10 @@
       height: 230px;
       padding: var(--padding-3x) var(--padding-3x)
         var(--card-frame-padding-bottom, var(--padding-3x));
+    }
+
+    &.dimmed {
+      --card-frame-background: var(--table-background);
     }
 
     &.highlighted {

--- a/frontend/src/lib/components/launchpad/ProjectCard2.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard2.svelte
@@ -74,6 +74,7 @@
 <CardFrame
   testId="project-card-component"
   highlighted={userHasParticipated}
+  dimmed
   mobileHref={href}
 >
   <div class="card-content" class:userHasParticipated>


### PR DESCRIPTION
# Motivation

The cards of projects in which the user hasn’t participated are currently displayed with a white background, which is not in sync with the design. This happened because the same card frame component is used for all other Launchpad cards. This PR addresses the issue by applying a dimmed background to these project cards.

# Changes

- Added a `dimmed` prop and applied it to the relevant project cards.

# Tests

- Verified manually.

| Before | Afrer |
|--------|--------|
| <img width="1068" height="338" alt="image" src="https://github.com/user-attachments/assets/9d8a01f4-4f8d-46a6-965b-131b5687e34a" /> | <img width="1067" height="337" alt="image" src="https://github.com/user-attachments/assets/a62f407e-cb8b-41db-acb9-b5aa90ba4d0e" /> | 

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
