### PR TITLE
docs(changelog): add missing feature entries

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,7 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Support for the new proposal action `DereisterKnownNeuron`.
+- Support for the new proposal action `DereisterKnownNeuron`.
+- Two new columns for the transactions report `accountId` and `neuronId`.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Support for the new proposal action `DereisterKnownNeuron`.
+
 #### Changed
 
 #### Deprecated


### PR DESCRIPTION
# Motivation

There were two changes merged without an update of the unreleased changelog:
* Support for the new proposal action `DereisterKnownNeuron`
  * https://github.com/dfinity/nns-dapp/pull/7366
  * https://github.com/dfinity/nns-dapp/pull/7370
  * https://github.com/dfinity/nns-dapp/pull/7367
* Two new columns for the reporting file
 * https://github.com/dfinity/nns-dapp/pull/7369

# Changes

- Update changelog.

# Tests

- Not necessary.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
