### PR TITLE
remove override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ resolver = "2"
 version = "2.0.122"
 
 [workspace.dependencies]
-slab = "0.4.11"
 ic-cdk = "0.17.1"
 ic-cdk-macros = "0.17.0"
 ic-cdk-timers = "0.11.0"


### PR DESCRIPTION
# Motivation

Keep dependencies up to date and free from vulnerabilities. This removes the transient dependency override introduced in #7269, as the main dependencies have been upgraded in #7270.

# Changes

- Remove override of transient dependency.

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
