### PR TITLE
fix(proposals): return "unknown" instead of throwing for unrecognized proposal status

### DIFF
--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -558,13 +558,7 @@ export const getUniversalProposalStatus = (
     [ProposalStatus.Executed]: "executed",
     [ProposalStatus.Failed]: "failed",
   };
-  const statusType = statusTypeMap[proposal.status];
-
-  if (isNullish(statusType)) {
-    throw new Error(`Unknown proposal status: ${proposal.status}`);
-  }
-
-  return statusType;
+  return statusTypeMap[proposal.status] ?? "unknown";
 };
 
 export const getVoteDisplay = (vote: Vote): string => {

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -1003,6 +1003,17 @@ describe("proposals-utils", () => {
         getUniversalProposalStatus(proposalWithStatus(ProposalStatus.Failed))
       ).toBe("failed");
     });
+
+    it("should return 'unknown' for unrecognized status values", () => {
+      const proposalWithStatus = (status: ProposalStatus): ProposalInfo => ({
+        ...mockProposalInfo,
+        status,
+      });
+
+      expect(
+        getUniversalProposalStatus(proposalWithStatus(999 as ProposalStatus))
+      ).toBe("unknown");
+    });
   });
 
   describe("getVoteDisplay", () => {


### PR DESCRIPTION
# Motivation

The `getUniversalProposalStatus` function was throwing an error for any status value not present in the `ProposalStatus` enum from `@icp-sdk/canisters/nns`. If the monorepo adds a new status before we update the library, the proposal card and navigation would break silently. 

Similar work to: https://github.com/dfinity/governance-app/pull/371

# Changes

-  Fixed `getUniversalProposalStatus` to default to `"unknown"` instead of throwing an error for unrecognized status values.
-  Added a test case to cover the fallback behavior for unrecognized status values.

# Tests

- CI should be green

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
