### PR TITLE
fix(apy): use correct token store for balance calculation in Staking page

### DIFF
--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -21,7 +21,7 @@
   import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
-  import { tokensListVisitorsStore } from "$lib/derived/tokens-list-visitors.derived";
+  import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
   import {
     loadAccountsBalances,
     loadSnsAccountsBalances,
@@ -216,7 +216,7 @@
   // Staking Rewards/APY related logic
   // ==================================
   const totalUsdAmount = $derived.by(() => {
-    const userTokens = $tokensListVisitorsStore;
+    const userTokens = $tokensListUserStore;
     const totalTokensBalanceInUsd = getTotalBalanceInUsd(userTokens);
     const totalStakedInUsd = getTotalStakeInUsd(tableProjects);
     return $authSignedInStore


### PR DESCRIPTION
# Motivation

#7172 introduced the `ApyCard` on the Staking page. It uses `tokensListVisitorsStore` to calculate the total staking amount, but this is incorrect. This store contains the generic tokens displayed before a user signs in, resulting in an inaccurate value when calculating `totalTokensBalanceInUsd`.

# Changes

- Replace `tokensListVisitorsStore` with `tokensListUserStore` for properly calculating APY.

# Tests

- Tests should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?