### PR TITLE
Display more ck tokens

### DIFF
--- a/frontend/src/lib/constants/ck-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/ck-canister-ids.constants.ts
@@ -2,84 +2,84 @@ import type { DefaultIcrcCanisters } from "$lib/stores/default-icrc-canisters.st
 import { Principal } from "@dfinity/principal";
 
 // ckEURC
-export const CKEURC_LEDGER_CANISTER_ID = "pe5t5-diaaa-aaaar-qahwa-cai";
-export const CKEURC_INDEX_CANISTER_ID = "pd4vj-oqaaa-aaaar-qahwq-cai";
+const CKEURC_LEDGER_CANISTER_ID_TEXT = "pe5t5-diaaa-aaaar-qahwa-cai";
+const CKEURC_INDEX_CANISTER_ID_TEXT = "pd4vj-oqaaa-aaaar-qahwq-cai";
 
 // ckUNI
-export const CKUNI_LEDGER_CANISTER_ID = "ilzky-ayaaa-aaaar-qahha-cai";
-export const CKUNI_INDEX_CANISTER_ID = "imymm-naaaa-aaaar-qahhq-cai";
+const CKUNI_LEDGER_CANISTER_ID_TEXT = "ilzky-ayaaa-aaaar-qahha-cai";
+const CKUNI_INDEX_CANISTER_ID_TEXT = "imymm-naaaa-aaaar-qahhq-cai";
 
 // ckWBTC
-export const CKWBTC_LEDGER_CANISTER_ID = "bptq2-faaaa-aaaar-qagxq-cai";
-export const CKWBTC_INDEX_CANISTER_ID = "dso6s-wiaaa-aaaar-qagya-cai";
+const CKWBTC_LEDGER_CANISTER_ID_TEXT = "bptq2-faaaa-aaaar-qagxq-cai";
+const CKWBTC_INDEX_CANISTER_ID_TEXT = "dso6s-wiaaa-aaaar-qagya-cai";
 
 // ckLINK
-export const CKLINK_LEDGER_CANISTER_ID = "g4tto-rqaaa-aaaar-qageq-cai";
-export const CKLINK_INDEX_CANISTER_ID = "gvqys-hyaaa-aaaar-qagfa-cai";
+const CKLINK_LEDGER_CANISTER_ID_TEXT = "g4tto-rqaaa-aaaar-qageq-cai";
+const CKLINK_INDEX_CANISTER_ID_TEXT = "gvqys-hyaaa-aaaar-qagfa-cai";
 
 // ckXAUT
-export const CKXAUT_LEDGER_CANISTER_ID = "nza5v-qaaaa-aaaar-qahzq-cai";
-export const CKXAUT_INDEX_CANISTER_ID = "nmhmy-riaaa-aaaar-qah2a-cai";
+const CKXAUT_LEDGER_CANISTER_ID_TEXT = "nza5v-qaaaa-aaaar-qahzq-cai";
+const CKXAUT_INDEX_CANISTER_ID_TEXT = "nmhmy-riaaa-aaaar-qah2a-cai";
 
 // ckPEPE
-export const CKPEPE_LEDGER_CANISTER_ID = "etik7-oiaaa-aaaar-qagia-cai";
-export const CKPEPE_INDEX_CANISTER_ID = "eujml-dqaaa-aaaar-qagiq-cai";
+const CKPEPE_LEDGER_CANISTER_ID_TEXT = "etik7-oiaaa-aaaar-qagia-cai";
+const CKPEPE_INDEX_CANISTER_ID_TEXT = "eujml-dqaaa-aaaar-qagiq-cai";
 
 // ckWSTETH
-export const CKWSTETH_LEDGER_CANISTER_ID = "j2tuh-yqaaa-aaaar-qahcq-cai";
-export const CKWSTETH_INDEX_CANISTER_ID = "jtq73-oyaaa-aaaar-qahda-cai";
+const CKWSTETH_LEDGER_CANISTER_ID_TEXT = "j2tuh-yqaaa-aaaar-qahcq-cai";
+const CKWSTETH_INDEX_CANISTER_ID_TEXT = "jtq73-oyaaa-aaaar-qahda-cai";
 
 // ckSHIB
-export const CKSHIB_LEDGER_CANISTER_ID = "fxffn-xiaaa-aaaar-qagoa-cai";
-export const CKSHIB_INDEX_CANISTER_ID = "fqedz-2qaaa-aaaar-qagoq-cai";
+const CKSHIB_LEDGER_CANISTER_ID_TEXT = "fxffn-xiaaa-aaaar-qagoa-cai";
+const CKSHIB_INDEX_CANISTER_ID_TEXT = "fqedz-2qaaa-aaaar-qagoq-cai";
 
 // ckUSDT
-export const CKUSDT_LEDGER_CANISTER_ID = "cngnf-vqaaa-aaaar-qag4q-cai";
-export const CKUSDT_INDEX_CANISTER_ID = "cefgz-dyaaa-aaaar-qag5a-cai";
+const CKUSDT_LEDGER_CANISTER_ID_TEXT = "cngnf-vqaaa-aaaar-qag4q-cai";
+const CKUSDT_INDEX_CANISTER_ID_TEXT = "cefgz-dyaaa-aaaar-qag5a-cai";
 
 // ckOCT
-export const CKOCT_LEDGER_CANISTER_ID = "ebo5g-cyaaa-aaaar-qagla-cai";
-export const CKOCT_INDEX_CANISTER_ID = "egp3s-paaaa-aaaar-qaglq-cai";
+const CKOCT_LEDGER_CANISTER_ID_TEXT = "ebo5g-cyaaa-aaaar-qagla-cai";
+const CKOCT_INDEX_CANISTER_ID_TEXT = "egp3s-paaaa-aaaar-qaglq-cai";
 
 export const allCkTokens: DefaultIcrcCanisters[] = [
   {
-    ledgerCanisterId: Principal.fromText(CKEURC_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKEURC_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKEURC_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKEURC_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKUNI_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKUNI_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKUNI_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKUNI_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKWBTC_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKWBTC_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKWBTC_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKWBTC_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKLINK_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKLINK_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKLINK_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKLINK_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKXAUT_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKXAUT_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKXAUT_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKXAUT_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKPEPE_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKPEPE_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKPEPE_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKPEPE_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKWSTETH_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKWSTETH_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKWSTETH_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKWSTETH_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKSHIB_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKSHIB_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKSHIB_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKSHIB_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKUSDT_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKUSDT_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKUSDT_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKUSDT_INDEX_CANISTER_ID_TEXT),
   },
   {
-    ledgerCanisterId: Principal.fromText(CKOCT_LEDGER_CANISTER_ID),
-    indexCanisterId: Principal.fromText(CKOCT_INDEX_CANISTER_ID),
+    ledgerCanisterId: Principal.fromText(CKOCT_LEDGER_CANISTER_ID_TEXT),
+    indexCanisterId: Principal.fromText(CKOCT_INDEX_CANISTER_ID_TEXT),
   },
 ];

--- a/frontend/src/lib/constants/ck-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/ck-canister-ids.constants.ts
@@ -1,0 +1,85 @@
+import type { DefaultIcrcCanisters } from "$lib/stores/default-icrc-canisters.store";
+import { Principal } from "@dfinity/principal";
+
+// ckEURC
+export const CKEURC_LEDGER_CANISTER_ID = "pe5t5-diaaa-aaaar-qahwa-cai";
+export const CKEURC_INDEX_CANISTER_ID = "pd4vj-oqaaa-aaaar-qahwq-cai";
+
+// ckUNI
+export const CKUNI_LEDGER_CANISTER_ID = "ilzky-ayaaa-aaaar-qahha-cai";
+export const CKUNI_INDEX_CANISTER_ID = "imymm-naaaa-aaaar-qahhq-cai";
+
+// ckWBTC
+export const CKWBTC_LEDGER_CANISTER_ID = "bptq2-faaaa-aaaar-qagxq-cai";
+export const CKWBTC_INDEX_CANISTER_ID = "dso6s-wiaaa-aaaar-qagya-cai";
+
+// ckLINK
+export const CKLINK_LEDGER_CANISTER_ID = "g4tto-rqaaa-aaaar-qageq-cai";
+export const CKLINK_INDEX_CANISTER_ID = "gvqys-hyaaa-aaaar-qagfa-cai";
+
+// ckXAUT
+export const CKXAUT_LEDGER_CANISTER_ID = "nza5v-qaaaa-aaaar-qahzq-cai";
+export const CKXAUT_INDEX_CANISTER_ID = "nmhmy-riaaa-aaaar-qah2a-cai";
+
+// ckPEPE
+export const CKPEPE_LEDGER_CANISTER_ID = "etik7-oiaaa-aaaar-qagia-cai";
+export const CKPEPE_INDEX_CANISTER_ID = "eujml-dqaaa-aaaar-qagiq-cai";
+
+// ckWSTETH
+export const CKWSTETH_LEDGER_CANISTER_ID = "j2tuh-yqaaa-aaaar-qahcq-cai";
+export const CKWSTETH_INDEX_CANISTER_ID = "jtq73-oyaaa-aaaar-qahda-cai";
+
+// ckSHIB
+export const CKSHIB_LEDGER_CANISTER_ID = "fxffn-xiaaa-aaaar-qagoa-cai";
+export const CKSHIB_INDEX_CANISTER_ID = "fqedz-2qaaa-aaaar-qagoq-cai";
+
+// ckUSDT
+export const CKUSDT_LEDGER_CANISTER_ID = "cngnf-vqaaa-aaaar-qag4q-cai";
+export const CKUSDT_INDEX_CANISTER_ID = "cefgz-dyaaa-aaaar-qag5a-cai";
+
+// ckOCT
+export const CKOCT_LEDGER_CANISTER_ID = "ebo5g-cyaaa-aaaar-qagla-cai";
+export const CKOCT_INDEX_CANISTER_ID = "egp3s-paaaa-aaaar-qaglq-cai";
+
+export const allCkTokens: DefaultIcrcCanisters[] = [
+  {
+    ledgerCanisterId: Principal.fromText(CKEURC_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKEURC_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKUNI_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKUNI_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKWBTC_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKWBTC_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKLINK_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKLINK_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKXAUT_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKXAUT_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKPEPE_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKPEPE_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKWSTETH_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKWSTETH_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKSHIB_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKSHIB_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKUSDT_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKUSDT_INDEX_CANISTER_ID),
+  },
+  {
+    ledgerCanisterId: Principal.fromText(CKOCT_LEDGER_CANISTER_ID),
+    indexCanisterId: Principal.fromText(CKOCT_INDEX_CANISTER_ID),
+  },
+];

--- a/frontend/src/lib/constants/tokens.constants.ts
+++ b/frontend/src/lib/constants/tokens.constants.ts
@@ -1,5 +1,12 @@
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import { allCkTokens } from "$lib/constants/ck-canister-ids.constants";
+import {
+  CKBTC_UNIVERSE_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKETH_UNIVERSE_CANISTER_ID,
+  CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import type { TokensStoreUniverseData } from "$lib/stores/tokens.store";
@@ -21,4 +28,8 @@ export const IMPORTANT_CK_TOKEN_IDS = [
   CKBTC_UNIVERSE_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
   CKUSDC_UNIVERSE_CANISTER_ID,
+  ...allCkTokens.map(({ ledgerCanisterId }) => ledgerCanisterId),
+  // test ck tokens
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+  CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
 ];

--- a/frontend/src/lib/services/icrc-canisters.services.ts
+++ b/frontend/src/lib/services/icrc-canisters.services.ts
@@ -1,3 +1,4 @@
+import { allCkTokens } from "$lib/constants/ck-canister-ids.constants";
 import {
   CKETHSEPOLIA_INDEX_CANISTER_ID,
   CKETHSEPOLIA_LEDGER_CANISTER_ID,
@@ -36,6 +37,14 @@ export const loadIcrcCanisters = async () => {
     defaultIcrcCanistersStore.setCanisters({
       ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
       indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
+    });
+  }
+  if (isNullish(storeData[allCkTokens[0].ledgerCanisterId.toText()])) {
+    allCkTokens.forEach(({ ledgerCanisterId, indexCanisterId }) => {
+      defaultIcrcCanistersStore.setCanisters({
+        ledgerCanisterId,
+        indexCanisterId,
+      });
     });
   }
 };

--- a/frontend/src/tests/lib/services/icrc-canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-canisters.services.spec.ts
@@ -1,9 +1,10 @@
+import { allCkTokens } from "$lib/constants/ck-canister-ids.constants";
 import {
+  CKETH_INDEX_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
   CKETHSEPOLIA_INDEX_CANISTER_ID,
   CKETHSEPOLIA_LEDGER_CANISTER_ID,
   CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
-  CKETH_INDEX_CANISTER_ID,
-  CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import {
   CKUSDC_INDEX_CANISTER_ID,
@@ -43,26 +44,29 @@ describe("icrc-canisters.services", () => {
             ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
             indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
           },
+          ...allCkTokens.reduce(
+            (acc, { ledgerCanisterId, indexCanisterId }) => {
+              acc[ledgerCanisterId.toText()] = {
+                ledgerCanisterId,
+                indexCanisterId,
+              };
+              return acc;
+            },
+            {}
+          ),
         });
       });
 
       it("should not load canisters if already present", async () => {
         vi.spyOn(defaultIcrcCanistersStore, "setCanisters");
-        defaultIcrcCanistersStore.setCanisters({
-          ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
-          indexCanisterId: CKETH_INDEX_CANISTER_ID,
-        });
-        defaultIcrcCanistersStore.setCanisters({
-          ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
-          indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
-        });
-        defaultIcrcCanistersStore.setCanisters({
-          ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
-          indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
-        });
-        expect(defaultIcrcCanistersStore.setCanisters).toHaveBeenCalledTimes(3);
         await loadIcrcCanisters();
-        expect(defaultIcrcCanistersStore.setCanisters).toHaveBeenCalledTimes(3);
+        expect(defaultIcrcCanistersStore.setCanisters).toHaveBeenCalledTimes(
+          13
+        );
+        await loadIcrcCanisters();
+        expect(defaultIcrcCanistersStore.setCanisters).toHaveBeenCalledTimes(
+          13
+        );
       });
     });
 
@@ -80,6 +84,16 @@ describe("icrc-canisters.services", () => {
             ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
             indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
           },
+          ...allCkTokens.reduce(
+            (acc, { ledgerCanisterId, indexCanisterId }) => {
+              acc[ledgerCanisterId.toText()] = {
+                ledgerCanisterId,
+                indexCanisterId,
+              };
+              return acc;
+            },
+            {}
+          ),
         });
       });
     });

--- a/frontend/src/tests/lib/utils/icrc-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-tokens.utils.spec.ts
@@ -1,4 +1,5 @@
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { allCkTokens } from "$lib/constants/ck-canister-ids.constants";
 import {
   CKBTC_LEDGER_CANISTER_ID,
   CKTESTBTC_LEDGER_CANISTER_ID,
@@ -80,6 +81,14 @@ describe("ICRC tokens utils", () => {
       expect(
         isImportantCkToken({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID })
       ).toEqual(true);
+      expect(
+        isImportantCkToken({ ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID })
+      ).toEqual(true);
+      expect(
+        isImportantCkToken({
+          ledgerCanisterId: allCkTokens[0].ledgerCanisterId,
+        })
+      ).toEqual(true);
     });
 
     it("should return false for not important token ledger canisters", () => {
@@ -89,9 +98,6 @@ describe("ICRC tokens utils", () => {
       expect(isImportantCkToken({ ledgerCanisterId: OWN_CANISTER_ID })).toEqual(
         false
       );
-      expect(
-        isImportantCkToken({ ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID })
-      ).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

To make the nns-dapp more versatile, this update adds support for additional ckTokens.

# Changes

- Added more ckTokens (canister IDs were sourced from the orchestrator API — https://dashboard.internetcomputer.org/canister/vxkom-oyaaa-aaaar-qafda-cai#get_orchestrator_info)

# Tests

- Updated

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
