### PR TITLE
chore(table sorting): change naming of token sort chip

### DIFF
--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -69,7 +69,6 @@
       templateColumns: ["1fr"],
       comparator: $authSignedInStore ? compareByStake : undefined,
     },
-
     ...($ENABLE_APY_PORTFOLIO
       ? [
           {
@@ -125,6 +124,7 @@
       alignment: "left",
       templateColumns: ["2fr"],
       comparator: $authSignedInStore ? compareByProject : undefined,
+      overrideSortLabel: $i18n.tokens.token_name,
     },
     ...commonColumns,
   ]);
@@ -138,6 +138,7 @@
       alignment: "left",
       templateColumns: ["2fr"],
       comparator: $authSignedInStore ? compareByProject : undefined,
+      overrideSortLabel: $i18n.tokens.token_name,
     },
     ...commonColumns,
   ]);

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -43,6 +43,7 @@
       alignment: "left",
       templateColumns: ["1fr"],
       comparator: enableSorting ? compareTokensByProject : undefined,
+      overrideSortLabel: $i18n.tokens.token_name,
     },
     {
       id: "balance",

--- a/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableSortControl.svelte
@@ -23,9 +23,9 @@
   let chips: ChipGroupItem[] = [];
   $: chips = columns
     .filter(({ comparator }) => nonNullish(comparator))
-    .map(({ id, title }) => ({
+    .map(({ id, title, overrideSortLabel }) => ({
       id: id ?? title,
-      label: title,
+      label: overrideSortLabel ?? title,
       selected: order[0]?.columnId === id,
     }));
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1255,6 +1255,7 @@
     "status_in_progress_detailed": "Checking for new transactions."
   },
   "tokens": {
+    "token_name": "Token Name",
     "projects_header": "Projects",
     "projects_header_icp": "ICP Tokens",
     "projects_header_icp_subtitle": "Native utility token of the Internet Computer",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1324,6 +1324,7 @@ interface I18nSync {
 }
 
 interface I18nTokens {
+  token_name: string;
   projects_header: string;
   projects_header_icp: string;
   projects_header_icp_subtitle: string;

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -27,6 +27,7 @@ export interface ResponsiveTableColumn<
   alignment: ColumnAlignment;
   templateColumns: TemplateItem[];
   comparator?: Comparator<RowDataType>;
+  overrideSortLabel?: string;
 }
 
 export type ResponsiveTableOrder<ColumnIdType = string> = Array<{

--- a/frontend/src/tests/lib/components/tokens/TokensTable.svelte.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.svelte.spec.ts
@@ -657,7 +657,7 @@ describe("TokensTable", () => {
 
       expect(await po.getOpenSettingsButtonPo().isPresent()).toBe(true);
       await po.openSettings();
-      await po.sortFromSettingsByLabel("Projects");
+      await po.sortFromSettingsByLabel("Token Name");
       expect(get(tokensTableOrderStore)).toEqual([
         {
           columnId: "title",


### PR DESCRIPTION
# Motivation

Align the sort label name of the tokens column.

# Changes

Provided a way to override the label.

# Tests

Updated tests.

# Todos

- [x] Accessibility (a11y) – any impact? no
- [x] Changelog – is it needed? no
