### PR TITLE
feat(rewards): handle FX provider unavailability

### DIFF
--- a/frontend/src/lib/utils/staking-rewards.utils.ts
+++ b/frontend/src/lib/utils/staking-rewards.utils.ts
@@ -117,6 +117,11 @@ export const getStakingRewardData = (
   params: StakingRewardCalcParams,
   forceInitialDate?: Date // For testing purposes
 ): StakingRewardResult => {
+  if (params.fxRates === "error") {
+    logWithTimestamp("FX provider is failing");
+    return { loading: false, error: "FX provider is failing" };
+  }
+
   if (!params.auth) {
     logWithTimestamp("Staking rewards: user is not logged in.");
     return { loading: false, error: "Not authorized." };

--- a/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
@@ -103,7 +103,7 @@ type TestStakingRewardCalcParams = {
       >;
     };
   };
-  fxRates: Record<string, number>;
+  fxRates: Record<string, number> | "error";
   governanceMetrics: {
     metrics: Pick<GovernanceCachedMetrics, "totalSupplyIcp">;
   };
@@ -160,6 +160,12 @@ describe("neuron-utils", () => {
     expect(
       roundToDecimals(getRewardData(params).icpOnly.maturityEstimateWeek, 2)
     ).toBe(0);
+  });
+
+  it("Errors when some condition is not met", () => {
+    // FX provider fails
+    params.fxRates = "error";
+    expect(() => getRewardData(params)).toThrow();
   });
 
   //////////////////

--- a/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
@@ -162,7 +162,7 @@ describe("neuron-utils", () => {
     ).toBe(0);
   });
 
-  it("Errors when some condition is not met", () => {
+  it("Errors when some conditions are not met", () => {
     // FX provider fails
     params.fxRates = "error";
     expect(() => getRewardData(params)).toThrow();


### PR DESCRIPTION
# Motivation

The FX provider may be unresponsive or failing. The Rewards UI should handle this situation by displaying a card with relevant information for the user.

| Before | After |
|--------|--------|
| <img width="1135" height="516" alt="Screenshot 2025-09-26 at 11 50 28" src="https://github.com/user-attachments/assets/30585616-337e-4b6c-a241-fee6e772c4e5" /> | <img width="1217" height="543" alt="Screenshot 2025-09-26 at 11 49 37" src="https://github.com/user-attachments/assets/73aa315f-1fb2-49b7-a974-91d7b162be9c" /> | 
| <img width="873" height="812" alt="Screenshot 2025-09-26 at 11 50 44" src="https://github.com/user-attachments/assets/8b34fd89-bdde-4130-89e9-aec3909a4eea" /> | <img width="897" height="783" alt="Screenshot 2025-09-26 at 11 50 01" src="https://github.com/user-attachments/assets/7d452e04-bf84-48b9-8b7d-989de0f37600" /> |

# Changes

- Handle FX provider error in the staking reward calculation function.

# Tests

- Unit test for the flow.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
