### PR TITLE
fix(sns_aggregator): ensure last page exists

### DIFF
--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -167,7 +167,7 @@ impl State {
             STATE.with(|state| {
                 if state.stable.borrow().sns_cache.borrow().max_index < index {
                     state.stable.borrow().sns_cache.borrow_mut().max_index = index;
-                    Self::ensure_last_page_is_not_full_v1(state);
+                    Self::ensure_last_page_exists_and_is_not_full_v1(state);
                 }
             });
         }
@@ -270,10 +270,11 @@ impl State {
             bytes: json_data.into_bytes(),
         }
     }
+    /// If the last page does not exist, create an empty page.
     /// If the last page is full, create an empty next page.
-    fn ensure_last_page_is_not_full_v1(state: &State) {
+    fn ensure_last_page_exists_and_is_not_full_v1(state: &State) {
         let (last_page, last_page_entries) = {
-            let num_entries = state.stable.borrow().sns_cache.borrow().max_index + 1;
+            let num_entries = state.stable.borrow().sns_cache.borrow().upstream_data.len() as u64;
             (num_entries / State::PAGE_SIZE, num_entries % State::PAGE_SIZE)
         };
         if last_page_entries == 0 {
@@ -286,8 +287,8 @@ impl State {
 
     /// Commands to call on `init` or `post_upgrade`.
     pub fn setup() {
-        // Establish the invariant that the last page is not full.
-        STATE.with(Self::ensure_last_page_is_not_full_v1);
+        // Establish the invariant that the last page exists and is not full.
+        STATE.with(Self::ensure_last_page_exists_and_is_not_full_v1);
     }
 }
 


### PR DESCRIPTION
# Motivation

This PR fixes the following issue: if there's no SNS (e.g., in local deployment), then there's no page at the path `/v1/sns/list/page/0/slow.json` listing SNS projects. Consequently, the NNS dapp fails to pull the list of all deployed SNS and keeps displaying an error.

# Changes

This PR fixes how the number of deployed SNS is determined: instead of using `max_index + 1` it uses `upstream_data.len()` which is equivalent if there's at least one SNS (e.g., in production) and also correct in case of no SNS (e.g., in local deployment).

# Tests

This PR has been tested manually by deploying the SNS aggregator along with the NNS dapp and confirming that the NNS dapp can successfully load the list of all deployed SNS.

# Todos

- [x] Accessibility (a11y) –  no impact.
- [x] Changelog – no updates needed.
