### PR TITLE
fix(markdown): preserve heading styles when headings contain links

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -61,19 +61,25 @@
 
     // Content header font size should not be larger than the summary header font size
     --summary-header-font-size: var(--font-size-h2);
-    :global(h1) {
+    :global(h1),
+    :global(h1 a) {
       font-size: calc(var(--summary-header-font-size) * 0.9);
     }
 
-    :global(h2) {
+    :global(h2),
+    :global(h2 a) {
       font-size: calc(var(--summary-header-font-size) * 0.8);
     }
 
     // H3-H6 looks the same
     :global(h3),
+    :global(h3 a),
     :global(h4),
+    :global(h4 a),
     :global(h5),
-    :global(h6) {
+    :global(h5 a),
+    :global(h6),
+    :global(h6 a) {
       @include fonts.h5;
       font-size: var(--font-size-standard);
       font-weight: var(--font-weight-bold);


### PR DESCRIPTION
# Motivation
Markdown headings that wrap a link were losing their heading styles, breaking visual hierarchy (see [report](https://dfinity.slack.com/archives/C01SBGL2AQL/p1755846244950189)).

# Changes
- Ensure heading styles apply even when the heading text is wrapped in an `<a>` tag.

# Tests
- Manually verified H1–H6 with and without nested links.

| Before | After |
|--------|--------|
| <img width="923" height="412" alt="image" src="https://github.com/user-attachments/assets/357e1b94-d7a5-4074-aa8c-4637d736f478" /> | <img width="922" height="400" alt="image" src="https://github.com/user-attachments/assets/0bebeb04-da4f-4ce6-89f7-8d2b3ba74c21" /> | 

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
