### PR TITLE
feat(reporting): add custom date range selection

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+- Custom date range selection for reporting.
+
 #### Changed
 
 - Hide technical error details.

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -106,13 +106,13 @@
     </div>
 
     {#if isCustom()}
-      <div class="custom-range" data-tid="custom-range-section">
+      <div class="range" data-tid="range-selection">
         <label class="date-input">
           <span>{$i18n.reporting.custom_start_date}</span>
           <input
             type="date"
             name="from"
-            data-tid="custom-from-date"
+            data-tid="from-date"
             value={customFrom}
             max={today}
             onchange={handleFromDateChange}
@@ -123,16 +123,14 @@
           <input
             type="date"
             name="to"
-            data-tid="custom-to-date"
+            data-tid="to-date"
             value={customTo}
             min={customFrom || ""}
             max={today}
             onchange={handleToDateChange}
           />
         </label>
-        <p class="range-hint" data-tid="range-hint"
-          >{$i18n.reporting.range_max_one_year}</p
-        >
+        <p class="hint">{$i18n.reporting.range_max_one_year}</p>
       </div>
     {/if}
   </div>
@@ -195,7 +193,7 @@
       }
     }
 
-    .custom-range {
+    .range {
       display: flex;
       flex-wrap: wrap;
       gap: var(--padding-2x);
@@ -214,7 +212,7 @@
         }
       }
 
-      .range-hint {
+      .hint {
         width: 100%;
         font-size: var(--font-size-small);
         color: var(--text-description);

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -45,12 +45,9 @@
   const isRangeWithinOneYear = (fromDate: string, toDate: string): boolean => {
     const [fy, fm, fd] = fromDate.split("-").map(Number);
     const [ty, tm, td] = toDate.split("-").map(Number);
-    const fromLocal = new Date(fy, (fm ?? 1) - 1, fd ?? 1).getTime();
     const toLocal = new Date(ty, (tm ?? 1) - 1, td ?? 1).getTime();
-    const oneYearLater = new Date(fy, (fm ?? 1) - 1, fd ?? 1);
-    oneYearLater.setFullYear(oneYearLater.getFullYear() + 1);
-    const oneYearLaterMs = oneYearLater.getTime();
-    return toLocal <= oneYearLaterMs;
+    const oneYearLater = new Date(fy + 1, (fm ?? 1) - 1, fd ?? 1).getTime();
+    return toLocal <= oneYearLater;
   };
 
   const handleFromDateChange = (event: Event) => {

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -106,12 +106,13 @@
     </div>
 
     {#if isCustom()}
-      <div class="custom-range">
+      <div class="custom-range" data-tid="custom-range-section">
         <label class="date-input">
           <span>{$i18n.reporting.custom_start_date}</span>
           <input
             type="date"
             name="from"
+            data-tid="custom-from-date"
             value={customFrom}
             max={today}
             onchange={handleFromDateChange}
@@ -122,14 +123,17 @@
           <input
             type="date"
             name="to"
+            data-tid="custom-to-date"
             value={customTo}
             min={customFrom || ""}
             max={today}
             onchange={handleToDateChange}
           />
         </label>
-        <p class="range-hint">{$i18n.reporting.range_max_one_year} </p></div
-      >
+        <p class="range-hint" data-tid="range-hint"
+          >{$i18n.reporting.range_max_one_year}</p
+        >
+      </div>
     {/if}
   </div>
 </fieldset>

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -43,10 +43,12 @@
 
   // Compare range in LOCAL time to avoid timezone drift
   const isRangeWithinOneYear = (fromDate: string, toDate: string): boolean => {
-    const [fy, fm, fd] = fromDate.split("-").map(Number);
     const [ty, tm, td] = toDate.split("-").map(Number);
     const toLocal = new Date(ty, (tm ?? 1) - 1, td ?? 1).getTime();
+
+    const [fy, fm, fd] = fromDate.split("-").map(Number);
     const oneYearLater = new Date(fy + 1, (fm ?? 1) - 1, fd ?? 1).getTime();
+
     return toLocal <= oneYearLater;
   };
 

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -32,15 +32,25 @@
 
   const isCustom = () => period === "custom";
 
+  // Build dates in LOCAL time to match <input type="date"> semantics
   const addYears = (dateString: string, years: number): string => {
-    const date = new Date(dateString);
-    date.setFullYear(date.getFullYear() + years);
-    return formatDateCompact(date, "-");
+    // Parse 'yyyy-mm-dd' parts (avoid Date.parse which treats date-only as UTC)
+    const [y, m, d] = dateString.split("-").map(Number);
+    const local = new Date(y, (m ?? 1) - 1, d ?? 1);
+    local.setFullYear(local.getFullYear() + years);
+    return formatDateCompact(local, "-");
   };
 
+  // Compare range in LOCAL time to avoid timezone drift
   const isRangeWithinOneYear = (fromDate: string, toDate: string): boolean => {
-    const oneYearFromStart = addYears(fromDate, 1);
-    return new Date(toDate) <= new Date(oneYearFromStart);
+    const [fy, fm, fd] = fromDate.split("-").map(Number);
+    const [ty, tm, td] = toDate.split("-").map(Number);
+    const fromLocal = new Date(fy, (fm ?? 1) - 1, fd ?? 1).getTime();
+    const toLocal = new Date(ty, (tm ?? 1) - 1, td ?? 1).getTime();
+    const oneYearLater = new Date(fy, (fm ?? 1) - 1, fd ?? 1);
+    oneYearLater.setFullYear(oneYearLater.getFullYear() + 1);
+    const oneYearLaterMs = oneYearLater.getTime();
+    return toLocal <= oneYearLaterMs;
   };
 
   const handleFromDateChange = (event: Event) => {

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -40,7 +40,7 @@
 
   const isRangeWithinOneYear = (fromDate: string, toDate: string): boolean => {
     const oneYearFromStart = addYears(fromDate, 1);
-    return toDate <= oneYearFromStart;
+    return new Date(toDate) <= new Date(oneYearFromStart);
   };
 
   const handleFromDateChange = (event: Event) => {
@@ -60,8 +60,8 @@
         // If 'to' is before 'from', set 'to' to 'from'
         customTo = newFromDate;
       } else if (!isRangeWithinOneYear(newFromDate, customTo)) {
-        const maxToDate = addYears(newFromDate, 1);
-        customTo = maxToDate > today ? today : maxToDate;
+        const maxAllowedToDate = addYears(newFromDate, 1);
+        customTo = maxAllowedToDate > today ? today : maxAllowedToDate;
       }
     }
   };

--- a/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
+++ b/frontend/src/lib/components/reporting/ReportingDateRangeSelector.svelte
@@ -41,15 +41,19 @@
     return formatDateCompact(local, "-");
   };
 
+  const stringToDate = (value: string): Date => {
+    const [y, m, d] = value.split("-").map(Number);
+    return new Date(y, (m ?? 1) - 1, d ?? 1);
+  };
+
   // Compare range in LOCAL time to avoid timezone drift
   const isRangeWithinOneYear = (fromDate: string, toDate: string): boolean => {
-    const [ty, tm, td] = toDate.split("-").map(Number);
-    const toLocal = new Date(ty, (tm ?? 1) - 1, td ?? 1).getTime();
+    const toLocal = stringToDate(toDate);
 
-    const [fy, fm, fd] = fromDate.split("-").map(Number);
-    const oneYearLater = new Date(fy + 1, (fm ?? 1) - 1, fd ?? 1).getTime();
+    const oneYearLater = stringToDate(fromDate);
+    oneYearLater.setFullYear(oneYearLater.getFullYear() + 1);
 
-    return toLocal <= oneYearLater;
+    return toLocal.getTime() <= oneYearLater.getTime();
   };
 
   const handleFromDateChange = (event: Event) => {

--- a/frontend/src/lib/components/reporting/ReportingTransactions.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactions.svelte
@@ -5,6 +5,8 @@
   import type { ReportingPeriod } from "$lib/types/reporting";
 
   let period: ReportingPeriod = $state("all");
+  let customFrom: string = $state("");
+  let customTo: string = $state("");
 </script>
 
 <div class="wrapper" data-tid="reporting-transactions-component">
@@ -13,8 +15,8 @@
     <p class="description">{$i18n.reporting.transactions_description}</p>
   </div>
 
-  <ReportingDateRangeSelector bind:period />
-  <ReportingTransactionsButton {period} />
+  <ReportingDateRangeSelector bind:period bind:customFrom bind:customTo />
+  <ReportingTransactionsButton {period} {customFrom} {customTo} />
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -44,12 +44,10 @@
   );
   let loading = $state(false);
 
-  const isDisabled = $derived(() => {
-    if (loading) return true;
-    if (period !== "custom") return false;
-    if (!(customFrom && customTo)) return true;
-    return false;
-  });
+  const isCustomPeriodIncomplete = $derived(
+    period === "custom" && (!customFrom || !customTo)
+  );
+  const isDisabled = $derived(loading || isCustomPeriodIncomplete);
 
   const fetchAllNnsNeuronsAndSortThemByStake = async (
     identity: Identity
@@ -182,7 +180,7 @@
   data-tid="reporting-transactions-button-component"
   onclick={exportIcpTransactions}
   class="primary with-icon"
-  disabled={isDisabled()}
+  disabled={isDisabled}
   aria-label={$i18n.reporting.transactions_download}
 >
   <IconDown />

--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -8,7 +8,6 @@
   import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
   import type { ReportingPeriod } from "$lib/types/reporting";
-  import { formatDateCompact } from "$lib/utils/date.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { sortNeuronsByStake } from "$lib/utils/neuron.utils";
   import {
@@ -16,6 +15,7 @@
     FileSystemAccessError,
   } from "$lib/utils/reporting.save-csv-to-file.utils";
   import {
+    buildFileName,
     buildTransactionsDatasets,
     convertPeriodToNanosecondRange,
     generateCsvFileToSave,
@@ -29,8 +29,10 @@
 
   type Props = {
     period: ReportingPeriod;
+    customFrom?: string;
+    customTo?: string;
   };
-  const { period }: Props = $props();
+  let { period, customFrom, customTo }: Props = $props();
 
   const identity = $derived($authStore.identity);
   const nnsAccounts = $derived($nnsAccountsListStore);
@@ -41,6 +43,13 @@
     $swapCanisterAccountsStore ?? new Set()
   );
   let loading = $state(false);
+
+  const isDisabled = $derived(() => {
+    if (loading) return true;
+    if (period !== "custom") return false;
+    if (!(customFrom && customTo)) return true;
+    return false;
+  });
 
   const fetchAllNnsNeuronsAndSortThemByStake = async (
     identity: Identity
@@ -74,7 +83,11 @@
       );
 
       const entities = [...nnsAccounts, ...nnsNeurons];
-      const range = convertPeriodToNanosecondRange({ period });
+      const range = convertPeriodToNanosecondRange({
+        period,
+        from: customFrom,
+        to: customTo,
+      });
       const transactions = await getAccountTransactionsConcurrently({
         entities,
         identity: signIdentity,
@@ -131,7 +144,11 @@
           label: $i18n.reporting.timestamp,
         },
       ];
-      const fileName = `icp_transactions_export_${formatDateCompact(new Date())}_${period}`;
+      const fileName = buildFileName({
+        period,
+        from: customFrom,
+        to: customTo,
+      });
 
       await generateCsvFileToSave({
         datasets,
@@ -165,7 +182,7 @@
   data-tid="reporting-transactions-button-component"
   onclick={exportIcpTransactions}
   class="primary with-icon"
-  disabled={loading}
+  disabled={isDisabled()}
   aria-label={$i18n.reporting.transactions_download}
 >
   <IconDown />

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -626,8 +626,8 @@
   },
   "wallet": {
     "title": "Account",
-    "direction_from": "From",
-    "direction_to": "To",
+    "direction_from": "From:",
+    "direction_to": "To:",
     "no_transactions": "Transactions will appear here.",
     "icp_qrcode_aria_label": "A QR code that renders the address to receive ICP",
     "icrc_qrcode_aria_label": "A QR code that renders the address to receive $tokenSymbol",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -240,7 +240,11 @@
     "range_filter_title": "Reporting Date Range",
     "range_filter_all": "All transactions",
     "range_last_year": "Last year",
-    "range_year_to_date": "Year to date"
+    "range_year_to_date": "Year to date",
+    "range_custom": "Custom",
+    "custom_start_date": "From Date:",
+    "custom_end_date": "To Date:",
+    "range_max_one_year": "Maximum range is one year"
   },
   "auth": {
     "login": "Sign in with Internet Identity",
@@ -622,8 +626,8 @@
   },
   "wallet": {
     "title": "Account",
-    "direction_from": "From:",
-    "direction_to": "To:",
+    "direction_from": "From",
+    "direction_to": "To",
     "no_transactions": "Transactions will appear here.",
     "icp_qrcode_aria_label": "A QR code that renders the address to receive ICP",
     "icrc_qrcode_aria_label": "A QR code that renders the address to receive $tokenSymbol",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -250,6 +250,10 @@ interface I18nReporting {
   range_filter_all: string;
   range_last_year: string;
   range_year_to_date: string;
+  range_custom: string;
+  custom_start_date: string;
+  custom_end_date: string;
+  range_max_one_year: string;
 }
 
 interface I18nAuth {

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -1,3 +1,4 @@
+import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import type {
   ReportingPeriod,
   TransactionResults,
@@ -410,7 +411,7 @@ export const convertPeriodToNanosecondRange = ({
   to?: string;
 }): TransactionsDateRange => {
   const now = new Date();
-  const currentYear = now.getFullYear();
+  const currentYear = now.getUTCFullYear();
   const toNanoseconds = (milliseconds: number): bigint =>
     BigInt(milliseconds) * BigInt(1_000_000);
 

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -1,4 +1,3 @@
-import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import type {
   ReportingPeriod,
   TransactionResults,
@@ -411,7 +410,7 @@ export const convertPeriodToNanosecondRange = ({
   to?: string;
 }): TransactionsDateRange => {
   const now = new Date();
-  const currentYear = now.getUTCFullYear();
+  const currentYear = now.getFullYear();
   const toNanoseconds = (milliseconds: number): bigint =>
     BigInt(milliseconds) * BigInt(1_000_000);
 

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -4,6 +4,7 @@ import type {
   TransactionsDateRange,
 } from "$lib/types/reporting";
 import {
+  formatDateCompact,
   getFutureDateFromDelayInSeconds,
   nanoSecondsToDateTime,
   nowInBigIntNanoSeconds,
@@ -448,4 +449,20 @@ export const convertPeriodToNanosecondRange = ({
       };
     }
   }
+};
+
+export const buildFileName = ({
+  period,
+  from,
+  to,
+}: {
+  period: ReportingPeriod;
+  from?: string;
+  to?: string;
+}) => {
+  const prefix = "icp_transactions_export_";
+  const date = formatDateCompact(new Date());
+  const suffix =
+    period === "custom" ? `_${period}_${from}_${to}` : `_${period}`;
+  return `${prefix}${date}${suffix}`;
 };

--- a/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
@@ -78,14 +78,14 @@ describe("ReportingDateRangeSelector", () => {
     });
 
     const { po } = renderComponent(testProps);
-    const allOptions = await po.getAllOptions();
+    const options = await po.getAllOptions();
 
     expect(testProps.period).toBe("all");
 
-    await allOptions[3].click();
+    await options[3].click();
     await tick();
 
-    expect(await po.isCustomRangeVisible()).toBe(true);
+    expect(await po.getCustomRangeSection().isPresent()).toBe(true);
     expect(await po.getFromDateInput().isPresent()).toBe(true);
     expect(await po.getToDateInput().isPresent()).toBe(true);
   });
@@ -108,8 +108,8 @@ describe("ReportingDateRangeSelector", () => {
       await po.setFromDate("2025-01-01");
       await tick();
 
-      expect(testProps.customFrom).toBe("01-01-2025");
-      expect(testProps.customTo).toBe("2025-06-15"); // Today (mock date)
+      expect(testProps.customFrom).toBe("2025-01-01");
+      expect(testProps.customTo).toBe("2025-10-01"); // Today (mock date)
     });
 
     it("should limit 'to' date to 1 year when 'from' exceeds range", async () => {
@@ -122,7 +122,7 @@ describe("ReportingDateRangeSelector", () => {
       const { po } = renderComponent(testProps);
 
       // Set 'from' date more than 1 year ago
-      await po.setFromDate("2043-01-01");
+      await po.setFromDate("2024-01-01");
       await tick();
 
       expect(testProps.customFrom).toBe("2024-01-01");
@@ -139,7 +139,7 @@ describe("ReportingDateRangeSelector", () => {
       const { po } = renderComponent(testProps);
 
       // Change 'from' to create >1 year range
-      await po.setFromDate("2043-06-01");
+      await po.setFromDate("2024-06-01");
       await tick();
 
       expect(testProps.customFrom).toBe("2024-06-01");
@@ -150,7 +150,7 @@ describe("ReportingDateRangeSelector", () => {
       const testProps = $state({
         period: "custom" as const,
         customFrom: "2024-01-01",
-        customTo: "2043-06-01",
+        customTo: "2024-06-01",
       });
 
       const { po } = renderComponent(testProps);

--- a/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
@@ -90,13 +90,13 @@ describe("ReportingDateRangeSelector", () => {
     expect(await po.getToDateInput().isPresent()).toBe(true);
   });
 
-  describe("Custom date range functionality", () => {
+  describe("Custom date", () => {
     beforeEach(() => {
       vi.useFakeTimers();
-      vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
+      vi.setSystemTime(new Date("2025-10-01T12:00:00Z"));
     });
 
-    it("should auto-set 'to' date when 'from' date is selected and no 'to' exists", async () => {
+    it.only("should auto-set 'to' date when 'from' date is selected and no 'to' exists", async () => {
       const testProps = $state({
         period: "custom" as const,
         customFrom: undefined,
@@ -105,11 +105,11 @@ describe("ReportingDateRangeSelector", () => {
 
       const { po } = renderComponent(testProps);
 
-      await po.setFromDate("2024-01-01");
+      await po.setFromDate("2025-01-01");
       await tick();
 
-      expect(testProps.customFrom).toBe("2024-01-01");
-      expect(testProps.customTo).toBe("2024-06-15"); // Today (mock date)
+      expect(testProps.customFrom).toBe("01-01-2025");
+      expect(testProps.customTo).toBe("2025-06-15"); // Today (mock date)
     });
 
     it("should limit 'to' date to 1 year when 'from' exceeds range", async () => {
@@ -122,79 +122,79 @@ describe("ReportingDateRangeSelector", () => {
       const { po } = renderComponent(testProps);
 
       // Set 'from' date more than 1 year ago
-      await po.setFromDate("2023-01-01");
+      await po.setFromDate("2043-01-01");
       await tick();
 
-      expect(testProps.customFrom).toBe("2023-01-01");
-      expect(testProps.customTo).toBe("2024-01-01"); // Exactly 1 year later
+      expect(testProps.customFrom).toBe("2024-01-01");
+      expect(testProps.customTo).toBe("2025-01-01"); // Exactly 1 year later
     });
 
     it("should adjust 'to' date when changing 'from' creates >1 year range", async () => {
       const testProps = $state({
         period: "custom" as const,
-        customFrom: "2024-01-01",
-        customTo: "2024-12-31",
+        customFrom: "2025-01-01",
+        customTo: "2025-12-31",
       });
 
       const { po } = renderComponent(testProps);
 
       // Change 'from' to create >1 year range
-      await po.setFromDate("2023-06-01");
+      await po.setFromDate("2043-06-01");
       await tick();
 
-      expect(testProps.customFrom).toBe("2023-06-01");
-      expect(testProps.customTo).toBe("2024-06-01"); // Adjusted to 1 year from new 'from'
+      expect(testProps.customFrom).toBe("2024-06-01");
+      expect(testProps.customTo).toBe("2025-06-01"); // Adjusted to 1 year from new 'from'
     });
 
     it("should adjust 'from' date when changing 'to' creates >1 year range", async () => {
       const testProps = $state({
         period: "custom" as const,
-        customFrom: "2023-01-01",
-        customTo: "2023-06-01",
+        customFrom: "2024-01-01",
+        customTo: "2043-06-01",
       });
 
       const { po } = renderComponent(testProps);
 
       // Change 'to' to create >1 year range
-      await po.setToDate("2024-06-01");
+      await po.setToDate("2025-06-01");
       await tick();
 
-      expect(testProps.customFrom).toBe("2023-06-01"); // Adjusted to 1 year before new 'to'
-      expect(testProps.customTo).toBe("2024-06-01");
+      expect(testProps.customFrom).toBe("2024-06-01"); // Adjusted to 1 year before new 'to'
+      expect(testProps.customTo).toBe("2025-06-01");
     });
 
     it("should set 'to' to 'from' when 'to' becomes earlier than 'from'", async () => {
       const testProps = $state({
         period: "custom" as const,
-        customFrom: "2024-06-01",
-        customTo: "2024-12-01",
+        customFrom: "2025-06-01",
+        customTo: "2025-12-01",
       });
 
       const { po } = renderComponent(testProps);
 
       // Set 'from' to date after current 'to'
-      await po.setFromDate("2024-12-15");
+      await po.setFromDate("2025-12-15");
       await tick();
 
-      expect(testProps.customFrom).toBe("2024-12-15");
-      expect(testProps.customTo).toBe("2024-12-15"); // Adjusted to match 'from'
+      expect(testProps.customFrom).toBe("2025-12-15");
+      expect(testProps.customTo).toBe("2025-12-15"); // Adjusted to match 'from'
     });
 
     it("should set 'from' to 'to' when 'to' becomes earlier than 'from'", async () => {
       const testProps = $state({
         period: "custom" as const,
-        customFrom: "2024-06-01",
-        customTo: "2024-12-01",
+        customFrom: "2025-06-01",
+        customTo: "2025-12-01",
       });
 
       const { po } = renderComponent(testProps);
 
       // Set 'to' to date before current 'from'
-      await po.setToDate("2024-05-01");
+      await po.setToDate("2025-05-01");
       await tick();
 
-      expect(testProps.customFrom).toBe("2024-05-01"); // Adjusted to match 'to'
-      expect(testProps.customTo).toBe("2024-05-01");
+      expect(testProps.customFrom).toBe("2025-05-01"); // Adjusted to match 'to'
+      expect(testProps.customTo).toBe("2025-05-01");
     });
   });
 });

--- a/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
@@ -96,7 +96,7 @@ describe("ReportingDateRangeSelector", () => {
       vi.setSystemTime(new Date("2025-10-01T12:00:00Z"));
     });
 
-    it.only("should auto-set 'to' date when 'from' date is selected and no 'to' exists", async () => {
+    it("should auto-set 'to' date when 'from' date is selected and no 'to' exists", async () => {
       const testProps = $state({
         period: "custom" as const,
         customFrom: undefined,

--- a/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingDateRangeSelector.svelte.spec.ts
@@ -27,10 +27,10 @@ describe("ReportingDateRangeSelector", () => {
     expect(await selectedOption.getValue()).toBe("last-year");
   });
 
-  it("should render three options", async () => {
+  it("should render four options", async () => {
     const { po } = renderComponent();
 
-    expect(await po.getAllOptions()).toHaveLength(3);
+    expect(await po.getAllOptions()).toHaveLength(4);
   });
 
   it("should select 'all' option by default", async () => {
@@ -56,7 +56,7 @@ describe("ReportingDateRangeSelector", () => {
     expect(await currentOption.getValue()).toBe(await secondOption.getValue());
   });
 
-  it("should update exported prop when selecting an option", async () => {
+  it("should update period when selecting an option", async () => {
     const testProps = $state({ period: "all" as const });
 
     const { po } = renderComponent(testProps);
@@ -67,6 +67,134 @@ describe("ReportingDateRangeSelector", () => {
     await allOptions[1].click();
     await tick();
 
-    expect(testProps.period).toBe("last-year");
+    expect(testProps.period).toBe("year-to-date");
+  });
+
+  it("should show custom date inputs when custom period is selected", async () => {
+    const testProps = $state({
+      period: "all" as const,
+      customFrom: undefined,
+      customTo: undefined,
+    });
+
+    const { po } = renderComponent(testProps);
+    const allOptions = await po.getAllOptions();
+
+    expect(testProps.period).toBe("all");
+
+    await allOptions[3].click();
+    await tick();
+
+    expect(await po.isCustomRangeVisible()).toBe(true);
+    expect(await po.getFromDateInput().isPresent()).toBe(true);
+    expect(await po.getToDateInput().isPresent()).toBe(true);
+  });
+
+  describe("Custom date range functionality", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
+    });
+
+    it("should auto-set 'to' date when 'from' date is selected and no 'to' exists", async () => {
+      const testProps = $state({
+        period: "custom" as const,
+        customFrom: undefined,
+        customTo: undefined,
+      });
+
+      const { po } = renderComponent(testProps);
+
+      await po.setFromDate("2024-01-01");
+      await tick();
+
+      expect(testProps.customFrom).toBe("2024-01-01");
+      expect(testProps.customTo).toBe("2024-06-15"); // Today (mock date)
+    });
+
+    it("should limit 'to' date to 1 year when 'from' exceeds range", async () => {
+      const testProps = $state({
+        period: "custom" as const,
+        customFrom: undefined,
+        customTo: undefined,
+      });
+
+      const { po } = renderComponent(testProps);
+
+      // Set 'from' date more than 1 year ago
+      await po.setFromDate("2023-01-01");
+      await tick();
+
+      expect(testProps.customFrom).toBe("2023-01-01");
+      expect(testProps.customTo).toBe("2024-01-01"); // Exactly 1 year later
+    });
+
+    it("should adjust 'to' date when changing 'from' creates >1 year range", async () => {
+      const testProps = $state({
+        period: "custom" as const,
+        customFrom: "2024-01-01",
+        customTo: "2024-12-31",
+      });
+
+      const { po } = renderComponent(testProps);
+
+      // Change 'from' to create >1 year range
+      await po.setFromDate("2023-06-01");
+      await tick();
+
+      expect(testProps.customFrom).toBe("2023-06-01");
+      expect(testProps.customTo).toBe("2024-06-01"); // Adjusted to 1 year from new 'from'
+    });
+
+    it("should adjust 'from' date when changing 'to' creates >1 year range", async () => {
+      const testProps = $state({
+        period: "custom" as const,
+        customFrom: "2023-01-01",
+        customTo: "2023-06-01",
+      });
+
+      const { po } = renderComponent(testProps);
+
+      // Change 'to' to create >1 year range
+      await po.setToDate("2024-06-01");
+      await tick();
+
+      expect(testProps.customFrom).toBe("2023-06-01"); // Adjusted to 1 year before new 'to'
+      expect(testProps.customTo).toBe("2024-06-01");
+    });
+
+    it("should set 'to' to 'from' when 'to' becomes earlier than 'from'", async () => {
+      const testProps = $state({
+        period: "custom" as const,
+        customFrom: "2024-06-01",
+        customTo: "2024-12-01",
+      });
+
+      const { po } = renderComponent(testProps);
+
+      // Set 'from' to date after current 'to'
+      await po.setFromDate("2024-12-15");
+      await tick();
+
+      expect(testProps.customFrom).toBe("2024-12-15");
+      expect(testProps.customTo).toBe("2024-12-15"); // Adjusted to match 'from'
+    });
+
+    it("should set 'from' to 'to' when 'to' becomes earlier than 'from'", async () => {
+      const testProps = $state({
+        period: "custom" as const,
+        customFrom: "2024-06-01",
+        customTo: "2024-12-01",
+      });
+
+      const { po } = renderComponent(testProps);
+
+      // Set 'to' to date before current 'from'
+      await po.setToDate("2024-05-01");
+      await tick();
+
+      expect(testProps.customFrom).toBe("2024-05-01"); // Adjusted to match 'to'
+      expect(testProps.customTo).toBe("2024-05-01");
+    });
   });
 });

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -464,7 +464,7 @@ describe("ReportingTransactionsButton", () => {
       const expectedFromNanos =
         BigInt(new Date("2024-01-01T00:00:00.000Z").getTime()) * NANOS_IN_MS;
       const expectedToNanos =
-        BigInt(new Date("2024-01-31T23:59:59.999Z").getTime()) * NANOS_IN_MS;
+        BigInt(new Date("2024-02-01T00:00:00.000Z").getTime()) * NANOS_IN_MS;
 
       expect(spyExportDataService).toHaveBeenCalledWith({
         entities: expect.any(Array),

--- a/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
+++ b/frontend/src/tests/lib/components/reporting/ReportingTransactionsButton.spec.ts
@@ -82,11 +82,20 @@ describe("ReportingTransactionsButton", () => {
     {
       onTrigger,
       period,
-    }: { onTrigger?: () => void; period: ReportingPeriod } = { period: "all" }
+      customFrom,
+      customTo,
+    }: {
+      onTrigger?: () => void;
+      period: ReportingPeriod;
+      customFrom?: string;
+      customTo?: string;
+    } = { period: "all" }
   ) => {
     const { container } = render(ReportingTransactionsButton, {
       props: {
         period,
+        customFrom,
+        customTo,
       },
       events: {
         ...(nonNullish(onTrigger) && {
@@ -396,5 +405,149 @@ describe("ReportingTransactionsButton", () => {
     await runResolvedPromises();
 
     expect(get(busyStore)).toEqual([]);
+  });
+
+  describe("Button state based on custom period", () => {
+    it("should be enabled when period is not custom", async () => {
+      const po = renderComponent({ period: "all" });
+      expect(await po.isEnabled()).toBe(true);
+    });
+
+    it("should be enabled when period is custom and both dates are provided", async () => {
+      const po = renderComponent({
+        period: "custom",
+        customFrom: "2024-01-01",
+        customTo: "2024-01-31",
+      });
+      expect(await po.isEnabled()).toBe(true);
+    });
+
+    it("should be disabled when period is custom and values are missing", async () => {
+      let po = renderComponent({ period: "custom" });
+      expect(await po.isDisabled()).toBe(true);
+
+      po = renderComponent({
+        period: "custom",
+        customTo: "2024-01-31",
+      });
+      expect(await po.isDisabled()).toBe(true);
+
+      po = renderComponent({
+        period: "custom",
+        customFrom: "2024-01-01",
+      });
+      expect(await po.isDisabled()).toBe(true);
+    });
+  });
+
+  describe("Custom date range values", () => {
+    it("should pass correct date range to convertPeriodToNanosecondRange for custom period", async () => {
+      const NANOS_IN_MS = BigInt(1_000_000);
+      const fromDate = "2024-01-01";
+      const toDate = "2024-01-31";
+
+      setAccountsForTesting({
+        main: mockMainAccount,
+      });
+
+      const po = renderComponent({
+        period: "custom",
+        customFrom: fromDate,
+        customTo: toDate,
+      });
+
+      expect(spyExportDataService).toBeCalledTimes(0);
+
+      await po.click();
+      await runResolvedPromises();
+
+      const expectedFromNanos =
+        BigInt(new Date("2024-01-01T00:00:00.000Z").getTime()) * NANOS_IN_MS;
+      const expectedToNanos =
+        BigInt(new Date("2024-01-31T23:59:59.999Z").getTime()) * NANOS_IN_MS;
+
+      expect(spyExportDataService).toHaveBeenCalledWith({
+        entities: expect.any(Array),
+        identity: mockIdentity,
+        range: {
+          from: expectedFromNanos,
+          to: expectedToNanos,
+        },
+      });
+    });
+
+    it("should handle empty custom dates gracefully", async () => {
+      setAccountsForTesting({
+        main: mockMainAccount,
+      });
+
+      const po = renderComponent({
+        period: "custom",
+        customFrom: "",
+        customTo: "",
+      });
+
+      // Should be disabled due to empty dates
+      expect(await po.isDisabled()).toBe(true);
+    });
+  });
+
+  describe("Filename generation", () => {
+    it("should generate correct filename for all period", async () => {
+      const po = renderComponent({ period: "all" });
+
+      await po.click();
+      await runResolvedPromises();
+
+      expect(spySaveGeneratedCsv).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: "icp_transactions_export_20231014_all",
+        })
+      );
+    });
+
+    it("should generate correct filename for year-to-date period", async () => {
+      const po = renderComponent({ period: "year-to-date" });
+
+      await po.click();
+      await runResolvedPromises();
+
+      expect(spySaveGeneratedCsv).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: "icp_transactions_export_20231014_year-to-date",
+        })
+      );
+    });
+
+    it("should generate correct filename for last-year period", async () => {
+      const po = renderComponent({ period: "last-year" });
+
+      await po.click();
+      await runResolvedPromises();
+
+      expect(spySaveGeneratedCsv).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: "icp_transactions_export_20231014_last-year",
+        })
+      );
+    });
+
+    it("should generate correct filename for custom period with dates", async () => {
+      const po = renderComponent({
+        period: "custom",
+        customFrom: "2024-01-01",
+        customTo: "2024-01-31",
+      });
+
+      await po.click();
+      await runResolvedPromises();
+
+      expect(spySaveGeneratedCsv).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName:
+            "icp_transactions_export_20231014_custom_2024-01-01_2024-01-31",
+        })
+      );
+    });
   });
 });

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -34,7 +34,7 @@ export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
   }
 
   getCustomRangeSection() {
-    return this.getElement().byTestId("range-selection");
+    return this.getElement("range-selection");
   }
 
   getFromDateInput() {
@@ -42,7 +42,7 @@ export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
   }
 
   getToDateInput() {
-    return this.getElement().byTestId("to-date");
+    return this.getElement("to-date");
   }
 
   async setFromDate(date: string): Promise<void> {
@@ -53,9 +53,5 @@ export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
   async setToDate(date: string): Promise<void> {
     const field = this.getToDateInput();
     await field.input(date, "change");
-  }
-
-  async isCustomRangeVisible(): Promise<boolean> {
-    return this.getCustomRangeSection().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -32,4 +32,30 @@ export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
 
     throw new Error(`Option ${option} not found`);
   }
+
+  getCustomRangeSection() {
+    return this.getElement().byTestId("custom-range-section");
+  }
+
+  getFromDateInput() {
+    return this.getElement().byTestId("custom-from-date");
+  }
+
+  getToDateInput() {
+    return this.getElement().byTestId("custom-to-date");
+  }
+
+  async isCustomRangeVisible(): Promise<boolean> {
+    return this.getCustomRangeSection().isPresent();
+  }
+
+  async setFromDate(date: string): Promise<void> {
+    const input = this.getFromDateInput();
+    await input.typeText(date);
+  }
+
+  async setToDate(date: string): Promise<void> {
+    const input = this.getToDateInput();
+    await input.typeText(date);
+  }
 }

--- a/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingDateRangeSelector.page-object.ts
@@ -34,28 +34,28 @@ export class ReportingDateRangeSelectorPo extends SimpleBasePageObject {
   }
 
   getCustomRangeSection() {
-    return this.getElement().byTestId("custom-range-section");
+    return this.getElement().byTestId("range-selection");
   }
 
   getFromDateInput() {
-    return this.getElement().byTestId("custom-from-date");
+    return this.getElement("from-date");
   }
 
   getToDateInput() {
-    return this.getElement().byTestId("custom-to-date");
+    return this.getElement().byTestId("to-date");
+  }
+
+  async setFromDate(date: string): Promise<void> {
+    const field = this.getFromDateInput();
+    await field.input(date, "change");
+  }
+
+  async setToDate(date: string): Promise<void> {
+    const field = this.getToDateInput();
+    await field.input(date, "change");
   }
 
   async isCustomRangeVisible(): Promise<boolean> {
     return this.getCustomRangeSection().isPresent();
-  }
-
-  async setFromDate(date: string): Promise<void> {
-    const input = this.getFromDateInput();
-    await input.typeText(date);
-  }
-
-  async setToDate(date: string): Promise<void> {
-    const input = this.getToDateInput();
-    await input.typeText(date);
   }
 }

--- a/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
+++ b/frontend/src/tests/page-objects/ReportingTransactionsButton.page-object.ts
@@ -13,4 +13,8 @@ export class ReportingTransactionsButtonPo extends ButtonPo {
       element.byTestId(ReportingTransactionsButtonPo.TID)
     );
   }
+
+  async isEnabled(): Promise<boolean> {
+    return !(await this.isDisabled());
+  }
 }

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -148,11 +148,13 @@ export class JestPageObjectElement implements PageObjectElement {
     await userEvent.type(element, input);
   }
 
-  async input(value: string): Promise<void> {
+  async input(value: string, type?: "input" | "change"): Promise<void> {
     await this.waitFor();
     // Svelte generates code for listening to the `input` event, not the `change` event in input fields.
     // https://github.com/testing-library/svelte-testing-library/issues/29#issuecomment-498055823
-    await fireEvent.input(this.getElement(), { target: { value } });
+    const eventMethod = type === "change" ? fireEvent.change : fireEvent.input;
+
+    await eventMethod(this.getElement(), { target: { value } });
   }
 
   async typeText(text: string): Promise<void> {

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -152,6 +152,7 @@ export class JestPageObjectElement implements PageObjectElement {
     await this.waitFor();
     // Svelte generates code for listening to the `input` event, not the `change` event in input fields.
     // https://github.com/testing-library/svelte-testing-library/issues/29#issuecomment-498055823
+    // but input type="date" requires the change event to trigger the binding
     const eventMethod = type === "change" ? fireEvent.change : fireEvent.input;
 
     await eventMethod(this.getElement(), { target: { value } });

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -30,7 +30,7 @@ export interface PageObjectElement {
   getClasses(): Promise<string[] | null>;
   click(): Promise<void>;
   keyDown(key: string, specialCharacters?: ("meta" | "ctrl")[]): Promise<void>;
-  input(value: string): Promise<void>;
+  input(value: string, type?: "input" | "change"): Promise<void>;
   isChecked(): Promise<boolean>;
   typeText(text: string): Promise<void>;
   selectOption(option: string): Promise<void>;


### PR DESCRIPTION
# Motivation

Allow users to export their transactions for a custom period, limited to one full year. Following up on #7390, this PR adds the necessary changes to the Transactions form to select a custom date range.

Notes:
* The maximum range is one year.  
* If the user only selects `from`, `to` is set to `today`.  
* If the user changes `from` to a date older than a year, `to` is updated to the latest possible value.

[NNS1-4134](https://dfinity.atlassian.net/browse/NNS1-4134)

| Header | Header |
|--------|--------|
| <img width="379" height="793" alt="Screenshot 2025-10-01 at 13 18 52" src="https://github.com/user-attachments/assets/1cb34230-705b-4515-8d5b-27d4eef8192c" /> | <img width="408" height="797" alt="Screenshot 2025-10-01 at 13 18 31" src="https://github.com/user-attachments/assets/da119c82-0c44-426d-8572-192eb1c06490" /> |
| <img width="813" height="707" alt="Screenshot 2025-10-01 at 13 17 17" src="https://github.com/user-attachments/assets/4dbfa45b-22fb-41cb-b80d-41d984dac728" /> | <img width="865" height="632" alt="Screenshot 2025-10-01 at 13 17 50" src="https://github.com/user-attachments/assets/f4ae38fd-3b76-4484-8993-8359b036825b" /> | 

# Changes

- Extend `ReportingDateRangeSelector` with date range selection.

# Tests

- Added unit tests to both utils.
- Manually tested in a larger PR #7374 

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-4134]: https://dfinity.atlassian.net/browse/NNS1-4134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ