### PR TITLE
feat(frontend): migrate ckbtc imports to @icp-sdk/canisters

### DIFF
--- a/frontend/src/lib/api/ckbtc-minter.api.ts
+++ b/frontend/src/lib/api/ckbtc-minter.api.ts
@@ -1,6 +1,7 @@
 import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
+import type { QueryParams } from "@dfinity/utils";
 import {
   CkBTCMinterCanister,
   type EstimateWithdrawalFee,
@@ -10,8 +11,7 @@ import {
   type RetrieveBtcOk,
   type RetrieveBtcStatusV2WithId,
   type UpdateBalanceOk,
-} from "@dfinity/ckbtc";
-import type { QueryParams } from "@dfinity/utils";
+} from "@icp-sdk/canisters/ckbtc";
 import type { Agent, Identity } from "@icp-sdk/core/agent";
 import type { Principal } from "@icp-sdk/core/principal";
 

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedFee.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedFee.svelte
@@ -6,7 +6,7 @@
   import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
   import { numberToE8s } from "$lib/utils/token.utils";
   import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
-  import type { EstimateWithdrawalFee } from "@dfinity/ckbtc";
+  import type { EstimateWithdrawalFee } from "@icp-sdk/canisters/ckbtc";
   import { debounce, nonNullish } from "@dfinity/utils";
 
   export let minterCanisterId: CanisterId;

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -22,7 +22,7 @@
     mapCkbtcPendingUtxo,
     mapCkbtcTransactions,
   } from "$lib/utils/icrc-transactions.utils";
-  import type { PendingUtxo } from "@dfinity/ckbtc";
+  import type { PendingUtxo } from "@icp-sdk/canisters/ckbtc";
   import { isNullish } from "@dfinity/utils";
 
   export let indexCanisterId: CanisterId;

--- a/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
@@ -8,7 +8,7 @@
     invalidIcrcAddress,
   } from "$lib/utils/accounts.utils";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
-  import { BtcNetwork } from "@dfinity/ckbtc";
+  import { BtcNetwork } from "@icp-sdk/canisters/ckbtc";
   import { Dropdown, DropdownItem } from "@dfinity/gix-components";
   import { isNullish, nonNullish } from "@dfinity/utils";
 

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -13,6 +13,7 @@ import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
+import { nonNullish } from "@dfinity/utils";
 import {
   MinterAlreadyProcessingError,
   MinterAmountTooLowError,
@@ -20,8 +21,7 @@ import {
   MinterInsufficientFundsError,
   MinterMalformedAddressError,
   MinterTemporaryUnavailableError,
-} from "@dfinity/ckbtc";
-import { nonNullish } from "@dfinity/utils";
+} from "@icp-sdk/canisters/ckbtc";
 
 export type ConvertCkBTCToBtcParams = {
   destinationAddress: string;

--- a/frontend/src/lib/services/ckbtc-info.services.ts
+++ b/frontend/src/lib/services/ckbtc-info.services.ts
@@ -7,8 +7,8 @@ import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { isLastCall } from "$lib/utils/env.utils";
 import { isUniverseCkBTC } from "$lib/utils/universe.utils";
-import type { MinterInfo } from "@dfinity/ckbtc";
 import { isNullish } from "@dfinity/utils";
+import type { MinterInfo } from "@icp-sdk/canisters/ckbtc";
 import { get } from "svelte/store";
 
 export const loadCkBTCInfo = async ({

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -19,6 +19,7 @@ import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { toToastError } from "$lib/utils/error.utils";
 import { waitForMilliseconds } from "$lib/utils/utils";
+import { nonNullish } from "@dfinity/utils";
 import {
   MinterAlreadyProcessingError,
   MinterGenericError,
@@ -28,8 +29,7 @@ import {
   type EstimateWithdrawalFeeParams,
   type PendingUtxo,
   type UpdateBalanceOk,
-} from "@dfinity/ckbtc";
-import { nonNullish } from "@dfinity/utils";
+} from "@icp-sdk/canisters/ckbtc";
 import { get } from "svelte/store";
 
 const getBTCAddress = async (minterCanisterId: CanisterId): Promise<string> => {

--- a/frontend/src/lib/stores/ckbtc-info.store.ts
+++ b/frontend/src/lib/stores/ckbtc-info.store.ts
@@ -3,7 +3,7 @@ import type {
   UniverseCanisterIdText,
 } from "$lib/types/universe";
 import { removeKeys } from "$lib/utils/utils";
-import type { MinterInfo } from "@dfinity/ckbtc";
+import type { MinterInfo } from "@icp-sdk/canisters/ckbtc";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 

--- a/frontend/src/lib/stores/ckbtc-pending-utxos.store.ts
+++ b/frontend/src/lib/stores/ckbtc-pending-utxos.store.ts
@@ -2,7 +2,7 @@ import type {
   UniverseCanisterId,
   UniverseCanisterIdText,
 } from "$lib/types/universe";
-import type { PendingUtxo } from "@dfinity/ckbtc";
+import type { PendingUtxo } from "@icp-sdk/canisters/ckbtc";
 import { writable, type Readable } from "svelte/store";
 
 type CkbtcPendingUtxosStoreData = Record<UniverseCanisterIdText, PendingUtxo[]>;

--- a/frontend/src/lib/stores/ckbtc-retrieve-btc-statuses.store.ts
+++ b/frontend/src/lib/stores/ckbtc-retrieve-btc-statuses.store.ts
@@ -2,7 +2,7 @@ import type {
   UniverseCanisterId,
   UniverseCanisterIdText,
 } from "$lib/types/universe";
-import type { RetrieveBtcStatusV2WithId } from "@dfinity/ckbtc";
+import type { RetrieveBtcStatusV2WithId } from "@icp-sdk/canisters/ckbtc";
 import { writable, type Readable } from "svelte/store";
 
 type CkbtcRetrieveBtcStatusesStoreData = Record<

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -10,7 +10,6 @@ import { TransactionNetwork } from "$lib/types/transaction";
 import { sumAmounts } from "$lib/utils/token.utils";
 import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
-import { BtcNetwork, parseBtcAddress, type BtcAddress } from "@dfinity/ckbtc";
 import {
   AccountIdentifier,
   SubAccount,
@@ -18,6 +17,11 @@ import {
 } from "@dfinity/ledger-icp";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { isNullish, nonNullish } from "@dfinity/utils";
+import {
+  BtcNetwork,
+  parseBtcAddress,
+  type BtcAddress,
+} from "@icp-sdk/canisters/ckbtc";
 import { Principal } from "@icp-sdk/core/principal";
 
 /*

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -11,11 +11,6 @@ import { AccountTransactionType } from "$lib/types/transaction";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { transactionName } from "$lib/utils/transactions.utils";
 import type {
-  PendingUtxo,
-  RetrieveBtcStatusV2,
-  RetrieveBtcStatusV2WithId,
-} from "@dfinity/ckbtc";
-import type {
   IcrcTransaction,
   IcrcTransactionWithId,
 } from "@dfinity/ledger-icrc";
@@ -29,6 +24,11 @@ import {
   uint8ArrayToHexString,
   type Token,
 } from "@dfinity/utils";
+import type {
+  PendingUtxo,
+  RetrieveBtcStatusV2,
+  RetrieveBtcStatusV2WithId,
+} from "@icp-sdk/canisters/ckbtc";
 import { Cbor } from "@icp-sdk/core/agent";
 import type { Principal } from "@icp-sdk/core/principal";
 

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -18,7 +18,7 @@ import {
   CkBTCMinterCanister,
   type RetrieveBtcOk,
   type RetrieveBtcStatusV2WithId,
-} from "@dfinity/ckbtc";
+} from "@icp-sdk/canisters/ckbtc";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { mock } from "vitest-mock-extended";
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -19,7 +19,7 @@ import {
 import { UiTransactionsListPo } from "$tests/page-objects/UiTransactionsList.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import type { RetrieveBtcStatusV2 } from "@dfinity/ckbtc";
+import type { RetrieveBtcStatusV2 } from "@icp-sdk/canisters/ckbtc";
 import { Cbor } from "@icp-sdk/core/agent";
 import { render } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCUpdateBalanceButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCUpdateBalanceButton.spec.ts
@@ -10,7 +10,7 @@ import { page } from "$mocks/$app/stores";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { advanceTime } from "$tests/utils/timers.test-utils";
-import { MinterNoNewUtxosError } from "@dfinity/ckbtc";
+import { MinterNoNewUtxosError } from "@icp-sdk/canisters/ckbtc";
 import { waitFor } from "@testing-library/dom";
 import { fireEvent, render } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -31,7 +31,7 @@ import {
   advanceTime,
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
-import type { RetrieveBtcStatusV2WithId } from "@dfinity/ckbtc";
+import type { RetrieveBtcStatusV2WithId } from "@icp-sdk/canisters/ckbtc";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -17,12 +17,12 @@ import {
   mockCkBTCMainAccount,
 } from "$tests/mocks/ckbtc-accounts.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { toastsStore } from "@dfinity/gix-components";
 import {
   CkBTCMinterCanister,
   MinterInsufficientFundsError,
   type RetrieveBtcOk,
-} from "@dfinity/ckbtc";
-import { toastsStore } from "@dfinity/gix-components";
+} from "@icp-sdk/canisters/ckbtc";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { get } from "svelte/store";
 import type { Mock } from "vitest";

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -20,14 +20,14 @@ import {
 } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockUpdateBalanceOk } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
-import type { RetrieveBtcStatusV2WithId } from "@dfinity/ckbtc";
+import { toastsStore } from "@dfinity/gix-components";
+import type { RetrieveBtcStatusV2WithId } from "@icp-sdk/canisters/ckbtc";
 import {
   MinterAlreadyProcessingError,
   MinterGenericError,
   MinterNoNewUtxosError,
   MinterTemporaryUnavailableError,
-} from "@dfinity/ckbtc";
-import { toastsStore } from "@dfinity/gix-components";
+} from "@icp-sdk/canisters/ckbtc";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -33,10 +33,6 @@ import {
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import type {
-  RetrieveBtcStatusV2,
-  RetrieveBtcStatusV2WithId,
-} from "@dfinity/ckbtc";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import {
   ICPToken,
@@ -44,6 +40,10 @@ import {
   TokenAmountV2,
   toNullable,
 } from "@dfinity/utils";
+import type {
+  RetrieveBtcStatusV2,
+  RetrieveBtcStatusV2WithId,
+} from "@icp-sdk/canisters/ckbtc";
 import { Cbor } from "@icp-sdk/core/agent";
 
 describe("icrc-transaction utils", () => {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -55,11 +55,14 @@ import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setCkUSDCCanisters } from "$tests/utils/ckusdc.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { MinterNoNewUtxosError, type UpdateBalanceOk } from "@dfinity/ckbtc";
 import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { isNullish } from "@dfinity/utils";
 import { AuthClient } from "@icp-sdk/auth/client";
+import {
+  MinterNoNewUtxosError,
+  type UpdateBalanceOk,
+} from "@icp-sdk/canisters/ckbtc";
 import {
   AgentError,
   ErrorKindEnum,


### PR DESCRIPTION
# Motivation

We want to start using the sub-entries library `@icp-sdk/canisters` instead of referencing multiple libraries.

# Notes

We will need an ESLint rule to enforce it. Provided in PR #7580.

# Changes

- `@dfinity/ckbtc` -> `@icp-sdk/canisters/ckbtc`

