### PR TITLE
Fix spelling: unistalled -> uninstalled in index_canister_uninstalled…

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1281,7 +1281,7 @@
     "ledger_canister": "Ledger Canister",
     "index_canister": "Index Canister",
     "ledger_canister_error_tooltip": "The ledger canister is not responding. This may be because it ran out of cycles. Please check back later.",
-    "index_canister_uninstalled_tooltip": "The index canister has been unistalled. Transaction details are not available."
+    "index_canister_uninstalled_tooltip": "The index canister has been uninstalled. Transaction details are not available."
   },
   "import_token": {
     "import_token": "Import Token",


### PR DESCRIPTION
# Motivation

The tooltip text had a spelling mistake (unistalled -> uninstalled). This PR corrects the typo for clarity.

# Changes

Corrected "unistalled" to "uninstalled" in the index_canister_uninstalled_tooltip string.

# Tests

I've not tested, but this is a very minimal change.

# Todos

- [✓] Accessibility (a11y) – no impact
- [✓] Changelog – not needed, trivial text fix
