### PR TITLE
chore(launchpad): remove project from featured list

### DIFF
--- a/frontend/src/lib/constants/sns.constants.ts
+++ b/frontend/src/lib/constants/sns.constants.ts
@@ -10,7 +10,6 @@ export const WATCH_SALE_STATE_EVERY_MILLISECONDS = 10_000;
 export const AGGREGATOR_METRICS_TIME_WINDOW_SECONDS = 2 * 30 * 24 * 3600;
 
 export const FEATURED_SNS_PROJECTS = [
-  "ormnc-tiaaa-aaaaq-aadyq-cai",
   "csyra-haaaa-aaaaq-aacva-cai",
   "tw2vt-hqaaa-aaaaq-aab6a-cai",
   "x4kx5-ziaaa-aaaaq-aabeq-cai",


### PR DESCRIPTION
# Motivation

One of the featured projects is no longer actively developed, so it no longer makes sense to keep it highlighted above the others.

# Changes

- Removed `ormnc-tiaaa-aaaaq-aadyq-cai` project from the featured SNS projects list.

# Tests

- Visually tested.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
