### PR TITLE
fix(deps): patch vite security vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,7 @@
         "svelte-preprocess": "^6.0.3",
         "typescript": "^5.5",
         "typescript-eslint": "^8.24.0",
-        "vite": "^6.3.5",
+        "vite": "^6.3.6",
         "vitest": "^3.1.2",
         "vitest-mock-extended": "^3.0.1"
       },
@@ -6406,9 +6406,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "svelte-preprocess": "^6.0.3",
     "typescript": "^5.5",
     "typescript-eslint": "^8.24.0",
-    "vite": "^6.3.5",
+    "vite": "^6.3.6",
     "vitest": "^3.1.2",
     "vitest-mock-extended": "^3.0.1"
   },


### PR DESCRIPTION
# Motivation

There is a vulnerability reported by `npm audit`:

```
# npm audit report

vite  6.0.0 - 6.3.5
Vite middleware may serve files starting with the same name with the public directory - https://github.com/advisories/GHSA-g4jq-h2w9-997c
Vite's `server.fs` settings were not applied to HTML files - https://github.com/advisories/GHSA-jqfw-vq24-v9c3
fix available via `npm audit fix`
node_modules/vite

1 low severity vulnerability

To address all issues, run:
  npm audit fix
```

# Changes

- Run `npm audit fix`

# Tests

- CI should pass

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
