### PR TITLE
feat(utils): extend reporting utils for custom date range

### DIFF
--- a/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingTransactionsButton.svelte
@@ -74,7 +74,7 @@
       );
 
       const entities = [...nnsAccounts, ...nnsNeurons];
-      const range = convertPeriodToNanosecondRange(period);
+      const range = convertPeriodToNanosecondRange({ period });
       const transactions = await getAccountTransactionsConcurrently({
         entities,
         identity: signIdentity,

--- a/frontend/src/lib/types/reporting.ts
+++ b/frontend/src/lib/types/reporting.ts
@@ -2,7 +2,7 @@ import type { Account } from "$lib/types/account";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
 import type { NeuronInfo } from "@dfinity/nns";
 
-export type ReportingPeriod = "all" | "last-year" | "year-to-date";
+export type ReportingPeriod = "all" | "last-year" | "year-to-date" | "custom";
 
 export type TransactionsDateRange = {
   /** Start of the date range (inclusive) - timestamp in nanoseconds */

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -135,14 +135,21 @@ export const getFutureDateFromDelayInSeconds = (seconds: bigint): string => {
 /**
  * Formats a date into YYYYMMDD string
  * @param {Date} date - The date to format
+ * @param {string} delimiter - Custom delimiter to separate year, month and day. Default is empty string.
  * @returns {string} Date formatted as YYYYMMDD
  * @example
+ * ```
  * formatDateCompact(new Date('2024-11-22')) // Returns "20241122"
+ * formatDateCompact(new Date('2024-11-22'), '-') // Returns "2024-11-22"
+ * ```
  */
-export const formatDateCompact = (date: Date): string => {
+export const formatDateCompact = (
+  date: Date,
+  delimiter: string = ""
+): string => {
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, "0");
   const day = date.getDate().toString().padStart(2, "0");
 
-  return `${year}${month}${day}`;
+  return [year, month, day].join(delimiter);
 };

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -240,5 +240,10 @@ describe("daysToSeconds", () => {
       const date = new Date("2024-01-01");
       expect(formatDateCompact(date)).toBe("20240101");
     });
+
+    it("should add delimiter when providedpad single digit month and day", () => {
+      const date = new Date("2024-01-01");
+      expect(formatDateCompact(date, "")).toBe("2024-01-01");
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -241,7 +241,7 @@ describe("daysToSeconds", () => {
       expect(formatDateCompact(date)).toBe("20240101");
     });
 
-    it("should add delimiter when providedpad single digit month and day", () => {
+    it("should add delimiter when provided and pad single digit month and day", () => {
       const date = new Date("2024-01-01");
       expect(formatDateCompact(date, "-")).toBe("2024-01-01");
     });

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -243,7 +243,7 @@ describe("daysToSeconds", () => {
 
     it("should add delimiter when providedpad single digit month and day", () => {
       const date = new Date("2024-01-01");
-      expect(formatDateCompact(date, "")).toBe("2024-01-01");
+      expect(formatDateCompact(date, "-")).toBe("2024-01-01");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -440,12 +440,12 @@ describe("reporting utils", () => {
     });
 
     it('returns empty object for "all" period', () => {
-      const result = convertPeriodToNanosecondRange("all");
+      const result = convertPeriodToNanosecondRange({ period: "all" });
       expect(result).toEqual({});
     });
 
     it('returns correct range for "last-year"', () => {
-      const result = convertPeriodToNanosecondRange("last-year");
+      const result = convertPeriodToNanosecondRange({ period: "last-year" });
 
       expect(result).toEqual({
         from: BigInt(new Date("2023-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,
@@ -454,10 +454,93 @@ describe("reporting utils", () => {
     });
 
     it('returns correct range for "year-to-date"', () => {
-      const result = convertPeriodToNanosecondRange("year-to-date");
+      const result = convertPeriodToNanosecondRange({
+        period: "year-to-date",
+      });
 
       expect(result).toEqual({
         from: BigInt(new Date("2024-01-01T00:00:00Z").getTime()) * NANOS_IN_MS,
+      });
+    });
+
+    describe("custom period", () => {
+      it("returns correct date range including end of day for 'to' date", () => {
+        const result = convertPeriodToNanosecondRange({
+          period: "custom",
+          from: "2024-01-01",
+          to: "2024-01-31",
+        });
+
+        expect(result).toEqual({
+          from:
+            BigInt(new Date("2024-01-01T00:00:00.000Z").getTime()) *
+            NANOS_IN_MS,
+          to:
+            BigInt(new Date("2024-01-31T23:59:59.999Z").getTime()) *
+            NANOS_IN_MS,
+        });
+      });
+
+      it("handles single day range correctly", () => {
+        const result = convertPeriodToNanosecondRange({
+          period: "custom",
+          from: "2024-01-15",
+          to: "2024-01-15",
+        });
+
+        expect(result).toEqual({
+          from:
+            BigInt(new Date("2024-01-15T00:00:00.000Z").getTime()) *
+            NANOS_IN_MS,
+          to:
+            BigInt(new Date("2024-01-15T23:59:59.999Z").getTime()) *
+            NANOS_IN_MS,
+        });
+      });
+
+      it("handles leap year correctly", () => {
+        const result = convertPeriodToNanosecondRange({
+          period: "custom",
+          from: "2024-02-28",
+          to: "2024-03-01",
+        });
+
+        expect(result).toEqual({
+          from:
+            BigInt(new Date("2024-02-28T00:00:00.000Z").getTime()) *
+            NANOS_IN_MS,
+          to:
+            BigInt(new Date("2024-03-01T23:59:59.999Z").getTime()) *
+            NANOS_IN_MS,
+        });
+      });
+
+      it("returns empty object when 'from' is missing", () => {
+        const result = convertPeriodToNanosecondRange({
+          period: "custom",
+          to: "2024-01-31",
+        });
+
+        expect(result).toEqual({});
+      });
+
+      it("returns empty object when 'to' is missing", () => {
+        const result = convertPeriodToNanosecondRange({
+          period: "custom",
+          from: "2024-01-01",
+        });
+
+        expect(result).toEqual({});
+      });
+
+      it("returns empty object when 'from' is after 'to'", () => {
+        const result = convertPeriodToNanosecondRange({
+          period: "custom",
+          from: "2024-01-31",
+          to: "2024-01-01",
+        });
+
+        expect(result).toEqual({});
       });
     });
   });

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -476,7 +476,7 @@ describe("reporting utils", () => {
             BigInt(new Date("2024-01-01T00:00:00.000Z").getTime()) *
             NANOS_IN_MS,
           to:
-            BigInt(new Date("2024-01-31T23:59:59.999Z").getTime()) *
+            BigInt(new Date("2024-02-01T00:00:00.000Z").getTime()) *
             NANOS_IN_MS,
         });
       });
@@ -493,7 +493,7 @@ describe("reporting utils", () => {
             BigInt(new Date("2024-01-15T00:00:00.000Z").getTime()) *
             NANOS_IN_MS,
           to:
-            BigInt(new Date("2024-01-15T23:59:59.999Z").getTime()) *
+            BigInt(new Date("2024-01-16T00:00:00.000Z").getTime()) *
             NANOS_IN_MS,
         });
       });
@@ -510,7 +510,7 @@ describe("reporting utils", () => {
             BigInt(new Date("2024-02-28T00:00:00.000Z").getTime()) *
             NANOS_IN_MS,
           to:
-            BigInt(new Date("2024-03-01T23:59:59.999Z").getTime()) *
+            BigInt(new Date("2024-03-02T00:00:00.000Z").getTime()) *
             NANOS_IN_MS,
         });
       });


### PR DESCRIPTION
# Motivation

The nns-dapp will introduce a date range selector for the Reporting Transactions feature. This initial PR prepares some of the utils to support this new case.

Note: The implementation uses the local date and time to accommodate the user's timezone. It is then converted to UTC in nanoseconds, as this is the format supported by the API.

[NNS1-4134](https://dfinity.atlassian.net/browse/NNS1-4134)

# Changes

- Extend `formatDateCompact` to support delimiters on the dates.
- Extend `convertPeriodToNanosecondRange` to support custom date range with provided `from` and `to`.

# Tests

- Added unit tests to both utils.
- Manually tested in a larger PR #7374 

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-4134]: https://dfinity.atlassian.net/browse/NNS1-4134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ