### PR TITLE
fix(aggregator): handle new InfoTopic extension field

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -351,9 +351,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "4.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-4.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-0/bvWIxOUjGKbjHRey3xH4R6QRyAE3SqJ3llmRjlgQJzm36rCjtni588UsfpZlqXB0wOZg3RjV/7huvtT/wptQ==",
+      "version": "4.0.1-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-4.0.1-next-2025-09-03.tgz",
+      "integrity": "sha512-ztNp6llVo75zVkmd/85DLnRR5Pj2o2zKKRdEqEr43dv6Z1rlaSadn5reD9cnl7CGdtTDzb2UFiiLxdLxmVb7RA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "6.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-6.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-8xZQWVfnit3ln0aZv58pV+E9+FvtykaskwON9p2kSKHVoo79srByHsi/j7M0YuglwAc8Jx5BfIVSYg7q/a70XQ==",
+      "version": "6.0.1-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-6.0.1-next-2025-09-03.tgz",
+      "integrity": "sha512-mxErD1lnkpdsM2/Za8rokrLYKsKW6vMzwaLX9HrtUD7u2VKKgjJdDjGGuNVKdKAWLZyEZWe6NuEv2EALG2q9OQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "7.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-VTZamnHEsUSGp+1zqdBm0aiv6l7S35Q3QN5jBynwlB3HN68bZH95n1yl7xByWvAuFTxH/zCCLAuNOWTmFkHYkg==",
+      "version": "7.0.1-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.0.1-next-2025-09-03.tgz",
+      "integrity": "sha512-/5shAPZ8gbqOabyT5kSOokb5AjkuDUJn4dtjs07AijDCzA7j8az8DvMspCSyooottaREpa8oX5Cc5xcBR99R6g==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -422,9 +422,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "5.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-leIBAgY/iDLKH8sxuYoyT2ojdo734DYRm9WWkeTGAUHuIqBS+SPHAYPkxIcoDoDNhL56SZM78hMpcCUoGMXeQA==",
+      "version": "6.0.0-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-6.0.0-next-2025-09-03.tgz",
+      "integrity": "sha512-UNpsE0BH6Oxj8sYFZzv5l6gJsBSVxls33iloZ9G/yVRG5WvOi8o5LhJ41VtjP4/cn1dmJFdIN4qaja5PXqrr5g==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -434,9 +434,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "3.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-pIusjXeid4Z4JqMfK7tKR1TOkK1PZ101FWSAfsdNlwMX4IS1LsOtS82H2bH+K3MkuS3uvz5cXOIOThv5++jCjQ==",
+      "version": "4.0.0-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-4.0.0-next-2025-09-03.tgz",
+      "integrity": "sha512-i02iQWW+f0R/m0fkQbBf4XZCaTKJl/7pJzWAWrVOQigvw6vq+1coeVkWQSis1LO7aKDZNY0QBveoAeEh9iZctg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -446,13 +446,12 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "10.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-10.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-DR2lZbGGN6eP20t81yH94sZck2sNFc77quOsy+EeoH4OLYHRmBu2E3xutk7/nW2MU3oo8cWC1ijI1j/hsGTwjg==",
+      "version": "10.0.1-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-10.0.1-next-2025-09-03.tgz",
+      "integrity": "sha512-aPuHQy1XN2JQQxzORCGNF1HJwg8RjcMZ0+4w0uqTruuWW8KfmDgaZhX5jZimCY4dO2/UUK3uZqATk1cnd09z9Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/hashes": "^1.8.0",
-        "buffer": "^6.0.3"
+        "@noble/hashes": "^1.8.0"
       },
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -472,9 +471,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "4.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-4.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-O0TD0oSg9FcYgfWdwI9e9Qfi1q5sHnU/sllwLXfkIuRevuE2iartW+X5s3ASJhWL7ZYkxLWIQ84CWHjgfXAjig==",
+      "version": "4.0.1-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-4.0.1-next-2025-09-03.tgz",
+      "integrity": "sha512-O+V49OVyQdhsKnnkiSM437ye7je8cruDRw2wAUJZdQGCcqeKEdGzD3MjO4IBKq69cfmcXo1BR0vMmf4USWYHxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
@@ -488,9 +487,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "3.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-21LeUuRThVjtEgzxnZh1zIQ5XAx20UtW/basCEW63hgnM/e/cJ6nPGsG4xV7c7r/+XKZeuNqMy2JWKJs364xQA==",
+      "version": "3.0.1-next-2025-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.1-next-2025-09-03.tgz",
+      "integrity": "sha512-nDW6f+O3xsobukn0pTmzVr2F5ZZ6NH0qbZ9f9gzmXZtlGrIjoFnhCrXcFpc5b8yNgeE7bNJK0WG6cqEVCSb/Iw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -566,6 +566,9 @@ export const convertDtoTopicInfo = ({
   native_functions: toNullable(native_functions.map(convertNervousFunction)),
   custom_functions: toNullable(custom_functions.map(convertNervousFunction)),
   is_critical: toNullable(is_critical),
+  // NOTE: This field has been initialized to [] as we don't use it for now.
+  // It was added to ic-js in https://github.com/dfinity/ic-js/pull/1032/files
+  extension_operations: [],
 });
 
 export const convertDtoToListTopicsResponse = ({

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -567,7 +567,7 @@ export const convertDtoTopicInfo = ({
   custom_functions: toNullable(custom_functions.map(convertNervousFunction)),
   is_critical: toNullable(is_critical),
   // NOTE: This field has been initialized to [] as we don't use it for now.
-  // It was added to ic-js in https://github.com/dfinity/ic-js/pull/1032/files
+  // It was added to ic-js in https://github.com/dfinity/ic-js/pull/1032/files#diff-684ab36c5e16fec984732ec9c53e9fe5690f4dddf1ddd713d7fd48a210de5707R1051
   extension_operations: [],
 });
 

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -71,6 +71,7 @@ describe("ProposalSystemInfoSection", () => {
       name: [topicName],
       description: [topicDescription],
       custom_functions: [],
+      extension_operations: [],
     };
     const {
       rewardStatusString,

--- a/frontend/src/tests/lib/derived/sns-topics.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-topics.derived.spec.ts
@@ -88,6 +88,7 @@ describe("sns topics store", () => {
               description: ["This is a description"],
               is_critical: [false],
               name: ["Topic1"],
+              extension_operations: [],
               native_functions: [
                 [
                   {

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicItem.spec.ts
@@ -25,6 +25,7 @@ describe("FollowSnsNeuronsByTopicItem", () => {
     name: ["Known topic name"],
     description: ["Known topic description"],
     custom_functions: [[]],
+    extension_operations: [],
   };
   const neuronId1: SnsNeuronId = { id: Uint8Array.from([1, 2, 3]) };
   const neuronId2: SnsNeuronId = { id: Uint8Array.from([4, 5, 6]) };

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicStepTopics.svelte.spec.ts
@@ -52,6 +52,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     name: [criticalTopicName1],
     description: [criticalTopicDescription1],
     custom_functions: [[]],
+    extension_operations: [],
   };
   const criticalTopicKey2: SnsTopicKey = "TreasuryAssetManagement";
   const criticalTopicName2 = "Treasury Asset Management";
@@ -67,6 +68,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     name: [criticalTopicName2],
     description: [criticalTopicDescription2],
     custom_functions: [[]],
+    extension_operations: [],
   };
   const topicKey1: SnsTopicKey = "DaoCommunitySettings";
   const topicName1 = "Dao Community Settings";
@@ -82,6 +84,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     name: [topicName1],
     description: [topicDescription1],
     custom_functions: [[]],
+    extension_operations: [],
   };
   const topicKey2: SnsTopicKey = "ApplicationBusinessLogic";
   const topicName2 = "Application Business Logic";
@@ -97,6 +100,7 @@ describe("FollowSnsNeuronsByTopicStepTopics", () => {
     name: [topicName2],
     description: [topicDescription2],
     custom_functions: [[]],
+    extension_operations: [],
   };
 
   const renderComponent = (props: {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsTopic.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsTopicDefinitionsTopic.spec.ts
@@ -38,6 +38,7 @@ describe("SnsTopicDefinitionsTopic", () => {
     name: [topicName],
     description: [topicDescription],
     custom_functions: [[genericNsFunction]],
+    extension_operations: [],
   };
 
   const renderComponent = (props: { topicInfo: TopicInfoWithUnknown }) => {

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -1113,6 +1113,7 @@ describe("sns aggregator converters utils", () => {
           name: ["Unknown topic name"],
           description: ["Unknown topic description"],
           custom_functions: [[]],
+          extension_operations: [],
         };
         expect(convertDtoTopicInfo(unknownTopicInfo)).toEqual(
           expectedUnknownTopicInfo

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -1070,6 +1070,8 @@ describe("sns aggregator converters utils", () => {
           is_critical: [false],
           name: ["DAO community settings"],
           description: ["Description 2"],
+
+          extension_operations: [],
           custom_functions: [
             [
               {
@@ -1173,6 +1175,7 @@ describe("sns aggregator converters utils", () => {
                     },
                   ],
                 ],
+                extension_operations: [],
               },
               // Unknown TopicInfo
               {
@@ -1186,6 +1189,7 @@ describe("sns aggregator converters utils", () => {
                 name: ["Unknown topic name"],
                 description: ["Unknown topic description"],
                 custom_functions: [[]],
+                extension_operations: [],
               },
             ],
           ],

--- a/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-topics.utils.spec.ts
@@ -86,6 +86,7 @@ describe("sns-topics utils", () => {
     name: ["Known topic name"],
     description: ["Known topic description"],
     custom_functions: [[genericNsFunction]],
+    extension_operations: [],
   };
   const completelyUnknownTopicInfo: TopicInfoWithUnknown = {
     native_functions: [[nativeNsFunction]],
@@ -98,6 +99,7 @@ describe("sns-topics utils", () => {
     name: ["Unknown topic name"],
     description: ["Unknown topic description"],
     custom_functions: [[]],
+    extension_operations: [],
   };
   const listTopics: ListTopicsResponseWithUnknown = {
     topics: [[knownTopicInfo, completelyUnknownTopicInfo]],

--- a/frontend/src/tests/mocks/sns-topics.mock.ts
+++ b/frontend/src/tests/mocks/sns-topics.mock.ts
@@ -63,4 +63,5 @@ export const topicInfoMock: SnsTopicInfo = {
   name: ["Topic name"],
   description: ["Topic description"],
   custom_functions: [],
+  extension_operations: [],
 };


### PR DESCRIPTION
# Motivation

The latest upgrade of candid files in [ic-js](https://github.com/dfinity/ic-js/pull/1032/files#diff-684ab36c5e16fec984732ec9c53e9fe5690f4dddf1ddd713d7fd48a210de5707R1051) introduced a new field, `extension_operations`, to the `InfoTopic` field. This change requires that the nns-dapp be updated to initialize this new field. Since the front end does not need it and the value is not exposed by the Aggregator, this PR initializes it to an empty value, `[]`.

NOTE: If the value is needed in the future, a proper adaptation will be made at that time.

# Changes

- Add `extension_operations` field
- Initialize new property to `[]`

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
