### PR TITLE
fix(staking): exclude ck tokens when building table projects

### DIFF
--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -180,69 +180,71 @@ export const getTableProjects = ({
   failedActionableSnses: FailedActionableSnsesStoreData;
   stakingRewardsResult: StakingRewardResult | undefined;
 }): TableProject[] => {
-  return universes
-    .filter(
-      (universe) =>
-        universe.canisterId === OWN_CANISTER_ID_TEXT ||
-        nonNullish(universe.summary)
-    )
-    .map((universe) => {
-      const token =
-        universe.canisterId === OWN_CANISTER_ID_TEXT
-          ? ICPToken
-          : // If the universe is an SNS universe then the summary is non-nullish.
-            asNonNullish(universe.summary).token;
-      const {
-        neuronCount,
-        stake,
-        availableMaturity,
-        stakedMaturity,
-        isStakeLoading,
-      } = getNeuronAggregateInfo({
-        isSignedIn,
-        universe,
-        token,
-        nnsNeurons,
-        snsNeurons,
-        failedActionableSnses,
-      });
-      const rowHref =
-        stake instanceof FailedTokenAmount
-          ? undefined
-          : buildNeuronsUrl({ universe: universe.canisterId });
-      const universeId = universe.canisterId;
-      const ledgerCanisterId = getLedgerCanisterIdFromUniverse(universe);
-      const tokenPrice =
-        isNullish(icpSwapUsdPrices) || icpSwapUsdPrices === "error"
-          ? undefined
-          : icpSwapUsdPrices[ledgerCanisterId.toText()];
-      const stakeInUsd =
-        stake instanceof TokenAmountV2
-          ? getUsdValue({
-              amount: stake,
-              tokenPrice,
-            })
+  return (
+    universes
+      // Filters out ck projects: projects without a summary or non-icp
+      .filter(
+        ({ canisterId, summary }) =>
+          canisterId === OWN_CANISTER_ID_TEXT || nonNullish(summary)
+      )
+      .map((universe) => {
+        const token =
+          universe.canisterId === OWN_CANISTER_ID_TEXT
+            ? ICPToken
+            : // If the universe is an SNS universe then the summary is non-nullish.
+              asNonNullish(universe.summary).token;
+        const {
+          neuronCount,
+          stake,
+          availableMaturity,
+          stakedMaturity,
+          isStakeLoading,
+        } = getNeuronAggregateInfo({
+          isSignedIn,
+          universe,
+          token,
+          nnsNeurons,
+          snsNeurons,
+          failedActionableSnses,
+        });
+        const rowHref =
+          stake instanceof FailedTokenAmount
+            ? undefined
+            : buildNeuronsUrl({ universe: universe.canisterId });
+        const universeId = universe.canisterId;
+        const ledgerCanisterId = getLedgerCanisterIdFromUniverse(universe);
+        const tokenPrice =
+          isNullish(icpSwapUsdPrices) || icpSwapUsdPrices === "error"
+            ? undefined
+            : icpSwapUsdPrices[ledgerCanisterId.toText()];
+        const stakeInUsd =
+          stake instanceof TokenAmountV2
+            ? getUsdValue({
+                amount: stake,
+                tokenPrice,
+              })
+            : undefined;
+        const apy = isStakingRewardDataReady(stakingRewardsResult)
+          ? stakingRewardsResult?.apy.get(universeId)
           : undefined;
-      const apy = isStakingRewardDataReady(stakingRewardsResult)
-        ? stakingRewardsResult?.apy.get(universeId)
-        : undefined;
 
-      return {
-        rowHref,
-        domKey: universeId,
-        universeId,
-        title: universe.title,
-        logo: universe.logo,
-        tokenSymbol: token.symbol,
-        neuronCount,
-        stake,
-        stakeInUsd,
-        apy,
-        availableMaturity,
-        stakedMaturity,
-        isStakeLoading,
-      };
-    });
+        return {
+          rowHref,
+          domKey: universeId,
+          universeId,
+          title: universe.title,
+          logo: universe.logo,
+          tokenSymbol: token.symbol,
+          neuronCount,
+          stake,
+          stakeInUsd,
+          apy,
+          availableMaturity,
+          stakedMaturity,
+          isStakeLoading,
+        };
+      })
+  );
 };
 
 export const isIcpProject = (project: TableProject) =>


### PR DESCRIPTION
# Motivation

#7509 introduced a navigation bug that can only be reproduced in very specific flows. The bug seems a race condition on how svelte updates the `page` store and how some derived stores consume this new value. The "special" thing of this bug is that it is only present in certain user navigation flows.

To reproduce:
- Navigate to tokens page.
- Navigate to ICP accounts page.
- Navigate to staking page.

The thrown error is not related to the bug; it pertains to an expectation about the data that should be sent to a staking utility. This PR addresses the issue by filtering out unnecessary universes for staking.

Note: Svelte has deprecated `page/store` and does not recommend using it. Derived stores rely on this store, so migration is not straightforward.

<img width="457" height="525" alt="Screenshot 2025-11-06 at 07 17 29" src="https://github.com/user-attachments/assets/5a486bba-d8cb-46fa-a07c-6dd53d4a6df9" />

Note 2: To simplify code review, select the Hide Whitespace option.
<img width="359" height="351" alt="Screenshot 2025-11-06 at 13 37 21" src="https://github.com/user-attachments/assets/ee412678-9acb-4b57-a86c-af1fa862a72c" />

# Changes

- Filter out ck tokens when building table projects.

# Tests

- Visually tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
