### PR TITLE
feat(transactions): implement memo field in transaction service

### DIFF
--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -6,6 +6,7 @@ export type NewTransaction = {
   sourceAccount: Account;
   destinationAddress: string;
   amount: number;
+  memo?: string;
 };
 
 export interface TransactionInit {

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -289,21 +289,29 @@ export const mapIcpTransactionToUi = ({
   }
 };
 
-// it should only contain positive numbers and limit to 64 bits
+export const encodeMemoToIcp = (memo: string): bigint => {
+  return BigInt(memo);
+};
+
+// it should only contain positive numbers and limit to 64bits
 export const isValidIcpMemo = (memo: string): boolean => {
   try {
     const UINT64_MAX = 2n ** 64n - 1n;
-    const memoBigInt = BigInt(memo);
+    const memoBigInt = encodeMemoToIcp(memo);
     return memoBigInt >= 0n && memoBigInt <= UINT64_MAX;
   } catch {
     return false;
   }
 };
 
+export const encodeMemoToIcrc1 = (memo: string): Uint8Array => {
+  return new TextEncoder().encode(memo);
+};
+
 // it should be less than 32 bytes when encoded as UTF-8
 export const isValidIcrc1Memo = (memo: string): boolean => {
   try {
-    return new TextEncoder().encode(memo).length <= 32;
+    return encodeMemoToIcrc1(memo).length <= 32;
   } catch {
     return false;
   }


### PR DESCRIPTION
# Motivation

Support the transaction memo for both ICP and ICRC1 addresses in ICP transaction flows. This PR implements the necessary changes to the service layer to encode the memo according to the target address type.

Previous PR #7399

# Changes

- Update `transferICP` to process the memo field and encode based on the target address type.
- Added utils for the conversion.

# Tests

- Added unit tests for the change.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?