### PR TITLE
feat(services): add ICRC transaction history fetcher

### DIFF
--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -245,7 +245,7 @@ export const getAllIcrcTransactionsFromAccountAndIdentity = async ({
 
     // Early return if we've gone past our date range. It assumes sorted transactions from newest to oldest.
     const oldestTransactionInPageTimestamp =
-      transactions[transactions.length - 1].transaction.timestamp;
+      transactions[transactions.length - 1]?.transaction.timestamp;
     const from = range?.from;
     if (nonNullish(from) && nonNullish(oldestTransactionInPageTimestamp)) {
       if (oldestTransactionInPageTimestamp < from) {


### PR DESCRIPTION
# Motivation

A new option to export transactions from ck-tokens will be added to the Reporting page. This PR introduces a service to fetch all ICRC transactions for a given principal, index canister, and range. The service will continue calling the canister until all the required transactions are loaded.

Note: The index canister defines a page size of 50 elements for update calls.

[NNS1-4231](https://dfinity.atlassian.net/browse/NNS1-4231)

# Changes

- Added service to fetch ICRC transactions and filter them based on range.

# Tests

- Added unit test.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed? - Not yet

[NNS1-4231]: https://dfinity.atlassian.net/browse/NNS1-4231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ