### PR TITLE
Improve following error handling

### DIFF
--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -20,6 +20,7 @@ import type {
 } from "@dfinity/nns";
 import {
   GovernanceCanister,
+  GovernanceError,
   NeuronVisibility,
   type RewardEvent,
 } from "@dfinity/nns";
@@ -392,6 +393,12 @@ export const setFollowees = async ({
 }: ApiSetFolloweesParams): Promise<void> => {
   logWithTimestamp(`Setting Followees (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
+
+  throw new GovernanceError({
+    // error_message: `${followees.map((followee) => followee.toString()).join()}: Followee (${neuronId.toString()}) does not exist.\n`,
+    error_message: `${followees.map((followee) => followee.toString()).join()}: Not authorized to follow private neuron: ${neuronId.toString()}\n\t\To follow a private neuron, you must be the controller or a hotkey of it.\n`,
+    error_type: 501,
+  });
 
   await canister.setFollowees({
     neuronId,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -500,7 +500,10 @@
     "options_title": "Options for Following",
     "follow": "Follow",
     "unfollow": "Unfollow",
+    "followee_no_self_following": "A neuron is not allowed to follow itself.",
+    "followee_incorrect_id_format": "Incorrect followee format.",
     "followee_does_not_exist": "Neuron with id $neuronId does not exist.",
+    "followee_not_permit": "To follow a private neuron, you must be the controller or a hotkey of it. More info <a href=\"https://internetcomputer.org/docs/building-apps/governing-apps/nns/using-the-nns-dapp/nns-dapp-following-other-neurons\" rel=\"noopener noreferrer\" aria-label=\"more info about following neurons\" target=\"_blank\">here</a>.",
     "neuron_not_followee": "Sorry, you can't unfollow neuron $neuronId because you are not following it.",
     "already_followed": "You are already following this neuron."
   },

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -907,31 +907,27 @@ const setFolloweesHelper = async ({
   topic: Topic;
   followees: NeuronId[];
 }) => {
-  try {
-    if (neuron === undefined) {
-      throw new NotFoundError(
-        "Neuron not found in store. We can't check authorization to set followees."
-      );
-    }
-    // We try to control by hotkey by default
-    let identity: Identity = await getAuthenticatedIdentity();
-    if (!isHotKeyControllable({ neuron, identity })) {
-      identity = await getIdentityOfControllerByNeuronId(neuron.neuronId);
-    }
-    // ManageNeuron topic followes can only be handled by controllers
-    if (topic === Topic.NeuronManagement) {
-      identity = await getIdentityOfControllerByNeuronId(neuron.neuronId);
-    }
-    await governanceApiService.setFollowees({
-      identity,
-      neuronId: neuron.neuronId,
-      topic,
-      followees,
-    });
-    await getAndLoadNeuron(neuron.neuronId);
-  } catch (err) {
-    toastsShow(mapNeuronErrorToToastMessage(err));
+  if (neuron === undefined) {
+    throw new NotFoundError(
+      "Neuron not found in store. We can't check authorization to set followees."
+    );
   }
+  // We try to control by hotkey by default
+  let identity: Identity = await getAuthenticatedIdentity();
+  if (!isHotKeyControllable({ neuron, identity })) {
+    identity = await getIdentityOfControllerByNeuronId(neuron.neuronId);
+  }
+  // ManageNeuron topic followes can only be handled by controllers
+  if (topic === Topic.NeuronManagement) {
+    identity = await getIdentityOfControllerByNeuronId(neuron.neuronId);
+  }
+  await governanceApiService.setFollowees({
+    identity,
+    neuronId: neuron.neuronId,
+    topic,
+    followees,
+  });
+  await getAndLoadNeuron(neuron.neuronId);
 };
 
 export const addFollowee = async ({

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -519,7 +519,10 @@ interface I18nNew_followee {
   options_title: string;
   follow: string;
   unfollow: string;
+  followee_no_self_following: string;
+  followee_incorrect_id_format: string;
   followee_does_not_exist: string;
+  followee_not_permit: string;
   neuron_not_followee: string;
   already_followed: string;
 }


### PR DESCRIPTION
# Motivation

Currently add-following error handling is inconsistent (some are shown through system alerts, some with error toasts).
To make error handling more consistent, the error state is now indicated within the input field (border and hint) rather than being shown.


# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Accessibility (a11y) – any impact?
- [ ] Changelog – is it needed?
