### PR TITLE
refactor(reporting): migrate components to runes

### DIFF
--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -2,7 +2,10 @@
   import { i18n } from "$lib/stores/i18n";
   import type { ReportingPeriod } from "$lib/types/reporting";
 
-  export let period: ReportingPeriod = "all";
+  type Props = {
+    period: ReportingPeriod;
+  };
+  let { period = $bindable() }: Props = $props();
 
   const options: Array<{
     value: ReportingPeriod;
@@ -30,7 +33,7 @@
             value={option.value}
             checked={period === option.value}
             aria-checked={period === option.value}
-            on:change={() => handleChange(option.value)}
+            onchange={() => handleChange(option.value)}
           />
           <span class="label">{option.label}</span>
         </label>

--- a/frontend/src/lib/components/reporting/ReportingTransactions.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactions.svelte
@@ -4,7 +4,7 @@
   import { i18n } from "$lib/stores/i18n";
   import type { ReportingPeriod } from "$lib/types/reporting";
 
-  let period: ReportingPeriod = "all";
+  let period: ReportingPeriod = $state("all");
 </script>
 
 <div class="wrapper" data-tid="reporting-transactions-component">

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -7,7 +7,6 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
-  import type { Account } from "$lib/types/account";
   import type { ReportingPeriod } from "$lib/types/reporting";
   import { formatDateCompact } from "$lib/utils/date.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -27,22 +26,21 @@
   import { IconDown } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import { ICPToken, nonNullish } from "@dfinity/utils";
-  import type { Readable } from "svelte/store";
 
-  export let period: ReportingPeriod = "all";
+  type Props = {
+    period: ReportingPeriod;
+  };
+  const { period }: Props = $props();
 
-  let identity: Identity | null | undefined;
-  let swapCanisterAccounts: Set<string>;
-  let nnsAccounts: Account[];
-  let swapCanisterAccountsStore: Readable<Set<string>>;
-  let loading = false;
-
-  $: identity = $authStore.identity;
-  $: nnsAccounts = $nnsAccountsListStore;
-  $: swapCanisterAccountsStore = createSwapCanisterAccountsStore(
-    identity?.getPrincipal()
+  const identity = $derived($authStore.identity);
+  const nnsAccounts = $derived($nnsAccountsListStore);
+  const swapCanisterAccountsStore = $derived(
+    createSwapCanisterAccountsStore(identity?.getPrincipal())
   );
-  $: swapCanisterAccounts = $swapCanisterAccountsStore ?? new Set();
+  const swapCanisterAccounts = $derived(
+    $swapCanisterAccountsStore ?? new Set()
+  );
+  let loading = $state(false);
 
   const fetchAllNnsNeuronsAndSortThemByStake = async (
     identity: Identity
@@ -157,7 +155,7 @@
 
 <button
   data-tid="reporting-transactions-button-component"
-  on:click={exportIcpTransactions}
+  onclick={exportIcpTransactions}
   class="primary with-icon"
   disabled={loading}
   aria-label={$i18n.reporting.transactions_download}


### PR DESCRIPTION
# Motivation

The nns-dapp will display more information in the reporting tables. This initial PR updates the related components to facilitate future changes by migrating to runes.

[NNS-4133](https://dfinity.atlassian.net/browse/NNS1-4133)

# Changes

- Migrate reporting related components to use runes.

# Tests

- Tests should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
