### PR TITLE
refactor(neurons): migrate autostake controls to svelte 5

### DIFF
--- a/frontend/src/lib/components/neuron-detail/actions/AutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/AutoStakeMaturity.svelte
@@ -2,8 +2,12 @@
   import { i18n } from "$lib/stores/i18n";
   import { Checkbox } from "@dfinity/gix-components";
 
-  export let hasAutoStakeOn: boolean;
-  export let disabled = false;
+  type Props = {
+    hasAutoStakeOn: boolean;
+    disabled?: boolean;
+  };
+
+  let { hasAutoStakeOn = $bindable(), disabled = false }: Props = $props();
 </script>
 
 <Checkbox

--- a/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
@@ -14,17 +14,20 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { getContext } from "svelte";
 
-  export let neuron: NeuronInfo;
+  type Props = {
+    neuron: NeuronInfo;
+  };
+  const { neuron }: Props = $props();
 
-  let hasAutoStakeOn: boolean;
-  $: hasAutoStakeOn = hasAutoStakeMaturityOn(neuron);
+  let hasAutoStakeOn = $derived(hasAutoStakeMaturityOn(neuron));
 
-  let disabled: boolean;
-  $: disabled = !isNeuronControllable({
-    neuron,
-    identity: $authStore.identity,
-    accounts: $icpAccountsStore,
-  });
+  const disabled = $derived(
+    !isNeuronControllable({
+      neuron,
+      identity: $authStore.identity,
+      accounts: $icpAccountsStore,
+    })
+  );
 
   const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(
     NNS_NEURON_CONTEXT_KEY

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte
@@ -10,27 +10,21 @@
     hasAutoStakeMaturityOn,
     hasPermissionToStakeMaturity,
   } from "$lib/utils/sns-neuron.utils";
-  import type { SnsNeuron } from "@dfinity/sns";
   import { isNullish } from "@dfinity/utils";
   import { getContext } from "svelte";
 
-  const context: SelectedSnsNeuronContext =
+  const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
-  const { store }: SelectedSnsNeuronContext = context;
 
-  let neuron: SnsNeuron | undefined | null;
-  $: ({ neuron } = $store);
-
-  let hasAutoStakeOn: boolean;
-  $: hasAutoStakeOn = hasAutoStakeMaturityOn(neuron);
-
-  let disabled: boolean;
-  $: disabled =
+  const { neuron } = $derived($store);
+  let hasAutoStakeOn = $derived(hasAutoStakeMaturityOn(neuron));
+  let disabled = $derived(
     isNullish(neuron) ||
-    !hasPermissionToStakeMaturity({
-      neuron,
-      identity: $authStore.identity,
-    });
+      !hasPermissionToStakeMaturity({
+        neuron,
+        identity: $authStore.identity,
+      })
+  );
 </script>
 
 <AutoStakeMaturityCheckbox


### PR DESCRIPTION
# Motivation

The Neuron details page displays the option to turn on or off autostake. Only the main controller of a neuron can perform this action. This initial PR prepares the components to utilize the runes syntax.

[NNS1-4245](https://dfinity.atlassian.net/browse/NNS1-4245)

# Changes

* Prepares component to handle runes notation.

# Tests

- CI should pass as before.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed? - Not Yet


[NNS1-4245]: https://dfinity.atlassian.net/browse/NNS1-4245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ