### PR TITLE
chore(ci): replace individual reviewers with governance-team handle

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -63,7 +63,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
-          reviewers: aterga, yhabib
+          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: yhabib
+          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: config.json
           commit-message: Update didc release

--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: yhabib
+          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             Cargo.lock

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -51,7 +51,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-bump-next
           branch-suffix: timestamp
-          reviewers: yhabib
+          reviewers: governance-team
           add-paths: |
             frontend
           delete-branch: true

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -70,7 +70,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-proposals-update
           branch-suffix: timestamp
-          reviewers: yhabib
+          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: yhabib
+          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: ./rust-toolchain.toml
           commit-message: Update rust version

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -40,7 +40,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
-          reviewers: yhabib
+          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.
           add-paths: frontend/src/tests/workflows/Launchpad/*.json
           branch: bot-aggregator-response-update

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -70,7 +70,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update
           branch-suffix: timestamp
-          reviewers: yhabib
+          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json


### PR DESCRIPTION
# Motivation

#7503 updated the list of reviewers, but this can be automated using the team's handler, `governance-team`, so no further updates will be necessary in the future.

# Changes

- Replaced individual reviewers with the team's handler.

# Tests

- Not applicable

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
