### PR TITLE
feat: missing i18n in Alfred search modal

### DIFF
--- a/frontend/src/lib/components/alfred/Alfred.svelte
+++ b/frontend/src/lib/components/alfred/Alfred.svelte
@@ -147,7 +147,7 @@
           <Input
             inputType="text"
             name="alfred-search"
-            placeholder="Search for pages or actions..."
+            placeholder={$i18n.alfred.search_placeholder}
             autocomplete="off"
             spellcheck={false}
             testId="alfred-input"

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -191,7 +191,8 @@
     "log_in_title": "Log In",
     "log_in_description": "Log in to your account",
     "log_out_title": "Log Out",
-    "log_out_description": "Log out of your account"
+    "log_out_description": "Log out of your account",
+    "search_placeholder": "Search for pages or actions..."
   },
   "header": {
     "menu": "Open menu to access navigation options",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -199,6 +199,7 @@ interface I18nAlfred {
   log_in_description: string;
   log_out_title: string;
   log_out_description: string;
+  search_placeholder: string;
 }
 
 interface I18nHeader {


### PR DESCRIPTION
# Motivation

Randomly spotted a missing i18n key in the `<Alfred />` search modal.

# Changes

- Extract text and use i18n key
