### PR TITLE
feat(config): disable CK tokens through feature flag

### DIFF
--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -15,6 +15,7 @@ export const PLAUSIBLE_DOMAIN = envVars.plausibleDomain;
 
 export interface FeatureFlags<T> {
   ENABLE_CKTESTBTC: T;
+  DISABLE_CKTOKENS: T;
   DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING: T;
   ENABLE_DISBURSE_MATURITY: T;
   // Used only in tests and set up in jest-setup.ts
@@ -28,6 +29,7 @@ export interface FeatureFlags<T> {
 }
 export const defaultFeatureFlagValues: FeatureFlags<boolean> = {
   ENABLE_CKTESTBTC: false,
+  DISABLE_CKTOKENS: false,
   DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING: false,
   ENABLE_DISBURSE_MATURITY: false,
   TEST_FLAG_EDITABLE: false,

--- a/frontend/src/lib/derived/ckbtc-universes.derived.ts
+++ b/frontend/src/lib/derived/ckbtc-universes.derived.ts
@@ -1,17 +1,34 @@
 import { ckBTCUniverseStore } from "$lib/derived/ckbtc-universe.derived";
 import { ckTESTBTCUniverseStore } from "$lib/derived/cktestbtc-universe.derived";
-import { ENABLE_CKTESTBTC } from "$lib/stores/feature-flags.store";
+import {
+  DISABLE_CKTOKENS,
+  ENABLE_CKTESTBTC,
+} from "$lib/stores/feature-flags.store";
 import type { Universe } from "$lib/types/universe";
 import { derived, type Readable } from "svelte/store";
 
 export const ckBTCUniversesStore = derived<
-  [Readable<Universe>, Readable<Universe>, Readable<boolean>],
+  [
+    Readable<Universe>,
+    Readable<Universe>,
+    Readable<boolean>,
+    Readable<boolean>,
+  ],
   Universe[]
 >(
-  [ckBTCUniverseStore, ckTESTBTCUniverseStore, ENABLE_CKTESTBTC],
-  ([ckBTCUniverse, ckTESTBTCUniverse, $ENABLE_CKTESTBTC]: [
+  [
+    ckBTCUniverseStore,
+    ckTESTBTCUniverseStore,
+    ENABLE_CKTESTBTC,
+    DISABLE_CKTOKENS,
+  ],
+  ([ckBTCUniverse, ckTESTBTCUniverse, $ENABLE_CKTESTBTC, $DISABLE_CKTOKENS]: [
     Universe,
     Universe,
     boolean,
-  ]) => [ckBTCUniverse, ...($ENABLE_CKTESTBTC ? [ckTESTBTCUniverse] : [])]
+    boolean,
+  ]) =>
+    $DISABLE_CKTOKENS
+      ? []
+      : [ckBTCUniverse, ...($ENABLE_CKTESTBTC ? [ckTESTBTCUniverse] : [])]
 );

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -3,11 +3,18 @@ import {
   CKTESTBTC_LEDGER_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { loadIcrcToken } from "$lib/services/icrc-accounts.services";
-import { ENABLE_CKTESTBTC } from "$lib/stores/feature-flags.store";
+import {
+  DISABLE_CKTOKENS,
+  ENABLE_CKTESTBTC,
+} from "$lib/stores/feature-flags.store";
 import { get } from "svelte/store";
 
 export const loadCkBTCTokens = async () => {
   const enableCkBTCTest = get(ENABLE_CKTESTBTC);
+  const disableCkTokens = get(DISABLE_CKTOKENS);
+
+  if (disableCkTokens) return undefined;
+
   return Promise.all([
     loadIcrcToken({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID }),
     enableCkBTCTest

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -13,7 +13,7 @@ export const loadCkBTCTokens = async () => {
   const enableCkBTCTest = get(ENABLE_CKTESTBTC);
   const disableCkTokens = get(DISABLE_CKTOKENS);
 
-  if (disableCkTokens) return undefined;
+  if (disableCkTokens) return;
 
   return Promise.all([
     loadIcrcToken({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID }),

--- a/frontend/src/lib/services/icrc-canisters.services.ts
+++ b/frontend/src/lib/services/icrc-canisters.services.ts
@@ -11,21 +11,30 @@ import {
 } from "$lib/constants/ckusdc-canister-ids.constants";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
 import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
-import { ENABLE_CKTESTBTC } from "$lib/stores/feature-flags.store";
+import {
+  DISABLE_CKTOKENS,
+  ENABLE_CKTESTBTC,
+} from "$lib/stores/feature-flags.store";
 import { isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 export const loadIcrcCanisters = async () => {
   const storeData = get(defaultIcrcCanistersStore);
+  const disableCkTokens = get(DISABLE_CKTOKENS);
+
   // To avoid rerendering the UI and possibly triggering new requests
   // We don't change the store if it's already filled.
-  if (isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])) {
+  if (
+    !disableCkTokens &&
+    isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])
+  ) {
     defaultIcrcCanistersStore.setCanisters({
       ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
       indexCanisterId: CKETH_INDEX_CANISTER_ID,
     });
   }
   if (
+    !disableCkTokens &&
     get(ENABLE_CKTESTBTC) &&
     isNullish(storeData[CKETHSEPOLIA_LEDGER_CANISTER_ID.toText()])
   ) {
@@ -34,7 +43,10 @@ export const loadIcrcCanisters = async () => {
       indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
     });
   }
-  if (isNullish(storeData[CKUSDC_LEDGER_CANISTER_ID.toText()])) {
+  if (
+    !disableCkTokens &&
+    isNullish(storeData[CKUSDC_LEDGER_CANISTER_ID.toText()])
+  ) {
     defaultIcrcCanistersStore.setCanisters({
       ledgerCanisterId: CKUSDC_LEDGER_CANISTER_ID,
       indexCanisterId: CKUSDC_INDEX_CANISTER_ID,
@@ -42,6 +54,7 @@ export const loadIcrcCanisters = async () => {
   }
   // Skip for test environment, because these canisters do not exist there.
   if (
+    !disableCkTokens &&
     !IS_TESTNET &&
     isNullish(storeData[allCkTokens[0].ledgerCanisterId.toText()])
   ) {

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -32,6 +32,7 @@ const assertEditableFeatureFlag = (flag: FeatureKey) => {
 export const EDITABLE_FEATURE_FLAGS: Array<FeatureKey> = [
   "TEST_FLAG_EDITABLE",
   "ENABLE_CKTESTBTC",
+  "DISABLE_CKTOKENS",
   "DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING",
   "ENABLE_DISBURSE_MATURITY",
   "ENABLE_SNS_TOPICS",
@@ -151,6 +152,7 @@ const featureFlagsStore = initFeatureFlagsStore();
 
 export const {
   ENABLE_CKTESTBTC,
+  DISABLE_CKTOKENS,
   DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING,
   ENABLE_DISBURSE_MATURITY,
   // Used only in tests only

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -159,6 +159,7 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
     dfxNetwork: "testnet",
     featureFlags: JSON.stringify({
       ENABLE_CKTESTBTC: true,
+      DISABLE_CKTOKENS: false,
       ENABLE_DISBURSE_MATURITY: false,
       DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING: false,
       TEST_FLAG_EDITABLE: true,


### PR DESCRIPTION
# Motivation

The nns-dapp currently shows many errors when any of the CK canisters are unavailable. This behavior prevents the use of the latest version of the nns-dapp in the [monorepo dependencies](https://github.com/dfinity/ic/blob/c04b07cb230cb0c2efd19b8aad97f31aa42ecf79/MODULE.bazel#L567-L583).

More info [here](https://dfinity.slack.com/archives/C01S03NBM7S/p1755184658526049)

# Changes

- New feature flag to disable loading CK canisters.
- Skip loading CK canisters if FF is true.

# Tests

- Manually tested locally with a version of snsdemo that does not install CK canisters.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
