### PR TITLE
test(e2e): wait for accounts to be ready to reduce flakiness

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -36,6 +36,10 @@ test("Test accounts requirements", async ({ page, context }) => {
   await addAccountModalPo.addAccount(subAccountName);
   await addAccountModalPo.waitForClosed();
 
+  // Wait for the subaccount row to be rendered to avoid race conditions
+  const newSubaccountRow = await tokensTablePo.getRowByName(subAccountName);
+  await newSubaccountRow.waitFor();
+
   step("AU001: The user MUST be able to see a list of all their accounts");
   const accountNames = async () =>
     (await tokensTablePo.getRowsData()).map(({ projectName }) => projectName);


### PR DESCRIPTION
# Motivation

E2E tests often fail due to a race condition between preparing the environment and executing specific tests. Two sources of flakiness have been identified: one related to SNS and another concerning accounts. This first PR addresses the Accounts issue, where the UI took longer than expected for the assertion.

# Changes

- Wait for the accounts to be ready.

# Tests

- CI should pass.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
