### PR TITLE
fix(deps): update gix for markdown SVG rendering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "8.0.0-next-2025-08-18",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-8.0.0-next-2025-08-18.tgz",
-      "integrity": "sha512-1VNFdBlvObUuskMYKH5TMyMlZ04apfQi7e2rLnYg+KjXiTiixUBiv7wygJHO4sfSXguhv58RIDdxrDRpnxKDKA==",
+      "version": "8.0.0-next-2025-08-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-8.0.0-next-2025-08-29.tgz",
+      "integrity": "sha512-m9919h/sPk8Xx1iOFgSTkp9DhFD18TqPk5nMQ5kjwy7S7+ok/ugoE1Y/pL4JnPShjWViU91gi6Yp4uX3C5MFyw==",
       "license": "Apache-2.0",
       "dependencies": {
         "decimal.js": "^10.6.0",


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/gix-components/pull/707 fixed an issue on how `svg` are render as part of code blocks in the Markdown component.

This issue has arisen with the II proposal that was rendered incorrectly in the nns-dapp, causing problems when attempting to validate the payload.
* https://dashboard.internetcomputer.org/proposal/138188
* https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=138188

This PR fixes it as shown in the following screenshot:

<img width="809" height="633" alt="Screenshot 2025-08-29 at 11 25 39" src="https://github.com/user-attachments/assets/37bf5cad-b56a-4a36-8e3e-65f4d4b80cc9" />

[NNS1-4082](https://dfinity.atlassian.net/browse/NNS1-4082)

# Changes

- Bump gix to latest.

# Tests

- Validate the payload with the new rendering output and getting `1c18791e243e9c00cfb124320df7b11a216660cf9f9616a39e8565f62f3a2236`

[NNS1-4082]: https://dfinity.atlassian.net/browse/NNS1-4082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ