### PR TITLE
fix(assets): update font endpoint to non-raw URL

### DIFF
--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -13,7 +13,7 @@
     <style>
       @font-face {
         font-family: CircularXX;
-        src: url("https://nns.raw.ic0.app/assets/fonts/CircularXXWeb-Regular.woff2")
+        src: url("https://nns.ic0.app/assets/fonts/CircularXXWeb-Regular.woff2")
           format("woff2");
         font-weight: 400;
         font-style: normal;


### PR DESCRIPTION
# Motivation

As described [here](https://dfinity.slack.com/archives/C01S03NBM7S/p1761823057443259), the font endpoint can be updated to the non-raw version.

# Changes

- Updated endpoint.

# Tests

- Non-applicable.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
