### PR TITLE
chore(ci): remove governance-team from required reviewers

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -63,7 +63,6 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
-          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: config.json
           commit-message: Update didc release

--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -33,7 +33,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             Cargo.lock

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -51,7 +51,6 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-bump-next
           branch-suffix: timestamp
-          reviewers: governance-team
           add-paths: |
             frontend
           delete-branch: true

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -70,7 +70,6 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-proposals-update
           branch-suffix: timestamp
-          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -66,7 +66,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: ./rust-toolchain.toml
           commit-message: Update rust version

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -40,7 +40,6 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
-          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.
           add-paths: frontend/src/tests/workflows/Launchpad/*.json
           branch: bot-aggregator-response-update

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -70,7 +70,6 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update
           branch-suffix: timestamp
-          reviewers: governance-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             config.json


### PR DESCRIPTION
# Motivation

Some CI jobs are failing because they do not accept the `governance-team` as a reviewer for a PR. It appears that this team is automatically added due to its definition in the CODEOWNERS file. Here are some examples:
* https://github.com/dfinity/nns-dapp/actions/runs/19040696921/job/54376783564
* https://github.com/dfinity/nns-dapp/actions/runs/19061209654
* https://github.com/dfinity/nns-dapp/actions/runs/19057108890

# Changes

- Remove `governance-team` from reviewers.

# Tests

- Tested [here](https://github.com/dfinity/nns-dapp/actions/runs/19064925065)

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
