### PR TITLE
fix(markup): remove trailing characters from snippets

### DIFF
--- a/frontend/src/lib/modals/canisters/AddCanisterControllerModal.svelte
+++ b/frontend/src/lib/modals/canisters/AddCanisterControllerModal.svelte
@@ -36,10 +36,12 @@
   bind:this={modal}
   onClose={() => dispatcher("nnsClose")}
 >
-  {#snippet title()}<span data-tid="add-controller-canister-modal-title"
-      >{currentStep?.title ?? $i18n.canister_detail.add_controller}</span
-    >{/snippet}
-  >
+  {#snippet title()}
+    <span data-tid="add-controller-canister-modal-title">
+      {currentStep?.title ?? $i18n.canister_detail.add_controller}
+    </span>
+  {/snippet}
+
   <svelte:fragment>
     {#if currentStep?.name === "EnterController"}
       <AddPrincipal bind:principal on:nnsSelectPrincipal={next} on:nnsClose>

--- a/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -104,10 +104,12 @@
   bind:this={modal}
   onClose={() => dispatcher("nnsClose")}
 >
-  {#snippet title()}<span data-tid="top-up-canister-modal-title"
-      >{currentStep?.title ?? $i18n.accounts.select_source}</span
-    >{/snippet}
-  >
+  {#snippet title()}
+    <span data-tid="top-up-canister-modal-title">
+      {currentStep?.title ?? $i18n.accounts.select_source}
+    </span>
+  {/snippet}
+
   <svelte:fragment>
     {#if currentStep?.name === "SelectCycles"}
       <div class="from">

--- a/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
@@ -110,9 +110,12 @@
   bind:this={modal}
   onClose={() => dispatcher("nnsClose")}
 >
-  {#snippet title()}<span data-tid="create-canister-modal-title"
-      >{currentStep?.title ?? $i18n.canisters.add_canister}</span
-    >{/snippet}
+  {#snippet title()}
+    <span data-tid="create-canister-modal-title">
+      {currentStep?.title ?? $i18n.canisters.add_canister}
+    </span>
+  {/snippet}
+
   <svelte:fragment>
     {#if currentStep?.name === "SelectData"}
       <div class="from">

--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -115,10 +115,12 @@
   {steps}
   testId="disburse-sns-neuron-modal-component"
 >
-  {#snippet title()}<span data-tid="disburse-sns-neuron-modal"
-      >{currentStep?.title}</span
-    >{/snippet}
-  >
+  {#snippet title()}
+    <span data-tid="disburse-sns-neuron-modal">
+      {currentStep?.title}
+    </span>
+  {/snippet}
+
   {#if currentStep?.name === "ConfirmDisburse" && destinationAddress !== undefined}
     <ConfirmDisburseNeuron
       on:nnsClose

--- a/frontend/src/lib/modals/neurons/MergeNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/MergeNeuronsModal.svelte
@@ -67,8 +67,9 @@
   bind:this={modal}
   onClose={() => dispatcher("nnsClose")}
 >
-  {#snippet title()}{currentStep?.title ??
-      $i18n.neurons.merge_neurons_modal_title}{/snippet}
+  {#snippet title()}
+    {currentStep?.title ?? $i18n.neurons.merge_neurons_modal_title}
+  {/snippet}
   {#if currentStep?.name === "SelectNeurons"}
     <SelectNeuronsToMerge on:nnsSelect={handleNeuronSelection} on:nnsClose />
   {/if}

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -174,8 +174,9 @@
     ? "scroll"
     : "auto"}
 >
-  {#snippet title()}{currentStep?.title ??
-      $i18n.accounts.select_source}{/snippet}
+  {#snippet title()}
+    {currentStep?.title ?? $i18n.accounts.select_source}
+  {/snippet}
   {#if currentStep?.name === "StakeNeuron"}
     <NnsStakeNeuron
       bind:account={selectedAccount}

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -97,7 +97,9 @@
   bind:currentStep
   onClose={() => dispatcher("nnsClose")}
 >
-  {#snippet title()}{currentStep?.title ?? steps[0].title}{/snippet}
+  {#snippet title()}
+    {currentStep?.title ?? steps[0].title}
+  {/snippet}
   {#if currentStep?.name === "SelectPercentage"}
     <NeuronSelectPercentage
       availableMaturityE8s={neuron.fullNeuron?.maturityE8sEquivalent ?? 0n}


### PR DESCRIPTION
# Motivation

There are some trailing `>` characters on several pages introduced by the new `snippet` syntax. Affected pages:
* AddCanisterControllerModal
* AddCyclesModal
* DisburseSnsNeuronModal

# Changes

- Remove trailing `>`.  
- Improve code readability by breaking snippets into logical multiple lines.

# Tests

- Manually tested

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
