### PR TITLE
Nns1-4031: Limit disburse maturity addresses to user-owned accounts

### DIFF
--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -183,6 +183,7 @@
           bind:selectedDestinationAddress
           bind:showManualAddress
           {selectedNetwork}
+          selectMethods="dropdown"
           on:nnsOpenQRCodeReader={goQRCode}
         />
       </div>

--- a/frontend/src/tests/lib/modals/neurons/NnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsDisburseMaturityModal.spec.ts
@@ -6,10 +6,7 @@ import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
-import {
-  mockHardwareWalletAccount,
-  mockMainAccount,
-} from "$tests/mocks/icp-accounts.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { DisburseMaturityModalPo } from "$tests/page-objects/DisburseMaturityModal.page-object";
@@ -124,45 +121,6 @@ describe("NnsDisburseMaturityModal", () => {
     expect(await po.getConfirmPercentage()).toEqual("50%");
     expect(await po.getConfirmTokens()).toBe("50.00-55.27 ICP");
     expect(await po.getConfirmDestination()).toEqual("Main");
-  });
-
-  it("should disburse maturity to entered destination", async () => {
-    const neuron = testNeuron();
-    const close = vi.fn();
-    const spyDisburseMaturity = vi
-      .spyOn(api, "disburseMaturity")
-      .mockResolvedValue();
-    // Add the neuron to the store to avoid extra query from getIdentityOfControllerByNeuronId
-    neuronsStore.setNeurons({
-      neurons: [neuron],
-      certified: true,
-    });
-    const po = await renderNnsDisburseMaturityModal({ neuron, close });
-
-    await po.setPercentage(50);
-    await po.getSelectDestinationAddressPo().toggleSelect();
-    await po
-      .getSelectDestinationAddressPo()
-      .enterAddress(mockHardwareWalletAccount.identifier);
-
-    await po.clickNextButton();
-
-    expect(
-      await po.getNeuronConfirmActionScreenPo().getConfirmButton().isDisabled()
-    ).toEqual(false);
-    expect(spyDisburseMaturity).toHaveBeenCalledTimes(0);
-
-    await po.clickConfirmButton();
-    await runResolvedPromises();
-
-    expect(spyDisburseMaturity).toHaveBeenCalledTimes(1);
-    expect(spyDisburseMaturity).toHaveBeenCalledWith({
-      neuronId: neuron.neuronId,
-      percentageToDisburse: 50,
-      identity: mockIdentity,
-      toAccountIdentifier: mockHardwareWalletAccount.identifier,
-    });
-    expect(close).toHaveBeenCalledTimes(1);
   });
 
   // FIXME: This test makes other tests fail if it runs first.


### PR DESCRIPTION
# Motivation

Due to reports that not all destination addresses accept direct disbursements, we now limit disburse maturity to user-owned accounts only, to avoid further confusion.

# Changes

- Disabled text-based address entry.

# Changes

- Disabled text-based address entry.

# Tests

- Updated.

| NNS | SNS |
|--------|--------|
| <img width="498" height="484" alt="image" src="https://github.com/user-attachments/assets/eab564ff-217b-404f-ba3f-ddc486b41133" /> | <img width="467" height="461" alt="image" src="https://github.com/user-attachments/assets/baa7d78f-b4d2-465f-9b7b-0648a3d76838" /> |

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
