### PR TITLE
fix(ui): remove extra character from a Project's page details

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Remove extra character from a Project's page details.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -38,7 +38,7 @@
         >{/snippet}
     </KeyValuePair>
     <KeyValuePair>
-      {#snippet key()}>{$i18n.sns_project_detail.token_symbol}{/snippet}
+      {#snippet key()}{$i18n.sns_project_detail.token_symbol}{/snippet}
       {#snippet value()}
         <span class="value" data-tid="sns-project-detail-info-token-symbol"
           >{token.symbol}</span


### PR DESCRIPTION
# Motivation

#7169 introduced a minor bug in the Projects page by displaying an `<` symbol before the Token Value label.

| Before | After |
|--------|--------|
| <img width="651" height="410" alt="Screenshot 2025-09-01 at 17 28 04" src="https://github.com/user-attachments/assets/a0b1d0fa-bba4-4d3f-9b8e-711a1c02ac69" /> | <img width="626" height="399" alt="Screenshot 2025-09-01 at 17 28 51" src="https://github.com/user-attachments/assets/d686a609-a9ba-4212-affe-cff4e50e8bc5" /> |


# Changes

- Remove symbol

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
