### PR TITLE
chore(deps): bump gix-components for nested collapsible fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "9.0.0-next-2025-10-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-9.0.0-next-2025-10-25.tgz",
-      "integrity": "sha512-7X/SfpAED98wEBzt0ML00FRyhzsnTVaT42T8yioYjpjCB0zDandGVHWTOGhMGNgox58+1nY91C6gtpnXpQSp5g==",
+      "version": "9.0.0-next-2025-11-05",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-9.0.0-next-2025-11-05.tgz",
+      "integrity": "sha512-nuc/dLrb9/fvqP25tQwoAQQ2xv4WqDdpLTTE+Hs83NL9P1bAa8MzDdag4ishHtxO6Imd1LitQt3lkxOlUK4m0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "decimal.js": "^10.6.0",
@@ -397,7 +397,7 @@
         "qr-creator": "^1.0.0"
       },
       "engines": {
-        "node": ">=22",
+        "node": ">=24",
         "npm": ">=11.5.1 <12.0.0"
       },
       "peerDependencies": {


### PR DESCRIPTION
# Motivation

Bump the Gix version to include the [change](https://github.com/dfinity/gix-components/pull/734) that fixes issues with nested collapsibles.

# Changes

- Ran `npm run update:gix`

# Tests

- CI should pass as before

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
