### PR TITLE
docs(links): update voting rewards documentation URL

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -791,7 +791,7 @@
     "vote_delegation_tooltip_some": "Voting delegated on some topics.",
     "vote_delegation_tooltip_none": "Voting not delegated on any topic.",
     "maturity_last_distribution": "Last Maturity Distribution",
-    "maturity_last_distribution_info": "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed. <a href=\"https://wiki.internetcomputer.org/wiki/Roll-over_of_NNS_voting_rewards\" rel=\"noopener noreferrer\" aria-label=\"more info about the voting rewards\" target=\"_blank\">Learn more</a>",
+    "maturity_last_distribution_info": "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed. <a href=\"https://learn.internetcomputer.org/hc/en-us/articles/34142993417108-Voting-Rewards\" rel=\"noopener noreferrer\" aria-label=\"more info about the voting rewards\" target=\"_blank\">Learn more</a>",
     "stake_maturity": "Stake",
     "view_active_disbursements_total": "Total Maturity Disbursing",
     "view_active_disbursements": "View Active Disbursements",


### PR DESCRIPTION
# Motivation

The nns-dapp displays a link that is no longer valid. This link currently redirects to a valid page, but it may stop working at some point. This PR updates the link to point to the final destination.

# Changes

- Updated the link to the Voting Rewards page.

# Tests

- Not applicable.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
