### PR TITLE
fix(deps): resolve ic-cdk-executor version conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candid-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "candid_parser",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstream",
  "anstyle",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "codespan-reporting"
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1098,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "on_wire",
  "prost",
@@ -1329,7 +1329,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1730,10 +1730,10 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
- "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e)",
  "ic-interfaces-adapter-client",
  "ic-protobuf",
  "serde",
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "ic-ed25519",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "serde",
 ]
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-metrics-encoder",
  "ic0",
@@ -1862,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex",
  "ic-types",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "sha2",
 ]
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-canister-threshold-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2030,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2048,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "serde",
  "zeroize",
@@ -2057,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "ic-ed25519",
@@ -2101,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2111,15 +2111,15 @@ dependencies = [
 [[package]]
 name = "ic-dummy-getrandom-for-wasm"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "ic-ed25519"
-version = "0.3.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+version = "0.4.0"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2146,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-heap-bytes",
  "serde",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "ic-heap-bytes"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-heap-bytes-derive",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "ic-heap-bytes-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "ic-http-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "serde",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ciborium",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ciborium",
@@ -2239,7 +2239,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2269,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "ic-interfaces-adapter-client"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "strum_macros 0.26.4",
  "thiserror 2.0.17",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "hex",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-management-canister-types"
@@ -2361,13 +2361,13 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types-private"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-base-types",
  "ic-btc-interface",
  "ic-btc-replica-types",
- "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e)",
  "ic-protobuf",
  "ic-utils",
  "num-traits",
@@ -2387,7 +2387,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-chunks"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-crypto-sha2",
  "ic-stable-structures",
@@ -2419,14 +2419,14 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e)",
  "ic-ledger-core",
  "ic-management-canister-types-private",
  "ic-nervous-system-canisters",
@@ -2444,12 +2444,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2484,12 +2484,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2502,12 +2502,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-initial-supply"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-linear-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "rust_decimal",
 ]
@@ -2541,12 +2541,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-nervous-system-long-message"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -2557,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "comparable",
@@ -2570,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "ic-cdk",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-rate-limits"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-stable-structures",
  "serde",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2618,17 +2618,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-cdk",
 ]
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-timer-task"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-timers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-cdk-timers",
  "slotmap",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-timestamp"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "time",
 ]
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-cdk",
  "ic-nervous-system-common",
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "comparable",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "bytes",
  "candid",
@@ -2829,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2846,12 +2846,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2865,25 +2865,27 @@ dependencies = [
 [[package]]
 name = "ic-node-rewards-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "chrono",
  "ic-base-types",
  "ic-nervous-system-proto",
+ "ic-protobuf",
  "rewards-calculation",
+ "rust_decimal",
  "serde",
 ]
 
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "bincode",
  "candid",
  "erased-serde",
- "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e)",
  "prost",
  "serde",
  "serde_json",
@@ -2894,7 +2896,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2908,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-chunkify"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-cdk",
  "ic-nervous-system-chunks",
@@ -2920,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "hex",
@@ -2933,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-base-types",
  "ic-cdk",
@@ -2943,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2954,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-management-canister-types-private",
@@ -2965,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2977,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2991,8 +2993,8 @@ dependencies = [
 
 [[package]]
 name = "ic-secp256k1"
-version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+version = "0.3.0"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex-literal",
  "hmac",
@@ -3010,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3080,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "bytes",
  "candid",
@@ -3105,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3113,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3124,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -3146,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3174,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3204,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3243,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "comparable",
@@ -3258,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -3302,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3314,7 +3316,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
- "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e)",
  "ic-heap-bytes",
  "ic-limits",
  "ic-management-canister-types-private",
@@ -3341,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3352,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3360,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3432,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "comparable",
@@ -3461,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "icrc-cbor"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "minicbor",
@@ -3472,7 +3474,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.4"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -3482,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.3"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "async-trait",
  "candid",
@@ -3493,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.11"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "base32",
  "candid",
@@ -4215,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 
 [[package]]
 name = "once_cell"
@@ -4369,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "ic-heap-bytes",
@@ -4916,7 +4918,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4984,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "rewards-calculation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "chrono",
  "ic-base-types",
@@ -5392,7 +5394,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "sns-treasury-manager"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+source = "git+https://github.com/dfinity/ic?rev=6d21917c2f587f8390546c7e37c21879a0cebd6e#6d21917c2f587f8390546c7e37c21879a0cebd6e"
 dependencies = [
  "candid",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc8f7d2ded5f9209535e4b3fd4d39c002f30902ff5ce9f64e2c33d549576500"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -3799,7 +3799,7 @@ dependencies = [
  "petgraph 0.6.5",
  "pico-args",
  "regex",
- "regex-syntax 0.8.7",
+ "regex-syntax 0.8.8",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -4670,7 +4670,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.7",
+ "regex-syntax 0.8.8",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -4880,25 +4880,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.7",
+ "regex-syntax 0.8.8",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.7",
+ "regex-syntax 0.8.8",
 ]
 
 [[package]]
@@ -4909,9 +4909,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "registry-canister"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli 0.31.1",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
@@ -211,9 +211,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -221,7 +221,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -501,18 +501,18 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.12"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "candid"
-version = "0.10.18"
+version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae495fbaf9ee8f4f7898affbd3df85dba8598bfa4ffaca24726c42aa4beb7b1"
+checksum = "3ea81e16df186fae1979175058f05dfbfac6e2fdf3b161edcbdc440ef09232cf"
 dependencies = [
  "anyhow",
  "binread",
@@ -532,10 +532,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid-utils"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+dependencies = [
+ "candid",
+ "candid_parser",
+]
+
+[[package]]
 name = "candid_derive"
-version = "0.10.18"
+version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7388be3b345b1a2ad30e529619b4db0d1955852afb56da821fa6a805f7cbf6be"
+checksum = "2e6d499625531c41f474e55160a40313b33d002262ddaae40cade71bcc3bc75a"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -586,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -615,7 +624,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -642,14 +651,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.6.0",
+ "half 2.7.0",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -657,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -692,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -887,7 +896,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -932,8 +941,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -951,27 +970,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
-name = "dary_heap"
-version = "0.3.7"
+name = "darling_macro"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 
 [[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "datasize"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65c07d59e45d77a8bda53458c24a828893a99ac6cdd9c84111e09176ab739a2"
+dependencies = [
+ "datasize_derive",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613e4ee15899913285b7612004bbd490abd605be7b11d35afada5902fb6b91d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "der"
@@ -1000,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -1034,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1047,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1056,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1068,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1081,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "on_wire",
  "prost",
@@ -1247,7 +1311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1265,7 +1329,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1305,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixedbitset"
@@ -1323,9 +1387,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1449,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "1dc8f7d2ded5f9209535e4b3fd4d39c002f30902ff5ce9f64e2c33d549576500"
 dependencies = [
  "typenum",
  "version_check",
@@ -1478,7 +1542,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1494,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -1523,12 +1587,13 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "e54c115d4f30f52c67202f079c5f9d8b49db4691f460fdb0b4c2e838261b2ba5"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1553,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -1607,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1632,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1640,6 +1705,7 @@ dependencies = [
  "comparable",
  "hex",
  "ic-crypto-sha2",
+ "ic-heap-bytes",
  "ic-protobuf",
  "phantom_newtype",
  "prost",
@@ -1651,11 +1717,12 @@ dependencies = [
 
 [[package]]
 name = "ic-btc-interface"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0152e14e697b0e988dbfdcb3f7e352d1c76a65b7d2d75c5d76bad22c3aca10d"
+checksum = "eb974b1626d8a45dad7d1e2383829c6b08c5fd53b42d9f0938a51f2f0e057c7e"
 dependencies = [
  "candid",
+ "datasize",
  "serde",
  "serde_bytes",
 ]
@@ -1663,11 +1730,11 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
- "ic-btc-interface",
- "ic-error-types",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
+ "ic-interfaces-adapter-client",
  "ic-protobuf",
  "serde",
  "serde_bytes",
@@ -1676,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "ic-ed25519",
@@ -1689,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "serde",
 ]
@@ -1697,55 +1764,63 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-metrics-encoder",
- "ic0 1.0.0",
+ "ic0",
 ]
 
 [[package]]
 name = "ic-cdk"
-version = "0.17.2"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a7344f41493cbf591f13ae9f90181076f808a83af799815c3074b19c693d2e"
+checksum = "4efb278f5d3ef033b3eed7f01f1096eaf67701896aa5ef69f5eddf5a84833dc0"
 dependencies = [
  "candid",
  "ic-cdk-executor",
  "ic-cdk-macros",
- "ic0 0.23.0",
+ "ic-error-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-management-canister-types 0.3.3",
+ "ic0",
  "serde",
  "serde_bytes",
+ "slotmap",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "ic-cdk-executor"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903057edd3d4ff4b3fe44a64eaee1ceb73f579ba29e3ded372b63d291d7c16c2"
+checksum = "99f4ee8930fd2e491177e2eb7fff53ee1c407c13b9582bdc7d6920cf83109a2d"
+dependencies = [
+ "ic0",
+ "slotmap",
+]
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.17.2"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cbaa50fa36d3e0616114becf81faa95a099e0d60948ed6978f30f1c77399fd"
+checksum = "7eb14c5d691cc9d72bb95459b4761e3a4b3444b85a63d17555d5ddd782969a1e"
 dependencies = [
  "candid",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "serde",
- "serde_tokenstream",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "ic-cdk-timers"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
+checksum = "9ea87cf31444de833db85bbd15e97bc135ee14529b13158ffdaf6530bf6d7e85"
 dependencies = [
+ "candid",
  "futures",
  "ic-cdk",
- "ic0 0.23.0",
+ "ic0",
  "serde",
  "serde_bytes",
  "slotmap",
@@ -1787,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "hex",
  "ic-types",
@@ -1797,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -1819,12 +1894,11 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "hex",
  "ic_bls12_381",
  "itertools 0.12.1",
- "lazy_static",
  "pairing",
  "paste",
  "rand 0.8.5",
@@ -1837,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1845,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -1864,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -1877,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "sha2",
 ]
@@ -1885,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -1896,7 +1970,6 @@ dependencies = [
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
  "ic-types",
- "lazy_static",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -1911,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-canister-threshold-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -1925,7 +1998,6 @@ dependencies = [
  "ic-crypto-sha2",
  "ic-types",
  "k256",
- "lazy_static",
  "p256",
  "paste",
  "rand 0.8.5",
@@ -1941,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -1951,14 +2023,14 @@ dependencies = [
  "serde_cbor",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -1976,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "serde",
  "zeroize",
@@ -1985,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1993,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2006,20 +2078,20 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-protobuf",
  "serde",
  "serde_bytes",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "ic-ed25519",
@@ -2029,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2039,31 +2111,32 @@ dependencies = [
 [[package]]
 name = "ic-dummy-getrandom-for-wasm"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "ic-ed25519"
-version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+version = "0.3.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
- "candid",
  "curve25519-dalek",
  "ed25519-dalek",
  "hex-literal",
  "hkdf",
+ "ic_principal",
  "pem",
  "rand 0.8.5",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
 [[package]]
 name = "ic-error-types"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbeeb3d91aa179d6496d7293becdacedfc413c825cac79fd54ea1906f003ee55"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -2071,9 +2144,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-error-types"
+version = "0.2.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+dependencies = [
+ "ic-heap-bytes",
+ "serde",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "ic-heap-bytes"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+dependencies = [
+ "candid",
+ "ic-heap-bytes-derive",
+ "paste",
+ "prometheus",
+ "tempfile",
+]
+
+[[package]]
+name = "ic-heap-bytes-derive"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "ic-http-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "serde",
@@ -2083,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ciborium",
@@ -2099,13 +2206,13 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_bytes",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ciborium",
@@ -2132,7 +2239,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2162,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2173,9 +2280,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-interfaces-adapter-client"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+dependencies = [
+ "strum_macros 0.26.4",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2194,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2208,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "hex",
@@ -2218,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-management-canister-types"
@@ -2232,15 +2348,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-management-canister-types"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7e5b8a0f7c3b320d9450ac950547db4f24a31601b5d398f9680b64427455d2"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-management-canister-types-private"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-base-types",
  "ic-btc-interface",
  "ic-btc-replica-types",
- "ic-error-types",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
  "ic-protobuf",
  "ic-utils",
  "num-traits",
@@ -2260,7 +2387,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2281,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-chunks"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-crypto-sha2",
  "ic-stable-structures",
@@ -2292,14 +2419,14 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-error-types",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
  "ic-ledger-core",
  "ic-management-canister-types-private",
  "ic-nervous-system-canisters",
@@ -2317,12 +2444,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2357,12 +2484,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2375,12 +2502,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2392,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-initial-supply"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2406,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-linear-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "rust_decimal",
 ]
@@ -2414,12 +2541,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-nervous-system-long-message"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -2430,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "comparable",
@@ -2443,16 +2570,25 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "ic-cdk",
 ]
 
 [[package]]
+name = "ic-nervous-system-rate-limits"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+dependencies = [
+ "ic-stable-structures",
+ "serde",
+]
+
+[[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2469,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2482,17 +2618,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-cdk",
 ]
@@ -2500,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-timer-task"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2515,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-timers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-cdk-timers",
  "slotmap",
@@ -2524,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-timestamp"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "time",
 ]
@@ -2532,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-cdk",
  "ic-nervous-system-common",
@@ -2546,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "comparable",
@@ -2572,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2581,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2600,6 +2736,7 @@ dependencies = [
  "ic-dummy-getrandom-for-wasm",
  "ic-http-types",
  "ic-ledger-core",
+ "ic-limits",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
@@ -2607,10 +2744,12 @@ dependencies = [
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-common-test-keys",
+ "ic-nervous-system-common-validation",
  "ic-nervous-system-governance",
  "ic-nervous-system-linear-map",
  "ic-nervous-system-long-message",
  "ic-nervous-system-proto",
+ "ic-nervous-system-rate-limits",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-nervous-system-temporary",
@@ -2660,11 +2799,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "bytes",
  "candid",
  "comparable",
+ "hex",
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-nervous-system-clients",
@@ -2689,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2706,12 +2846,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2725,22 +2865,25 @@ dependencies = [
 [[package]]
 name = "ic-node-rewards-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
- "ic-cdk",
+ "chrono",
+ "ic-base-types",
+ "ic-nervous-system-proto",
+ "rewards-calculation",
  "serde",
 ]
 
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "bincode",
  "candid",
  "erased-serde",
- "ic-error-types",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
  "prost",
  "serde",
  "serde_json",
@@ -2751,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2759,13 +2902,13 @@ dependencies = [
  "ic-registry-transport",
  "ic-utils",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "ic-registry-canister-chunkify"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-cdk",
  "ic-nervous-system-chunks",
@@ -2777,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "hex",
@@ -2790,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-base-types",
  "ic-cdk",
@@ -2800,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2811,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-management-canister-types-private",
@@ -2822,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2834,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -2848,14 +2991,13 @@ dependencies = [
 
 [[package]]
 name = "ic-secp256k1"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+version = "0.2.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
- "candid",
  "hex-literal",
  "hmac",
+ "ic_principal",
  "k256",
- "lazy_static",
  "num-bigint",
  "pem",
  "rand 0.8.5",
@@ -2868,13 +3010,14 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
  "build-info",
  "build-info-build",
  "candid",
+ "candid-utils",
  "clap",
  "comparable",
  "futures",
@@ -2910,6 +3053,7 @@ dependencies = [
  "ic-sns-governance-proposal-criticality",
  "ic-sns-governance-proposals-amount-total-limit",
  "ic-sns-governance-token-valuation",
+ "ic-stable-structures",
  "ic-utils",
  "icp-ledger",
  "icrc-ledger-client",
@@ -2930,13 +3074,13 @@ dependencies = [
  "sns-treasury-manager",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "ic-sns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "bytes",
  "candid",
@@ -2961,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2969,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2980,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -3002,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3030,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3060,7 +3204,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3099,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "comparable",
@@ -3114,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -3158,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3170,7 +3314,8 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
- "ic-error-types",
+ "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base)",
+ "ic-heap-bytes",
  "ic-limits",
  "ic-management-canister-types-private",
  "ic-protobuf",
@@ -3189,14 +3334,14 @@ dependencies = [
  "serde_with",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "thousands",
 ]
 
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3207,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3215,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3251,15 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "ic0"
-version = "0.23.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
-
-[[package]]
-name = "ic0"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8877193e1921b5fd16accb0305eb46016868cd1935b05c05eca0ec007b943272"
+checksum = "1499d08fd5be8f790d477e1865d63bab6a8d748300e141270c4296e6d5fdd6bc"
 
 [[package]]
 name = "ic_bls12_381"
@@ -3293,13 +3432,11 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "comparable",
  "crc32fast",
- "dfn_candid",
- "dfn_core",
  "dfn_protobuf",
  "hex",
  "ic-base-types",
@@ -3324,7 +3461,7 @@ dependencies = [
 [[package]]
 name = "icrc-cbor"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "minicbor",
@@ -3334,8 +3471,8 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-client"
-version = "0.1.3"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+version = "0.1.4"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -3344,8 +3481,8 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-client-cdk"
-version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+version = "0.1.3"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "async-trait",
  "candid",
@@ -3355,8 +3492,8 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.10"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+version = "0.1.11"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "base32",
  "candid",
@@ -3519,13 +3656,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3605,9 +3743,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3661,7 +3799,7 @@ dependencies = [
  "petgraph 0.6.5",
  "pico-args",
  "regex",
- "regex-syntax 0.8.6",
+ "regex-syntax 0.8.7",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3695,9 +3833,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libflate"
@@ -3731,14 +3869,20 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3754,11 +3898,10 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3829,9 +3972,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "merlin"
@@ -3878,6 +4021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -4052,9 +4196,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -4071,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 
 [[package]]
 name = "once_cell"
@@ -4108,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -4118,15 +4262,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -4161,20 +4305,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4182,9 +4325,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4195,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
  "sha2",
@@ -4210,7 +4353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -4220,15 +4363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
+ "ic-heap-bytes",
  "num-traits",
  "serde",
  "slog",
@@ -4335,13 +4479,13 @@ dependencies = [
 
 [[package]]
 name = "pretty"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac98773b7109bc75f475ab5a134c9b64b87e59d776d31098d8f346922396a477"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
 dependencies = [
  "arrayvec 0.5.2",
  "typed-arena",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4385,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -4432,6 +4576,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "prometheus-parse"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4458,7 +4642,7 @@ dependencies = [
  "ic-btc-interface",
  "ic-cdk",
  "ic-crypto-sha2",
- "ic-management-canister-types",
+ "ic-management-canister-types 0.1.0",
  "ic-nervous-system-common",
  "ic-nervous-system-root",
  "ic-nns-constants",
@@ -4486,7 +4670,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.6",
+ "regex-syntax 0.8.7",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -4545,10 +4729,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.26"
+name = "protobuf"
+version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "psm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e66fcd288453b748497d8fb18bccc83a16b0518e3906d4b8df0a8d42d93dbb1c"
 dependencies = [
  "cc",
 ]
@@ -4581,9 +4771,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -4670,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -4690,25 +4880,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.6",
+ "regex-syntax 0.8.7",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax 0.8.7",
 ]
 
 [[package]]
@@ -4719,14 +4909,14 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
 
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4751,6 +4941,7 @@ dependencies = [
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
+ "ic-nervous-system-rate-limits",
  "ic-nervous-system-string",
  "ic-nervous-system-temporary",
  "ic-nervous-system-time-helpers",
@@ -4788,6 +4979,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "rewards-calculation"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
+dependencies = [
+ "chrono",
+ "ic-base-types",
+ "ic-protobuf",
+ "itertools 0.12.1",
+ "maplit",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
 ]
 
 [[package]]
@@ -4837,9 +5043,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rust_decimal"
-version = "1.37.2"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
 dependencies = [
  "arrayvec 0.7.6",
  "borsh",
@@ -4853,9 +5059,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.37.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6268b74858287e1a062271b988a0c534bf85bbeb567fe09331bf40ed78113d5"
+checksum = "ae8c0cb48f413ebe24dc2d148788e0efbe09ba3e011d9277162f2eaf8e1069a3"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -4887,6 +5093,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -4894,8 +5113,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.61.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4906,9 +5125,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -4965,29 +5184,32 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5001,10 +5223,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5013,26 +5244,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.106",
+ "serde_core",
 ]
 
 [[package]]
@@ -5051,7 +5271,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5063,7 +5283,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itoa",
  "ryu",
  "serde",
@@ -5107,6 +5327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,7 +5346,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -5138,11 +5364,14 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slog"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
 dependencies = [
+ "anyhow",
  "erased-serde",
+ "rustversion",
+ "serde_core",
 ]
 
 [[package]]
@@ -5163,7 +5392,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "sns-treasury-manager"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2025-08-14_03-27-base#1db8f933fdadc81a90e7db2389b081e21263a9b6"
+source = "git+https://github.com/dfinity/ic?rev=release-2025-10-09_03-15-base#285897dae3a2cb60c50d9d8dd7327f18c3c372b9"
 dependencies = [
  "candid",
  "derivative",
@@ -5182,7 +5411,7 @@ dependencies = [
  "ic-cdk",
  "ic-cdk-timers",
  "ic-certified-map 0.3.2",
- "ic-management-canister-types",
+ "ic-management-canister-types 0.1.0",
  "ic-nervous-system-common",
  "lazy_static",
  "num-traits",
@@ -5197,12 +5426,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5223,15 +5452,15 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5362,15 +5591,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
- "windows-sys 0.61.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5410,11 +5639,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -5430,9 +5659,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5447,11 +5676,12 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -5542,18 +5772,31 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
  "winnow",
 ]
 
@@ -5565,9 +5808,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"
@@ -5598,6 +5841,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5712,27 +5961,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5743,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -5757,9 +6006,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5767,9 +6016,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5780,9 +6029,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -5805,7 +6054,7 @@ dependencies = [
  "ahash 0.8.12",
  "bitflags",
  "hashbrown 0.14.5",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "semver",
  "serde",
 ]
@@ -5832,7 +6081,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5843,22 +6092,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5867,9 +6116,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5878,32 +6127,26 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -5921,16 +6164,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -5951,19 +6194,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5974,9 +6217,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5986,9 +6229,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5998,9 +6241,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -6010,9 +6253,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6022,9 +6265,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6034,9 +6277,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6046,9 +6289,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6058,9 +6301,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6073,9 +6316,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -6111,12 +6354,12 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -6207,9 +6450,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,23 +15,23 @@ ic-cdk-macros = "0.18.5"
 ic-cdk-timers = "0.12.0"
 ic-management-canister-types = "0.1.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-registry-canister = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+registry-canister = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "6d21917c2f587f8390546c7e37c21879a0cebd6e" }
 
 [profile.release]
 lto = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,28 +10,28 @@ resolver = "2"
 version = "2.0.129"
 
 [workspace.dependencies]
-ic-cdk = "0.17.1"
-ic-cdk-macros = "0.17.0"
-ic-cdk-timers = "0.11.0"
+ic-cdk = "0.18.4"
+ic-cdk-macros = "0.18.5"
+ic-cdk-timers = "0.12.0"
 ic-management-canister-types = "0.1.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-registry-canister = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2025-08-14_03-27-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+registry-canister = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2025-10-09_03-15-base" }
 
 [profile.release]
 lto = false

--- a/rs/sns_aggregator/Cargo.toml
+++ b/rs/sns_aggregator/Cargo.toml
@@ -15,8 +15,8 @@ dfn_candid = { workspace = true }
 ic-base-types = { workspace = true }
 # This next candid is 0.9.0_beta code that fixes serde Nat but has other issues.  Keep checking until the issues are fixed.
 #candid = { git = "https://github.com/dfinity/candid" , rev = "42ffed660ded37585c4b9f97e3ce90919e24c518" }
-ic-cdk = { version = "0.17.1" }
-ic-cdk-timers = "0.11.0"
+ic-cdk = { workspace = true }
+ic-cdk-timers = { workspace = true }
 ic-certified-map = { git = "https://github.com/dfinity/cdk-rs", rev = "58791941b72471e09e3d9e733f2a3d4d54e52b5a" }
 ic-management-canister-types = { workspace = true }
 ic-nervous-system-common = { workspace = true }


### PR DESCRIPTION
# Motivation

The IC Cargo dependencies job has been consistently failing due compatibility issues of dependencies. Eg:
* https://dfinity.slack.com/archives/C05G2RZFJAJ/p1757230388151629
* https://github.com/dfinity/nns-dapp/actions/runs/17525586842

The error is introduced due different versions of `ic-cdk-executor`:
```
error: failed to select a version for `ic-cdk-executor`.
    ... required by package `ic-cdk v0.18.7`
    ... which satisfies dependency `ic-cdk = "^0.18.7"` of package `cycles-minting-canister v0.9.0 (https://github.com/dfinity/ic?rev=release-2025-08-28_03-17-snapshot-feature#91732387)`
    ... which satisfies git dependency `cycles-minting-canister` of package `nns-dapp v2.0.125 (/home/runner/work/nns-dapp/nns-dapp/rs/backend)`
versions that meet the requirements `^1.0.2` are: 1.0.2

package `ic-cdk-executor` links to the native library `ic-cdk async executor, see [https://github.com/dfinity/cdk-rs/blob/links-pin/TROUBLESHOOTING.md`,](https://github.com/dfinity/cdk-rs/blob/links-pin/TROUBLESHOOTING.md%60,) but it conflicts with a previous package which links to `ic-cdk async executor, see [https://github.com/dfinity/cdk-rs/blob/links-pin/TROUBLESHOOTING.md`](https://github.com/dfinity/cdk-rs/blob/links-pin/TROUBLESHOOTING.md%60) as well:
package `ic-cdk-executor v0.1.0`
    ... which satisfies dependency `ic-cdk-executor = "^0.1.0"` of package `ic-cdk v0.17.2`
    ... which satisfies dependency `ic-cdk = "^0.17.1"` of package `nns-dapp v2.0.125 (/home/runner/work/nns-dapp/nns-dapp/rs/backend)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "ic-cdk async executor, see https://github.com/dfinity/cdk-rs/blob/links-pin/TROUBLESHOOTING.md"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `ic-cdk-executor` which could resolve this conflict
```

# Changes

- Define workspace versions for the SNS aggregator module.  
- Update `ic-timers` to the latest version.  
- Update `ic-cdk` to the latest version.  
- Run `scripts/update-ic-cargo-deps --ref "release-10-09_03-15-base"`

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
