### PR TITLE
chore(ci): improve CI flakiness

### DIFF
--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -62,6 +62,8 @@ export const signInWithNewUser = async ({
   const iiPage = await iiPagePromise;
   await expect(iiPage).toHaveTitle("Internet Identity");
 
+  await iiPage.waitForLoadState("networkidle");
+
   await iiPage
     .getByRole("button", { name: "Create Internet Identity" })
     .click();

--- a/scripts/sns/aggregator/test-fast
+++ b/scripts/sns/aggregator/test-fast
@@ -139,20 +139,20 @@ title If we buy 1 ICP, the ICP and participant count should increase
 dfx-sns-sale-buy --icp 1
 EXPECTED_FIELDS='{"buyer_total_icp_e8s":100000000,"direct_participant_count":1,"lifecycle":2}'
 printf "Waiting for ICP and participant  count to increase..."
-wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 120
+wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 300
 
 title If we buy more, only the ICP should increase
 dfx-sns-sale-buy --icp 2
 EXPECTED_FIELDS='{"buyer_total_icp_e8s":300000000,"direct_participant_count":1,"lifecycle":2}'
 printf "Waiting for the ICP to increase..."
-wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 120
+wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 300
 
 title If we increase participation the maximum available, the SNS lifecycle should change as the SNS configuration allows one buyer to buy all tokens.
 MAY_BUY="$(curl -sSL --fail "$AGGREGATOR_URL" | jq '(.swap_params.params.max_participant_icp_e8s - .derived_state.buyer_total_icp_e8s)/100000000')"
 dfx-sns-sale-buy --icp "$MAY_BUY"
 EXPECTED_FIELDS="$(curl -sSL --fail "$AGGREGATOR_URL" | jq -c '{buyer_total_icp_e8s: .swap_params.params.max_participant_icp_e8s, direct_participant_count: 1, lifecycle: 3}')"
 printf "Waiting for the SNS lifecycle to change..."
-wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 120
+wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 300
 
 : TODO: Make a slow update counter. Verify that the last number of slow updates is as expected.
 : TODO: Make a fast update counter. Verify that the number of fast updates is as expected.


### PR DESCRIPTION
# Motivation

CI pipeline has been flaky in the last days. Several checks require on the context to be ready and this sometimes is taking longer.

This PR follows up #7252.

# Changes

- Increase timers for the aggregator tests.
- Check that network is idle for II.

# Tests

- CI should pass.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
