### PR TITLE
chore(i18n): regenerate types with i18n script

### DIFF
--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -186,14 +186,14 @@ interface I18nAddress_book {
   save_address: string;
   add_success: string;
   edit_success: string;
+  delete_success: string;
+  remove_address_title: string;
+  remove_address_message: string;
   nickname_too_short: string;
   nickname_too_long: string;
   nickname_already_used: string;
   invalid_address: string;
   max_addresses_reached: string;
-  remove_address_title: string;
-  remove_address_message: string;
-  delete_success: string;
 }
 
 interface I18nAlfred {


### PR DESCRIPTION
# Motivation

It seems that types were added manually but incorrectly located. This PR fixes it.

# Changes

- Ran `npm run i18n` to autogenerate those types.

# Tests

- Not applicable

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
