### PR TITLE
feat(security): update CSP to allow secondary pricing provider

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -206,6 +206,7 @@ const cspConnectSrc = () => {
     "${{HOST}}",
     "${{SNS_AGGREGATOR_URL}}",
     "${{ICP_SWAP_URL}}",
+    "${{KONG_SWAP_URL}}",
     // TODO: solve with a worker
     // Used for the metrics of OC launch
     "https://2hx64-daaaa-aaaaq-aaana-cai.raw.icp0.io",


### PR DESCRIPTION
# Motivation

With the introduction of a second provider for fiat values, we need to update CSP rules to allow requests to this domain.

[NNS1-4238](https://dfinity.atlassian.net/browse/NNS1-4238)

# Changes

- Updated CSP 

# Tests

- Manually tested

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?


[NNS1-4238]: https://dfinity.atlassian.net/browse/NNS1-4238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ