### PR TITLE
chore(ci): remove former contributor from workflow permissions

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -4,7 +4,7 @@ name: Update sns_aggregator candid bindings
 on:
   schedule:
     # Check for updates on candid interface for the aggregator every monday at 3:30am.
-    - cron: '30 3 * * TUE'
+    - cron: "30 3 * * TUE"
   workflow_dispatch:
   push:
     branches:
@@ -63,7 +63,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
-          reviewers: mstrasinskis, aterga, yhabib
+          reviewers: aterga, yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json
@@ -72,7 +72,7 @@ jobs:
           branch: bot-aggregator-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'bot: Update sns_aggregator candid bindings'
+          title: "bot: Update sns_aggregator candid bindings"
           body: |
             # Motivation
             A newer release of the internet computer is available.

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -4,7 +4,7 @@ name: didc Update
 on:
   schedule:
     # check for new `didc` releases every tuesday at 7:30.
-    - cron: '30 7 * * TUE'
+    - cron: "30 7 * * TUE"
   workflow_dispatch:
 jobs:
   didc-update:
@@ -54,7 +54,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: mstrasinskis, yhabib
+          reviewers: yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: config.json
           commit-message: Update didc release
@@ -63,7 +63,7 @@ jobs:
           branch: bot-didc-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'bot: Update didc release to ${{ steps.update.outputs.version }}'
+          title: "bot: Update didc release to ${{ steps.update.outputs.version }}"
           body: |
             # Motivation
             A newer version of `didc` is available.

--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: mstrasinskis, yhabib
+          reviewers: yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             Cargo.lock

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       gix_components:
-        description: 'Update gix-components'
+        description: "Update gix-components"
         default: true
         type: boolean
       ic_js:
-        description: 'Update ic-js'
+        description: "Update ic-js"
         default: true
         type: boolean
 jobs:
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
           node-version: ${{ env.NODE_VERSION }}
       - name: Update gix-components
         if: ${{ inputs.gix_components }}
@@ -51,7 +51,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-bump-next
           branch-suffix: timestamp
-          reviewers: mstrasinskis, yhabib
+          reviewers: yhabib
           add-paths: |
             frontend
           delete-branch: true

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -4,7 +4,7 @@ name: Update proposals candid bindings
 on:
   schedule:
     # Check for updates on candid interface for the proposals every thursday at 3:30am.
-    - cron: '30 3 * * MON'
+    - cron: "30 3 * * MON"
   workflow_dispatch:
   push:
     branches:
@@ -70,14 +70,14 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-proposals-update
           branch-suffix: timestamp
-          reviewers: mstrasinskis, yhabib
+          reviewers: yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json
             declarations/*/*.did
             rs/proposals/src/canisters/*/api.rs
           delete-branch: true
-          title: 'bot: Update proposals candid bindings'
+          title: "bot: Update proposals candid bindings"
           # Note: It is _likely_ but not guaranteed that the .did files match the `IC_COMMIT` in `config.json`.  The files in the PR have a header that give this information reliably.
           #       We do _not_ put a commit in the PR title as it could be misleading.
           body: |

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -4,7 +4,7 @@ name: Update rust
 on:
   schedule:
     # check for new rust versions weekly
-    - cron: '30 3 * * FRI'
+    - cron: "30 3 * * FRI"
   workflow_dispatch:
   push:
     branches:
@@ -66,7 +66,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: mstrasinskis, yhabib
+          reviewers: yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: ./rust-toolchain.toml
           commit-message: Update rust version
@@ -75,7 +75,7 @@ jobs:
           branch: bot-rust-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'bot: Update rust version to ${{ steps.update.outputs.version }}'
+          title: "bot: Update rust version to ${{ steps.update.outputs.version }}"
           body: |
             # Motivation
             A new verion of Rust is available.

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -3,7 +3,7 @@
 name: Update the SNS aggregator response for ProdLaunchpad.spec
 on:
   schedule:
-    - cron: '30 3 * * THU'
+    - cron: "30 3 * * THU"
   workflow_dispatch:
   push:
     branches:
@@ -40,13 +40,13 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
-          reviewers: mstrasinskis, yhabib
+          reviewers: yhabib
           # Note: Please be careful when updating the add-paths field.
           add-paths: frontend/src/tests/workflows/Launchpad/*.json
           branch: bot-aggregator-response-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'bot: Update SNS Aggregator Response'
+          title: "bot: Update SNS Aggregator Response"
           body: |
             # Motivation
             We would like to keep the ProdLaunchpad.spec up to date with mainnet data.

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -4,7 +4,7 @@ name: Update snsdemo
 on:
   schedule:
     # check for new snsdemo commits weekly
-    - cron: '30 3 * * FRI'
+    - cron: "30 3 * * FRI"
   workflow_dispatch:
   push:
     branches:
@@ -41,8 +41,8 @@ jobs:
         uses: actions/checkout@v5
         if: ${{ steps.update.outputs.updated == '1' }}
         with:
-          repository: 'dfinity/snsdemo'
-          path: 'snsdemo'
+          repository: "dfinity/snsdemo"
+          path: "snsdemo"
           ref: ${{ steps.update.outputs.release }}
       - name: Update snsdemo
         if: ${{ steps.update.outputs.updated == '1' }}
@@ -70,13 +70,13 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update
           branch-suffix: timestamp
-          reviewers: mstrasinskis, yhabib
+          reviewers: yhabib
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json
             dfx.json
           delete-branch: true
-          title: 'bot: Update snsdemo to ${{ steps.update.outputs.release }}'
+          title: "bot: Update snsdemo to ${{ steps.update.outputs.release }}"
           body: |
             # Motivation
             We would like to keep the testing environment, provided by snsdemo, up to date.


### PR DESCRIPTION
# Motivation

Pipelines like this [one](https://github.com/dfinity/nns-dapp/actions/runs/18962005458) or this [one](https://github.com/dfinity/nns-dapp/actions/runs/18962060106) are failing because a contributor was remove from the organization. 

# Changes

- Remove contributor from CI jobs.
- Apply formatting to files.

# Tests

- CI should pass.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
