### PR TITLE
fix(portfolio): "View Tokens" link when logged-out

### DIFF
--- a/frontend/src/lib/components/portfolio/NoHeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/NoHeldTokensCard.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import Card from "$lib/components/portfolio/Card.svelte";
   import TokensCardHeader from "$lib/components/portfolio/TokensCardHeader.svelte";
-  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+  import { AppPath } from "$lib/constants/routes.constants";
   import { isMobileViewportStore } from "$lib/derived/viewport.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { buildAccountsUrl } from "$lib/utils/navigation.utils";
   import { IconAccountsPage, IconHeldTokens } from "@dfinity/gix-components";
 
-  const href = buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT });
+  const href = AppPath.Tokens;
 </script>
 
 <Card testId="no-held-tokens-card">


### PR DESCRIPTION
# Motivation

Currently, when logged out, the "View Tokens" link navigates to the ICP tokens page, which is not desirable, as it should link to the All Tokens page.

# Changes

- Update the link.

# Tests

- Tested manually.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
