### PR TITLE
chore(messages): simplify error messages

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+- Hide technical error details.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/stores/toasts.store.ts
+++ b/frontend/src/lib/stores/toasts.store.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_TOAST_DURATION_MILLIS } from "$lib/constants/constants";
 import type { ToastLabelKey, ToastMsg } from "$lib/types/toast";
+import { errorToString } from "$lib/utils/error.utils";
 import type { I18nSubstitutions } from "$lib/utils/i18n.utils";
 import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
 import { stringifyJson } from "$lib/utils/utils";
@@ -61,11 +62,13 @@ export const toastsError = ({
   err,
   substitutions,
   renderAsHtml,
+  showDetails = false,
 }: {
   labelKey: ToastLabelKey;
   err?: unknown;
   substitutions?: I18nSubstitutions;
   renderAsHtml?: boolean;
+  showDetails?: boolean;
 }): symbol => {
   if (err !== undefined) {
     console.error(err);
@@ -74,9 +77,7 @@ export const toastsError = ({
   return toastsShow({
     labelKey,
     level: "error",
-    // Hiding errors detail to make the dApp more user friendly (feedback received).
-    // Leaving this part commented in case of debugging needs.
-    // detail: errorToString(err),
+    detail: showDetails ? errorToString(err) : undefined,
     substitutions,
     renderAsHtml,
   });

--- a/frontend/src/lib/stores/toasts.store.ts
+++ b/frontend/src/lib/stores/toasts.store.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_TOAST_DURATION_MILLIS } from "$lib/constants/constants";
 import type { ToastLabelKey, ToastMsg } from "$lib/types/toast";
-import { errorToString } from "$lib/utils/error.utils";
 import type { I18nSubstitutions } from "$lib/utils/i18n.utils";
 import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
 import { stringifyJson } from "$lib/utils/utils";
@@ -75,7 +74,9 @@ export const toastsError = ({
   return toastsShow({
     labelKey,
     level: "error",
-    detail: errorToString(err),
+    // Hiding errors detail to make the dApp more user friendly (feedback received).
+    // Leaving this part commented in case of debugging needs.
+    // detail: errorToString(err),
     substitutions,
     renderAsHtml,
   });

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -42,15 +42,8 @@ export const errorToString = (err?: unknown): string | undefined => {
             ? (err as Error).message
             : undefined;
 
-  if (typeof text !== "string") return text;
-
   // replace with i18n version if available
-  const translatedText = translate({ labelKey: text });
-  // Instead of showing all the underlying error details,
-  // we display only the “Body” section of the error (if any),
-  // as it typically contains the information most relevant to the user.
-  const matchBody = translatedText.match(/Body:\s*([\s\S]*)/);
-  return matchBody ? matchBody[1].trim() : translatedText;
+  return typeof text === "string" ? translate({ labelKey: text }) : text;
 };
 
 const factoryMappingErrorToToastMessage =

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -209,7 +209,7 @@ describe("ImportTokenModal", () => {
       await runResolvedPromises();
 
       expectToastError(
-        "Unable to load token details using the provided ledger canister ID. Not a ledger canister"
+        "Unable to load token details using the provided ledger canister ID."
       );
 
       // Stays on the form.

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -939,7 +939,7 @@ describe("FollowSnsNeuronsByTopicModal", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an error while unfollowing the neuron. Test Error",
+          text: "There was an error while unfollowing the neuron.",
         },
       ]);
       expect(spyConsoleError).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/FollowSnsNeuronsByTopicModal.svelte.spec.ts
@@ -345,7 +345,7 @@ describe("FollowSnsNeuronsByTopicModal", () => {
     expect(get(toastsStore)).toMatchObject([
       {
         level: "error",
-        text: "There was an error while adding a followee. Test Error",
+        text: "There was an error while adding a followee.",
       },
     ]);
   });
@@ -575,7 +575,7 @@ describe("FollowSnsNeuronsByTopicModal", () => {
     expect(get(toastsStore)).toMatchObject([
       {
         level: "error",
-        text: "There was an error while unfollowing the neuron. Test Error",
+        text: "There was an error while unfollowing the neuron.",
       },
     ]);
     expect(spyConsoleError).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -824,7 +824,7 @@ describe("IcrcWallet", () => {
         expect(get(toastsStore)).toMatchObject([
           {
             level: "error",
-            text: "There was an unexpected issue while updating the imported token. test",
+            text: "There was an unexpected issue while updating the imported token.",
           },
         ]);
         expect(get(busyStore)).toEqual([]);

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -155,7 +155,7 @@ describe("canisters-services", () => {
       expect(get(canistersStore).canisters).toEqual([]);
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: `There was an unexpected issue while searching for the canisters. ${errorMessage}`,
+        text: `There was an unexpected issue while searching for the canisters.`,
       });
     });
 
@@ -214,7 +214,6 @@ describe("canisters-services", () => {
       expect(spyQueryCanisters).not.toBeCalled();
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: expect.stringContaining(en.error.missing_identity),
       });
 
       resetIdentity();

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -273,7 +273,6 @@ describe("canisters-services", () => {
       expect(spyQueryCanisters).not.toBeCalled();
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: expect.stringContaining(en.error.missing_identity),
       });
 
       resetIdentity();
@@ -471,7 +470,6 @@ describe("canisters-services", () => {
       expect(spyGetExchangeRate).not.toBeCalled();
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: expect.stringContaining(en.error.missing_identity),
       });
 
       resetIdentity();

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -282,7 +282,7 @@ describe("ckbtc-convert-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Insufficient funds. ",
+          text: "Insufficient funds.",
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
@@ -84,7 +84,7 @@ describe("ckbtc-info-services", () => {
       expect(get(ckBTCInfoStore)).toEqual({});
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: `Sorry, there was an error loading the ckBTC minter information. ${errorMessage}`,
+        text: "Sorry, there was an error loading the ckBTC minter information.",
       });
     });
 

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -247,7 +247,7 @@ describe("icp-accounts.services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: `${en.error.accounts_not_found} ${errorTest}`,
+          text: en.error.accounts_not_found,
         },
       ]);
     });
@@ -435,7 +435,6 @@ describe("icp-accounts.services", () => {
       expect(queryAccountBalanceSpy).toBeCalledTimes(2);
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: expect.stringContaining(error.message),
       });
     });
 
@@ -559,7 +558,7 @@ describe("icp-accounts.services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, there was an unexpected error when creating your linked account, please try again. The operation cannot be executed without any identity.",
+          text: "Sorry, there was an unexpected error when creating your linked account, please try again.",
         },
       ]);
       resetIdentity();
@@ -688,7 +687,7 @@ describe("icp-accounts.services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, there was an error trying to execute the transaction. ",
+          text: "Sorry, there was an error trying to execute the transaction.",
         },
       ]);
 
@@ -705,7 +704,7 @@ describe("icp-accounts.services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Transaction is too old, could not be completed. Make sure your computer’s clock is set correctly, and try again. ",
+          text: "Transaction is too old, could not be completed. Make sure your computer’s clock is set correctly, and try again.",
         },
       ]);
 
@@ -722,7 +721,7 @@ describe("icp-accounts.services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Transaction was created in the future, could not be completed. Make sure your computer’s clock is set correctly, and try again. ",
+          text: "Transaction was created in the future, could not be completed. Make sure your computer’s clock is set correctly, and try again.",
         },
       ]);
 
@@ -804,7 +803,7 @@ describe("icp-accounts.services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "An error occurred while renaming your linked account. The operation cannot be executed without any identity.",
+          text: "An error occurred while renaming your linked account.",
         },
       ]);
 

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -167,7 +167,7 @@ describe("icp-transactions services", () => {
       expect(get(toastsStore)).toHaveLength(1);
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: "Sorry, there was an error loading the transactions for this account. Something happened",
+        text: "Sorry, there was an error loading the transactions for this account.",
       });
     });
   });
@@ -252,7 +252,7 @@ describe("icp-transactions services", () => {
       expect(get(toastsStore)).toHaveLength(1);
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: "Sorry, there was an error loading the transactions for this account. Something happened",
+        text: "Sorry, there was an error loading the transactions for this account.",
       });
     });
   });

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -358,7 +358,7 @@ describe("icrc-accounts-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "An error occurred while loading the accounts. test",
+          text: "An error occurred while loading the accounts.",
         },
       ]);
     });
@@ -607,7 +607,7 @@ describe("icrc-accounts-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, there was an error loading the token metadata information. test",
+          text: "Sorry, there was an error loading the token metadata information.",
         },
       ]);
       expect(consoleSpy).toBeCalledWith(error);
@@ -662,7 +662,7 @@ describe("icrc-accounts-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, there was an error loading the token metadata information. test",
+          text: "Sorry, there was an error loading the token metadata information.",
         },
       ]);
       expect(consoleSpy).toBeCalledWith(error);

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -69,7 +69,7 @@ describe("icrc-index.services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: `An error occurred while validating the index canister ID. It appears that ${indexCanisterId} might not be a valid index canister ID. ${error.message}`,
+          text: `An error occurred while validating the index canister ID. It appears that ${indexCanisterId} might not be a valid index canister ID.`,
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
@@ -93,7 +93,7 @@ describe("icrc-transactions services", () => {
       expect(get(toastsStore)).toHaveLength(1);
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: "Sorry, there was an error loading the transactions for this account. Something happened",
+        text: "Sorry, there was an error loading the transactions for this account.",
       });
     });
   });
@@ -241,7 +241,7 @@ describe("icrc-transactions services", () => {
       expect(get(toastsStore)).toHaveLength(1);
       expect(get(toastsStore)[0]).toMatchObject({
         level: "error",
-        text: "Sorry, there was an error loading the transactions for this account. Something happened",
+        text: "Sorry, there was an error loading the transactions for this account.",
       });
     });
   });

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -92,7 +92,7 @@ describe("imported-tokens-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an unexpected issue while loading imported tokens. test",
+          text: "There was an unexpected issue while loading imported tokens.",
         },
       ]);
     });
@@ -172,7 +172,7 @@ describe("imported-tokens-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an unexpected issue while loading imported tokens. test",
+          text: "There was an unexpected issue while loading imported tokens.",
         },
       ]);
       toastsStore.reset();
@@ -282,7 +282,7 @@ describe("imported-tokens-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an unexpected issue while importing the token. test",
+          text: "There was an unexpected issue while importing the token.",
         },
       ]);
     });
@@ -420,7 +420,7 @@ describe("imported-tokens-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an unexpected issue while removing the imported token. test",
+          text: "There was an unexpected issue while removing the imported token.",
         },
       ]);
     });
@@ -523,7 +523,7 @@ describe("imported-tokens-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an unexpected issue while updating the imported token. test",
+          text: "There was an unexpected issue while updating the imported token.",
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -483,7 +483,7 @@ describe("neurons-services", () => {
 
       expect(get(definedNeuronsStore)).toEqual([]);
       expectToastError(
-        `There was an unexpected issue while searching for the neurons. ${errorMessage}`
+        `There was an unexpected issue while searching for the neurons.`
       );
     });
 
@@ -2144,9 +2144,7 @@ describe("neurons-services", () => {
         setNeuron: vi.fn(),
       });
 
-      expectToastError(
-        `An error occurred while loading the neuron. ${errorMessage}`
-      );
+      expectToastError(`An error occurred while loading the neuron.`);
     });
 
     it("should not show a toast on uncertified error", async () => {

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -160,7 +160,7 @@ describe("proposals-services", () => {
         expect(get(toastsStore)[0].text).toMatch(errorMessage);
         expect(get(toastsStore)[0]).toMatchObject({
           level: "error",
-          text: "There was an unexpected issue while searching for the proposals. Error message from api.",
+          text: "There was an unexpected issue while searching for the proposals.",
         });
       });
 

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -146,7 +146,8 @@ describe("proposals-services", () => {
       });
 
       it("show error message from api", async () => {
-        const errorMessage = "Error message from api.";
+        const errorMessage =
+          "There was an unexpected issue while searching for the proposals.";
         vi.spyOn(api, "queryProposals").mockRejectedValue(
           new Error(errorMessage)
         );

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -560,7 +560,7 @@ describe("sns-proposals services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an error while registering vote (Neuron: 010203). ",
+          text: "There was an error while registering vote (Neuron: 010203).",
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -57,7 +57,7 @@ describe("sns-accounts-balance.services", () => {
     expect(get(toastsStore)).toMatchObject([
       {
         level: "error",
-        text: "An error occurred while loading the accounts. ",
+        text: "An error occurred while loading the accounts.",
       },
     ]);
   });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -572,7 +572,7 @@ describe("sns-neurons-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an error while staking the neuron. The caller should make sure the amount is at least the minimum stake",
+          text: "There was an error while staking the neuron.",
         },
       ]);
     });
@@ -715,7 +715,7 @@ describe("sns-neurons-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an error while disbursing the maturity of the neuron. Invalid account. Invalid checksum.",
+          text: "There was an error while disbursing the maturity of the neuron.",
         },
       ]);
     });
@@ -1094,7 +1094,7 @@ describe("sns-neurons-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "There was an error while unfollowing the neuron. Test Error",
+          text: "There was an error while unfollowing the neuron.",
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -573,7 +573,7 @@ describe("sns-api", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, the swap was already closed. Please reload the page. ",
+          text: "Sorry, the swap was already closed. Please reload the page.",
         },
       ]);
       expect(ticketFromStore()?.ticket).toEqual(null);
@@ -597,7 +597,7 @@ describe("sns-api", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, the swap is not yet open. Please reload the page. ",
+          text: "Sorry, the swap is not yet open. Please reload the page.",
         },
       ]);
       expect(ticketFromStore()?.ticket).toEqual(null);
@@ -1329,7 +1329,7 @@ describe("sns-api", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, There was an unexpected error while participating. Please refresh the page and try again. test",
+          text: "Sorry, There was an unexpected error while participating. Please refresh the page and try again.",
         },
       ]);
       expect(ticketFromStore().ticket).toEqual(null);
@@ -1354,7 +1354,7 @@ describe("sns-api", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, the account doesn't have enough funds for this transaction. ",
+          text: "Sorry, the account doesn't have enough funds for this transaction.",
         },
       ]);
       expect(ticketFromStore().ticket).toEqual(null);
@@ -1419,7 +1419,7 @@ describe("sns-api", () => {
         expect(get(toastsStore)).toMatchObject([
           {
             level: "error",
-            text: "Sorry, There was an unexpected error while participating. Please refresh and try again The token amount can only be refreshed when the canister is in the OPEN state",
+            text: "Sorry, There was an unexpected error while participating. Please refresh and try again",
           },
         ]);
         // the button/increase_participation should not be enabled

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -139,7 +139,7 @@ describe("sns-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: `There was an unexpected error while loading the commitment of the project. ${errorMessage}`,
+          text: `There was an unexpected error while loading the commitment of the project.`,
         },
       ]);
 
@@ -402,7 +402,7 @@ describe("sns-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: `There was an unexpected error while loading the commitment of the project. ${errorMessage}`,
+          text: `There was an unexpected error while loading the commitment of the project.`,
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -430,7 +430,7 @@ describe("vote-registration-services", () => {
         },
         {
           level: "error",
-          text: "Sorry, there was an unexpected error while registering the vote. Please try again later. test",
+          text: "Sorry, there was an unexpected error while registering the vote. Please try again later.",
         },
       ]);
     });
@@ -554,7 +554,7 @@ describe("vote-registration-services", () => {
         },
         {
           level: "error",
-          text: "Sorry, there was an unexpected error while registering the vote. Please try again later. The operation cannot be executed without any identity.",
+          text: "Sorry, there was an unexpected error while registering the vote. Please try again later.",
         },
       ]);
     });

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -47,20 +47,6 @@ describe("error-utils", () => {
       );
     });
 
-    it("should extract body content", () => {
-      expect(
-        errorToString(
-          new Error(`
-Headers: [["content-length","67"],["content-type","text/plain"],["x-request-id","01992a04-b36a-7a60-aec8-3b8b53f0329a"]]
-Body: Canister mxzaz-hqaaa-aaaar-qaada-cai does not belong to any subnet.
-        `)
-        )
-      ).toEqual(
-        "Canister mxzaz-hqaaa-aaaar-qaada-cai does not belong to any subnet."
-      );
-    });
-  });
-
   describe("to toast", () => {
     it("should use fallback message", () => {
       expect(

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -46,6 +46,7 @@ describe("error-utils", () => {
         en.error__sns.undefined_project
       );
     });
+  });
 
   describe("to toast", () => {
     it("should use fallback message", () => {


### PR DESCRIPTION
# Motivation

Following the already-done error deduplication task.
To make the UI more user-friendly, technical error details are now hidden by default to the user.

# Changes

Hid error details, simplified messages.
<img width="2424" height="1090" alt="localhost_5173_" src="https://github.com/user-attachments/assets/240624ed-1130-416a-a75c-63cac43e72d8" />

# Tests

Updated tests.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
