### PR TITLE
test(ci): increase aggregator data wait timeout for test-fast 

### DIFF
--- a/scripts/sns/aggregator/test-fast
+++ b/scripts/sns/aggregator/test-fast
@@ -139,13 +139,13 @@ title If we buy 1 ICP, the ICP and participant count should increase
 dfx-sns-sale-buy --icp 1
 EXPECTED_FIELDS='{"buyer_total_icp_e8s":100000000,"direct_participant_count":1,"lifecycle":2}'
 printf "Waiting for ICP and participant  count to increase..."
-wait_for_aggregator_to_contain "$EXPECTED_FIELDS"
+wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 120
 
 title If we buy more, only the ICP should increase
 dfx-sns-sale-buy --icp 2
 EXPECTED_FIELDS='{"buyer_total_icp_e8s":300000000,"direct_participant_count":1,"lifecycle":2}'
 printf "Waiting for the ICP to increase..."
-wait_for_aggregator_to_contain "$EXPECTED_FIELDS"
+wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 120
 
 title If we increase participation the maximum available, the SNS lifecycle should change as the SNS configuration allows one buyer to buy all tokens.
 MAY_BUY="$(curl -sSL --fail "$AGGREGATOR_URL" | jq '(.swap_params.params.max_participant_icp_e8s - .derived_state.buyer_total_icp_e8s)/100000000')"


### PR DESCRIPTION
# Motivation

Following up on #7250, this PR adds additional delays to the checks for the sns-aggregator.

This PR handles errors like the following:
* https://github.com/dfinity/nns-dapp/actions/runs/16914170754/job/47924530550?pr=7235

# Changes

- Increase timer for ICP increase
- Increase timer for ICP participants.

# Tests

- CI should pass

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
