### PR TITLE
Extra logs for safari

### DIFF
--- a/frontend/src/lib/services/public/app.services.ts
+++ b/frontend/src/lib/services/public/app.services.ts
@@ -6,6 +6,7 @@ import { loadSnsProjects } from "$lib/services/public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import { logOnSafariMacOS } from "$lib/utils/dev.utils";
 
 /**
  * Load the application public data that are available globally ("global stores").
@@ -23,6 +24,7 @@ export const initAppPublicData = (): Promise<
 
 const syncAuthStore = async () => {
   try {
+    logOnSafariMacOS("syncAuthStore", !!browser);
     await authStore.sync();
   } catch (err) {
     toastsError({ labelKey: "error.auth_sync", err });
@@ -42,6 +44,8 @@ export const initAppAuth = async () => {
   if (!browser) {
     return;
   }
+
+  logOnSafariMacOS("initAppAuth", !!browser);
 
   await syncAuthStore();
 

--- a/frontend/src/lib/services/public/app.services.ts
+++ b/frontend/src/lib/services/public/app.services.ts
@@ -6,7 +6,7 @@ import { loadSnsProjects } from "$lib/services/public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
 
 /**
  * Load the application public data that are available globally ("global stores").
@@ -24,7 +24,7 @@ export const initAppPublicData = (): Promise<
 
 const syncAuthStore = async () => {
   try {
-    logOnSafariMacOS("syncAuthStore", !!browser);
+    logWithTimestamp("#4124:syncAuthStore", !!browser);
     await authStore.sync();
   } catch (err) {
     toastsError({ labelKey: "error.auth_sync", err });
@@ -45,7 +45,7 @@ export const initAppAuth = async () => {
     return;
   }
 
-  logOnSafariMacOS("initAppAuth", !!browser);
+  logWithTimestamp("#4124:initAppAuth", !!browser);
 
   await syncAuthStore();
 

--- a/frontend/src/lib/stores/auth.store.ts
+++ b/frontend/src/lib/stores/auth.store.ts
@@ -6,7 +6,7 @@ import {
   createAuthClient,
   getIdentityProviderUrl,
 } from "$lib/utils/auth.utils";
-import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { isNnsAlternativeOrigin } from "$lib/utils/env.utils";
 import type { Identity } from "@dfinity/agent";
 import type { AuthClient } from "@dfinity/auth-client";
@@ -65,11 +65,11 @@ const initAuthStore = (): AuthStore => {
     },
 
     sync: async () => {
-      logOnSafariMacOS("authStore:sync:0", !!authClient);
+      logWithTimestamp("#4124:authStore:sync:0", !!authClient);
       authClient = authClient ?? (await createAuthClient());
-      logOnSafariMacOS("authStore:sync:1", !!authClient);
+      logWithTimestamp("#4124:authStore:sync:1", !!authClient);
       const isAuthenticated = await authClient.isAuthenticated();
-      logOnSafariMacOS("authStore:sync:2", isAuthenticated);
+      logWithTimestamp("#4124:authStore:sync:2", isAuthenticated);
 
       set({
         identity: isAuthenticated ? authClient.getIdentity() : null,

--- a/frontend/src/lib/stores/auth.store.ts
+++ b/frontend/src/lib/stores/auth.store.ts
@@ -6,6 +6,7 @@ import {
   createAuthClient,
   getIdentityProviderUrl,
 } from "$lib/utils/auth.utils";
+import { logOnSafariMacOS } from "$lib/utils/dev.utils";
 import { isNnsAlternativeOrigin } from "$lib/utils/env.utils";
 import type { Identity } from "@dfinity/agent";
 import type { AuthClient } from "@dfinity/auth-client";
@@ -64,8 +65,11 @@ const initAuthStore = (): AuthStore => {
     },
 
     sync: async () => {
+      logOnSafariMacOS("authStore:sync:0", !!authClient);
       authClient = authClient ?? (await createAuthClient());
+      logOnSafariMacOS("authStore:sync:1", !!authClient);
       const isAuthenticated = await authClient.isAuthenticated();
+      logOnSafariMacOS("authStore:sync:2", isAuthenticated);
 
       set({
         identity: isAuthenticated ? authClient.getIdentity() : null,

--- a/frontend/src/lib/utils/dev.utils.ts
+++ b/frontend/src/lib/utils/dev.utils.ts
@@ -39,3 +39,26 @@ export const digestText = async (text: string): Promise<string> => {
     .join("");
   return hashHex;
 };
+
+export const isMacOSSafari = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+
+  const ua = navigator.userAgent || "";
+  const vendor = navigator.vendor || "";
+
+  return (
+    /Macintosh/.test(ua) &&
+    vendor === "Apple Computer, Inc." &&
+    ua.includes("Safari") &&
+    !ua.includes("Chrome") &&
+    !ua.includes("Chromium") &&
+    !ua.includes("Edg")
+  );
+};
+
+// Log only on Safari MacOS with "safari" prefix
+export const logOnSafariMacOS = (...args: Array<unknown>): void => {
+  if (isMacOSSafari()) {
+    console.log("safari", ...args);
+  }
+};

--- a/frontend/src/lib/utils/dev.utils.ts
+++ b/frontend/src/lib/utils/dev.utils.ts
@@ -39,26 +39,3 @@ export const digestText = async (text: string): Promise<string> => {
     .join("");
   return hashHex;
 };
-
-export const isMacOSSafari = (): boolean => {
-  if (typeof navigator === "undefined") return false;
-
-  const ua = navigator.userAgent || "";
-  const vendor = navigator.vendor || "";
-
-  return (
-    /Macintosh/.test(ua) &&
-    vendor === "Apple Computer, Inc." &&
-    ua.includes("Safari") &&
-    !ua.includes("Chrome") &&
-    !ua.includes("Chromium") &&
-    !ua.includes("Edg")
-  );
-};
-
-// Log only on Safari MacOS with "safari" prefix
-export const logOnSafariMacOS = (...args: Array<unknown>): void => {
-  if (isMacOSSafari()) {
-    console.log("safari", ...args);
-  }
-};

--- a/frontend/src/routes/(app)/(home)/+layout.svelte
+++ b/frontend/src/routes/(app)/(home)/+layout.svelte
@@ -2,7 +2,7 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+  import { logWithTimestamp } from "$lib/utils/dev.utils";
   import type { Snippet } from "svelte";
 
   type Props = {
@@ -12,7 +12,7 @@
 
   const title = $i18n.navigation.portfolio;
 
-  logOnSafariMacOS("(app)(home)l");
+  logWithTimestamp("#4124:(app)(home)l");
 </script>
 
 <Layout {title}>

--- a/frontend/src/routes/(app)/(home)/+layout.svelte
+++ b/frontend/src/routes/(app)/(home)/+layout.svelte
@@ -2,6 +2,7 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
   import type { Snippet } from "svelte";
 
   type Props = {
@@ -10,6 +11,8 @@
   const { children }: Props = $props();
 
   const title = $i18n.navigation.portfolio;
+
+  logOnSafariMacOS("(app)(home)l");
 </script>
 
 <Layout {title}>

--- a/frontend/src/routes/(app)/(home)/+page.svelte
+++ b/frontend/src/routes/(app)/(home)/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+  import { logWithTimestamp } from "$lib/utils/dev.utils";
   import PortfolioRoute from "../(nns)/portfolio/+page.svelte";
 
-  logOnSafariMacOS("(app)(home)p");
+  logWithTimestamp("#4124:(app)(home)p");
 </script>
 
 <PortfolioRoute />

--- a/frontend/src/routes/(app)/(home)/+page.svelte
+++ b/frontend/src/routes/(app)/(home)/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
   import PortfolioRoute from "../(nns)/portfolio/+page.svelte";
+
+  logOnSafariMacOS("(app)(home)p");
 </script>
 
 <PortfolioRoute />

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -24,6 +24,7 @@
   import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
   import type { TableProject } from "$lib/types/staking";
   import type { UserToken } from "$lib/types/tokens-page";
+  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
   import { getTableProjects } from "$lib/utils/staking.utils";
 
   resetBalanceLoading();
@@ -68,6 +69,7 @@
   }
 
   $: if ($snsProposalsStoreIsLoading) {
+    logOnSafariMacOS("Loading SNS proposals...");
     loadProposalsSnsCF({ omitLargeFields: false });
   }
 

--- a/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/portfolio/+page.svelte
@@ -24,7 +24,7 @@
   import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
   import type { TableProject } from "$lib/types/staking";
   import type { UserToken } from "$lib/types/tokens-page";
-  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+  import { logWithTimestamp } from "$lib/utils/dev.utils";
   import { getTableProjects } from "$lib/utils/staking.utils";
 
   resetBalanceLoading();
@@ -69,7 +69,7 @@
   }
 
   $: if ($snsProposalsStoreIsLoading) {
-    logOnSafariMacOS("Loading SNS proposals...");
+    logWithTimestamp("#4124:Loading SNS proposals...");
     loadProposalsSnsCF({ omitLargeFields: false });
   }
 

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -12,6 +12,7 @@
   import { referrerPathStore } from "$lib/stores/routes.store";
   import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
   import { confirmCloseApp } from "$lib/utils/before-unload.utils";
+  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
   import { referrerPathForNav } from "$lib/utils/page.utils";
   import { voteRegistrationActive } from "$lib/utils/proposals.utils";
   import { BusyScreen, Toasts } from "@dfinity/gix-components";
@@ -24,8 +25,11 @@
     )
   );
 
+  logOnSafariMacOS("s2");
+
   // Use the top level layout to set the `referrerPath` because anything under `{#if isNullish($navigating)}` will miss the `afterNavigate` events
   afterNavigate(async (nav: AfterNavigate) => {
+    logOnSafariMacOS("s2:after navigation");
     // TODO: e2e to test this
     if (!browser) return;
 
@@ -42,6 +46,7 @@
   // To improve the UX while the app is loading on mainnet we display a spinner which is attached statically in the index.html files.
   // Once the authentication has been initialized we know most JavaScript resources has been loaded and therefore we can hide the spinner, the loading information.
   $: (() => {
+    logOnSafariMacOS("s2:$", !!browser);
     if (!browser) {
       return;
     }
@@ -52,6 +57,7 @@
     }
 
     const spinner = document.querySelector("body > #app-spinner");
+    logOnSafariMacOS("s2:$:remove spinner");
     spinner?.remove();
   })();
 </script>

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -12,7 +12,7 @@
   import { referrerPathStore } from "$lib/stores/routes.store";
   import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
   import { confirmCloseApp } from "$lib/utils/before-unload.utils";
-  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+  import { logWithTimestamp } from "$lib/utils/dev.utils";
   import { referrerPathForNav } from "$lib/utils/page.utils";
   import { voteRegistrationActive } from "$lib/utils/proposals.utils";
   import { BusyScreen, Toasts } from "@dfinity/gix-components";
@@ -25,11 +25,11 @@
     )
   );
 
-  logOnSafariMacOS("s2");
+  logWithTimestamp("#4124:s2");
 
   // Use the top level layout to set the `referrerPath` because anything under `{#if isNullish($navigating)}` will miss the `afterNavigate` events
   afterNavigate(async (nav: AfterNavigate) => {
-    logOnSafariMacOS("s2:after navigation");
+    logWithTimestamp("#4124:s2:after navigation");
     // TODO: e2e to test this
     if (!browser) return;
 
@@ -46,7 +46,7 @@
   // To improve the UX while the app is loading on mainnet we display a spinner which is attached statically in the index.html files.
   // Once the authentication has been initialized we know most JavaScript resources has been loaded and therefore we can hide the spinner, the loading information.
   $: (() => {
-    logOnSafariMacOS("s2:$", !!browser);
+    logWithTimestamp("#4124:s2:$", !!browser);
     if (!browser) {
       return;
     }
@@ -57,7 +57,7 @@
     }
 
     const spinner = document.querySelector("body > #app-spinner");
-    logOnSafariMacOS("s2:$:remove spinner");
+    logWithTimestamp("#4124:s2:$:remove spinner");
     spinner?.remove();
   })();
 </script>

--- a/frontend/src/routes/(app)/+layout.ts
+++ b/frontend/src/routes/(app)/+layout.ts
@@ -7,11 +7,13 @@ import {
   UNIVERSE_PARAM,
 } from "$lib/constants/routes.constants";
 import type { Page } from "$lib/derived/page.derived";
+import { logOnSafariMacOS } from "$lib/utils/dev.utils";
 import { nonNullish } from "@dfinity/utils";
 import type { LoadEvent } from "@sveltejs/kit";
 import type { LayoutLoad } from "./$types";
 
 export const load: LayoutLoad = ($event: LoadEvent): Partial<Page> => {
+  logOnSafariMacOS("t2:load");
   if (!browser) {
     return {
       universe: OWN_CANISTER_ID_TEXT,

--- a/frontend/src/routes/(app)/+layout.ts
+++ b/frontend/src/routes/(app)/+layout.ts
@@ -7,13 +7,13 @@ import {
   UNIVERSE_PARAM,
 } from "$lib/constants/routes.constants";
 import type { Page } from "$lib/derived/page.derived";
-import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { nonNullish } from "@dfinity/utils";
 import type { LoadEvent } from "@sveltejs/kit";
 import type { LayoutLoad } from "./$types";
 
 export const load: LayoutLoad = ($event: LoadEvent): Partial<Page> => {
-  logOnSafariMacOS("t2:load");
+  logWithTimestamp("#4124:t2:load");
   if (!browser) {
     return {
       universe: OWN_CANISTER_ID_TEXT,

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -19,13 +19,13 @@
   import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import { toastsClean } from "$lib/stores/toasts.store";
-  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
+  import { logWithTimestamp } from "$lib/utils/dev.utils";
   import { onMount } from "svelte";
 
   let ready = false;
   let worker: AuthWorker | undefined;
 
-  logOnSafariMacOS("s1");
+  logWithTimestamp("#4124:s1");
 
   const syncAuth = async (auth: AuthStoreData) => {
     worker?.syncAuthIdle(auth);
@@ -55,12 +55,12 @@
   onMount(async () => {
     initAnalytics();
 
-    logOnSafariMacOS("s1:before worker");
+    logWithTimestamp("#4124:s1:before worker");
     worker = await initAuthWorker();
-    logOnSafariMacOS("s1:worker initialized", worker);
+    logWithTimestamp("#4124:s1:worker initialized", worker);
 
     await syncAuth($authStore);
-    logOnSafariMacOS("s1:syncAuth");
+    logWithTimestamp("#4124:s1:syncAuth");
   });
 
   $: syncAuth($authStore);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -55,8 +55,12 @@
   onMount(async () => {
     initAnalytics();
 
+    logOnSafariMacOS("s1:before worker");
     worker = await initAuthWorker();
+    logOnSafariMacOS("s1:worker initialized", worker);
+
     await syncAuth($authStore);
+    logOnSafariMacOS("s1:syncAuth");
   });
 
   $: syncAuth($authStore);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -19,10 +19,13 @@
   import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import { toastsClean } from "$lib/stores/toasts.store";
+  import { logOnSafariMacOS } from "$lib/utils/dev.utils";
   import { onMount } from "svelte";
 
   let ready = false;
   let worker: AuthWorker | undefined;
+
+  logOnSafariMacOS("s1");
 
   const syncAuth = async (auth: AuthStoreData) => {
     worker?.syncAuthIdle(auth);


### PR DESCRIPTION
# Motivation

In Safari, **nns-dapp** occasionally hangs during initialization (about once every couple of weeks for a user), showing only the app background.

The issue could not be reproduced with the same browser version, but the provided DevTools logs suggest a problem in the `AuthStore.sync` function.

To help pinpoint the root cause, additional logs have been added. ~~These logs are enabled **only in Safari** to avoid polluting logs for other users.~~

# Changes

- Added extra logs around the suspected issue location, ~~scoped to Safari only~~.

# Tests

- ~~Verified that the new logs appear only in Safari.~~

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
