### PR TITLE
chore(config): update domains from ic-domains and ii-alternative-origins

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,11 +30,15 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+- Add `sns.internetcomputer.org` to the list of supported domains.
+
 #### Changed
 
 #### Deprecated
 
 #### Removed
+
+- Remove `wallet.internetcomputer.org` and `wallet.ic0.app` from the list of supported domains.
 
 #### Fixed
 

--- a/frontend/static/.well-known/ic-domains
+++ b/frontend/static/.well-known/ic-domains
@@ -1,5 +1,3 @@
-nns.internetcomputer.org
 wallet.internetcomputer.org
 wallet.ic0.app
-beta.nns.internetcomputer.org
 beta.nns.ic0.app

--- a/frontend/static/.well-known/ic-domains
+++ b/frontend/static/.well-known/ic-domains
@@ -1,3 +1,1 @@
-wallet.internetcomputer.org
-wallet.ic0.app
 beta.nns.ic0.app

--- a/frontend/static/.well-known/ic-domains
+++ b/frontend/static/.well-known/ic-domains
@@ -1,1 +1,3 @@
 beta.nns.ic0.app
+sns.internetcomputer.org
+

--- a/frontend/static/.well-known/ii-alternative-origins
+++ b/frontend/static/.well-known/ii-alternative-origins
@@ -1,1 +1,1 @@
-{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://wallet.internetcomputer.org", "https://wallet.ic0.app", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app", "https://governance.internetcomputer.org", "https://gov.internetcomputer.org"]}
+{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app"]}

--- a/frontend/static/.well-known/ii-alternative-origins
+++ b/frontend/static/.well-known/ii-alternative-origins
@@ -1,1 +1,1 @@
-{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app"]}
+{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app", "https://sns.internetcomputer.org"]}


### PR DESCRIPTION
# Motivation

Update supported domains from `ic-domains` and `ii-alternative-origins`.

# Changes

-  Removed `nns.internetcomputer.org` and `beta.nns.internetcomputer.org` from `ic-domains` as they are now own by https://github.com/dfinity/governance-app
-  Deprecated `wallet.internetcomputer.org` and `wallet.ic0.app` as we have almost no traffic, 23 visitors in the last 12 months.
- Added `sns.internetcomputer.org` as an alternative origin but also a valid domain for nns.ic0.app.