### PR TITLE
chore(build): run npm prepare during Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ COPY --from=mainnet_configurator /build/frontend/.env /build/frontend/.env
 COPY ./build-frontend.sh /build/
 COPY ./scripts/require-dfx-network.sh /build/scripts/
 WORKDIR /build
-RUN ( cd frontend && npm ci )
+RUN ( cd frontend && npm ci && npm run prepare )
 RUN ./build-frontend.sh
 
 # Title: Image to build the nns-dapp backend.


### PR DESCRIPTION
# Motivation

After https://github.com/dfinity/nns-dapp/pull/7654, we also need this change to unblock https://github.com/dfinity/nns-dapp/pull/7653, as the preparation must run for the Docker image to build.

# Changes

- Added `npm run prepare` after `npm ci` in Dockerfile.

# Tests

- CI should pass
- #7653 should pass on top of this one.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
