### PR TITLE
fix(wallet): restore index canister navigation

### DIFF
--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -38,4 +38,4 @@ export const abandonedProjectsCanisterId = [
   FUEL_EV_ROOT_CANISTER_ID,
 ];
 
-export const uninstalledIndexCanistersId = [];
+export const uninstalledIndexCanistersId: string[] = [];


### PR DESCRIPTION
# Motivation

Proposals [138998](https://dashboard.internetcomputer.org/proposal/138998) and [138999](https://dashboard.internetcomputer.org/proposal/138999) passed, and now the Index canister has been recovered.

This PR enables the routing to the index canister from the wallet page.

# Changes

- Removed index canister from the list of uninstalled canisters.

# Tests

- Updated tests

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
