### PR TITLE
test(e2e): stabilize APY values in screenshots

### DIFF
--- a/frontend/src/tests/e2e/neuron-details.spec.ts
+++ b/frontend/src/tests/e2e/neuron-details.spec.ts
@@ -70,8 +70,8 @@ test("Test neuron details", async ({ page, context }) => {
   });
   await replaceContent({
     page,
-    selectors: ['[data-tid="apy-current-value"]'],
-    pattern: /\d+\.\d+%/,
+    selectors: ['[data-tid="apy-current-value"]', '[data-tid="apy-max-value"]'],
+    pattern: /\(?\d+\.\d+%\)?/,
     replacements: ["12.25%"],
   });
 


### PR DESCRIPTION
# Motivation

The Apy value and max value were added in #7184. These values appear on the neuron details page and are dynamic, which causes them to disrupt end-to-end screenshot testing regularly. This PR overrides both values with a hardcoded value.

# Changes

- Override the current and maximum APY value to a fixed 12.25% to ensure consistent screenshots.

# Tests

- Update the screenshots.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
