### PR TITLE
feat(frontend): use ic-js next + ledger and nns canisters renamed (prefixed)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "4.0.1-next-2025-12-10",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-4.0.1-next-2025-12-10.tgz",
-      "integrity": "sha512-8CdJUtsYd0RIq7hTI8trgUAF07HLSsDV1kATQhuQPKTtxugAd+BDHyQliF2IITHzGWxmtXBv2ZFYKU6R/WNcVg==",
+      "version": "4.0.1-next-2025-12-10.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-4.0.1-next-2025-12-10.1.tgz",
+      "integrity": "sha512-OUw3sIiFu1cyNHwSlMzbmMYoze7M/ImvEMHsAPPtEl8OHmHJSLdIRP0v+LxvGlGfIh1wxk7bxs09eudhRmjTjw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -1055,9 +1055,9 @@
       }
     },
     "node_modules/@icp-sdk/canisters": {
-      "version": "2.0.1-next-2025-12-10",
-      "resolved": "https://registry.npmjs.org/@icp-sdk/canisters/-/canisters-2.0.1-next-2025-12-10.tgz",
-      "integrity": "sha512-svOSf/f014SumtvPkY3NK3h4uiItyUMWoWuaL4mWPbjtuNNIkjRl9+cJAkxYBESNyT2gGqN9nhOtxL6/EjVXAQ==",
+      "version": "2.0.1-next-2025-12-10.1",
+      "resolved": "https://registry.npmjs.org/@icp-sdk/canisters/-/canisters-2.0.1-next-2025-12-10.1.tgz",
+      "integrity": "sha512-ObkR03VeZXsgk7RnQEXI98f1r3CA/RLf9sIrkRVbHnrMi0f5x76CVSgzMGt3Xo0j15OcfBRDAEQT1mkX36HXyw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -14,7 +14,7 @@ import {
 import type { BlockHeight } from "@icp-sdk/canisters/ledger/icp";
 import {
   AccountIdentifier,
-  LedgerCanister,
+  IcpLedgerCanister,
 } from "@icp-sdk/canisters/ledger/icp";
 import {
   IcrcLedgerCanister,
@@ -64,7 +64,7 @@ export const getTestIcpAccountBalance = async (): Promise<bigint> => {
 
   const agent = await getTestAccountAgent();
 
-  const ledgerCanister: LedgerCanister = LedgerCanister.create({ agent });
+  const ledgerCanister: IcpLedgerCanister = IcpLedgerCanister.create({ agent });
 
   return ledgerCanister.accountBalance({
     accountIdentifier: AccountIdentifier.fromHex(testAccountAddress),
@@ -126,7 +126,7 @@ export const acquireICPTs = async ({
   }
 
   // Old school ICP
-  const ledgerCanister: LedgerCanister = LedgerCanister.create({ agent });
+  const ledgerCanister: IcpLedgerCanister = IcpLedgerCanister.create({ agent });
 
   return ledgerCanister.transfer({
     amount: e8s,

--- a/frontend/src/lib/api/governace-test.api.ts
+++ b/frontend/src/lib/api/governace-test.api.ts
@@ -2,7 +2,7 @@ import * as governanceApiService from "$lib/api-services/governance.api-service"
 import { createAgent } from "$lib/api/agent.api";
 import { GOVERNANCE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST } from "$lib/constants/environment.constants";
-import { GovernanceTestCanister, type Neuron } from "@icp-sdk/canisters/nns";
+import { NnsGovernanceTestCanister, type Neuron } from "@icp-sdk/canisters/nns";
 import type { Identity } from "@icp-sdk/core/agent";
 
 const governanceTestCanister = async (identity: Identity) => {
@@ -11,7 +11,7 @@ const governanceTestCanister = async (identity: Identity) => {
     host: HOST,
   });
 
-  return GovernanceTestCanister.create({
+  return NnsGovernanceTestCanister.create({
     agent,
     canisterId: GOVERNANCE_CANISTER_ID,
   });

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -19,8 +19,8 @@ import type {
   Vote,
 } from "@icp-sdk/canisters/nns";
 import {
-  GovernanceCanister,
   NeuronVisibility,
+  NnsGovernanceCanister,
   type NnsGovernanceDid,
 } from "@icp-sdk/canisters/nns";
 import type { Agent, Identity } from "@icp-sdk/core/agent";
@@ -553,7 +553,7 @@ export const registerVote = async ({
     `Registering Vote (${hashCode(proposalId)}, ${hashCode(neuronId)}) call...`
   );
 
-  const governance: GovernanceCanister = GovernanceCanister.create({
+  const governance: NnsGovernanceCanister = NnsGovernanceCanister.create({
     agent: await createAgent({ identity, host: HOST }),
   });
 
@@ -599,7 +599,7 @@ export const governanceCanister = async ({
 }: {
   identity: Identity;
 }): Promise<{
-  canister: GovernanceCanister;
+  canister: NnsGovernanceCanister;
   agent: Agent;
 }> => {
   const agent = await createAgent({
@@ -607,7 +607,7 @@ export const governanceCanister = async ({
     host: HOST,
   });
 
-  const canister = GovernanceCanister.create({
+  const canister = NnsGovernanceCanister.create({
     agent,
     canisterId: GOVERNANCE_CANISTER_ID,
   });

--- a/frontend/src/lib/api/icp-index.api.ts
+++ b/frontend/src/lib/api/icp-index.api.ts
@@ -3,7 +3,10 @@ import { INDEX_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { fromNullable } from "@dfinity/utils";
-import { IndexCanister, type IcpIndexDid } from "@icp-sdk/canisters/ledger/icp";
+import {
+  IcpIndexCanister,
+  type IcpIndexDid,
+} from "@icp-sdk/canisters/ledger/icp";
 import type { Agent, Identity } from "@icp-sdk/core/agent";
 
 export interface GetTransactionsParams {
@@ -50,7 +53,7 @@ const indexCanister = async ({
 }: {
   identity: Identity;
 }): Promise<{
-  canister: IndexCanister;
+  canister: IcpIndexCanister;
   agent: Agent;
 }> => {
   const agent = await createAgent({
@@ -58,7 +61,7 @@ const indexCanister = async ({
     host: HOST,
   });
 
-  const canister = IndexCanister.create({
+  const canister = IcpIndexCanister.create({
     agent,
     canisterId: INDEX_CANISTER_ID,
   });

--- a/frontend/src/lib/api/icp-ledger.api.ts
+++ b/frontend/src/lib/api/icp-ledger.api.ts
@@ -10,7 +10,7 @@ import { toNullable } from "@dfinity/utils";
 import type { BlockHeight } from "@icp-sdk/canisters/ledger/icp";
 import {
   AccountIdentifier,
-  LedgerCanister,
+  IcpLedgerCanister,
 } from "@icp-sdk/canisters/ledger/icp";
 import type { IcrcAccount } from "@icp-sdk/canisters/ledger/icrc";
 import type { Agent, Identity } from "@icp-sdk/core/agent";
@@ -158,7 +158,7 @@ export const ledgerCanister = async ({
 }: {
   identity: Identity;
 }): Promise<{
-  canister: LedgerCanister;
+  canister: IcpLedgerCanister;
   agent: Agent;
 }> => {
   logWithTimestamp(`LC call...`);
@@ -167,7 +167,7 @@ export const ledgerCanister = async ({
     host: HOST,
   });
 
-  const canister = LedgerCanister.create({
+  const canister = IcpLedgerCanister.create({
     agent,
     canisterId: LEDGER_CANISTER_ID,
   });

--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -2,9 +2,9 @@ import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
 import { fromNullable } from "@dfinity/utils";
 import {
-  IcrcIndexNgCanister,
+  IcrcIndexCanister,
   type IcrcAccount,
-  type IcrcIndexNgDid,
+  type IcrcIndexDid,
 } from "@icp-sdk/canisters/ledger/icrc";
 import type { Agent, Identity } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
@@ -18,7 +18,7 @@ export interface GetTransactionsParams {
 }
 
 export interface GetTransactionsResponse
-  extends Omit<IcrcIndexNgDid.GetTransactions, "oldest_tx_id"> {
+  extends Omit<IcrcIndexDid.GetTransactions, "oldest_tx_id"> {
   oldestTxId?: bigint;
 }
 
@@ -69,7 +69,7 @@ export const listSubaccounts = async ({
   identity: Identity;
   indexCanisterId: Principal;
   certified?: boolean;
-}): Promise<Array<IcrcIndexNgDid.SubAccount>> => {
+}): Promise<Array<IcrcIndexDid.SubAccount>> => {
   const {
     canister: { listSubaccounts },
   } = await indexNgCanister({
@@ -93,7 +93,7 @@ const indexNgCanister = async ({
   identity: Identity;
   canisterId: Principal;
 }): Promise<{
-  canister: IcrcIndexNgCanister;
+  canister: IcrcIndexCanister;
   agent: Agent;
 }> => {
   const agent = await createAgent({
@@ -101,7 +101,7 @@ const indexNgCanister = async ({
     host: HOST,
   });
 
-  const canister = IcrcIndexNgCanister.create({
+  const canister = IcrcIndexCanister.create({
     agent,
     canisterId,
   });

--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -5,7 +5,7 @@ import { HOST } from "$lib/constants/environment.constants";
 import { hashCode, logWithTimestamp } from "$lib/utils/dev.utils";
 import { enumsExclude } from "$lib/utils/enum.utils";
 import {
-  GovernanceCanister,
+  NnsGovernanceCanister,
   ProposalRewardStatus,
   ProposalStatus,
   Topic,
@@ -38,7 +38,7 @@ export const queryProposals = async ({
     }) certified:${certified} call...`
   );
 
-  const governance: GovernanceCanister = GovernanceCanister.create({
+  const governance: NnsGovernanceCanister = NnsGovernanceCanister.create({
     agent: await createAgent({ identity, host: HOST }),
   });
 
@@ -89,7 +89,7 @@ export const queryProposal = async ({
     `Querying Proposal (${hashCode(proposalId)}) certified:${certified} call...`
   );
 
-  const governance: GovernanceCanister = GovernanceCanister.create({
+  const governance: NnsGovernanceCanister = NnsGovernanceCanister.create({
     agent: await createAgent({ identity, host: HOST }),
   });
 

--- a/frontend/src/lib/services/reporting.services.ts
+++ b/frontend/src/lib/services/reporting.services.ts
@@ -12,10 +12,7 @@ import { neuronStake } from "$lib/utils/neuron.utils";
 import { mapPool } from "$lib/utils/reporting.utils";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import type { IcpIndexDid } from "@icp-sdk/canisters/ledger/icp";
-import type {
-  IcrcAccount,
-  IcrcIndexNgDid,
-} from "@icp-sdk/canisters/ledger/icrc";
+import type { IcrcAccount, IcrcIndexDid } from "@icp-sdk/canisters/ledger/icrc";
 import type { NeuronInfo } from "@icp-sdk/canisters/nns";
 import { SignIdentity } from "@icp-sdk/core/agent";
 import type { Principal } from "@icp-sdk/core/principal";
@@ -215,12 +212,12 @@ export const getAllIcrcTransactionsFromAccountAndIdentity = async ({
   identity: SignIdentity;
   indexCanisterId: Principal;
   lastTransactionId?: bigint;
-  allTransactions?: IcrcIndexNgDid.TransactionWithId[];
+  allTransactions?: IcrcIndexDid.TransactionWithId[];
   currentPageIndex?: number;
   range?: TransactionsDateRange;
   initialBalance?: bigint;
 }): Promise<{
-  transactions: IcrcIndexNgDid.TransactionWithId[];
+  transactions: IcrcIndexDid.TransactionWithId[];
   balance: bigint;
 }> => {
   const pageSize = 50n;
@@ -295,9 +292,9 @@ export const getAllIcrcTransactionsFromAccountAndIdentity = async ({
 };
 
 const filterIcrcTransactionsByRange = (
-  transactions: IcrcIndexNgDid.TransactionWithId[],
+  transactions: IcrcIndexDid.TransactionWithId[],
   range?: TransactionsDateRange
-): IcrcIndexNgDid.TransactionWithId[] => {
+): IcrcIndexDid.TransactionWithId[] => {
   if (isNullish(range)) return transactions;
 
   return transactions.filter((tx) => {

--- a/frontend/src/lib/services/seed-neurons.services.ts
+++ b/frontend/src/lib/services/seed-neurons.services.ts
@@ -8,7 +8,7 @@ import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import { mapNeuronErrorToToastMessage } from "$lib/utils/error.utils";
 import { translate } from "$lib/utils/i18n.utils";
 import { uint8ArrayToHexString } from "@dfinity/utils";
-import { GenesisTokenCanister } from "@icp-sdk/canisters/nns";
+import { NnsGenesisTokenCanister } from "@icp-sdk/canisters/nns";
 import { get } from "svelte/store";
 
 // TODO: Remove after all seed neurons have been claimed.
@@ -33,7 +33,7 @@ export const claimSeedNeurons = async () => {
       labelKey: "busy_screen.pending_approval_hw",
     });
     const identity = await getLedgerIdentityProxy(hardwareWallet?.identifier);
-    const governance = GenesisTokenCanister.create({
+    const governance = NnsGenesisTokenCanister.create({
       agent: await createAgent({ identity, host: HOST }),
     });
 

--- a/frontend/src/lib/stores/icrc-transactions.store.ts
+++ b/frontend/src/lib/stores/icrc-transactions.store.ts
@@ -7,7 +7,7 @@ import type {
 import { getUniqueTransactions } from "$lib/utils/transactions.utils";
 import { removeKeys } from "$lib/utils/utils";
 import { nonNullish } from "@dfinity/utils";
-import type { IcrcIndexNgDid } from "@icp-sdk/canisters/ledger/icrc";
+import type { IcrcIndexDid } from "@icp-sdk/canisters/ledger/icrc";
 import type { Principal } from "@icp-sdk/core/principal";
 import { writable, type Readable } from "svelte/store";
 
@@ -16,7 +16,7 @@ import { writable, type Readable } from "svelte/store";
 export type IcrcTransactions = Record<
   IcrcAccountIdentifierText,
   {
-    transactions: IcrcIndexNgDid.TransactionWithId[];
+    transactions: IcrcIndexDid.TransactionWithId[];
     oldestTxId?: bigint;
     completed: boolean;
   }
@@ -68,7 +68,7 @@ const initIcrcTransactionsStore = (): IcrcTransactionsStore => {
     }: {
       accountIdentifier: string;
       canisterId: Principal;
-      transactions: IcrcIndexNgDid.TransactionWithId[];
+      transactions: IcrcIndexDid.TransactionWithId[];
       oldestTxId?: bigint;
       completed: boolean;
     }) {

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -1,6 +1,6 @@
 import type { Account } from "$lib/types/account";
 import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
-import type { IcrcIndexNgDid } from "@icp-sdk/canisters/ledger/icrc";
+import type { IcrcIndexDid } from "@icp-sdk/canisters/ledger/icrc";
 
 export type NewTransaction = {
   sourceAccount: Account;
@@ -42,7 +42,7 @@ export type ValidateAmountFn = (params: {
 
 export interface IcrcTransactionData {
   toSelfTransaction: boolean;
-  transaction: IcrcIndexNgDid.TransactionWithId;
+  transaction: IcrcIndexDid.TransactionWithId;
 }
 
 export interface IcrcTransactionInfo {

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -23,12 +23,12 @@ import type {
   CkBtcMinterDid,
   RetrieveBtcStatusV2WithId,
 } from "@icp-sdk/canisters/ckbtc";
-import type { IcrcIndexNgDid } from "@icp-sdk/canisters/ledger/icrc";
+import type { IcrcIndexDid } from "@icp-sdk/canisters/ledger/icrc";
 import { encodeIcrcAccount } from "@icp-sdk/canisters/ledger/icrc";
 import { Cbor } from "@icp-sdk/core/agent";
 import type { Principal } from "@icp-sdk/core/principal";
 
-const isToSelf = (transaction: IcrcIndexNgDid.Transaction): boolean => {
+const isToSelf = (transaction: IcrcIndexDid.Transaction): boolean => {
   if (transaction.transfer.length !== 1) {
     return false;
   }
@@ -53,9 +53,9 @@ const isToSelf = (transaction: IcrcIndexNgDid.Transaction): boolean => {
  * the transactions has toSelfTransaction set to true and the other to false.
  */
 const mapToSelfTransactions = (
-  transactions: IcrcIndexNgDid.TransactionWithId[]
+  transactions: IcrcIndexDid.TransactionWithId[]
 ): {
-  transaction: IcrcIndexNgDid.TransactionWithId;
+  transaction: IcrcIndexDid.TransactionWithId;
   toSelfTransaction: boolean;
 }[] => {
   const resultTransactions = transactions.flatMap((transaction) => {
@@ -102,7 +102,7 @@ const getIcrcTransactionType = ({
   governanceCanisterId,
   isReceive,
 }: {
-  transaction: IcrcIndexNgDid.Transaction;
+  transaction: IcrcIndexDid.Transaction;
   governanceCanisterId?: Principal;
   isReceive: boolean;
 }): AccountTransactionType => {
@@ -136,7 +136,7 @@ const getIcrcTransactionType = ({
 };
 
 const getTransactionInformation = (
-  transaction: IcrcIndexNgDid.Transaction
+  transaction: IcrcIndexDid.Transaction
 ): IcrcTransactionInfo | undefined => {
   const data =
     fromNullable(transaction.approve) ??
@@ -178,7 +178,7 @@ export const mapIcrcTransactionToReport = ({
   token,
 }: {
   account: Account;
-  transaction: IcrcIndexNgDid.TransactionWithId;
+  transaction: IcrcIndexDid.TransactionWithId;
   token: Token;
 }) => {
   const txInfo = getTransactionInformation(transaction.transaction);
@@ -223,7 +223,7 @@ export const mapIcrcTransaction = ({
   token,
   i18n,
 }: {
-  transaction: IcrcIndexNgDid.TransactionWithId;
+  transaction: IcrcIndexDid.TransactionWithId;
   account: Account;
   toSelfTransaction: boolean;
   governanceCanisterId?: Principal;
@@ -316,7 +316,7 @@ const isCkbtcReimbursementMintMemo = (
 };
 
 export const mapCkbtcTransaction = (params: {
-  transaction: IcrcIndexNgDid.TransactionWithId;
+  transaction: IcrcIndexDid.TransactionWithId;
   account: Account;
   toSelfTransaction: boolean;
   governanceCanisterId?: Principal;
@@ -392,7 +392,7 @@ export const mapCkbtcTransactions = ({
   i18n: I18n;
   retrieveBtcStatuses: RetrieveBtcStatusV2WithId[];
 }): UiTransaction[] => {
-  let prevTransaction: IcrcIndexNgDid.TransactionWithId | undefined = undefined;
+  let prevTransaction: IcrcIndexDid.TransactionWithId | undefined = undefined;
   let prevUiTransaction: UiTransaction | undefined = undefined;
   const statusById = new Map<bigint, CkBtcMinterDid.RetrieveBtcStatusV2>();
   for (const { id, status } of retrieveBtcStatuses) {

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -46,7 +46,7 @@ import {
   secondsToDuration,
   type Token,
 } from "@dfinity/utils";
-import type { IcrcIndexNgDid } from "@icp-sdk/canisters/ledger/icrc";
+import type { IcrcIndexDid } from "@icp-sdk/canisters/ledger/icrc";
 import { NeuronState, type NeuronInfo } from "@icp-sdk/canisters/nns";
 import type { SnsGovernanceDid } from "@icp-sdk/canisters/sns";
 import type { Principal } from "@icp-sdk/core/principal";
@@ -350,7 +350,7 @@ export const buildIcrcTransactionsDataset = ({
 }: {
   account: Account;
   token: Token;
-  transactions: IcrcIndexNgDid.TransactionWithId[];
+  transactions: IcrcIndexDid.TransactionWithId[];
   i18n: I18n;
 }): CsvDataset<TransactionsCsvData> => {
   const amount = TokenAmountV2.fromUlps({ amount: account.balanceUlps, token });

--- a/frontend/src/lib/worker-api/icrc-index.worker-api.ts
+++ b/frontend/src/lib/worker-api/icrc-index.worker-api.ts
@@ -11,7 +11,7 @@ import {
   type CreateCanisterWorkerParams,
 } from "$lib/worker-utils/canister.worker-utils";
 import { fromNullable } from "@dfinity/utils";
-import { IcrcIndexNgCanister } from "@icp-sdk/canisters/ledger/icrc";
+import { IcrcIndexCanister } from "@icp-sdk/canisters/ledger/icrc";
 
 export const getIcrcTransactions = async ({
   identity,
@@ -56,11 +56,11 @@ export const getIcrcTransactions = async ({
 
 const createCanister = (
   params: CanisterActorParams & { canisterId: CanisterId }
-): Promise<IcrcIndexNgCanister> =>
-  createCanisterWorker<IcrcIndexNgCanister>({
+): Promise<IcrcIndexCanister> =>
+  createCanisterWorker<IcrcIndexCanister>({
     ...params,
     create: ({ agent, canisterId }: CreateCanisterWorkerParams) =>
-      IcrcIndexNgCanister.create({
+      IcrcIndexCanister.create({
         agent,
         canisterId: mapCanisterId(canisterId),
       }),

--- a/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
+++ b/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
@@ -16,7 +16,7 @@ import type {
 import { jsonReplacer, nonNullish } from "@dfinity/utils";
 import {
   decodeIcrcAccount,
-  type IcrcIndexNgDid,
+  type IcrcIndexDid,
 } from "@icp-sdk/canisters/ledger/icrc";
 
 export type GetAccountsTransactionsResults = Omit<
@@ -71,7 +71,7 @@ export const getIcrcAccountsTransactions = ({
             ) !== undefined;
 
           return [...acc, ...(alreadyExist() ? [] : [value])];
-        }, [] as IcrcIndexNgDid.TransactionWithId[]),
+        }, [] as IcrcIndexDid.TransactionWithId[]),
         ...rest,
       };
     })
@@ -111,7 +111,7 @@ const getIcrcAccountTransactions = async ({
   // Therefore, we still need to get between 95 and 98
   //
   // Note that  we do not perform a sort based on the timestamp but on the ID for simplicity reason as we do not really care here if two transactions have the same ID, we are just looking for the oldest ID.
-  const oldestTxId: IcrcIndexNgDid.BlockIndex | undefined = [
+  const oldestTxId: IcrcIndexDid.BlockIndex | undefined = [
     ...transactions,
   ].sort(({ id: idA }, { id: idB }) => Number(idA - idB))[0]?.id;
 

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -37,7 +37,7 @@ import { principalToSubAccount } from "@dfinity/utils";
 import { CmcCanister, ProcessingError } from "@icp-sdk/canisters/cmc";
 import {
   AccountIdentifier,
-  LedgerCanister,
+  IcpLedgerCanister,
   SubAccount,
 } from "@icp-sdk/canisters/ledger/icp";
 import { Principal } from "@icp-sdk/core/principal";
@@ -47,7 +47,7 @@ describe("canisters-api", () => {
   const mockNNSDappCanister = mock<NNSDappCanister>();
   const mockCmcCanister = mock<CmcCanister>();
   const mockIcManagementCanister = mock<IcManagementCanister>();
-  const mockLedgerCanister = mock<LedgerCanister>();
+  const mockLedgerCanister = mock<IcpLedgerCanister>();
   const fee = 10_000n;
 
   beforeEach(() => {
@@ -69,7 +69,7 @@ describe("canisters-api", () => {
       () => mockIcManagementCanister
     );
 
-    vi.spyOn(LedgerCanister, "create").mockImplementation(
+    vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
       () => mockLedgerCanister
     );
   });

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -31,10 +31,10 @@ import {
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { LedgerCanister } from "@icp-sdk/canisters/ledger/icp";
+import { IcpLedgerCanister } from "@icp-sdk/canisters/ledger/icp";
 import {
-  GovernanceCanister,
   NeuronVisibility,
+  NnsGovernanceCanister,
   Topic,
   Vote,
 } from "@icp-sdk/canisters/nns";
@@ -49,7 +49,7 @@ vi.mock("$lib/api/agent.api", () => {
 });
 
 describe("neurons-api", () => {
-  const mockGovernanceCanister = mock<GovernanceCanister>();
+  const mockGovernanceCanister = mock<NnsGovernanceCanister>();
   beforeEach(() => {
     mockGovernanceCanister.listNeurons.mockImplementation(
       vi.fn().mockResolvedValue([])
@@ -62,14 +62,14 @@ describe("neurons-api", () => {
       vi.fn().mockResolvedValue(mockNeuron)
     );
     mockGovernanceCanister.registerVote.mockResolvedValue(undefined);
-    vi.spyOn(GovernanceCanister, "create").mockImplementation(
+    vi.spyOn(NnsGovernanceCanister, "create").mockImplementation(
       () => mockGovernanceCanister
     );
   });
 
   it("stakeNeuron creates a new neuron", async () => {
-    vi.spyOn(LedgerCanister, "create").mockImplementation(() =>
-      mock<LedgerCanister>()
+    vi.spyOn(IcpLedgerCanister, "create").mockImplementation(() =>
+      mock<IcpLedgerCanister>()
     );
 
     expect(mockGovernanceCanister.stakeNeuron).not.toBeCalled();

--- a/frontend/src/tests/lib/api/icp-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-index.api.spec.ts
@@ -3,7 +3,10 @@ import { getTransactions } from "$lib/api/icp-index.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockTransactionWithId } from "$tests/mocks/transaction.mock";
-import { IndexCanister, type IcpIndexDid } from "@icp-sdk/canisters/ledger/icp";
+import {
+  IcpIndexCanister,
+  type IcpIndexDid,
+} from "@icp-sdk/canisters/ledger/icp";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { mock } from "vitest-mock-extended";
 
@@ -21,22 +24,22 @@ describe("icp-index.api", () => {
         balance: 200_000_000n,
       };
     let currentResponse = defaultResponse;
-    const indexCanisterMock = mock<IndexCanister>();
+    const indexCanisterMock = mock<IcpIndexCanister>();
 
     beforeEach(() => {
       currentResponse = defaultResponse;
       indexCanisterMock.getTransactions.mockImplementation(
         async () => currentResponse
       );
-      vi.spyOn(IndexCanister, "create").mockImplementation(
-        (): IndexCanister => indexCanisterMock
+      vi.spyOn(IcpIndexCanister, "create").mockImplementation(
+        (): IcpIndexCanister => indexCanisterMock
       );
     });
 
     describe("getTransactions", () => {
       it("should call the index canister method to get transactions", async () => {
         const maxResults = 20n;
-        expect(IndexCanister.create).toHaveBeenCalledTimes(0);
+        expect(IcpIndexCanister.create).toHaveBeenCalledTimes(0);
 
         const response = await getTransactions({
           identity: mockIdentity,
@@ -44,7 +47,7 @@ describe("icp-index.api", () => {
           accountIdentifier,
         });
 
-        expect(IndexCanister.create).toHaveBeenCalledTimes(1);
+        expect(IcpIndexCanister.create).toHaveBeenCalledTimes(1);
         expect(indexCanisterMock.getTransactions).toHaveBeenCalledWith({
           start: undefined,
           accountIdentifier,
@@ -60,7 +63,7 @@ describe("icp-index.api", () => {
       it("should pass the start parameter", async () => {
         const maxResults = 20n;
         const start = 1234n;
-        expect(IndexCanister.create).toHaveBeenCalledTimes(0);
+        expect(IcpIndexCanister.create).toHaveBeenCalledTimes(0);
 
         await getTransactions({
           identity: mockIdentity,
@@ -69,7 +72,7 @@ describe("icp-index.api", () => {
           start,
         });
 
-        expect(IndexCanister.create).toHaveBeenCalledTimes(1);
+        expect(IcpIndexCanister.create).toHaveBeenCalledTimes(1);
         expect(indexCanisterMock.getTransactions).toHaveBeenCalledWith({
           start,
           accountIdentifier,
@@ -83,7 +86,7 @@ describe("icp-index.api", () => {
           ...defaultResponse,
           oldest_tx_id: [],
         };
-        expect(IndexCanister.create).toHaveBeenCalledTimes(0);
+        expect(IcpIndexCanister.create).toHaveBeenCalledTimes(0);
 
         const response = await getTransactions({
           identity: mockIdentity,

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -10,7 +10,7 @@ import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import {
   AccountIdentifier,
-  LedgerCanister,
+  IcpLedgerCanister,
 } from "@icp-sdk/canisters/ledger/icp";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { mock } from "vitest-mock-extended";
@@ -31,12 +31,12 @@ describe("icp-ledger.api", () => {
     const nowInBigIntNanoSeconds = BigInt(now) * 1_000_000n;
 
     beforeEach(() => {
-      const ledgerMock = mock<LedgerCanister>();
+      const ledgerMock = mock<IcpLedgerCanister>();
       ledgerMock.transfer.mockResolvedValue(0n);
       vi.useFakeTimers().setSystemTime(now);
 
-      vi.spyOn(LedgerCanister, "create").mockImplementation(
-        (): LedgerCanister => ledgerMock
+      vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
+        (): IcpLedgerCanister => ledgerMock
       );
 
       spyTransfer = vi.spyOn(ledgerMock, "transfer");
@@ -134,12 +134,12 @@ describe("icp-ledger.api", () => {
     const nowInBigIntNanoSeconds = BigInt(now) * 1_000_000n;
 
     beforeEach(() => {
-      const ledgerMock = mock<LedgerCanister>();
+      const ledgerMock = mock<IcpLedgerCanister>();
       ledgerMock.icrc1Transfer.mockResolvedValue(0n);
       vi.useFakeTimers().setSystemTime(now);
 
-      vi.spyOn(LedgerCanister, "create").mockImplementation(
-        (): LedgerCanister => ledgerMock
+      vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
+        (): IcpLedgerCanister => ledgerMock
       );
 
       spyTransfer = vi.spyOn(ledgerMock, "icrc1Transfer");
@@ -259,12 +259,12 @@ describe("icp-ledger.api", () => {
 
   describe("transactionFee", () => {
     const fee = 10_000n;
-    const ledgerMock = mock<LedgerCanister>();
+    const ledgerMock = mock<IcpLedgerCanister>();
 
     beforeEach(() => {
       ledgerMock.transactionFee.mockResolvedValue(fee);
-      vi.spyOn(LedgerCanister, "create").mockImplementation(
-        (): LedgerCanister => ledgerMock
+      vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
+        (): IcpLedgerCanister => ledgerMock
       );
     });
 
@@ -277,12 +277,12 @@ describe("icp-ledger.api", () => {
 
   describe("queryAccountBalance", () => {
     const balance = 10_000_000n;
-    const ledgerMock = mock<LedgerCanister>();
+    const ledgerMock = mock<IcpLedgerCanister>();
 
     beforeEach(() => {
       ledgerMock.accountBalance.mockResolvedValue(balance);
-      vi.spyOn(LedgerCanister, "create").mockImplementation(
-        (): LedgerCanister => ledgerMock
+      vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
+        (): IcpLedgerCanister => ledgerMock
       );
     });
 

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -9,7 +9,7 @@ import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { IcrcIndexNgCanister } from "@icp-sdk/canisters/ledger/icrc";
+import { IcrcIndexCanister } from "@icp-sdk/canisters/ledger/icrc";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { mock } from "vitest-mock-extended";
 
@@ -23,14 +23,14 @@ describe("icrc-index api", () => {
     indexCanisterId: principal(0),
   };
 
-  const indexNgCanisterMock = mock<IcrcIndexNgCanister>();
+  const indexNgCanisterMock = mock<IcrcIndexCanister>();
   let spyOnIndexNgCanisterCreate;
 
   const agentMock = mock<HttpAgent>();
 
   beforeEach(() => {
     spyOnIndexNgCanisterCreate = vi
-      .spyOn(IcrcIndexNgCanister, "create")
+      .spyOn(IcrcIndexCanister, "create")
       .mockImplementation(() => indexNgCanisterMock);
 
     vi.spyOn(agent, "createAgent").mockResolvedValue(agentMock);

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -10,7 +10,7 @@ import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import {
-  GovernanceCanister,
+  NnsGovernanceCanister,
   ProposalRewardStatus,
 } from "@icp-sdk/canisters/nns";
 import type { HttpAgent } from "@icp-sdk/core/agent";
@@ -26,8 +26,8 @@ describe("proposals-api", () => {
   let spyListProposals;
 
   beforeEach(() => {
-    vi.spyOn(GovernanceCanister, "create").mockImplementation(
-      (): GovernanceCanister => mockGovernanceCanister
+    vi.spyOn(NnsGovernanceCanister, "create").mockImplementation(
+      (): NnsGovernanceCanister => mockGovernanceCanister
     );
 
     spyListProposals = vi.spyOn(mockGovernanceCanister, "listProposals");

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -37,7 +37,7 @@ import {
 } from "$tests/mocks/sns.api.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
-import { LedgerCanister } from "@icp-sdk/canisters/ledger/icp";
+import { IcpLedgerCanister } from "@icp-sdk/canisters/ledger/icp";
 import * as dfinitySns from "@icp-sdk/canisters/sns";
 import {
   SnsNeuronPermissionType,
@@ -58,7 +58,7 @@ vi.mock("$lib/api/agent.api", () => {
 vi.mock("@icp-sdk/canisters/sns", { spy: true });
 
 describe("sns-api", () => {
-  const ledgerCanisterMock = mock<LedgerCanister>();
+  const ledgerCanisterMock = mock<IcpLedgerCanister>();
   const proposals = [mockSnsProposal];
   const queryNeuronsSpy = vi.fn();
   const getNeuronSpy = vi.fn();
@@ -112,7 +112,7 @@ describe("sns-api", () => {
     disburseMaturitySpy.mockResolvedValue(undefined);
     getFunctionsSpy.mockResolvedValue(nervousSystemFunctionsMock);
 
-    vi.spyOn(LedgerCanister, "create").mockImplementation(
+    vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );
 

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -25,7 +25,7 @@ import {
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
-import { LedgerCanister } from "@icp-sdk/canisters/ledger/icp";
+import { IcpLedgerCanister } from "@icp-sdk/canisters/ledger/icp";
 import * as dfinitySns from "@icp-sdk/canisters/sns";
 import {
   SnsSwapLifecycle,
@@ -69,7 +69,7 @@ describe("sns-api", () => {
   const getUserCommitmentSpy = vi.fn();
   const getDerivedStateSpy = vi.fn();
   const getLifecycleSpy = vi.fn();
-  const ledgerCanisterMock = mock<LedgerCanister>();
+  const ledgerCanisterMock = mock<IcpLedgerCanister>();
   const stakeNeuronSpy = vi.fn();
   const increaseStakeNeuronSpy = vi.fn();
 
@@ -80,7 +80,7 @@ describe("sns-api", () => {
     getLifecycleSpy.mockResolvedValue(lifecycleResponse);
     stakeNeuronSpy.mockResolvedValue(mockSnsNeuron.id);
 
-    vi.spyOn(LedgerCanister, "create").mockImplementation(
+    vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );
 

--- a/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
@@ -8,7 +8,7 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
 import type { BallotInfo } from "@icp-sdk/canisters/nns";
-import { GovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
+import { NnsGovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { render, waitFor } from "@testing-library/svelte";
 import { mock } from "vitest-mock-extended";
@@ -25,8 +25,8 @@ describe("BallotSummary", () => {
   beforeEach(() => {
     silentConsoleErrors();
 
-    vi.spyOn(GovernanceCanister, "create").mockImplementation(
-      (): GovernanceCanister => mockGovernanceCanister
+    vi.spyOn(NnsGovernanceCanister, "create").mockImplementation(
+      (): NnsGovernanceCanister => mockGovernanceCanister
     );
 
     resetIdentity();

--- a/frontend/src/tests/lib/components/neurons/Ballots.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/Ballots.spec.ts
@@ -7,7 +7,7 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
 import type { BallotInfo } from "@icp-sdk/canisters/nns";
-import { GovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
+import { NnsGovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { render } from "@testing-library/svelte";
 import { mock } from "vitest-mock-extended";
@@ -23,8 +23,8 @@ describe("Ballots", () => {
 
   beforeEach(() => {
     silentConsoleErrors();
-    vi.spyOn(GovernanceCanister, "create").mockImplementation(
-      (): GovernanceCanister => mockGovernanceCanister
+    vi.spyOn(NnsGovernanceCanister, "create").mockImplementation(
+      (): NnsGovernanceCanister => mockGovernanceCanister
     );
 
     resetIdentity();

--- a/frontend/src/tests/lib/components/neurons/VoteHistoryCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/VoteHistoryCard.spec.ts
@@ -7,7 +7,7 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
 import type { Proposal } from "@icp-sdk/canisters/nns";
-import { GovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
+import { NnsGovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { render, waitFor } from "@testing-library/svelte";
 import { mock } from "vitest-mock-extended";
@@ -35,8 +35,8 @@ describe("VoteHistoryCard", () => {
   beforeEach(() => {
     silentConsoleErrors();
 
-    vi.spyOn(GovernanceCanister, "create").mockImplementation(
-      (): GovernanceCanister => mockGovernanceCanister
+    vi.spyOn(NnsGovernanceCanister, "create").mockImplementation(
+      (): NnsGovernanceCanister => mockGovernanceCanister
     );
 
     resetIdentity();

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -36,9 +36,9 @@ import {
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
 import { nonNullish } from "@dfinity/utils";
-import { LedgerCanister } from "@icp-sdk/canisters/ledger/icp";
+import { IcpLedgerCanister } from "@icp-sdk/canisters/ledger/icp";
 import type { NeuronInfo } from "@icp-sdk/canisters/nns";
-import { GovernanceCanister } from "@icp-sdk/canisters/nns";
+import { NnsGovernanceCanister } from "@icp-sdk/canisters/nns";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -79,11 +79,11 @@ describe("NnsStakeNeuronModal", () => {
       undefined
     );
 
-    vi.spyOn(LedgerCanister, "create").mockImplementation(() =>
-      mock<LedgerCanister>()
+    vi.spyOn(IcpLedgerCanister, "create").mockImplementation(() =>
+      mock<IcpLedgerCanister>()
     );
-    vi.spyOn(GovernanceCanister, "create").mockImplementation(() =>
-      mock<GovernanceCanister>()
+    vi.spyOn(NnsGovernanceCanister, "create").mockImplementation(() =>
+      mock<NnsGovernanceCanister>()
     );
     queryBalanceSpy = vi
       .spyOn(ledgerApi, "queryAccountBalance")

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -16,7 +16,7 @@ import { mockNetworkEconomics } from "$tests/mocks/network-economics.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
-import { LedgerCanister } from "@icp-sdk/canisters/ledger/icp";
+import { IcpLedgerCanister } from "@icp-sdk/canisters/ledger/icp";
 import type { HttpAgent } from "@icp-sdk/core/agent";
 import { get } from "svelte/store";
 import { mock } from "vitest-mock-extended";
@@ -24,14 +24,14 @@ import { mock } from "vitest-mock-extended";
 vi.mock("$lib/api/sns-aggregator.api");
 
 describe("app-services", () => {
-  const mockLedgerCanister = mock<LedgerCanister>();
+  const mockLedgerCanister = mock<IcpLedgerCanister>();
   const mockNNSDappCanister = mock<NNSDappCanister>();
 
   beforeEach(() => {
     resetIdentity();
     clearSnsAggregatorCache();
-    vi.spyOn(LedgerCanister, "create").mockImplementation(
-      (): LedgerCanister => mockLedgerCanister
+    vi.spyOn(IcpLedgerCanister, "create").mockImplementation(
+      (): IcpLedgerCanister => mockLedgerCanister
     );
 
     vi.spyOn(NNSDappCanister, "create").mockImplementation(

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -40,7 +40,7 @@ import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import type { IcpIndexDid } from "@icp-sdk/canisters/ledger/icp";
-import { LedgerCanister } from "@icp-sdk/canisters/ledger/icp";
+import { IcpLedgerCanister } from "@icp-sdk/canisters/ledger/icp";
 import {
   NeuronVisibility,
   Topic,
@@ -298,8 +298,8 @@ describe("neurons-services", () => {
     });
 
     it("stakeNeuron return undefined if amount less than 1 ICP", async () => {
-      vi.spyOn(LedgerCanister, "create").mockImplementation(() =>
-        mock<LedgerCanister>()
+      vi.spyOn(IcpLedgerCanister, "create").mockImplementation(() =>
+        mock<IcpLedgerCanister>()
       );
 
       const response = await stakeNeuron({
@@ -313,8 +313,8 @@ describe("neurons-services", () => {
     });
 
     it("stake neuron should return undefined if amount not valid", async () => {
-      vi.spyOn(LedgerCanister, "create").mockImplementation(() =>
-        mock<LedgerCanister>()
+      vi.spyOn(IcpLedgerCanister, "create").mockImplementation(() =>
+        mock<IcpLedgerCanister>()
       );
 
       const response = await stakeNeuron({
@@ -328,8 +328,8 @@ describe("neurons-services", () => {
     });
 
     it("stake neuron should return undefined if not enough funds in account", async () => {
-      vi.spyOn(LedgerCanister, "create").mockImplementation(() =>
-        mock<LedgerCanister>()
+      vi.spyOn(IcpLedgerCanister, "create").mockImplementation(() =>
+        mock<IcpLedgerCanister>()
       );
 
       // 10 ICPs

--- a/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
@@ -4,16 +4,16 @@ import { getIcrcTransactions } from "$lib/worker-api/icrc-index.worker-api";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import * as dfinityUtils from "@dfinity/utils";
 import {
-  IcrcIndexNgCanister,
-  type IcrcIndexNgDid,
+  IcrcIndexCanister,
+  type IcrcIndexDid,
 } from "@icp-sdk/canisters/ledger/icrc";
 import { mock } from "vitest-mock-extended";
 
 describe("icrc-index.worker-api", () => {
-  const indexCanisterMock = mock<IcrcIndexNgCanister>();
+  const indexCanisterMock = mock<IcrcIndexCanister>();
 
   beforeEach(() => {
-    vi.spyOn(IcrcIndexNgCanister, "create").mockImplementation(
+    vi.spyOn(IcrcIndexCanister, "create").mockImplementation(
       () => indexCanisterMock
     );
     // Prevent HttpAgent.create(), which is called by createAgent, from making a
@@ -34,7 +34,7 @@ describe("icrc-index.worker-api", () => {
 
   const transaction = {
     burn: [],
-  } as unknown as IcrcIndexNgDid.Transaction;
+  } as unknown as IcrcIndexDid.Transaction;
 
   it("should returns transactions", async () => {
     const id = 1n;

--- a/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
@@ -10,16 +10,16 @@ import {
 } from "$tests/mocks/sns-accounts.mock";
 import * as dfinityUtils from "@dfinity/utils";
 import {
-  IcrcIndexNgCanister,
-  type IcrcIndexNgDid,
+  IcrcIndexCanister,
+  type IcrcIndexDid,
 } from "@icp-sdk/canisters/ledger/icrc";
 import { mock } from "vitest-mock-extended";
 
 describe("transactions.worker-services", () => {
-  const indexCanisterMock = mock<IcrcIndexNgCanister>();
+  const indexCanisterMock = mock<IcrcIndexCanister>();
 
   beforeEach(() => {
-    vi.spyOn(IcrcIndexNgCanister, "create").mockImplementation(
+    vi.spyOn(IcrcIndexCanister, "create").mockImplementation(
       () => indexCanisterMock
     );
     // Prevent HttpAgent.create(), which is called by createAgent, from making a
@@ -29,7 +29,7 @@ describe("transactions.worker-services", () => {
 
   const transaction = {
     burn: [],
-  } as unknown as IcrcIndexNgDid.Transaction;
+  } as unknown as IcrcIndexDid.Transaction;
 
   const request: Omit<
     PostMessageDataRequestTransactions,
@@ -167,7 +167,7 @@ describe("transactions.worker-services", () => {
 
     const getTransactionsSpy =
       indexCanisterMock.getTransactions.mockImplementation(
-        async (): Promise<IcrcIndexNgDid.GetTransactions> => {
+        async (): Promise<IcrcIndexDid.GetTransactions> => {
           if (firstCall) {
             firstCall = false;
 

--- a/frontend/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/src/tests/mocks/governance.canister.mock.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import type { LedgerCanister } from "@icp-sdk/canisters/ledger/icp";
+import type { IcpLedgerCanister } from "@icp-sdk/canisters/ledger/icp";
 import type {
   ListProposalsRequest,
   ListProposalsResponse,
@@ -8,12 +8,12 @@ import type {
   NeuronInfo,
   ProposalInfo,
 } from "@icp-sdk/canisters/nns";
-import { GovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
+import { NnsGovernanceCanister, Vote } from "@icp-sdk/canisters/nns";
 import type { Principal } from "@icp-sdk/core/principal";
 
 // eslint-disable-next-line
 // @ts-ignore: test file
-export class MockGovernanceCanister extends GovernanceCanister {
+export class MockGovernanceCanister extends NnsGovernanceCanister {
   constructor(private proposals: ProposalInfo[]) {
     super();
   }
@@ -98,7 +98,7 @@ export class MockGovernanceCanister extends GovernanceCanister {
   }: {
     stake: bigint;
     principal: Principal;
-    ledgerCanister: LedgerCanister;
+    ledgerCanister: IcpLedgerCanister;
   }): Promise<NeuronId> => {
     return mockNeuron.neuronId;
   };

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -3,7 +3,7 @@ import type { IcrcTransactionsStoreData } from "$lib/stores/icrc-transactions.st
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { toNullable } from "@dfinity/utils";
-import type { IcrcIndexNgDid } from "@icp-sdk/canisters/ledger/icrc";
+import type { IcrcIndexDid } from "@icp-sdk/canisters/ledger/icrc";
 import { Principal } from "@icp-sdk/core/principal";
 import type { Subscriber } from "svelte/store";
 
@@ -28,7 +28,7 @@ export const createIcrcTransactionWithId = ({
   amount?: bigint;
   timestamp?: Date;
   memo?: Uint8Array;
-}): IcrcIndexNgDid.TransactionWithId => ({
+}): IcrcIndexDid.TransactionWithId => ({
   id: id ?? 123n,
   transaction: {
     kind: "transfer",
@@ -68,7 +68,7 @@ const fakeSubAccount = {
   subaccount: [new Uint8Array([2, 3, 4])] as [Uint8Array],
 };
 
-const mockIcrcTransactionTransfer: IcrcIndexNgDid.Transaction = {
+const mockIcrcTransactionTransfer: IcrcIndexDid.Transaction = {
   kind: "transfer",
   timestamp: 12_354n,
   burn: [],
@@ -88,7 +88,7 @@ const mockIcrcTransactionTransfer: IcrcIndexNgDid.Transaction = {
   fee_collector: [],
 };
 
-const mockIcrcTransactionTransferToSelf: IcrcIndexNgDid.Transaction = {
+const mockIcrcTransactionTransferToSelf: IcrcIndexDid.Transaction = {
   kind: "transfer",
   timestamp: 12_354n,
   burn: [],
@@ -120,7 +120,7 @@ export const createMintTransaction = ({
   to?: IcrcCandidAccount;
   memo?: Uint8Array;
   createdAt?: bigint;
-}): IcrcIndexNgDid.Transaction => {
+}): IcrcIndexDid.Transaction => {
   return {
     kind: "burn",
     timestamp,
@@ -156,7 +156,7 @@ export const createApproveTransaction = ({
   memo?: Uint8Array;
   createdAt?: bigint;
   spender?: IcrcCandidAccount;
-}): IcrcIndexNgDid.Transaction => {
+}): IcrcIndexDid.Transaction => {
   return {
     kind: "approve",
     timestamp,
@@ -193,7 +193,7 @@ export const createBurnTransaction = ({
   memo?: Uint8Array;
   createdAt?: bigint;
   spender?: IcrcCandidAccount;
-}): IcrcIndexNgDid.Transaction => {
+}): IcrcIndexDid.Transaction => {
   return {
     kind: "burn",
     timestamp,
@@ -214,10 +214,10 @@ export const createBurnTransaction = ({
   };
 };
 
-export const mockIcrcTransactionBurn: IcrcIndexNgDid.Transaction =
+export const mockIcrcTransactionBurn: IcrcIndexDid.Transaction =
   createBurnTransaction({});
 
-export const mockIcrcTransactionMint: IcrcIndexNgDid.Transaction = {
+export const mockIcrcTransactionMint: IcrcIndexDid.Transaction = {
   kind: "mint",
   timestamp: 12_354n,
   burn: [],
@@ -235,16 +235,15 @@ export const mockIcrcTransactionMint: IcrcIndexNgDid.Transaction = {
   fee_collector: [],
 };
 
-export const mockIcrcTransactionWithId: IcrcIndexNgDid.TransactionWithId = {
+export const mockIcrcTransactionWithId: IcrcIndexDid.TransactionWithId = {
   id: 123n,
   transaction: mockIcrcTransactionTransfer,
 };
 
-export const mockIcrcTransactionWithIdToSelf: IcrcIndexNgDid.TransactionWithId =
-  {
-    id: 124n,
-    transaction: mockIcrcTransactionTransferToSelf,
-  };
+export const mockIcrcTransactionWithIdToSelf: IcrcIndexDid.TransactionWithId = {
+  id: 124n,
+  transaction: mockIcrcTransactionTransferToSelf,
+};
 
 export const mockIcrcTransactionsStoreSubscribe =
   (store: IcrcTransactionsStoreData) =>


### PR DESCRIPTION
# Motivation

Parts of next ic-js is a bit of clean-up that includes renaming:
- `IcrcIndexNg...` to `IcrcIndex...`
- `LedgerCanister` to `IcpLedgerCanister`
- `IndexCanister` to `IcpIndexCanister`
- `GovernanceCanister` to `NnsGovernanceCanister`
- `TestGovernanceCanister` to `NnsTestGovernanceCanister`
- `GenesisTokenCanister` to `NnsGenesisTokenCanister`

This PR bumps next ic-js that includes those changes.

# Notes

FI team confirmed that they are not aware of any known Index canisters that would not use the "index-ng" WASM. Likewise all SNSes have been migrated to "index-ng" a year ago or so and the original "non-ng index" source code has been removed from the IC repo. Therefore for consistency and to make the tooling comprehensive, we deleted the old implementation, kept "ng" but renamed it to `IcrcIndexCanister`.
