### PR TITLE
chore(deps): remove remaining ic-cdk-macros reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ version = "2.0.129"
 
 [workspace.dependencies]
 ic-cdk = "0.17.1"
-ic-cdk-macros = "0.17.0"
 ic-cdk-timers = "0.11.0"
 ic-management-canister-types = "0.1.0"
 


### PR DESCRIPTION
# Motivation

#7339 removed the dependency on `ic-cdk-macros`, but a reference was not removed.

# Changes

- Remove the dependency on `ic-cdk-macros` from the root of the project.

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
