### PR TITLE
fix(pricing): generalize provider error labels for multiple sources

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -382,7 +382,7 @@
     "received_amount_notice": "Received Amount *",
     "transaction_time": "Transaction Time",
     "transaction_time_seconds": "Seconds",
-    "token_price_error": "USD prices are temporarily unavailable — all pricing provider APIs are currently unreachable.",
+    "token_price_error": "USD prices are temporarily unavailable: all pricing provider APIs are currently unreachable.",
     "unpriced_tokens_warning": "Value may be inaccurate as some prices could not be fetched.",
     "token_price_source": "Token prices are given in USD and based on data provided by ICPSwap."
   },

--- a/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
@@ -174,7 +174,7 @@ describe("WalletPageHeading", () => {
     expect(await po.hasBalanceInUsd()).toBe(true);
     expect(await po.getBalanceInUsd()).toBe("$-/-");
     expect(await po.getTooltipIconPo().getTooltipText()).toBe(
-      "USD prices are temporarily unavailable — all pricing provider APIs are currently unreachable."
+      "USD prices are temporarily unavailable: all pricing provider APIs are currently unreachable."
     );
   });
 

--- a/frontend/src/tests/lib/components/common/HeadingSubtitleWithUsdValue.spec.ts
+++ b/frontend/src/tests/lib/components/common/HeadingSubtitleWithUsdValue.spec.ts
@@ -64,7 +64,7 @@ describe("HeadingSubtitleWithUsdValue", () => {
     expect(await po.hasAmountInUsd()).toBe(true);
     expect(await po.getAmountInUsd()).toBe("$-/-");
     expect(await po.getTooltipIconPo().getTooltipText()).toBe(
-      "USD prices are temporarily unavailable — all pricing provider APIs are currently unreachable."
+      "USD prices are temporarily unavailable: all pricing provider APIs are currently unreachable."
     );
   });
 

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -850,7 +850,7 @@ describe("ProjectsTable", () => {
       expect(
         await po.getUsdValueBannerPo().getIcpExchangeRatePo().getTooltipText()
       ).toBe(
-        "USD prices are temporarily unavailable — all pricing provider APIs are currently unreachable."
+        "USD prices are temporarily unavailable: all pricing provider APIs are currently unreachable."
       );
       expect(console.error).toBeCalledWith(error);
       expect(console.error).toBeCalledTimes(2);


### PR DESCRIPTION
# Motivation

#7558 introduced a secondary provider for fiat values. Errors in the nns-dapp related to the provider have hardcoded its name. 

[NNS1-4238](https://dfinity.atlassian.net/browse/NNS1-4238)

# Changes

- Changed provider error labels.

# Tests

- Updated tests.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-4238]: https://dfinity.atlassian.net/browse/NNS1-4238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ