### PR TITLE
chore(deps): bump tar-fs from 2.1.3 to 2.1.4

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6057,9 +6057,9 @@
       "license": "MIT"
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",


### PR DESCRIPTION
# Motivation

To handle the following vulnerability:

```
tar-fs  2.0.0 - 2.1.3
Severity: high
tar-fs has a symlink validation bypass if destination directory is predictable with a specific tarball - https://github.com/advisories/GHSA-vj76-c3g6-qr5v
fix available via `npm audit fix`
node_modules/tar-fs
```

# Changes

- Bump the version with `npm audit fix`

# Tests

- CI should pass

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
