### PR TITLE
Update ckToken sorting

### DIFF
--- a/frontend/src/lib/constants/ck-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/ck-canister-ids.constants.ts
@@ -22,7 +22,7 @@ const CKXAUT_LEDGER_CANISTER_ID_TEXT = "nza5v-qaaaa-aaaar-qahzq-cai";
 const CKXAUT_INDEX_CANISTER_ID_TEXT = "nmhmy-riaaa-aaaar-qah2a-cai";
 
 // ckPEPE
-const CKPEPE_LEDGER_CANISTER_ID_TEXT = "etik7-oiaaa-aaaar-qagia-cai";
+export const CKPEPE_LEDGER_CANISTER_ID_TEXT = "etik7-oiaaa-aaaar-qagia-cai";
 const CKPEPE_INDEX_CANISTER_ID_TEXT = "eujml-dqaaa-aaaar-qagiq-cai";
 
 // ckWSTETH
@@ -34,11 +34,11 @@ const CKSHIB_LEDGER_CANISTER_ID_TEXT = "fxffn-xiaaa-aaaar-qagoa-cai";
 const CKSHIB_INDEX_CANISTER_ID_TEXT = "fqedz-2qaaa-aaaar-qagoq-cai";
 
 // ckUSDT
-const CKUSDT_LEDGER_CANISTER_ID_TEXT = "cngnf-vqaaa-aaaar-qag4q-cai";
+export const CKUSDT_LEDGER_CANISTER_ID_TEXT = "cngnf-vqaaa-aaaar-qag4q-cai";
 const CKUSDT_INDEX_CANISTER_ID_TEXT = "cefgz-dyaaa-aaaar-qag5a-cai";
 
 // ckOCT
-const CKOCT_LEDGER_CANISTER_ID_TEXT = "ebo5g-cyaaa-aaaar-qagla-cai";
+export const CKOCT_LEDGER_CANISTER_ID_TEXT = "ebo5g-cyaaa-aaaar-qagla-cai";
 const CKOCT_INDEX_CANISTER_ID_TEXT = "egp3s-paaaa-aaaar-qaglq-cai";
 
 export const allCkTokens: DefaultIcrcCanisters[] = [

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -9,7 +9,10 @@
   import { ENABLE_NEW_TABLES } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import type { UserToken } from "$lib/types/tokens-page";
-  import { filterTokensByType } from "$lib/utils/tokens-table.utils";
+  import {
+    compareCkTokensByDefault,
+    filterTokensByType,
+  } from "$lib/utils/tokens-table.utils";
   import { IconAccountsPage, PageBanner } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
 
@@ -50,7 +53,7 @@
         userTokensData={filterTokensByType({
           tokens: userTokensData,
           type: "ck",
-        })}
+        }).sort(compareCkTokensByDefault)}
         firstColumnHeader={$i18n.tokens.projects_header_ck}
         subtitle={$i18n.tokens.projects_header_ck_subtitle}
       />

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -1,4 +1,8 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { CKUSDT_LEDGER_CANISTER_ID_TEXT } from "$lib/constants/ck-canister-ids.constants";
+import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { IMPORTANT_CK_TOKEN_IDS } from "$lib/constants/tokens.constants";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import type { UserToken } from "$lib/types/tokens-page";
@@ -18,6 +22,22 @@ export const isIcpToken = (token: UserToken) =>
   token.universeId.toText() === OWN_CANISTER_ID_TEXT;
 
 export const compareTokensIcpFirst = createDescendingComparator(isIcpToken);
+export const compareTokensCKBTCFirst = createDescendingComparator(
+  (token: UserToken) =>
+    token.universeId.toText() === CKBTC_UNIVERSE_CANISTER_ID.toText()
+);
+export const compareTokensCKUSDTFirst = createDescendingComparator(
+  (token: UserToken) =>
+    token.universeId.toText() === CKUSDT_LEDGER_CANISTER_ID_TEXT
+);
+export const compareTokensCKUSDCFirst = createDescendingComparator(
+  (token: UserToken) =>
+    token.universeId.toText() === CKUSDC_UNIVERSE_CANISTER_ID.toText()
+);
+export const compareTokensCKETHFirst = createDescendingComparator(
+  (token: UserToken) =>
+    token.universeId.toText() === CKETH_UNIVERSE_CANISTER_ID.toText()
+);
 
 export const compareFailedTokensLast = createAscendingComparator(
   (token: UserToken) => isUserTokenFailed(token)
@@ -55,8 +75,13 @@ export const compareTokensByImportance = createDescendingComparator(
   (token: UserToken) => ImportantCkTokenIds.indexOf(token.universeId.toText())
 );
 
+export const compareTokensImportantFirst = createDescendingComparator(
+  (token: UserToken) =>
+    ImportantCkTokenIds.indexOf(token.universeId.toText()) >= 0
+);
+
 export const compareTokensAlphabetically = createAscendingComparator(
-  ({ title }: UserToken) => title.toLowerCase()
+  (token: UserToken) => token.title?.toLowerCase() ?? ""
 );
 
 export const compareTokensByUsdBalance = createDescendingComparator(
@@ -74,6 +99,14 @@ export const compareTokensByProject = mergeComparators([
   compareTokensAlphabetically,
 ]);
 
+export const compareCkTokensByDefault = mergeComparators([
+  compareTokensCKBTCFirst,
+  compareTokensCKUSDTFirst,
+  compareTokensCKUSDCFirst,
+  compareTokensCKETHFirst,
+  compareTokensAlphabetically,
+]);
+
 // This is used when clicking the "Balance" header, but in addition to sorting
 // by balance, it has a number of tie breakers.
 // Note that it tries to sort by USD balance but also sorts tokens with balance
@@ -87,9 +120,14 @@ export const compareTokensByBalance = ({
     compareTokensIcpFirst,
     compareTokensByUsdBalance,
     compareTokenHasBalance,
-    compareTokensByImportance,
+    compareTokensImportantFirst,
+    compareTokensCKBTCFirst,
+    compareTokensCKUSDTFirst,
+    compareTokensCKUSDCFirst,
+    compareTokensCKETHFirst,
     compareTokensIsImported({ importedTokenIds }),
     compareFailedTokensLast,
+    compareTokensAlphabetically,
   ]);
 
 export const compareTokensForTokensTable = ({

--- a/frontend/src/tests/lib/components/tokens/TokensTable.svelte.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.svelte.spec.ts
@@ -509,8 +509,8 @@ describe("TokensTable", () => {
 
       expect(await getProjectNames(po)).toEqual([
         "Internet Computer",
-        "B",
         "A",
+        "B",
       ]);
 
       tokensTableOrderStore.set([

--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -1,9 +1,14 @@
+import {
+  CKOCT_LEDGER_CANISTER_ID_TEXT,
+  CKPEPE_LEDGER_CANISTER_ID_TEXT,
+} from "$lib/constants/ck-canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import type { UserTokenData, UserTokenFailed } from "$lib/types/tokens-page";
 import {
+  compareCkTokensByDefault,
   compareFailedTokensLast,
   compareTokenHasBalance,
   compareTokensAlphabetically,
@@ -12,6 +17,7 @@ import {
   compareTokensByProject,
   compareTokensByUsdBalance,
   compareTokensIcpFirst,
+  compareTokensImportantFirst,
   compareTokensWithBalanceOrImportedFirst,
   filterTokensByType,
 } from "$lib/utils/tokens-table.utils";
@@ -22,6 +28,7 @@ import {
   createUserToken,
   createUserTokenLoading,
 } from "$tests/mocks/tokens-page.mock";
+import { Principal } from "@dfinity/principal";
 import { TokenAmountV2 } from "@dfinity/utils";
 
 describe("tokens-table.utils", () => {
@@ -33,6 +40,14 @@ describe("tokens-table.utils", () => {
   });
   const ckUSDCToken = createUserToken({
     universeId: CKUSDC_UNIVERSE_CANISTER_ID,
+  });
+  const ckPepeToken = createUserToken({
+    universeId: Principal.fromText(CKPEPE_LEDGER_CANISTER_ID_TEXT),
+    title: "ckPEPE",
+  });
+  const ckOctToken = createUserToken({
+    universeId: Principal.fromText(CKOCT_LEDGER_CANISTER_ID_TEXT),
+    title: "ckOCT",
   });
   const createTokenWithBalance = ({
     id,
@@ -97,6 +112,46 @@ describe("tokens-table.utils", () => {
           compareTokensByImportance
         )
       ).toEqual(expectedOrder);
+    });
+  });
+
+  describe("compareCkTokensByDefault", () => {
+    it("should sort tokens by importance", () => {
+      const expectedOrder = [
+        ckBTCToken,
+        ckUSDCToken,
+        ckETHTToken,
+        ckOctToken,
+        ckPepeToken,
+      ];
+      expect(
+        [ckOctToken, ckPepeToken, ckUSDCToken, ckETHTToken, ckBTCToken].sort(
+          compareCkTokensByDefault
+        )
+      ).toEqual(expectedOrder);
+      expect(
+        [ckPepeToken, ckBTCToken, ckETHTToken, ckOctToken, ckUSDCToken].sort(
+          compareCkTokensByDefault
+        )
+      ).toEqual(expectedOrder);
+      expect(
+        [ckETHTToken, ckBTCToken, ckUSDCToken, ckPepeToken, ckOctToken].sort(
+          compareCkTokensByDefault
+        )
+      ).toEqual(expectedOrder);
+    });
+  });
+
+  describe("compareTokensImportantFirst", () => {
+    it("should sort tokens by importance", () => {
+      const token0 = createTokenWithBalance({ id: 0, amount: 0n });
+      const expectedOrder = [ckBTCToken, token0];
+      expect([token0, ckBTCToken].sort(compareTokensImportantFirst)).toEqual(
+        expectedOrder
+      );
+      expect([ckBTCToken, token0].sort(compareTokensImportantFirst)).toEqual(
+        expectedOrder
+      );
     });
   });
 

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -275,8 +275,8 @@ describe("Tokens route", () => {
           expect(await tokensPagePo.getTokenNames()).toEqual([
             "Internet Computer",
             "ckBTC",
-            "ckETH",
             "ckUSDC",
+            "ckETH",
             "Pacman",
             "Tetris",
           ]);
@@ -289,8 +289,8 @@ describe("Tokens route", () => {
           expect(await tokensPagePo.getRowsData()).toEqual([
             { projectName: "Internet Computer", balance: "1.23 ICP" },
             { projectName: "ckBTC", balance: "4.45 ckBTC" },
-            { projectName: "ckETH", balance: "4.14 ckETH" },
             { projectName: "ckUSDC", balance: "111.00 ckUSDC" },
+            { projectName: "ckETH", balance: "4.14 ckETH" },
             { projectName: "Pacman", balance: "3.14 PCMN" },
             { projectName: "Tetris", balance: "2.22 TST" },
           ]);
@@ -593,8 +593,8 @@ describe("Tokens route", () => {
           expect(await tokensPagePo.getTokenNames()).toEqual([
             "Internet Computer",
             "ckBTC",
-            "ckETH",
             "ckUSDC",
+            "ckETH",
             "Pacman",
             "Tetris",
           ]);


### PR DESCRIPTION
# Motivation

Currently the Chain-key Tokens sorting match the minter canister output, which is effectively random. To make the list predictably order this pr apply the following logic:

### When signed-out

**First the most active** (transaction count according the dashboard)
ckBTC, ckUSDT, ckUSDC, ckETH

**The rest in alphabetical order.**

### When signed in

**First by user balance**
then same as for signed-out state.


# Changes

- Update sort utils
- Apply sorting to signed-out state.

# Tests

- Updated.

| Before | After |
|--------|--------|
| <img width="598" height="738" alt="image" src="https://github.com/user-attachments/assets/0b443b09-efca-41b4-b9a9-dcd18de30336" /> | <img width="594" height="732" alt="image" src="https://github.com/user-attachments/assets/10d4d28f-c9a1-4205-8fe1-e4d424c04944" /> | 







# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
