### PR TITLE
feat(frontend): use icp-sdk/canisters with embedded ic-mgmt and camel case

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -319,9 +319,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "6.0.1-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-6.0.1-next-2025-12-03.tgz",
-      "integrity": "sha512-xOdfMtWnrJPcjWbAhr7z+JO+m2hzdVudzq4pUDoBolgK93hBwFo2wLn1tuLwUcBY3YQmFa42hQ6XdyDxZNJZ7w==",
+      "version": "6.0.1-next-2025-12-03.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-6.0.1-next-2025-12-03.2.tgz",
+      "integrity": "sha512-/qbrQ+/g1DCOuq6R7QCv1ZuZGLkCzrEXU79PYB2jEVbutZCroxYAPpztZTwBMEpqVD67lmSEtsNtWSLuqO9yUA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@dfinity/cketh": {
-      "version": "6.0.1-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/cketh/-/cketh-6.0.1-next-2025-12-03.tgz",
-      "integrity": "sha512-6U7JHXjp4KlUR7dHej7qv1URlnCHzsdLrWKtKrZ+MpO9U7PI6hmi5Gv37/MpP2Xo1OKZB1GdcTHb6qGwdI0liw==",
+      "version": "6.0.1-next-2025-12-03.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cketh/-/cketh-6.0.1-next-2025-12-03.2.tgz",
+      "integrity": "sha512-cT+SHgIFwRuzQmCk5vlic/lP365f/JKuxmAvDuI0fZ5gr3819zg3+kHN2xVY8IuX2kdQ62USKhtv8g6JeA3oiA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -364,17 +364,6 @@
       "peerDependencies": {
         "@dfinity/utils": "*",
         "svelte": "^5"
-      }
-    },
-    "node_modules/@dfinity/ic-management": {
-      "version": "9.0.1-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-9.0.1-next-2025-12-03.tgz",
-      "integrity": "sha512-tO6ZB+67Dl5K8CQ4TaXa/o+487X9jrEhR5wGwOvP0dApYZVITkmJPB/czFFVSeR45hTcgqOijEgvD9ayNT5Ksw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@dfinity/utils": "next",
-        "@icp-sdk/core": "*"
       }
     },
     "node_modules/@dfinity/identity": {
@@ -410,9 +399,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "8.0.1-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-8.0.1-next-2025-12-03.tgz",
-      "integrity": "sha512-WEEnS+/ClH8+CzD4I/vUZwNjtwFd+awMStmOWQVWpRFeZ/pKmK3HTIukrqSP/Y6uq6usjjJidNnes1pfqye1Jw==",
+      "version": "8.0.1-next-2025-12-03.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-8.0.1-next-2025-12-03.2.tgz",
+      "integrity": "sha512-6L/5IoTzcIODK20IsVLLcLIJN1GgGHlOc8uaLXtHS6qqVty4eICN0NK0Qz91dLqshct/j4XrVAhc347Gd7Mbhg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -421,9 +410,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "6.0.1-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-6.0.1-next-2025-12-03.tgz",
-      "integrity": "sha512-bLchcDJKGVXhANXyu7nAjA5mLlPMlT9XQIysZg5EMqjqv8FQjG6FHEGNOjr+um2Mh9M78Tfdh8RmAcL4LLWCzQ==",
+      "version": "6.0.1-next-2025-12-03.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-6.0.1-next-2025-12-03.2.tgz",
+      "integrity": "sha512-RaPTIRuFgzC0mymd0z62q2HnToPV/l98bI5uF1WFA6w00tP663DeMjt8zp3s4Y3jQ6oXXrEkh1QQ/f7CmOld+Q==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -432,9 +421,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "11.1.4-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-11.1.4-next-2025-12-03.tgz",
-      "integrity": "sha512-BNfFBKZ6x9fm71TzjHJPjyTSYpmrVal1QK4+/dYleMC2n1swUBTmiOKizrsK0lTFnjTAWvrOlGfwyniD+LnGug==",
+      "version": "11.1.4-next-2025-12-03.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-11.1.4-next-2025-12-03.2.tgz",
+      "integrity": "sha512-YBCjG/Ekculfq/z25hRcEvlHGMORl6da+vi3ZkRg9wOXEB8/b76m59+oTUTJM71awVwAzfLYOyAQHXoqMxOmrw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -457,9 +446,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "6.0.1-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-6.0.1-next-2025-12-03.tgz",
-      "integrity": "sha512-sDv1v1s2khNFG5yiBD9H8UCMw3M4LiOjGK08d+W7DrRpbJOkSuOGVEZMdt80yOKObkRc4no6u4JLC+HDSEDxgA==",
+      "version": "6.0.1-next-2025-12-03.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-6.0.1-next-2025-12-03.2.tgz",
+      "integrity": "sha512-w1+qx3OeKdDZ+GsuaWz5A07jaBxcF46qb0qaDNadgJMiWl+MfojpN7xdJagyVG2IyMbk9mF1yv++zAvBJ5BFxw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1145,14 +1134,13 @@
       }
     },
     "node_modules/@icp-sdk/canisters": {
-      "version": "2.0.1-next-2025-12-03",
-      "resolved": "https://registry.npmjs.org/@icp-sdk/canisters/-/canisters-2.0.1-next-2025-12-03.tgz",
-      "integrity": "sha512-C3NuHV6bCAZLlMCwyXgFxHMzgM1yYHusreyd5VfVLXxp7Ta3UvoI5wAnSEo4O38YUtkXi4CzzJ1X+3TCyJVC3g==",
+      "version": "2.0.1-next-2025-12-03.2",
+      "resolved": "https://registry.npmjs.org/@icp-sdk/canisters/-/canisters-2.0.1-next-2025-12-03.2.tgz",
+      "integrity": "sha512-Slbks0uZ86T804Ir7mYxz7F8LQ2pvPad6W+YUZHsAL/ZTxdlbhqHqTClWlYIc40LVo5wTt8tkpBAXtya3I4S0A==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/ckbtc": "next",
         "@dfinity/cketh": "next",
-        "@dfinity/ic-management": "next",
         "@dfinity/ledger-icp": "next",
         "@dfinity/ledger-icrc": "next",
         "@dfinity/nns": "next",

--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -1,7 +1,7 @@
 import { createAgent } from "$lib/api/agent.api";
 import { sendICP } from "$lib/api/icp-ledger.api";
 import { nnsDappCanister } from "$lib/api/nns-dapp.api";
-import { ICManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
+import { IcManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
 import type {
   CanisterDetails,
   CanisterSettings,
@@ -29,7 +29,7 @@ import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { poll, pollingLimit } from "$lib/utils/utils";
 import { nonNullish, principalToSubAccount } from "@dfinity/utils";
 import {
-  CMCCanister,
+  CmcCanister,
   ProcessingError,
   type CmcDid,
 } from "@icp-sdk/canisters/cmc";
@@ -190,7 +190,7 @@ const pollNotifyCreateCanister = async ({
   controller,
   blockHeight,
 }: {
-  cmc: CMCCanister;
+  cmc: CmcCanister;
   controller: Principal;
   blockHeight: bigint;
 }): Promise<Principal> => {
@@ -340,7 +340,7 @@ const pollNotifyTopUpCanister = async ({
   blockHeight,
   canisterId,
 }: {
-  cmc: CMCCanister;
+  cmc: CmcCanister;
   canisterId: Principal;
   blockHeight: bigint;
   counter?: number;
@@ -432,8 +432,8 @@ export const notifyTopUpCanister = async ({
 const canisters = async (
   identity: Identity
 ): Promise<{
-  cmc: CMCCanister;
-  icMgt: ICManagementCanister;
+  cmc: CmcCanister;
+  icMgt: IcManagementCanister;
   nnsDapp: NNSDappCanister;
 }> => {
   const agent = await createAgent({
@@ -441,12 +441,12 @@ const canisters = async (
     host: HOST,
   });
 
-  const cmc = CMCCanister.create({
+  const cmc = CmcCanister.create({
     agent,
     canisterId: CYCLES_MINTING_CANISTER_ID,
   });
 
-  const icMgt = ICManagementCanister.create({
+  const icMgt = IcManagementCanister.create({
     agent,
   });
 

--- a/frontend/src/lib/canisters/ic-management/ic-management.canister.ts
+++ b/frontend/src/lib/canisters/ic-management/ic-management.canister.ts
@@ -4,32 +4,32 @@ import type {
   CanisterSettings,
 } from "$lib/canisters/ic-management/ic-management.canister.types";
 import { mapError } from "$lib/canisters/ic-management/ic-management.errors";
-import type { ICManagementCanisterOptions } from "@icp-sdk/canisters/ic-management";
+import type { IcManagementCanisterOptions } from "@icp-sdk/canisters/ic-management";
 import {
-  ICManagementCanister as ICMgmtCanister,
+  IcManagementCanister as IcMgmtCanister,
   type CanisterStatusResponse,
 } from "@icp-sdk/canisters/ic-management";
 import type { Principal } from "@icp-sdk/core/principal";
 
 /**
- * The ICManagementCanister was initially implemented here, but it has since been moved to ic-js and packaged as a standalone library.
+ * The IcManagementCanister was initially implemented here, but it has since been moved to ic-js and packaged as a standalone library.
  * In order to maintain backwards compatibility and facilitate integration into NNS-dapp, we wrapped the new library within the existing wrapper, which extends the response of the canister.
  *
  * TODO: remove this wrapper and mapping of the types and use @icp-sdk/canisters/ic-management library only.
  */
-export class ICManagementCanister {
-  private readonly icMgmt: ICMgmtCanister;
+export class IcManagementCanister {
+  private readonly icMgmt: IcMgmtCanister;
 
-  private constructor(options: ICManagementCanisterOptions) {
-    this.icMgmt = ICMgmtCanister.create({
+  private constructor(options: IcManagementCanisterOptions) {
+    this.icMgmt = IcMgmtCanister.create({
       agent: options.agent,
       serviceOverride: options.serviceOverride,
       certifiedServiceOverride: options.certifiedServiceOverride,
     });
   }
 
-  public static create(options: ICManagementCanisterOptions) {
-    return new ICManagementCanister(options);
+  public static create(options: IcManagementCanisterOptions) {
+    return new IcManagementCanister(options);
   }
 
   /**

--- a/frontend/src/lib/worker-api/canisters.worker-api.ts
+++ b/frontend/src/lib/worker-api/canisters.worker-api.ts
@@ -6,7 +6,7 @@ import { mapCanisterId } from "$lib/utils/canisters.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { createAgent } from "@dfinity/utils";
 import type { CanisterStatusResponse } from "@icp-sdk/canisters/ic-management";
-import { ICManagementCanister } from "@icp-sdk/canisters/ic-management";
+import { IcManagementCanister } from "@icp-sdk/canisters/ic-management";
 
 export const queryCanisterDetails = async ({
   identity,
@@ -44,7 +44,7 @@ const canisters = async ({
   host,
   fetchRootKey,
 }: CanisterActorParams): Promise<{
-  icMgtService: ICManagementCanister;
+  icMgtService: IcManagementCanister;
 }> => {
   const agent = await createAgent({
     identity,
@@ -52,7 +52,7 @@ const canisters = async ({
     fetchRootKey,
   });
 
-  const icMgtService = ICManagementCanister.create({ agent });
+  const icMgtService = IcManagementCanister.create({ agent });
 
   return { icMgtService };
 };

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -11,7 +11,7 @@ import {
   topUpCanister,
   updateSettings,
 } from "$lib/api/canisters.api";
-import { ICManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
+import { IcManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { CanisterNameTooLongError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import {
@@ -34,7 +34,7 @@ import {
 } from "$tests/utils/timers.test-utils";
 import * as dfinityUtils from "@dfinity/utils";
 import { principalToSubAccount } from "@dfinity/utils";
-import { CMCCanister, ProcessingError } from "@icp-sdk/canisters/cmc";
+import { CmcCanister, ProcessingError } from "@icp-sdk/canisters/cmc";
 import {
   AccountIdentifier,
   LedgerCanister,
@@ -45,8 +45,8 @@ import { mock } from "vitest-mock-extended";
 
 describe("canisters-api", () => {
   const mockNNSDappCanister = mock<NNSDappCanister>();
-  const mockCMCCanister = mock<CMCCanister>();
-  const mockICManagementCanister = mock<ICManagementCanister>();
+  const mockCmcCanister = mock<CmcCanister>();
+  const mockIcManagementCanister = mock<IcManagementCanister>();
   const mockLedgerCanister = mock<LedgerCanister>();
   const fee = 10_000n;
 
@@ -63,10 +63,10 @@ describe("canisters-api", () => {
       (): NNSDappCanister => mockNNSDappCanister
     );
 
-    vi.spyOn(CMCCanister, "create").mockImplementation(() => mockCMCCanister);
+    vi.spyOn(CmcCanister, "create").mockImplementation(() => mockCmcCanister);
 
-    vi.spyOn(ICManagementCanister, "create").mockImplementation(
-      () => mockICManagementCanister
+    vi.spyOn(IcManagementCanister, "create").mockImplementation(
+      () => mockIcManagementCanister
     );
 
     vi.spyOn(LedgerCanister, "create").mockImplementation(
@@ -158,14 +158,14 @@ describe("canisters-api", () => {
 
   describe("updateSettings", () => {
     it("should call the ic management canister to update settings", async () => {
-      mockICManagementCanister.updateSettings.mockResolvedValue(undefined);
+      mockIcManagementCanister.updateSettings.mockResolvedValue(undefined);
       await updateSettings({
         identity: mockIdentity,
         canisterId: mockCanisterDetails.id,
         settings: mockCanisterSettings,
       });
 
-      expect(mockICManagementCanister.updateSettings).toBeCalled();
+      expect(mockIcManagementCanister.updateSettings).toBeCalled();
     });
 
     it("should call the ic management canister to update settings with partial settings", async () => {
@@ -174,14 +174,14 @@ describe("canisters-api", () => {
           "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
         ],
       };
-      mockICManagementCanister.updateSettings.mockResolvedValue(undefined);
+      mockIcManagementCanister.updateSettings.mockResolvedValue(undefined);
       await updateSettings({
         identity: mockIdentity,
         canisterId: mockCanisterDetails.id,
         settings,
       });
 
-      expect(mockICManagementCanister.updateSettings).toBeCalled();
+      expect(mockIcManagementCanister.updateSettings).toBeCalled();
     });
   });
 
@@ -198,7 +198,7 @@ describe("canisters-api", () => {
 
   describe("queryCanisterDetails", () => {
     it("should call IC Management Canister with canister id", async () => {
-      mockICManagementCanister.getCanisterDetails.mockResolvedValue(
+      mockIcManagementCanister.getCanisterDetails.mockResolvedValue(
         mockCanisterDetails
       );
 
@@ -206,7 +206,7 @@ describe("canisters-api", () => {
         identity: mockIdentity,
         canisterId: mockCanisterDetails.id,
       });
-      expect(mockICManagementCanister.getCanisterDetails).toBeCalledWith(
+      expect(mockIcManagementCanister.getCanisterDetails).toBeCalledWith(
         mockCanisterDetails.id
       );
       expect(response).toEqual(mockCanisterDetails);
@@ -215,10 +215,10 @@ describe("canisters-api", () => {
 
   describe("getIcpToCyclesExchangeRate", () => {
     it("should call CMC to get conversion rate", async () => {
-      mockCMCCanister.getIcpToCyclesConversionRate.mockResolvedValue(10_000n);
+      mockCmcCanister.getIcpToCyclesConversionRate.mockResolvedValue(10_000n);
 
       const response = await getIcpToCyclesExchangeRate(mockIdentity);
-      expect(mockCMCCanister.getIcpToCyclesConversionRate).toBeCalledWith({
+      expect(mockCmcCanister.getIcpToCyclesConversionRate).toBeCalledWith({
         certified: true,
       });
       expect(response).toEqual(10_000n);
@@ -229,7 +229,7 @@ describe("canisters-api", () => {
     it("should make a transfer, notify and attach the canister", async () => {
       const blockIndex = 10n;
       mockLedgerCanister.transfer.mockResolvedValue(blockIndex);
-      mockCMCCanister.notifyCreateCanister.mockResolvedValue(
+      mockCmcCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
 
@@ -239,7 +239,7 @@ describe("canisters-api", () => {
         fee,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
-      expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
+      expect(mockCmcCanister.notifyCreateCanister).toBeCalled();
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
         name: "",
         canisterId: mockCanisterDetails.id,
@@ -251,7 +251,7 @@ describe("canisters-api", () => {
     it("should attach the canister if name max length", async () => {
       const blockIndex = 10n;
       mockLedgerCanister.transfer.mockResolvedValue(blockIndex);
-      mockCMCCanister.notifyCreateCanister.mockResolvedValue(
+      mockCmcCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
 
@@ -272,7 +272,7 @@ describe("canisters-api", () => {
 
     it("should notify twice if the first call returns Processing", async () => {
       mockLedgerCanister.transfer.mockResolvedValue(10n);
-      mockCMCCanister.notifyCreateCanister
+      mockCmcCanister.notifyCreateCanister
         .mockRejectedValueOnce(new ProcessingError())
         .mockResolvedValue(mockCanisterDetails.id);
 
@@ -282,14 +282,14 @@ describe("canisters-api", () => {
         fee,
       });
       await advanceTime();
-      expect(mockCMCCanister.notifyCreateCanister).toHaveBeenCalledTimes(2);
+      expect(mockCmcCanister.notifyCreateCanister).toHaveBeenCalledTimes(2);
       expect(await responsePromise).toEqual(mockCanisterDetails.id);
     });
 
     it("handles creating from subaccounts", async () => {
       const blockIndex = 10n;
       mockLedgerCanister.transfer.mockResolvedValue(blockIndex);
-      mockCMCCanister.notifyCreateCanister.mockResolvedValue(
+      mockCmcCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
       const amount = 300_000_000n;
@@ -316,7 +316,7 @@ describe("canisters-api", () => {
         createdAt: nowInBigIntNanoSeconds(),
         fee,
       });
-      expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
+      expect(mockCmcCanister.notifyCreateCanister).toBeCalled();
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
         name: "",
         canisterId: mockCanisterDetails.id,
@@ -335,7 +335,7 @@ describe("canisters-api", () => {
           fee,
         });
       await expect(call).rejects.toThrow();
-      expect(mockCMCCanister.notifyCreateCanister).not.toBeCalled();
+      expect(mockCmcCanister.notifyCreateCanister).not.toBeCalled();
       expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
     });
 
@@ -354,7 +354,7 @@ describe("canisters-api", () => {
           $name: longName,
         })
       );
-      expect(mockCMCCanister.notifyCreateCanister).not.toBeCalled();
+      expect(mockCmcCanister.notifyCreateCanister).not.toBeCalled();
       expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
     });
   });
@@ -362,7 +362,7 @@ describe("canisters-api", () => {
   describe("notifyAndAttachCanister", () => {
     it("should notify the CMC and attach the canister", async () => {
       const blockIndex = 10n;
-      mockCMCCanister.notifyCreateCanister.mockResolvedValue(
+      mockCmcCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
 
@@ -370,14 +370,14 @@ describe("canisters-api", () => {
         identity: mockIdentity,
         blockIndex,
       });
-      expect(mockCMCCanister.notifyCreateCanister).toBeCalledWith({
+      expect(mockCmcCanister.notifyCreateCanister).toBeCalledWith({
         block_index: blockIndex,
         controller: mockIdentity.getPrincipal(),
         settings: [],
         subnet_selection: [],
         subnet_type: [],
       });
-      expect(mockCMCCanister.notifyCreateCanister).toBeCalledTimes(1);
+      expect(mockCmcCanister.notifyCreateCanister).toBeCalledTimes(1);
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
         name: "",
         canisterId: mockCanisterDetails.id,
@@ -388,7 +388,7 @@ describe("canisters-api", () => {
 
     it("should notify twice if the first call returns Processing", async () => {
       const blockIndex = 10n;
-      mockCMCCanister.notifyCreateCanister
+      mockCmcCanister.notifyCreateCanister
         .mockRejectedValueOnce(new ProcessingError())
         .mockResolvedValue(mockCanisterDetails.id);
 
@@ -405,15 +405,15 @@ describe("canisters-api", () => {
         subnet_selection: [],
         subnet_type: [],
       };
-      expect(mockCMCCanister.notifyCreateCanister).toBeCalledTimes(1);
-      expect(mockCMCCanister.notifyCreateCanister).toHaveBeenNthCalledWith(
+      expect(mockCmcCanister.notifyCreateCanister).toBeCalledTimes(1);
+      expect(mockCmcCanister.notifyCreateCanister).toHaveBeenNthCalledWith(
         1,
         expectedNotifyParams
       );
       await advanceTime();
 
-      expect(mockCMCCanister.notifyCreateCanister).toBeCalledTimes(2);
-      expect(mockCMCCanister.notifyCreateCanister).toHaveBeenNthCalledWith(
+      expect(mockCmcCanister.notifyCreateCanister).toBeCalledTimes(2);
+      expect(mockCmcCanister.notifyCreateCanister).toHaveBeenNthCalledWith(
         2,
         expectedNotifyParams
       );
@@ -436,7 +436,7 @@ describe("canisters-api", () => {
 
     it("should make a transfer and notify", async () => {
       mockLedgerCanister.transfer.mockResolvedValue(10n);
-      mockCMCCanister.notifyTopUp.mockResolvedValue(10n);
+      mockCmcCanister.notifyTopUp.mockResolvedValue(10n);
 
       await topUpCanister({
         identity: mockIdentity,
@@ -445,12 +445,12 @@ describe("canisters-api", () => {
         fee,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
-      expect(mockCMCCanister.notifyTopUp).toBeCalled();
+      expect(mockCmcCanister.notifyTopUp).toBeCalled();
     });
 
     it("should notify twice if the first returns ProcessingError", async () => {
       mockLedgerCanister.transfer.mockResolvedValue(10n);
-      mockCMCCanister.notifyTopUp
+      mockCmcCanister.notifyTopUp
         .mockRejectedValueOnce(new ProcessingError())
         .mockResolvedValue(10n);
 
@@ -460,12 +460,12 @@ describe("canisters-api", () => {
         canisterId: mockCanisterDetails.id,
         fee,
       });
-      expect(mockCMCCanister.notifyTopUp).toHaveBeenCalledTimes(2);
+      expect(mockCmcCanister.notifyTopUp).toHaveBeenCalledTimes(2);
     });
 
     it("should make a transfer from subaccounts", async () => {
       mockLedgerCanister.transfer.mockResolvedValue(10n);
-      mockCMCCanister.notifyTopUp.mockResolvedValue(10n);
+      mockCmcCanister.notifyTopUp.mockResolvedValue(10n);
 
       const toSubAccount = principalToSubAccount(mockCanisterDetails.id);
       // To create a canister you need to send ICP to an account owned by the CMC, so that the CMC can burn those funds.
@@ -493,7 +493,7 @@ describe("canisters-api", () => {
         fee,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
-      expect(mockCMCCanister.notifyTopUp).toBeCalled();
+      expect(mockCmcCanister.notifyTopUp).toBeCalled();
     });
 
     it("should not notify if transfer fails", async () => {
@@ -507,7 +507,7 @@ describe("canisters-api", () => {
           fee,
         });
       await expect(call).rejects.toThrow();
-      expect(mockCMCCanister.notifyTopUp).not.toBeCalled();
+      expect(mockCmcCanister.notifyTopUp).not.toBeCalled();
     });
   });
 
@@ -518,7 +518,7 @@ describe("canisters-api", () => {
       const cycles = 3_000_000_000_000n;
       const blockHeight = 14545n;
 
-      mockCMCCanister.notifyTopUp.mockResolvedValue(cycles);
+      mockCmcCanister.notifyTopUp.mockResolvedValue(cycles);
 
       const call = () =>
         notifyTopUpCanister({
@@ -529,8 +529,8 @@ describe("canisters-api", () => {
 
       await expect(call()).resolves.toBe(cycles);
 
-      expect(mockCMCCanister.notifyTopUp).toBeCalledTimes(1);
-      expect(mockCMCCanister.notifyTopUp).toBeCalledWith({
+      expect(mockCmcCanister.notifyTopUp).toBeCalledTimes(1);
+      expect(mockCmcCanister.notifyTopUp).toBeCalledWith({
         canister_id: canisterId,
         block_index: blockHeight,
       });

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -1,5 +1,5 @@
 import { toCanisterDetails } from "$lib/canisters/ic-management/converters";
-import { ICManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
+import { IcManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
 import { UserNotTheControllerError } from "$lib/canisters/ic-management/ic-management.errors";
 import {
   mockCanisterDetails,
@@ -8,27 +8,27 @@ import {
 } from "$tests/mocks/canisters.mock";
 import type {
   CanisterStatusResponse,
-  ICManagementCanisterOptions,
+  IcManagementCanisterOptions,
 } from "@icp-sdk/canisters/ic-management";
 import { type ActorSubclass, type HttpAgent } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import { mock } from "vitest-mock-extended";
 
 type IcManagementCertifiedService =
-  ICManagementCanisterOptions["certifiedServiceOverride"];
+  IcManagementCanisterOptions["certifiedServiceOverride"];
 
-describe("ICManagementCanister", () => {
-  const createICManagement = async (
+describe("IcManagementCanister", () => {
+  const createIcManagement = async (
     certifiedService: IcManagementCertifiedService
   ) => {
-    return ICManagementCanister.create({
+    return IcManagementCanister.create({
       agent: mock<HttpAgent>(),
       certifiedServiceOverride:
         certifiedService as ActorSubclass<IcManagementCertifiedService>,
     });
   };
 
-  describe("ICManagementCanister.getCanisterDetails", () => {
+  describe("IcManagementCanister.getCanisterDetails", () => {
     it("returns account identifier when success", async () => {
       const settings = {
         wasm_memory_threshold: 1_000_000_000n,
@@ -75,7 +75,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.canister_status.mockResolvedValue(response);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       const res = await icManagement.getCanisterDetails(mockCanisterDetails.id);
 
@@ -93,7 +93,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.canister_status.mockRejectedValue(error);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       const call = () =>
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
@@ -110,7 +110,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.canister_status.mockRejectedValue(error);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       const call = () =>
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
@@ -123,7 +123,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.canister_status.mockRejectedValue(error);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       const call = () =>
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
@@ -137,7 +137,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.update_settings.mockResolvedValue(undefined);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       await icManagement.updateSettings({
         canisterId: mockCanisterId,
@@ -155,7 +155,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.update_settings.mockResolvedValue(undefined);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       await icManagement.updateSettings({
         canisterId: mockCanisterId,
@@ -173,7 +173,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.update_settings.mockRejectedValue(error);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       const call = () =>
         icManagement.updateSettings({
@@ -188,7 +188,7 @@ describe("ICManagementCanister", () => {
       const service = mock<IcManagementCertifiedService>();
       service.update_settings.mockRejectedValue(error);
 
-      const icManagement = await createICManagement(service);
+      const icManagement = await createIcManagement(service);
 
       const call = () =>
         icManagement.updateSettings({

--- a/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
@@ -4,7 +4,7 @@ import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterDetails } from "$tests/mocks/canisters.mock";
 import * as dfinityUtils from "@dfinity/utils";
 import type { CanisterStatusResponse } from "@icp-sdk/canisters/ic-management";
-import { ICManagementCanister } from "@icp-sdk/canisters/ic-management";
+import { IcManagementCanister } from "@icp-sdk/canisters/ic-management";
 import { mock } from "vitest-mock-extended";
 
 describe("canisters-worker-api", () => {
@@ -47,12 +47,12 @@ describe("canisters-worker-api", () => {
   };
 
   beforeEach(async () => {
-    const mockICManagementCanister = mock<ICManagementCanister>();
-    vi.spyOn(ICManagementCanister, "create").mockImplementation(
-      () => mockICManagementCanister
+    const mockIcManagementCanister = mock<IcManagementCanister>();
+    vi.spyOn(IcManagementCanister, "create").mockImplementation(
+      () => mockIcManagementCanister
     );
 
-    mockICManagementCanister.canisterStatus.mockResolvedValue(response);
+    mockIcManagementCanister.canisterStatus.mockResolvedValue(response);
     // Prevent HttpAgent.create(), which is called by createAgent, from making a
     // real network request via agent.syncTime().
     vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);


### PR DESCRIPTION
# Motivation

Same as #7612 but, for the `@icp-sdk/canisters/ic-management`.

In addition, we noticed inconsistency in the naming between upper case and camel case (Icrc, Sns but CMC and ICManagement). Therefore we opted for taking the opportunity of the upcoming breaking change (DID namespace) to also resolve this "issue". We picked camel case, that's why `ICManagementCanister` becomes `IcManagementCanister` and likewise for `CMCCanister` which becomes `CmcCanister`.

# Changes

- Bump next
- Update naming as explained above
- Refactor also the naming of the custom `ICManagementCanister` class of NNS dapp for consistency

# Notes

Could have shipped a separate PR for the later but, feel like it did not arm to have it included here. If you which, I can revert and provide a separate PR. Just let know.
