### PR TITLE
fix(loading): clear busy state timeout on completion

### DIFF
--- a/frontend/src/lib/components/reporting/ReportingNeuronsButton.svelte
+++ b/frontend/src/lib/components/reporting/ReportingNeuronsButton.svelte
@@ -50,7 +50,7 @@
 
       if (source === "sns") {
         // This flow will take some time so we update the message to users to indicate progress
-        setTimeout(() => {
+        let timeoutId = setTimeout(() => {
           startBusy({
             initiator: "reporting-neurons",
             labelKey: "reporting.busy_screen_sns_getting_neurons",
@@ -123,6 +123,8 @@
           ],
           fileName,
         });
+
+        clearTimeout(timeoutId);
       } else {
         const data = await queryNeurons({
           certified: true,


### PR DESCRIPTION
# Motivation

The nns-dapp could query all SNS governance canisters in less time than the busy load message refresh. In that case, the busy page would be re-rendered even though the action finished. This is not really possible on the mainnet but could be feasible in a development environment.

# Changes

- Clean up timeout.

# Tests

- Not necessary.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
