### PR TITLE
test(ci): update expected SNS transaction fee parameter

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -342,7 +342,7 @@ jobs:
           Ledger canister ID:     np5km-uyaaa-aaaaq-aadrq-cai
           Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
           Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
-          Transaction fee:      1
+          Transaction fee:      5000000000
           Minimum neuron stake: 500000
           Proposal fee:         5000000")
   checks-pass:


### PR DESCRIPTION
# Motivation

The SNS project used for CI tests has changed a parameter. This is causing pipelines to fail like this [one](https://github.com/dfinity/nns-dapp/actions/runs/19846380182/job/56864618435?pr=7609).

# Changes

- Updated the expected `Transaction Fee`.

# Tests

- CI should pass

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
