### PR TITLE
test(ci): increase aggregator data wait timeout for test-fast

### DIFF
--- a/scripts/sns/aggregator/test-fast
+++ b/scripts/sns/aggregator/test-fast
@@ -55,7 +55,7 @@ wait_for_latest_sns() {
 
   echo Wait for the SNS to be listed in the aggregator
   printf "Waiting for the aggregator to list the SNS..."
-  for ((i = 30; i >= 0; i--)); do
+  for ((i = 60; i >= 0; i--)); do
     if curl -sSL --fail "$AGGREGATOR_URL" 2>/dev/null >/dev/null; then
       echo OK
       break


### PR DESCRIPTION
# Motivation

The aggregator-test job is frequently failing due to timeouts and missing values when they should be present. For example:  
-  https://github.com/dfinity/nns-dapp/actions/runs/16907850886/job/47902766839  

This PR doubles the waiting time for the fast-data check.

# Changes

- Double the time waiting for the data to be there.

# Tests

- Pipeline should be tere

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
