### PR TITLE
fix(following): recalculate parent collapsible when nested topics expand

### DIFF
--- a/frontend/src/lib/modals/neurons/FollowNnsNeuronsByTopicItem.svelte
+++ b/frontend/src/lib/modals/neurons/FollowNnsNeuronsByTopicItem.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import FollowNnsNeuronsByTopicFollowee from "$lib/modals/neurons/FollowNnsNeuronsByTopicFollowee.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { getTopicSubtitle, getTopicTitle } from "$lib/utils/neuron.utils";
   import {
     Checkbox,
     Collapsible,
@@ -6,10 +9,8 @@
     IconErrorOutline,
     IconExpandMore,
   } from "@dfinity/gix-components";
-  import FollowNnsNeuronsByTopicFollowee from "$lib/modals/neurons/FollowNnsNeuronsByTopicFollowee.svelte";
-  import { i18n } from "$lib/stores/i18n";
-  import { getTopicTitle, getTopicSubtitle } from "$lib/utils/neuron.utils";
   import { Topic, type FolloweesForTopic, type NeuronId } from "@dfinity/nns";
+  import { isNullish } from "@dfinity/utils";
 
   type Props = {
     topic: Topic;
@@ -17,6 +18,7 @@
     checked: boolean;
     onNnsChange: (args: { topic: Topic; checked: boolean }) => void;
     removeFollowing: (args: { topic: Topic; followee: NeuronId }) => void;
+    onExpandingOption?: () => void;
   };
 
   let {
@@ -25,6 +27,7 @@
     checked = false,
     onNnsChange,
     removeFollowing,
+    onExpandingOption,
   }: Props = $props();
 
   const title = $derived(getTopicTitle({ topic, i18n: $i18n }));
@@ -44,6 +47,13 @@
     followees.find((f) => f.topic === topic)?.followees ?? []
   );
   const isFollowingByTopic = $derived(topicFollowees.length > 0);
+
+  $effect(() => {
+    expanded;
+    if (isNullish(onExpandingOption)) return;
+
+    setTimeout(onExpandingOption, 250);
+  });
 </script>
 
 <div class="topic-item" data-tid="follow-nns-neurons-by-topic-item-component">

--- a/frontend/src/lib/modals/neurons/FollowNnsNeuronsByTopicStepTopics.svelte
+++ b/frontend/src/lib/modals/neurons/FollowNnsNeuronsByTopicStepTopics.svelte
@@ -65,6 +65,8 @@
   const isTopicSelected = (topic: Topic) => selectedTopics.includes(topic);
   let cmp = $state<Collapsible | undefined>(undefined);
   let toggleContent = () => cmp?.toggleContent();
+  let updateMaxHeight = () => cmp?.updateMaxHeight();
+
   let expanded: boolean = $state(false);
 
   const removeFollowing = async ({
@@ -148,6 +150,7 @@
           checked={isTopicSelected(topic)}
           onNnsChange={onTopicSelectionChange}
           {removeFollowing}
+          onExpandingOption={updateMaxHeight}
         />
       {/each}
     </Collapsible>


### PR DESCRIPTION
# Motivation

The new NNS neuron following flow has an issue when interacting with other topics in the select topics modal step. #7521 updated the Gix version to provide a way to control the recalculation of the collapsible container from the outside.

This PR exposes the function of the outer collapsible to the inner collapsible, allowing the child to invoke it when it expands. This forces the parent to recalculate the space needed to display the children.

Before:

https://github.com/user-attachments/assets/319efaef-2454-41fb-82a9-58ae22124c6d

After:

https://github.com/user-attachments/assets/62428c75-ab0f-4cdd-ac4a-d40f44bfe811

[NNS1-4251](https://dfinity.atlassian.net/browse/NNS1-4251)

# Changes

- Force the recalculation of container heights when interacting with collapsible topics.

# Tests

- Visually tested

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-4251]: https://dfinity.atlassian.net/browse/NNS1-4251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ