### PR TITLE
feat(commands): add transaction memo toggle option

### DIFF
--- a/frontend/src/lib/components/alfred/Alfred.svelte
+++ b/frontend/src/lib/components/alfred/Alfred.svelte
@@ -4,6 +4,7 @@
   import { authStore } from "$lib/stores/auth.store";
   import { balancePrivacyOptionStore } from "$lib/stores/balance-privacy-option.store";
   import { i18n } from "$lib/stores/i18n";
+  import { transactionMemoOptionStore } from "$lib/stores/transaction-memo-option.store";
   import { filterAlfredItems, type AlfredItem } from "$lib/utils/alfred.utils";
   import { Backdrop, Input, themeStore } from "@dfinity/gix-components";
   import { debounce } from "@dfinity/utils";
@@ -22,6 +23,7 @@
       isSignedIn: $authSignedInStore,
       theme: $themeStore,
       balancePrivacyOption: $balancePrivacyOptionStore,
+      memoOption: $transactionMemoOptionStore,
     })
   );
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -192,7 +192,15 @@
     "log_in_description": "Log in to your account",
     "log_out_title": "Log Out",
     "log_out_description": "Log out of your account",
-    "search_placeholder": "Search for pages or actions..."
+    "search_placeholder": "Search for pages or actions...",
+    "hide_balance_title": "Hide Balance",
+    "hide_balance_description": "Privacy mode for your balance",
+    "show_balance_title": "Show Balance",
+    "show_balance_description": "Display your balances",
+    "hide_memo_title": "Hide transaction memo",
+    "hide_memo_description": "Hide the memo input for ICP transaction forms",
+    "show_memo_title": "Show transaction memo",
+    "show_memo_description": "Show the memo input for ICP transaction forms"
   },
   "header": {
     "menu": "Open menu to access navigation options",

--- a/frontend/src/lib/stores/transaction-memo-option.store.ts
+++ b/frontend/src/lib/stores/transaction-memo-option.store.ts
@@ -1,0 +1,8 @@
+import { writable, type Writable } from "svelte/store";
+
+export type TransactionMemoOption = "show" | "hide";
+
+export type TransactionMemoOptionStore = Writable<TransactionMemoOption>;
+
+export const transactionMemoOptionStore: Writable<TransactionMemoOption> =
+  writable("hide");

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -200,6 +200,14 @@ interface I18nAlfred {
   log_out_title: string;
   log_out_description: string;
   search_placeholder: string;
+  hide_balance_title: string;
+  hide_balance_description: string;
+  show_balance_title: string;
+  show_balance_description: string;
+  hide_memo_title: string;
+  hide_memo_description: string;
+  show_memo_title: string;
+  show_memo_description: string;
 }
 
 interface I18nHeader {

--- a/frontend/src/lib/utils/alfred.utils.ts
+++ b/frontend/src/lib/utils/alfred.utils.ts
@@ -6,6 +6,10 @@ import {
 } from "$lib/stores/balance-privacy-option.store";
 import { i18n } from "$lib/stores/i18n";
 import {
+  transactionMemoOptionStore,
+  type TransactionMemoOption,
+} from "$lib/stores/transaction-memo-option.store";
+import {
   IconCopy,
   IconDarkMode,
   IconDocument,
@@ -38,6 +42,7 @@ interface AlfredItemBase {
     isSignedIn: boolean;
     theme: ThemeStoreData;
     balancePrivacyOption: BalancePrivacyOptionData;
+    memoOption: TransactionMemoOption;
   }) => boolean;
 }
 
@@ -153,8 +158,8 @@ const getAlfredItems = (): AlfredItem[] => {
     {
       id: "hide-balance",
       type: "action",
-      title: "Hide Balance",
-      description: "Privacy mode for your balance",
+      title: alfred.hide_balance_title,
+      description: alfred.hide_balance_description,
       icon: IconEyeClosed,
       action: () => balancePrivacyOptionStore.set("hide"),
       contextFilter: (context) =>
@@ -163,12 +168,32 @@ const getAlfredItems = (): AlfredItem[] => {
     {
       id: "show-balance",
       type: "action",
-      title: "Show Balance",
-      description: "Display your balances",
+      title: alfred.show_balance_title,
+      description: alfred.show_balance_description,
       icon: IconEyeOpen,
       action: () => balancePrivacyOptionStore.set("show"),
       contextFilter: (context) =>
         context.balancePrivacyOption === "hide" && context.isSignedIn,
+    },
+    {
+      id: "show-transaction-memo",
+      type: "action",
+      title: alfred.show_memo_title,
+      description: alfred.show_memo_description,
+      icon: IconDocument,
+      action: () => transactionMemoOptionStore.set("show"),
+      contextFilter: (context) =>
+        context.memoOption === "hide" && context.isSignedIn,
+    },
+    {
+      id: "hide-transaction-memo",
+      type: "action",
+      title: alfred.hide_memo_title,
+      description: alfred.hide_memo_description,
+      icon: IconDocument,
+      action: () => transactionMemoOptionStore.set("hide"),
+      contextFilter: (context) =>
+        context.memoOption === "show" && context.isSignedIn,
     },
     {
       id: "log-in",
@@ -202,6 +227,7 @@ export const filterAlfredItems = (
     isSignedIn: boolean;
     theme: ThemeStoreData;
     balancePrivacyOption: BalancePrivacyOptionData;
+    memoOption: TransactionMemoOption;
   }
 ): AlfredItem[] => {
   const items = alfredItems.filter(

--- a/frontend/src/tests/lib/components/alfred/Alfred.spec.ts
+++ b/frontend/src/tests/lib/components/alfred/Alfred.spec.ts
@@ -28,6 +28,7 @@ describe("Alfred Component", () => {
     "Settings",
     "Copy principal ID",
     "Hide Balance",
+    "Show transaction memo",
     "Log Out",
   ];
 


### PR DESCRIPTION
# Motivation

Support the transaction memo for both ICP and ICRC1 addresses for ICP transaction flows. This PR adds the options to the Command Palette for users to turn it on/off. The feature will be added in a follow-up PR.

Note: The feature is not persisted in localStorage. Users will have to turn it on on every session.

# Changes

- Add a memo option to the Command Palette.
- Change side: Move some translations to the translations file.

# Tests

- Added unit tests for the change.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?