### PR TITLE
chore: remove buffer and global polyfill

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,6 @@
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.8",
         "@ledgerhq/hw-transport-webhid": "^6.27.8",
         "@zondax/ledger-icp": "^0.6.1",
-        "buffer": "^6.0.3",
         "plausible-tracker": "0.3.9"
       },
       "devDependencies": {
@@ -34,7 +33,6 @@
         "@eslint/js": "^9.20.0",
         "@peculiar/webcrypto": "^1.5.0",
         "@playwright/test": "^1.49.1",
-        "@rollup/plugin-inject": "^5.0.5",
         "@sveltejs/adapter-static": "^3.0.8",
         "@sveltejs/kit": "^2.20.7",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -1433,52 +1431,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/plugin-inject": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
-      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.41.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
@@ -2821,30 +2773,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3541,13 +3469,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,6 @@
     "@eslint/js": "^9.20.0",
     "@peculiar/webcrypto": "^1.5.0",
     "@playwright/test": "^1.49.1",
-    "@rollup/plugin-inject": "^5.0.5",
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.20.7",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -88,7 +87,6 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.8",
     "@ledgerhq/hw-transport-webhid": "^6.27.8",
     "@zondax/ledger-icp": "^0.6.1",
-    "buffer": "^6.0.3",
     "plausible-tracker": "0.3.9"
   },
   "overrides": {

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -17,8 +17,3 @@ export const prerender = true;
 export const ssr = import.meta.env.PROD;
 
 export const trailingSlash = "always";
-
-// Polyfill Buffer for development purpose. node_modules/@ledgerhq needs buffer.
-// ⚠️ For production build the polyfill needs to be injected with Rollup (see vite.config.ts) because the page might be loaded before the _layout.js which will contains this polyfill
-import { Buffer } from "buffer";
-globalThis.Buffer = Buffer;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,3 @@
-import inject from "@rollup/plugin-inject";
 import { sveltekit } from "@sveltejs/kit/vite";
 import { readFileSync } from "fs";
 import { dirname } from "path";
@@ -46,25 +45,10 @@ const config: UserConfig = {
           return "index";
         },
       },
-      // Polyfill Buffer for production build. The hardware wallet needs Buffer.
-      plugins: [
-        inject({
-          include: ["node_modules/@ledgerhq/**"],
-          modules: { Buffer: ["buffer", "Buffer"] },
-        }),
-      ],
     },
   },
   define: {
     VITE_APP_VERSION: JSON.stringify(version),
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      // Node.js global to browser globalThis
-      define: {
-        global: "globalThis",
-      },
-    },
   },
   worker: {
     format: "es",


### PR DESCRIPTION
# Motivation

This requires **TESTs**, but now that AgentJS v3 is used, the need to polyfill NodeJS `Buffer` has been dropped.  

In addition, I believe, the hardware wallet no longer uses `proto`, which means the `Buffer` polyfill may not be required there either?

Long story short: this PR removes the polyfill.  The build should be slightly smaller, the app a bit faster and dependencies reduced  all of which is a good thing, given how often npm packages are compromised these days...

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
