### PR TITLE
feat: upgrade to ic-js v82+next with required types changes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -339,9 +339,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "4.0.6-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-4.0.6-next-2025-10-23.tgz",
-      "integrity": "sha512-ZDEAEkzU4VgeU4bN1bDKGARcc5XCuYpJaLUSzBVwjUK7EBRHCEnGS5cExZoU7JRj0wTuLVn2oYOzdnI45DXkdQ==",
+      "version": "5.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-5.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-DDvkVoCz3b7hs5rG1dHTJ8clsbu59GKLpx+clY17xZh7mVVcmcjssUpmfFSA/RE/t8tRV3qyaQZ3uoh6fDSgaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -349,22 +349,18 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/utils": "*",
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "6.0.6-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-6.0.6-next-2025-10-23.tgz",
-      "integrity": "sha512-ORBzRSOSS7mwy04AAnvwQMFo4h7MFAGGSAaF4Y1EnibCXfraV9AP5MxIvs6ua9gvpN0O/eshwFG1QayFXjaZMQ==",
+      "version": "7.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-7.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-XIHOPxkXvm5jIRHt6UyuJFBg2QpggXMYVQT3vmFYOEu75kEO1jOMA8cl5OnYt1tQbOkfUGLnF2PTDmgIRh3Ziw==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/utils": "*",
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/gix-components": {
@@ -389,15 +385,13 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "7.1.3-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.1.3-next-2025-10-23.tgz",
-      "integrity": "sha512-hHQ8T9qQrjtMYRYIP4/Kpn8j3jKmlzpp4SYZmCjQUnpR4nyZTEtsDMowwrFdlq/pDadyUBhDrjrRMXPhl+kGtw==",
+      "version": "8.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-8.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-D7fodQCZpnLvC1K3y700LgNZmizGmcpWZka4SznAInvAQ0ehMGDyLKSvbPyn6A5ppnrWKFcCfQtg3EbdTqI8YQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/utils": "*",
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/identity": {
@@ -433,45 +427,39 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "6.1.2-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-6.1.2-next-2025-10-23.tgz",
-      "integrity": "sha512-gjql0wyHxrctksn+gFxhKpfuEUoE8IRuHcHdiwX9hMrSQEXrTGPHPjsmkOmQvmh7I7GVggc822seGNahM+GQlQ==",
+      "version": "7.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-7.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-TkU3HkKegDAwFtBFntq+Mn1eI6iNzz0A4Nt//Z+qdSIer6tdhmveKtuf7Dl9PWKtL0jiTw36J6CaGUYPda5p/A==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/utils": "*",
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "4.1.2-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-4.1.2-next-2025-10-23.tgz",
-      "integrity": "sha512-z2DRtlmYXtuVA8aHodaKb20I2kv7JiSv2zozEk/cSN/J9KsDGnf9WsTHXmQRAmvAp8YnZgi0+3XIycAVpcpXWw==",
+      "version": "5.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-5.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-8U5YHHc8OE+S4K9ZpnJlsfLYfpcwJsauO//ZhxP4nbecE/LF+GoNGfT/fXOhm+x0PMuSOetXF3luCjSz2J2tHA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/utils": "*",
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "10.4.0-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-10.4.0-next-2025-10-23.tgz",
-      "integrity": "sha512-ufQyaadBVKdHgrtNUOqozWLNk5noI2yCv/fxyEoXseJRrVPuc5G5XLE7nN/S7woKyGW79JeMuajTTtGFlD3T0w==",
+      "version": "11.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-11.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-2YjMsDmoX499XTXj/vCWt5jlm3uOwoaXCebZB7NV+SoWTMUTIWUSenU1Bbf20K7Zwh22dZ1nUakY1s26Niww0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
         "@dfinity/ledger-icp": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/utils": "*",
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/principal": {
@@ -485,31 +473,27 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "4.1.2-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-4.1.2-next-2025-10-23.tgz",
-      "integrity": "sha512-uxA9QMIrBnM64M3NxMcNdQynTsdGNrDltXmbB3ukjV9nohiOzje097cbJm8Dt4xg0qTimvkGZWMT9oW0DcVYDQ==",
+      "version": "5.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-5.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-5xXDNY7Rc0ISelS1uJNjwhuN8YzDPDVXuPlKh6jTlcLJXaPxLC4qX6O0kwiCs6INZko48AT+mO8sIHDTbf8Izg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
         "@dfinity/ledger-icrc": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/utils": "*",
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "3.2.0-next-2025-10-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.2.0-next-2025-10-23.tgz",
-      "integrity": "sha512-vvUDY1Cwr+ldnUExLC/G4AoMLF4KL/NmGWdLhYCM31OlsrbMb2IuZ1k0A6Q5KGC3DeIe9QgLGkl8TFyFXj0ftg==",
+      "version": "4.0.0-next-2025-11-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-4.0.0-next-2025-11-05.1.tgz",
+      "integrity": "sha512-mIZKeQORu7CWfH+5i8RTmYUai/l6FSTFMe1mZ/odLZIy3unVN2yBAVMb0bwKtHtKI+S27L13VSvSUbmhVTBHbQ==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*"
+        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -1,11 +1,11 @@
 import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
+import type { IcrcSubaccount } from "@dfinity/ledger-icrc";
 import {
   IcrcIndexNgCanister,
   type IcrcAccount,
   type IcrcIndexNgGetTransactions,
 } from "@dfinity/ledger-icrc";
-import type { SubAccount } from "@dfinity/ledger-icrc/dist/candid/icrc_index";
 import { fromNullable } from "@dfinity/utils";
 import type { Agent, Identity } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
@@ -70,7 +70,7 @@ export const listSubaccounts = async ({
   identity: Identity;
   indexCanisterId: Principal;
   certified?: boolean;
-}): Promise<Array<SubAccount>> => {
+}): Promise<Array<IcrcSubaccount>> => {
   const {
     canister: { listSubaccounts },
   } = await indexNgCanister({

--- a/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
@@ -8,12 +8,12 @@
   import type { Universe } from "$lib/types/universe";
   import { Principal } from "@icp-sdk/core/principal";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
-  import type { ProposalData } from "@dfinity/sns/dist/candid/sns_governance";
+  import type { SnsProposalData } from "@dfinity/sns";
   import { fromNullable, nonNullish } from "@dfinity/utils";
   import type { Readable } from "svelte/store";
 
   export let universe: Universe;
-  export let proposals: ProposalData[];
+  export let proposals: SnsProposalData[];
 
   let rootCanisterId: RootCanisterIdText;
   $: rootCanisterId = universe.canisterId;

--- a/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementEntry.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementEntry.svelte
@@ -3,20 +3,17 @@
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import { formatMaturity } from "$lib/utils/neuron.utils";
   import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger-icrc";
-  import type {
-    Account,
-    DisburseMaturityInProgress,
-  } from "@dfinity/sns/dist/candid/sns_governance";
+  import type { SnsAccount, SnsDisburseMaturityInProgress } from "@dfinity/sns";
   import { fromDefinedNullable, fromNullable } from "@dfinity/utils";
 
-  export let disbursement: DisburseMaturityInProgress;
+  export let disbursement: SnsDisburseMaturityInProgress;
 
   let dateTime: string;
   $: dateTime = secondsToDateTime(
     disbursement.timestamp_of_disbursement_seconds
   );
 
-  let account: Account;
+  let account: SnsAccount;
   $: account = fromDefinedNullable(disbursement.account_to_disburse_to);
 
   let destination: string;

--- a/frontend/src/lib/modals/sns/neurons/SnsTopicDefinitionsTopic.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsTopicDefinitionsTopic.svelte
@@ -3,7 +3,7 @@
   import type { TopicInfoWithUnknown } from "$lib/types/sns-aggregator";
   import { fromDefinedNullable, fromNullable } from "@dfinity/utils";
   import { getAllSnsNSFunctions } from "$lib/utils/sns-topics.utils";
-  import type { NervousSystemFunction } from "@dfinity/sns/dist/candid/sns_governance";
+  import type { SnsNervousSystemFunction } from "@dfinity/sns";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let topicInfo: TopicInfoWithUnknown;
@@ -13,7 +13,7 @@
   let description: string;
   $: description = fromDefinedNullable(topicInfo.description);
 
-  let nsFunctions: NervousSystemFunction[];
+  let nsFunctions: SnsNervousSystemFunction[];
   $: nsFunctions = getAllSnsNSFunctions(topicInfo);
 </script>
 

--- a/frontend/src/lib/services/actionable-sns-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-sns-proposals.services.ts
@@ -16,9 +16,8 @@ import {
   lastProposalId,
   sortSnsProposalsById,
 } from "$lib/utils/sns-proposals.utils";
-import type { SnsNeuron } from "@dfinity/sns";
+import type { SnsNeuron, SnsProposalData } from "@dfinity/sns";
 import { SnsProposalRewardStatus } from "@dfinity/sns";
-import type { ProposalData } from "@dfinity/sns/dist/candid/sns_governance";
 import { isNullish } from "@dfinity/utils";
 import type { Identity } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
@@ -99,8 +98,8 @@ const querySnsProposals = async ({
 }: {
   rootCanisterId: string;
   identity: Identity;
-}): Promise<{ proposals: ProposalData[] }> => {
-  let sortedProposals: ProposalData[] = [];
+}): Promise<{ proposals: SnsProposalData[] }> => {
+  let sortedProposals: SnsProposalData[] = [];
   for (
     let pagesLoaded = 0;
     pagesLoaded < MAX_ACTIONABLE_REQUEST_COUNT;
@@ -124,7 +123,7 @@ const querySnsProposals = async ({
     sortedProposals = sortSnsProposalsById([
       ...sortedProposals,
       ...page,
-    ]) as ProposalData[];
+    ]) as SnsProposalData[];
 
     // no more proposals available
     if (page.length !== DEFAULT_LIST_PAGINATION_LIMIT) {

--- a/frontend/src/lib/services/sns-vote-registration.services.ts
+++ b/frontend/src/lib/services/sns-vote-registration.services.ts
@@ -24,12 +24,12 @@ import {
   toSnsVote,
 } from "$lib/utils/sns-proposals.utils";
 import type {
+  SnsBallot,
   SnsNervousSystemFunction,
   SnsNeuron,
   SnsProposalData,
   SnsVote,
 } from "@dfinity/sns";
-import type { Ballot } from "@dfinity/sns/dist/candid/sns_governance";
 import { fromDefinedNullable } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -151,16 +151,18 @@ const proposalAfterVote = ({
   vote: SnsVote;
 }): SnsProposalData => {
   // replace ballots of just voted neurons with optimistic ones
-  const optimisticBallots: Array<[string, Ballot]> = neurons.map((neuron) => [
-    // neuron id
-    getSnsNeuronIdAsHexString(neuron),
-    // optimistic ballot
-    {
-      vote,
-      cast_timestamp_seconds: BigInt(Math.round(Date.now() / 1000)),
-      voting_power: ballotVotingPower({ proposal, neuron }),
-    } as Ballot,
-  ]);
+  const optimisticBallots: Array<[string, SnsBallot]> = neurons.map(
+    (neuron) => [
+      // neuron id
+      getSnsNeuronIdAsHexString(neuron),
+      // optimistic ballot
+      {
+        vote,
+        cast_timestamp_seconds: BigInt(Math.round(Date.now() / 1000)),
+        voting_power: ballotVotingPower({ proposal, neuron }),
+      } as SnsBallot,
+    ]
+  );
   const votedNeuronsIds = new Set(neurons.map(getSnsNeuronIdAsHexString));
 
   return {

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -3,6 +3,7 @@ import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { UnknownTopic } from "$lib/types/sns-aggregator";
 import type {
   CfParticipant,
+  SnsFinalizeSwapResponse,
   SnsGetLifecycleResponse,
   SnsNervousSystemFunction,
   SnsNeuronId,
@@ -14,7 +15,6 @@ import type {
   SnsSwapTicket,
   SnsTopic,
 } from "@dfinity/sns";
-import type { FinalizeSwapResponse } from "@dfinity/sns/dist/candid/sns_swap";
 import type { Principal } from "@icp-sdk/core/principal";
 
 export type RootCanisterId = Principal;
@@ -31,7 +31,7 @@ export interface SnsSummaryMetadata {
 }
 
 export interface SnsSummarySwap {
-  auto_finalize_swap_response: [] | [FinalizeSwapResponse];
+  auto_finalize_swap_response: [] | [SnsFinalizeSwapResponse];
   next_ticket_id: [] | [bigint];
   already_tried_to_auto_finalize: [] | [boolean];
   purge_old_tickets_last_completion_timestamp_nanoseconds: [] | [bigint];

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -20,7 +20,6 @@ import type {
   IcrcTransactionWithId,
 } from "@dfinity/ledger-icrc";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
-import type { TransactionWithId } from "@dfinity/ledger-icrc/dist/candid/icrc_index-ng";
 import {
   TokenAmount,
   TokenAmountV2,
@@ -180,7 +179,7 @@ export const mapIcrcTransactionToReport = ({
   token,
 }: {
   account: Account;
-  transaction: TransactionWithId;
+  transaction: IcrcTransactionWithId;
   token: Token;
 }) => {
   const txInfo = getTransactionInformation(transaction.transaction);

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -11,8 +11,8 @@ import type {
   SnsGetDerivedStateResponse,
   SnsNervousSystemFunction,
   SnsProposalData,
+  SnsSwapDerivedState,
 } from "@dfinity/sns";
-import type { DerivedState } from "@dfinity/sns/dist/candid/sns_swap";
 import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
 import type { Principal } from "@icp-sdk/core/principal";
 
@@ -148,7 +148,7 @@ export const isSnsFinalizing = (
 
 export const convertDerivedStateResponseToDerivedState = (
   derivedState: SnsGetDerivedStateResponse
-): DerivedState | undefined => {
+): SnsSwapDerivedState | undefined => {
   const sns_tokens_per_icp = fromNullable(derivedState.sns_tokens_per_icp);
   const buyer_total_icp_e8s = fromNullable(derivedState.buyer_total_icp_e8s);
   // This is not expected, but in case it happens, we want to fail fast.

--- a/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
+++ b/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
@@ -15,7 +15,7 @@ import type {
 } from "$lib/worker-utils/timer.worker-utils";
 import {
   decodeIcrcAccount,
-  type IcrcTransactionWithId,
+  type IcrcIndexNgTransactionWithId,
   type IcrcTxId,
 } from "@dfinity/ledger-icrc";
 import { jsonReplacer, nonNullish } from "@dfinity/utils";
@@ -72,7 +72,7 @@ export const getIcrcAccountsTransactions = ({
             ) !== undefined;
 
           return [...acc, ...(alreadyExist() ? [] : [value])];
-        }, [] as IcrcTransactionWithId[]),
+        }, [] as IcrcIndexNgTransactionWithId[]),
         ...rest,
       };
     })

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -12,8 +12,8 @@ import {
 } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import type { RewardEvent } from "@dfinity/nns";
 import { NeuronVisibility, Topic, Vote } from "@dfinity/nns";
-import type { RewardEvent } from "@dfinity/nns/dist/candid/governance";
 import type { Mock } from "vitest";
 
 vi.mock("$lib/api/governance.api");

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -6,11 +6,15 @@ import {
   mockCanisterId,
   mockCanisterSettings,
 } from "$tests/mocks/canisters.mock";
-import type { CanisterStatusResponse } from "@dfinity/ic-management";
-import type { _SERVICE as IcManagementService } from "@dfinity/ic-management/dist/candid/ic-management";
+import type {
+  CanisterStatusResponse,
+  ICManagementCanisterOptions,
+} from "@dfinity/ic-management";
 import { type ActorSubclass, type HttpAgent } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import { mock } from "vitest-mock-extended";
+
+type IcManagementService = ICManagementCanisterOptions["serviceOverride"];
 
 describe("ICManagementCanister", () => {
   const createICManagement = async (service: IcManagementService) => {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -12,7 +12,11 @@ import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { mockSnsCanisterId } from "$tests/mocks/sns.api.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState, Vote } from "@dfinity/nns";
-import type { SnsNeuron, SnsProposalData } from "@dfinity/sns";
+import type {
+  SnsNeuron,
+  SnsNeuronPermission,
+  SnsProposalData,
+} from "@dfinity/sns";
 import {
   SnsNeuronPermissionType,
   SnsProposalDecisionStatus,
@@ -21,7 +25,6 @@ import {
   SnsVote,
   type SnsBallot,
 } from "@dfinity/sns";
-import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
 import { fromDefinedNullable } from "@dfinity/utils";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
@@ -72,7 +75,7 @@ describe("SnsVotingCard", () => {
       permission_type: Int32Array.from([
         SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
       ]),
-    } as NeuronPermission,
+    } as SnsNeuronPermission,
   ];
 
   const testNeurons: SnsNeuron[] = [

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsActiveDisbursementEntry.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsActiveDisbursementEntry.spec.ts
@@ -2,14 +2,14 @@ import SnsActiveDisbursementEntry from "$lib/modals/sns/neurons/SnsActiveDisburs
 import { mockPrincipalText } from "$tests/mocks/auth.store.mock";
 import { ActiveDisbursementEntryPo } from "$tests/page-objects/ActiveDisbursementEntry.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import type { DisburseMaturityInProgress } from "@dfinity/sns/dist/candid/sns_governance";
+import type { SnsDisburseMaturityInProgress } from "@dfinity/sns";
 import { Principal } from "@icp-sdk/core/principal";
 import { render } from "@testing-library/svelte";
 (".svelte");
 
 describe("SnsActiveDisbursementEntry", () => {
   const disbursementTimestamp = 1694000000n;
-  const testActiveDisbursement: DisburseMaturityInProgress = {
+  const testActiveDisbursement: SnsDisburseMaturityInProgress = {
     timestamp_of_disbursement_seconds: disbursementTimestamp,
     amount_e8s: 123_000_000n,
     account_to_disburse_to: [
@@ -20,7 +20,7 @@ describe("SnsActiveDisbursementEntry", () => {
     ],
     finalize_disbursement_timestamp_seconds: [],
   };
-  const renderComponent = (disbursement: DisburseMaturityInProgress) => {
+  const renderComponent = (disbursement: SnsDisburseMaturityInProgress) => {
     const { container } = render(SnsActiveDisbursementEntry, {
       props: { disbursement },
     });

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -11,9 +11,8 @@ import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import type { SnsNeuron } from "@dfinity/sns";
+import type { SnsDisburseMaturityInProgress, SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import type { DisburseMaturityInProgress } from "@dfinity/sns/dist/candid/sns_governance";
 import { Principal } from "@icp-sdk/core/principal";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -87,7 +86,7 @@ describe("nonEmptySnsNeuronStore", () => {
         disburse_maturity_in_progress: [
           {
             amount_e8s: 1n,
-          } as DisburseMaturityInProgress,
+          } as SnsDisburseMaturityInProgress,
         ],
       },
       {
@@ -100,7 +99,7 @@ describe("nonEmptySnsNeuronStore", () => {
         disburse_maturity_in_progress: [
           {
             amount_e8s: 0n,
-          } as DisburseMaturityInProgress,
+          } as SnsDisburseMaturityInProgress,
         ],
       },
       {
@@ -229,7 +228,7 @@ describe("definedSnsNeuronStore", () => {
         disburse_maturity_in_progress: [
           {
             amount_e8s: 500_000_000n,
-          } as DisburseMaturityInProgress,
+          } as SnsDisburseMaturityInProgress,
         ],
       },
       {
@@ -242,7 +241,7 @@ describe("definedSnsNeuronStore", () => {
         disburse_maturity_in_progress: [
           {
             amount_e8s: 1_500_000_000n,
-          } as DisburseMaturityInProgress,
+          } as SnsDisburseMaturityInProgress,
         ],
       },
       {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsActiveDisbursementsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsActiveDisbursementsModal.spec.ts
@@ -4,11 +4,10 @@ import { renderModal } from "$tests/mocks/modal.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { SnsActiveDisbursementsModalPo } from "$tests/page-objects/SnsActiveDisbursementsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import type { SnsNeuron } from "@dfinity/sns";
-import type { DisburseMaturityInProgress } from "@dfinity/sns/dist/candid/sns_governance";
+import type { SnsDisburseMaturityInProgress, SnsNeuron } from "@dfinity/sns";
 
 describe("SnsActiveDisbursementsModal", () => {
-  const testActiveDisbursement: DisburseMaturityInProgress = {
+  const testActiveDisbursement: SnsDisburseMaturityInProgress = {
     timestamp_of_disbursement_seconds: 10000n,
     amount_e8s: 100_000_000n,
     account_to_disburse_to: [

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -16,6 +16,7 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setIcpSwapUsdPrices } from "$tests/utils/icp-swap.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import type { SnsDisburseMaturityInProgress } from "@dfinity/sns";
 import {
   SnsNeuronPermissionType,
   SnsSwapLifecycle,
@@ -23,7 +24,6 @@ import {
   type SnsNeuron,
   type SnsNeuronId,
 } from "@dfinity/sns";
-import type { DisburseMaturityInProgress } from "@dfinity/sns/dist/candid/sns_governance";
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
 
@@ -55,7 +55,7 @@ describe("SnsNeurons", () => {
     disburse_maturity_in_progress: [
       {
         amount_e8s: 100_000_000n,
-      } as DisburseMaturityInProgress,
+      } as SnsDisburseMaturityInProgress,
     ],
   };
   const neuronNFStake = 400_000_000n;

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.svelte.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.svelte.spec.ts
@@ -34,6 +34,7 @@ import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { Vote } from "@dfinity/nns";
+import type { SnsNeuronPermission } from "@dfinity/sns";
 import {
   SnsGovernanceError,
   SnsNeuronPermissionType,
@@ -44,7 +45,6 @@ import {
   type SnsBallot,
   type SnsProposalData,
 } from "@dfinity/sns";
-import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
 import { AnonymousIdentity } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import { waitFor } from "@testing-library/svelte";
@@ -852,7 +852,7 @@ describe("SnsProposalDetail", () => {
             permission_type: Int32Array.from([
               SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
             ]),
-          } as NeuronPermission,
+          } as SnsNeuronPermission,
         ],
       };
       const neuron1 = fakeSnsGovernanceApi.addNeuronWith({

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -79,7 +79,10 @@ import {
 } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { NeuronState, Vote, type NeuronInfo } from "@dfinity/nns";
-import type { SnsNervousSystemParameters } from "@dfinity/sns";
+import type {
+  SnsNervousSystemParameters,
+  SnsNeuronPermission,
+} from "@dfinity/sns";
 import {
   SnsNeuronPermissionType,
   SnsVote,
@@ -88,7 +91,6 @@ import {
   type SnsNeuron,
   type SnsProposalData,
 } from "@dfinity/sns";
-import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import type { Identity } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
@@ -124,7 +126,7 @@ const permissionsWithTypeVote = [
     permission_type: Int32Array.from([
       SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
     ]),
-  } as NeuronPermission,
+  } as SnsNeuronPermission,
 ];
 const testSnsNeuronA: SnsNeuron = {
   ...mockSnsNeuron,

--- a/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
@@ -4,7 +4,7 @@ import { getIcrcTransactions } from "$lib/worker-api/icrc-index.worker-api";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   IcrcIndexNgCanister,
-  type IcrcTransaction,
+  type IcrcIndexNgTransaction,
 } from "@dfinity/ledger-icrc";
 import * as dfinityUtils from "@dfinity/utils";
 import { mock } from "vitest-mock-extended";
@@ -34,7 +34,7 @@ describe("icrc-index.worker-api", () => {
 
   const transaction = {
     burn: [],
-  } as unknown as IcrcTransaction;
+  } as unknown as IcrcIndexNgTransaction;
 
   it("should returns transactions", async () => {
     const id = 1n;

--- a/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
@@ -11,7 +11,7 @@ import {
 import type { IcrcIndexNgGetTransactions } from "@dfinity/ledger-icrc";
 import {
   IcrcIndexNgCanister,
-  type IcrcTransaction,
+  type IcrcIndexNgTransaction,
 } from "@dfinity/ledger-icrc";
 import * as dfinityUtils from "@dfinity/utils";
 import { mock } from "vitest-mock-extended";
@@ -30,7 +30,7 @@ describe("transactions.worker-services", () => {
 
   const transaction = {
     burn: [],
-  } as unknown as IcrcTransaction;
+  } as unknown as IcrcIndexNgTransaction;
 
   const request: Omit<
     PostMessageDataRequestTransactions,

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -3,8 +3,8 @@ import type { IcrcTransactionsStoreData } from "$lib/stores/icrc-transactions.st
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import type {
-  IcrcTransaction,
-  IcrcTransactionWithId,
+  IcrcIndexNgTransaction,
+  IcrcIndexNgTransactionWithId,
 } from "@dfinity/ledger-icrc";
 import { toNullable } from "@dfinity/utils";
 import { Principal } from "@icp-sdk/core/principal";
@@ -31,7 +31,7 @@ export const createIcrcTransactionWithId = ({
   amount?: bigint;
   timestamp?: Date;
   memo?: Uint8Array;
-}): IcrcTransactionWithId => ({
+}): IcrcIndexNgTransactionWithId => ({
   id: id ?? 123n,
   transaction: {
     kind: "transfer",
@@ -70,7 +70,7 @@ const fakeSubAccount = {
   subaccount: [new Uint8Array([2, 3, 4])] as [Uint8Array],
 };
 
-const mockIcrcTransactionTransfer: IcrcTransaction = {
+const mockIcrcTransactionTransfer: IcrcIndexNgTransaction = {
   kind: "transfer",
   timestamp: 12_354n,
   burn: [],
@@ -89,7 +89,7 @@ const mockIcrcTransactionTransfer: IcrcTransaction = {
   approve: [],
 };
 
-const mockIcrcTransactionTransferToSelf: IcrcTransaction = {
+const mockIcrcTransactionTransferToSelf: IcrcIndexNgTransaction = {
   kind: "transfer",
   timestamp: 12_354n,
   burn: [],
@@ -120,7 +120,7 @@ export const createMintTransaction = ({
   to?: IcrcCandidAccount;
   memo?: Uint8Array;
   createdAt?: bigint;
-}): IcrcTransaction => {
+}): IcrcIndexNgTransaction => {
   return {
     kind: "burn",
     timestamp,
@@ -131,6 +131,7 @@ export const createMintTransaction = ({
         to,
         memo: toNullable(memo),
         created_at_time: toNullable(createdAt),
+        fee: [],
       },
     ],
     transfer: [],
@@ -154,7 +155,7 @@ export const createApproveTransaction = ({
   memo?: Uint8Array;
   createdAt?: bigint;
   spender?: IcrcCandidAccount;
-}): IcrcTransaction => {
+}): IcrcIndexNgTransaction => {
   return {
     kind: "approve",
     timestamp,
@@ -190,7 +191,7 @@ export const createBurnTransaction = ({
   memo?: Uint8Array;
   createdAt?: bigint;
   spender?: IcrcCandidAccount;
-}): IcrcTransaction => {
+}): IcrcIndexNgTransaction => {
   return {
     kind: "burn",
     timestamp,
@@ -201,6 +202,7 @@ export const createBurnTransaction = ({
         memo: toNullable(memo),
         created_at_time: toNullable(createdAt),
         spender: toNullable(spender),
+        fee: [],
       },
     ],
     mint: [],
@@ -209,11 +211,10 @@ export const createBurnTransaction = ({
   };
 };
 
-export const mockIcrcTransactionBurn: IcrcTransaction = createBurnTransaction(
-  {}
-);
+export const mockIcrcTransactionBurn: IcrcIndexNgTransaction =
+  createBurnTransaction({});
 
-export const mockIcrcTransactionMint: IcrcTransaction = {
+export const mockIcrcTransactionMint: IcrcIndexNgTransaction = {
   kind: "mint",
   timestamp: 12_354n,
   burn: [],
@@ -223,18 +224,19 @@ export const mockIcrcTransactionMint: IcrcTransaction = {
       memo: [],
       created_at_time: [123n],
       to: fakeAccount,
+      fee: [],
     },
   ],
   transfer: [],
   approve: [],
 };
 
-export const mockIcrcTransactionWithId: IcrcTransactionWithId = {
+export const mockIcrcTransactionWithId: IcrcIndexNgTransactionWithId = {
   id: 123n,
   transaction: mockIcrcTransactionTransfer,
 };
 
-export const mockIcrcTransactionWithIdToSelf: IcrcTransactionWithId = {
+export const mockIcrcTransactionWithIdToSelf: IcrcIndexNgTransactionWithId = {
   id: 124n,
   transaction: mockIcrcTransactionTransferToSelf,
 };

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -12,16 +12,16 @@ import { snsTopicKeyToTopic } from "$lib/utils/sns-topics.utils";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { NeuronState, type NeuronId } from "@dfinity/nns";
+import type {
+  SnsDisburseMaturityInProgress,
+  SnsNeuronPermission,
+} from "@dfinity/sns";
 import {
   SnsNeuronPermissionType,
   type SnsNervousSystemParameters,
   type SnsNeuron,
   type SnsTopic,
 } from "@dfinity/sns";
-import type {
-  DisburseMaturityInProgress,
-  NeuronPermission,
-} from "@dfinity/sns/dist/candid/sns_governance";
 import {
   arrayOfNumberToUint8Array,
   isNullish,
@@ -32,7 +32,7 @@ import type { Subscriber } from "svelte/store";
 
 export const mockSnsNeuronTimestampSeconds = 3600 * 24 * 6;
 
-export const mockActiveDisbursement: DisburseMaturityInProgress = {
+export const mockActiveDisbursement: SnsDisburseMaturityInProgress = {
   timestamp_of_disbursement_seconds: 10_000n,
   amount_e8s: 1_000_000n,
   account_to_disburse_to: [
@@ -66,7 +66,7 @@ export const createMockSnsNeuron = ({
   stake?: bigint;
   id?: number[];
   state?: NeuronState;
-  permissions?: NeuronPermission[];
+  permissions?: SnsNeuronPermission[];
   // `undefined` means no vesting at all (default)
   // `true` means is still vesting
   // `false` means vesting period has passed


### PR DESCRIPTION
# Motivation

Today we released ic-js v82. After that, I merged the patch that was included in the NNS dapp last week and generated the latest Candid files. Due to the structural changes in the release and the updated DID files, a few type changes are required to upgrade the libraries. That's why this PR includes both.

# Changes

- Upgrade to ic-js v82 and the subsequent version that depends on `@icp-sdk/core`.
- Candid types can no longer be imported via `/dist/` paths, so references were updated to use the re-exported types instead (see #7524 for the scoped change).
- The new Candid files introduce differences between the Index NG canister types and the legacy ones. A few parts of the NNS dapp were still relying on the old declarations, so some types needed to be updated (see #7525 for the scoped change).

