### PR TITLE
chore(deps): update ic-js for new proposal field

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -351,9 +351,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "4.0.1-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-4.0.1-next-2025-09-24.tgz",
-      "integrity": "sha512-uDk7B7uBEHv6razCfaDMsHr+1bJNjCOBosMp3DCDuUBQstfSU9OshE36jnpd5TJbezvsPcpdnrG3iO5cx6dV4g==",
+      "version": "4.0.3-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-4.0.3-next-2025-10-07.tgz",
+      "integrity": "sha512-IxFlJ68IX1uuiHzPMWBhBh5JvG8KL4fgyX3/qRYUninR87GJI2h2qM21UxA2HBaI5IOOY8c6/FO3X2ELPaUSzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "6.0.1-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-6.0.1-next-2025-09-24.tgz",
-      "integrity": "sha512-8JnjXqIDgSHnxS3sGAJBrAU0tfsiJxGnQCvB5/pQ/ZOzazkyVzCQpr70FLFF2av43wPnYk+ZhIeIyUNlBMTiIw==",
+      "version": "6.0.3-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-6.0.3-next-2025-10-07.tgz",
+      "integrity": "sha512-2hCMM3PbS38dYxeF5z/cjO0txPPtGbI8WlsoiJNET+a41HpTPadCBOcyWirvaeuEHiuWxfeefvCXkqpvhwspbQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "7.0.2-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.0.2-next-2025-09-24.tgz",
-      "integrity": "sha512-ZUXiePYtjcvk3+DnqBGL5u9P2KfuY729oPwDFUyDi5NrDktlKPUnTfPBTfES4IU8J1vPPF3HK2ld8qLDEUmdVQ==",
+      "version": "7.1.0-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.1.0-next-2025-10-07.tgz",
+      "integrity": "sha512-sMtg3phdkqgaNNde5KMO7ohRuctFgIkuHCpqP2r5zbwy0SlEDj1BaLHShbzP72G1vVkVOHLiR3UPjj/92UxkpA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -422,9 +422,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "6.0.0-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-6.0.0-next-2025-09-24.tgz",
-      "integrity": "sha512-+vBhEeeuFRemluS2mvVlT5XsuVkBiXWZ1wR1OwzFjz3phh+Mh5wqjdz4s+YIS3Ut1njqFjM/J0QCcdQusKJKDA==",
+      "version": "6.0.2-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-6.0.2-next-2025-10-07.tgz",
+      "integrity": "sha512-4NsTWNRjbXr67c4LuStqcPM+nSXnDzlFKffSa49t4Xn1nWR87VBkdTArigsIf/x6wPGdOHueufqpyaLXZVJm0w==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -434,9 +434,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "4.0.1-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-4.0.1-next-2025-09-24.tgz",
-      "integrity": "sha512-fYeKtQQTEkeqwoebGOiE1RhRMvtmj8ONCtHeRs0v7RGBbK6svYejxABWSB0LHSZq5Son31QZrC6fiV6tWm/fSg==",
+      "version": "4.0.3-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-4.0.3-next-2025-10-07.tgz",
+      "integrity": "sha512-ptPbhcxFsDIt/XuzGvxZc93mfokIEPDGOM4NCnp75MxOwTHmsND0cG5DRNCA8fPv0AbTkwP0+uz+L2h/lBrW9w==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "10.0.1-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-10.0.1-next-2025-09-24.tgz",
-      "integrity": "sha512-2A7wAV8IU1Q/soBqH2wp+nN4aZHsrfwgKldK10pHzzXm0EwPp+ytZN+QAJbmL2vzO9DjqSin1gI+Llz4etH1YA==",
+      "version": "10.1.1-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-10.1.1-next-2025-10-07.tgz",
+      "integrity": "sha512-fgu3jyyGa6VCxuz2nGeulaOrhVtRvwlUXHrF1KUxt1OXhZvMgaMt0dGR5NIpBeHemXEA6oSxTlZ/QWBdmUp15Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "4.0.2-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-4.0.2-next-2025-09-24.tgz",
-      "integrity": "sha512-vGIxFSWPrWXtXZXdmxEnFKNpEzbauIf0ojJMmfzSc5v0IavbC3tx52pU58KNQeWZsZ6GYIMa2u2zKjSRtgNPNA==",
+      "version": "4.0.4-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-4.0.4-next-2025-10-07.tgz",
+      "integrity": "sha512-HKhOJjTH2F7soWnxsCBnS3C5RyuUNpXIi5dfQnI+kuFaURmIg7E6Nq7tb+JUgZqGYCBGW73fU9YoogDw8wzMoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "3.1.0-next-2025-09-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.1.0-next-2025-09-24.tgz",
-      "integrity": "sha512-+LuuqMnO5iXIUSJGm1tGDosHjs85m9qD5NxHTNTmbYwHOF5hrYEe4WV737anFkT1K1dASxQQ7laer/CHdXYnPg==",
+      "version": "3.2.0-next-2025-10-07",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.2.0-next-2025-10-07.tgz",
+      "integrity": "sha512-j2AiYKxq2pm2QmIfmW/0w3efTHhUT2G3b2MGuhZYf8h5YGP8Kaz99ZO8oz4rkf20xult6LP56p/jRaL8vIwogw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",


### PR DESCRIPTION
# Motivation

Bumps the ic-js dependency to the latest version to include the new field [skip_update_latest_version](https://sourcegraph.com/github.com/dfinity/ic@f21c91f50877772aad7bfd6b31e6fbc4f86935f7/-/blob/rs/nns/sns-wasm/canister/sns-wasm.did?L4) in the proposals added [here](https://github.com/dfinity/ic-js/pull/1090).

For more context, see [here](https://dfinity.slack.com/archives/C0175CHJ0P6/p1759774757645709).

# Changes

- Run `npm run update:next`

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
