### PR TITLE
feat(store): filter out sunset projects from aggregator

### DIFF
--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -1,12 +1,5 @@
-import {
-  abandonedProjectsCanisterId,
-  CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID,
-  SEERS_ROOT_CANISTER_ID,
-} from "$lib/constants/canister-ids.constants";
-import type {
-  CachedSnsDto,
-  CachedSnsTokenMetadataDto,
-} from "$lib/types/sns-aggregator";
+import { abandonedProjectsCanisterId } from "$lib/constants/canister-ids.constants";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
@@ -51,71 +44,13 @@ export const snsAggregatorStore: SnsAggregatorStore = derived(
 
     if (isNullish(data)) return { data: undefined };
 
-    const abandonedProjects = data.filter((sns) =>
-      abandonedProjectsCanisterId.includes(sns.list_sns_canisters.root)
-    );
-    if (abandonedProjects.length === 0) return { data };
     const dataWithoutAbandonedProjects = data.filter(
       (sns) =>
         !abandonedProjectsCanisterId.includes(sns.list_sns_canisters.root)
     );
 
     return {
-      data: [
-        ...dataWithoutAbandonedProjects,
-        ...abandonedProjects.map(overrideAbandonedProjects),
-      ],
+      data: [...dataWithoutAbandonedProjects],
     };
   }
 );
-
-const overrideAbandonedProjects = (
-  sns: CachedSnsDto
-): CachedSnsDto & { isAbandoned?: boolean } => {
-  const originalData: Record<string, { name: string; symbol: string }> = {
-    [CYCLES_TRANSFER_STATION_ROOT_CANISTER_ID]: {
-      name: "CYCLES-TRANSFER-STATION",
-      symbol: "CTS",
-    },
-    [SEERS_ROOT_CANISTER_ID]: {
-      name: "SEERS",
-      symbol: "SEER",
-    },
-  };
-  const originalProjectData = originalData[sns.list_sns_canisters.root];
-  const hiddenCharacterToPushSnsToEndOfList = "\u200B";
-  let name = sns.meta.name;
-
-  if (name !== originalProjectData.name) {
-    name = `${hiddenCharacterToPushSnsToEndOfList}${name} (formerly ${originalProjectData.name})`;
-  }
-
-  const newMeta = {
-    ...sns.meta,
-    name,
-  };
-
-  const newIcrc1Metadata = sns.icrc1_metadata.map<
-    [string, CachedSnsTokenMetadataDto[0][1]]
-  >(([name, value]) => {
-    if (name === "icrc1:symbol" && "Text" in value) {
-      const symbol = value.Text;
-      if (symbol !== originalProjectData.symbol) {
-        return [
-          name,
-          {
-            Text: `${symbol} (${originalProjectData.symbol})`,
-          },
-        ];
-      }
-    }
-    return [name, value];
-  });
-
-  return {
-    ...sns,
-    meta: { ...newMeta },
-    icrc1_metadata: [...newIcrc1Metadata],
-    isAbandoned: true,
-  };
-};


### PR DESCRIPTION
# Motivation

Following #7245, the nns-dapp should not display information about Sunset projects. This PR removes these projects from the aggregator store.

# Changes

- Filter aggregator projects using the list of abandoned projects.

# Tests

- Remove outdated tests
- Add a test to ensure that any project listed as abandoned is filtered out from the aggregator store.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
