### PR TITLE
style(ui): polish table layouts and components

### DIFF
--- a/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/HeldTokensCard.svelte
@@ -47,7 +47,7 @@
       otherCardNumberOfTokens: numberOfTopStakedTokens,
     })
   );
-  const showLinkRow = $derived(numberOfTopHeldTokens >= 4);
+  const showLinkRow = $derived(numberOfTopHeldTokens >= 3);
 </script>
 
 {#snippet tableHeader({

--- a/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
+++ b/frontend/src/lib/components/portfolio/StakedTokensCard.svelte
@@ -62,7 +62,7 @@
   );
   // TODO: Do we still want to have the maturity as a fallback for the APY?
   const showApy = $derived($ENABLE_APY_PORTFOLIO && !hasApyCalculationErrored);
-  const showLinkRow = $derived(numberOfTopStakedTokens >= 4);
+  const showLinkRow = $derived(numberOfTopStakedTokens >= 3);
 </script>
 
 {#snippet tableHeader({

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -398,6 +398,7 @@
 
     @include media.min-width(large) {
       column-gap: var(--padding-2x);
+      row-gap: var(--padding-3x);
     }
   }
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1374,8 +1374,5 @@
     "start_staking_card_content": "Stake ICP tokens and participate in NNS governance to earn up to 13% of yearly voting rewards",
     "start_staking_card_link": "Open Staking"
   },
-  "highlight": {
-    "disburse_maturity_title": "Farewell, Spawn Neuron!",
-    "disburse_maturity_description": "Now you can directly disburse your NNS neurons' maturity to the account of your choice."
-  }
+  "highlight": {}
 }

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -80,9 +80,16 @@
 </TestIdWrapper>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
   .content {
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
+
+    @include media.min-width(large) {
+      column-gap: var(--padding-2x);
+      row-gap: var(--padding-3x);
+    }
   }
 </style>

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -262,6 +262,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
+
+    @include media.min-width(large) {
+      column-gap: var(--padding-2x);
+      row-gap: var(--padding-3x);
+    }
   }
 
   [slot="last-row"] {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1445,10 +1445,7 @@ interface I18nPortfolio {
   start_staking_card_link: string;
 }
 
-interface I18nHighlight {
-  disburse_maturity_title: string;
-  disburse_maturity_description: string;
-}
+interface I18nHighlight {}
 
 interface I18nNeuron_state {
   Unspecified: string;

--- a/frontend/src/lib/utils/portfolio.utils.ts
+++ b/frontend/src/lib/utils/portfolio.utils.ts
@@ -94,8 +94,6 @@ export const getTopStakedTokens = ({
  * with a message instead of leaving a blank space.
  * Rules for showing the info row:
  * 1. When the other card has more tokens than the current card
- * 2. When the other card is empty (has 0 tokens) AND current card has fewer than 4 tokens
- * 3. When both cards have fewer than 4 tokens (for visual balance)
  */
 export const shouldShowInfoRow = ({
   currentCardNumberOfTokens,
@@ -104,14 +102,7 @@ export const shouldShowInfoRow = ({
   currentCardNumberOfTokens: number;
   otherCardNumberOfTokens: number;
 }) => {
-  const MAX_NUMBER_OF_ITEMS = 4;
-
-  return (
-    otherCardNumberOfTokens > currentCardNumberOfTokens ||
-    (otherCardNumberOfTokens === 0 && currentCardNumberOfTokens < 4) ||
-    (currentCardNumberOfTokens < MAX_NUMBER_OF_ITEMS &&
-      otherCardNumberOfTokens < MAX_NUMBER_OF_ITEMS)
-  );
+  return otherCardNumberOfTokens > currentCardNumberOfTokens;
 };
 
 export const formatParticipation = (ulps: bigint) => {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Alfred from "$lib/components/alfred/Alfred.svelte";
-  import Highlight from "$lib/components/ui/Highlight.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { icpSwapUsdPricesStore } from "$lib/derived/icp-swap.derived";
   import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
@@ -13,9 +12,7 @@
     type AuthWorker,
   } from "$lib/services/worker-auth.services";
   import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
-  import { ENABLE_DISBURSE_MATURITY } from "$lib/stores/feature-flags.store";
   import { governanceMetricsStore } from "$lib/stores/governance-metrics.store";
-  import { i18n } from "$lib/stores/i18n";
   import { networkEconomicsStore } from "$lib/stores/network-economics.store";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { nnsTotalVotingPowerStore } from "$lib/stores/nns-total-voting-power.store";
@@ -80,16 +77,6 @@
 </script>
 
 <Alfred />
-
-{#if $ENABLE_DISBURSE_MATURITY && $authSignedInStore}
-  <Highlight
-    level="info"
-    title={$i18n.highlight.disburse_maturity_title}
-    description={$i18n.highlight.disburse_maturity_description}
-    link="https://internetcomputer.org/docs/building-apps/governing-apps/nns/using-the-nns-dapp/nns-dapp-advanced-neuron-operations#maturity-disbursements"
-    id="disburse-maturity-feature"
-  />
-{/if}
 
 <slot />
 

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -186,16 +186,24 @@ describe("HeldTokensCard", () => {
       expect(await po.getLinkRow().isPresent()).toBe(false);
     });
 
-    it("should not show info row but show link row when tokens length the same", async () => {
+    it("should not show info row but show link row when tokens length is 3 or more", async () => {
       const po = renderComponent({
         topHeldTokens: [
           createUserToken({
             balanceInUsd: 300,
             rowHref: "/tokens/test1",
           }),
+          createUserToken({
+            balanceInUsd: 300,
+            rowHref: "/tokens/test2",
+          }),
+          createUserToken({
+            balanceInUsd: 300,
+            rowHref: "/tokens/test3",
+          }),
         ],
         usdAmount: 300,
-        numberOfTopStakedTokens: 1,
+        numberOfTopStakedTokens: 3,
       });
 
       expect(await po.getInfoRow().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/HeldTokensCard.spec.ts
@@ -175,40 +175,27 @@ describe("HeldTokensCard", () => {
       });
     });
 
-    it("should show info row when tokens length is 1", async () => {
+    it("should show info row when tokens length is different", async () => {
       const po = renderComponent({
         topHeldTokens: mockTokens.slice(0, 1),
         usdAmount: 100,
+        numberOfTopStakedTokens: 3,
       });
 
       expect(await po.getInfoRow().isPresent()).toBe(true);
       expect(await po.getLinkRow().isPresent()).toBe(false);
     });
 
-    it("should show info row when tokens length is 2", async () => {
-      const po = renderComponent({
-        topHeldTokens: mockTokens.slice(0, 2),
-        usdAmount: 300,
-      });
-
-      expect(await po.getInfoRow().isPresent()).toBe(true);
-      expect(await po.getLinkRow().isPresent()).toBe(false);
-    });
-
-    it("should not show info row but show link row when tokens length is 4 or more", async () => {
+    it("should not show info row but show link row when tokens length the same", async () => {
       const po = renderComponent({
         topHeldTokens: [
-          ...mockTokens,
           createUserToken({
             balanceInUsd: 300,
             rowHref: "/tokens/test1",
           }),
-          createUserToken({
-            balanceInUsd: 100,
-            rowHref: "/tokens/test2",
-          }),
         ],
         usdAmount: 300,
+        numberOfTopStakedTokens: 1,
       });
 
       expect(await po.getInfoRow().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
+++ b/frontend/src/tests/lib/components/portfolio/StakedTokensCard.spec.ts
@@ -362,19 +362,9 @@ describe("StakedTokensCard", () => {
       });
     });
 
-    it("should show info row when the number of topStakedTokens is less than numberOfTopHeldTokens like 1", async () => {
+    it("should show info row when the number of topStakedTokens is different than numberOfTopHeldTokens ", async () => {
       const po = renderComponent({
         topStakedTokens: mockStakedTokens.slice(0, 2),
-        numberOfTopHeldTokens: 4,
-      });
-
-      expect(await po.getInfoRow().isPresent()).toBe(true);
-      expect(await po.getLinkRow().isPresent()).toBe(false);
-    });
-
-    it("should show info row when the number of topStakedTokens is less than numberOfTopHeldTokens like 2", async () => {
-      const po = renderComponent({
-        topStakedTokens: mockStakedTokens.slice(0, 1),
         numberOfTopHeldTokens: 3,
       });
 
@@ -382,21 +372,10 @@ describe("StakedTokensCard", () => {
       expect(await po.getLinkRow().isPresent()).toBe(false);
     });
 
-    it("should not show info row but show link row when tokens length is 4 or more", async () => {
+    it("should not show info row but show link row when tokens length is 3 or more", async () => {
       const po = renderComponent({
-        topStakedTokens: [
-          ...mockStakedTokens,
-          {
-            ...mockTableProject,
-            title: "Project 5",
-            stakeInUsd: 200,
-            domKey: "/staking/5",
-            stake: TokenAmountV2.fromUlps({
-              amount: 1000_000n,
-              token: mockToken,
-            }),
-          },
-        ],
+        topStakedTokens: [...mockStakedTokens],
+        numberOfTopHeldTokens: 3,
       });
 
       expect(await po.getInfoRow().isPresent()).toBe(false);

--- a/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/portfolio.utils.spec.ts
@@ -25,7 +25,7 @@ import {
 import type { ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 
-describe.skip("Portfolio utils", () => {
+describe("Portfolio utils", () => {
   describe("getTopTokens", () => {
     const mockNonUserToken = createUserTokenLoading();
 
@@ -221,73 +221,34 @@ describe.skip("Portfolio utils", () => {
   });
 
   describe("shouldShowInfoRow", () => {
-    it("should show info row when other card has more tokens", () => {
+    it("should show info row when other card has more entries", () => {
       expect(
         shouldShowInfoRow({
-          currentCardNumberOfTokens: 1,
-          otherCardNumberOfTokens: 4,
-        })
-      ).toBe(true);
-    });
-
-    it("should show info row when other card is empty and current card has less than 4 tokens", () => {
-      expect(
-        shouldShowInfoRow({
-          currentCardNumberOfTokens: 2,
-          otherCardNumberOfTokens: 0,
-        })
-      ).toBe(true);
-
-      expect(
-        shouldShowInfoRow({
-          currentCardNumberOfTokens: 3,
-          otherCardNumberOfTokens: 0,
-        })
-      ).toBe(true);
-
-      expect(
-        shouldShowInfoRow({
-          currentCardNumberOfTokens: 4,
-          otherCardNumberOfTokens: 0,
-        })
-      ).toBe(false);
-
-      expect(
-        shouldShowInfoRow({
-          currentCardNumberOfTokens: 5,
-          otherCardNumberOfTokens: 0,
-        })
-      ).toBe(false);
-    });
-
-    it("should show info row when both cards have fewer than 4 tokens", () => {
-      expect(
-        shouldShowInfoRow({
-          currentCardNumberOfTokens: 2,
-          otherCardNumberOfTokens: 2,
+          currentCardNumberOfTokens: 0,
+          otherCardNumberOfTokens: 1,
         })
       ).toBe(true);
 
       expect(
         shouldShowInfoRow({
           currentCardNumberOfTokens: 1,
-          otherCardNumberOfTokens: 2,
-        })
-      ).toBe(true);
-    });
-
-    it("should not show info row when both cards have 4 or more tokens", () => {
-      expect(
-        shouldShowInfoRow({
-          currentCardNumberOfTokens: 4,
-          otherCardNumberOfTokens: 4,
-        })
-      ).toBe(false);
-
-      expect(
-        shouldShowInfoRow({
-          currentCardNumberOfTokens: 4,
           otherCardNumberOfTokens: 3,
+        })
+      ).toBe(true);
+    });
+
+    it("should not show info row when both cards have same amount of entries", () => {
+      expect(
+        shouldShowInfoRow({
+          currentCardNumberOfTokens: 0,
+          otherCardNumberOfTokens: 0,
+        })
+      ).toBe(false);
+
+      expect(
+        shouldShowInfoRow({
+          currentCardNumberOfTokens: 2,
+          otherCardNumberOfTokens: 2,
         })
       ).toBe(false);
     });

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -3,14 +3,11 @@ import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.
 import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
 import * as analytics from "$lib/services/analytics.services";
 import { initAuthWorker } from "$lib/services/worker-auth.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
 import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
 import App from "$routes/+layout.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcpSwapTicker } from "$tests/mocks/icp-swap.mock";
-import { HighlightPo } from "$tests/page-objects/Highlight.page-object";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { render } from "@testing-library/svelte";
@@ -93,29 +90,6 @@ describe("Layout", () => {
     await runResolvedPromises();
 
     expect(initAnalyticsSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("should not show the Highlight component by default", async () => {
-    const { container } = render(App);
-
-    setNoIdentity();
-    const po = HighlightPo.under(new JestPageObjectElement(container));
-
-    expect(await po.isPresent()).toBe(false);
-  });
-
-  it("should show the Highlight component if the user is signed in and the feature is on", async () => {
-    const renderComponent = () => {
-      const { container } = render(App);
-      return HighlightPo.under(new JestPageObjectElement(container));
-    };
-
-    setNoIdentity();
-    expect(await renderComponent().isPresent()).toBe(false);
-
-    resetIdentity();
-    overrideFeatureFlagsStore.setFlag("ENABLE_DISBURSE_MATURITY", true);
-    expect(await renderComponent().isPresent()).toBe(true);
   });
 
   it("should load ICP Swap tickers", async () => {

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -80,8 +80,6 @@ export const signInWithNewUser = async ({
   await iiPage.waitForEvent("close");
   await expect(iiPage.isClosed()).toBe(true);
 
-  await closeHighlight(page);
-
   await step("Running the main test");
 };
 


### PR DESCRIPTION
# Motivation

A variety of improvements before the release.

# Changes

- Simplify the logic for displaying the info row to show it only when SNS tables have an uneven number of elements.  
-  Remove the Highlight component, as it was originally implemented in #7220 but was missed during the revert in #7227.  
-  Standardize the gap size for table pages to 24px on desktop.

# Tests

- Enable portfolio utils tests
- Update tests for the new show info row logic.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
