### PR TITLE
ci(test): upgrade aggregator test runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,7 @@ jobs:
           }
   aggregator_test:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-m
     timeout-minutes: 60
     steps:
       - name: Checkout nns-dapp


### PR DESCRIPTION
# Motivation

The aggregator_test job is still unreliable. It seems to take longer to boot, causing the timing tests to fail occasionally. This PR replaces the current test runner with a more effective one.

# Changes

- Increase runner.

# Tests

- CI should pass.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
