### PR TITLE
test(e2e): stabilize APY column screenshots

### DIFF
--- a/frontend/src/tests/e2e/portfolio.spec.ts
+++ b/frontend/src/tests/e2e/portfolio.spec.ts
@@ -108,7 +108,7 @@ test("Visual test Landing Page", async ({ page, browser }) => {
 
   await replaceContent({
     page,
-    selectors: ['[data-tid="projection"]'],
+    selectors: ['[data-tid="projection"]', '[data-tid="apy-current-value"]'],
     pattern: /\(?\d+\.\d+\)?/,
     replacements: ["2.25"],
   });
@@ -118,7 +118,7 @@ test("Visual test Landing Page", async ({ page, browser }) => {
 
   await replaceContent({
     page,
-    selectors: ['[data-tid="projection"]'],
+    selectors: ['[data-tid="projection"]', '[data-tid="apy-current-value"]'],
     pattern: /\(?\d+\.\d+\)?/,
     replacements: ["2.25"],
   });


### PR DESCRIPTION
# Motivation

Tests for the Portfolio page are failing because the APY column values change over time, making the screenshots outdated. This PR replaces those values with placeholder content to prevent these issues in the future.

# Changes

- Replace APY current value column with placeholder.

# Tests

- CI should pass.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
