### PR TITLE
style(cards): fix title layout and remove extra character

### DIFF
--- a/frontend/src/lib/components/canisters/CanisterCardSubTitle.svelte
+++ b/frontend/src/lib/components/canisters/CanisterCardSubTitle.svelte
@@ -3,11 +3,12 @@
   import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
   import { mapCanisterDetails } from "$lib/utils/canisters.utils";
 
-  export let canister: CanisterDetails;
+  type Props = {
+    canister: CanisterDetails;
+  };
+  const { canister }: Props = $props();
 
-  let canisterId: string;
-  let validName: boolean;
-  $: ({ canisterId, validName } = mapCanisterDetails(canister));
+  const { canisterId, validName } = $derived(mapCanisterDetails(canister));
 </script>
 
 {#if validName}

--- a/frontend/src/lib/components/canisters/CanisterCardTitle.svelte
+++ b/frontend/src/lib/components/canisters/CanisterCardTitle.svelte
@@ -33,8 +33,14 @@
   }
 
   .title {
-    white-space: pre-wrap;
-    display: initial;
+    display: flex;
+    align-items: center;
     text-align: left;
+
+    span {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 </style>

--- a/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
@@ -113,7 +113,6 @@
   {#snippet title()}<span data-tid="create-canister-modal-title"
       >{currentStep?.title ?? $i18n.canisters.add_canister}</span
     >{/snippet}
-  >
   <svelte:fragment>
     {#if currentStep?.name === "SelectData"}
       <div class="from">


### PR DESCRIPTION
# Motivation

Fix visual issues with the Canister cards.

<img width="912" height="418" alt="Screenshot 2025-08-27 at 08 18 16" src="https://github.com/user-attachments/assets/9bc7d81e-b5c6-416e-b557-5e234ccd4eaf" />

# Changes

- Remove trailing `>`
- Card title should display `Copy` icon in the same line.

# Tests

- Visually tested
- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
