### PR TITLE
chore(gix): update gix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "9.0.0-next-2025-11-05",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-9.0.0-next-2025-11-05.tgz",
-      "integrity": "sha512-nuc/dLrb9/fvqP25tQwoAQQ2xv4WqDdpLTTE+Hs83NL9P1bAa8MzDdag4ishHtxO6Imd1LitQt3lkxOlUK4m0g==",
+      "version": "9.0.0-next-2025-11-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-9.0.0-next-2025-11-26.tgz",
+      "integrity": "sha512-0BLkphoNbKa6Dgf9LRxTaEnFC4nX4h+CyOiKf3BfyCt3VhEY8dXG7Rm7qYNJ0BkoAQ3Pnr49+atlWtMX/AtFGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "decimal.js": "^10.6.0",


### PR DESCRIPTION
# Motivation

Update GIX to the latest version: fixes a problem with dropdowns not being visible on windows when the dark theme is used.
https://github.com/dfinity/gix-components/pull/739

# Changes

Update GIX to the latest version.

# Tests

Tests should pass.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
