### PR TITLE
fix(test): ignore whitespace in SNS response diff

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -334,7 +334,7 @@ jobs:
         run: scripts/network-config.test
       - name: Get SNS tool
         run: |
-          diff <(scripts/sns/aggregator/get-sns PokedBots) <(echo "Name:   PHASMA
+          diff -w <(scripts/sns/aggregator/get-sns PokedBots) <(echo -n "Name:   PHASMA
           Symbol: PHASMA
           Aggregator URL:         https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/nb7he-piaaa-aaaaq-aadqq-cai/slow.json
           Root canister ID:       nb7he-piaaa-aaaaq-aadqq-cai


### PR DESCRIPTION
# Motivation

The Update SNS Aggregator Response is failing due some white spaces. Eg: #7373

Tested by locally running:

```
diff -w <(scripts/sns/aggregator/get-sns PokedBots) <(echo "Name:   PHASMA
  Symbol: PHASMA
  Aggregator URL:         https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/nb7he-piaaa-aaaaq-aadqq-cai/slow.json
  Root canister ID:       nb7he-piaaa-aaaaq-aadqq-cai
  Governance canister ID: ni4my-zaaaa-aaaaq-aadra-cai
  Ledger canister ID:     np5km-uyaaa-aaaaq-aadrq-cai
  Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
  Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
  Transaction fee:      1
  Minimum neuron stake: 500000
  Proposal fee:         5000000")
```

# Changes

- Ignore white spaces when diffing the expectation to the result.

# Tests

- Locally tested

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
