### PR TITLE
feat(accounts): recognize burn address in SNS token transfer

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+- When sending SNS tokens to a burn address (minting account), the transaction fee is shown as 0 and labeled as a burn address.
+
 #### Changed
 
 #### Deprecated

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -8,6 +8,7 @@ import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import {
   arrayOfNumberToUint8Array,
+  fromNullable,
   isNullish,
   nonNullish,
   toNullable,
@@ -43,6 +44,24 @@ export const queryIcrcToken = async ({
   }
 
   return token;
+};
+
+export const queryIcrcMintingAccount = async ({
+  certified,
+  identity,
+  canisterId,
+}: {
+  certified: boolean;
+  identity: Identity;
+  canisterId: Principal;
+}): Promise<IcrcAccount | undefined> => {
+  const { canister } = await icrcLedgerCanister({ identity, canisterId });
+  const result = fromNullable(await canister.getMintingAccount({ certified }));
+  if (isNullish(result)) return undefined;
+  return {
+    owner: result.owner,
+    subaccount: fromNullable(result.subaccount),
+  };
 };
 
 export const queryIcrcBalance = async ({

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -57,7 +57,7 @@ export const queryIcrcMintingAccount = async ({
 }): Promise<IcrcAccount | undefined> => {
   const { canister } = await icrcLedgerCanister({ identity, canisterId });
   const result = fromNullable(await canister.getMintingAccount({ certified }));
-  if (isNullish(result)) return undefined;
+  if (isNullish(result)) return;
   return {
     owner: result.owner,
     subaccount: fromNullable(result.subaccount),

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -365,7 +365,9 @@
     {#if showLedgerFee}
       <TransactionFormFee
         transactionFee={effectiveFee}
-        description={isBurnDestination ? $i18n.accounts.burn_address : undefined}
+        description={isBurnDestination
+          ? $i18n.accounts.burn_address
+          : undefined}
       />
     {/if}
 

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -88,6 +88,11 @@
     ? 0n
     : toTokenAmountV2(transactionFee).toUlps();
 
+  let effectiveFee: TokenAmountV2 | TokenAmount;
+  $: effectiveFee = isBurnDestination
+    ? TokenAmountV2.fromUlps({ amount: 0n, token })
+    : transactionFee;
+
   let max = 0;
   $: max = getMaxTransactionAmount({
     balance: selectedAccount?.balanceUlps,
@@ -338,12 +343,6 @@
     {/if}
   {/if}
 
-  {#if isBurnDestination}
-    <p class="burn-address-label" data-tid="burn-address-label">
-      {$i18n.accounts.burn_address}
-    </p>
-  {/if}
-
   {#if mustSelectNetwork}
     <TransactionFormItemNetwork
       bind:selectedNetwork
@@ -363,8 +362,11 @@
       {balance}
     />
 
-    {#if showLedgerFee && !isBurnDestination}
-      <TransactionFormFee {transactionFee} />
+    {#if showLedgerFee}
+      <TransactionFormFee
+        transactionFee={effectiveFee}
+        description={isBurnDestination ? $i18n.accounts.burn_address : undefined}
+      />
     {/if}
 
     <slot name="additional-info" />
@@ -432,12 +434,6 @@
         color: var(--text-description);
       }
     }
-  }
-
-  .burn-address-label {
-    font-size: var(--font-size-small);
-    color: var(--text-description);
-    margin: 0;
   }
 
   .manual-address-info {

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -67,6 +67,7 @@
   export let validateAmount: ValidateAmountFn = () => undefined;
   export let withMemo: boolean = false;
   export let memo: string | undefined = undefined;
+  export let burnAddress: string | undefined = undefined;
 
   let filterSourceAccounts: (account: Account) => boolean;
   $: filterSourceAccounts = (account: Account) => {
@@ -78,10 +79,19 @@
     return account.identifier !== selectedAccount?.identifier;
   };
 
+  let isBurnDestination: boolean;
+  $: isBurnDestination =
+    nonNullish(burnAddress) && selectedDestinationAddress === burnAddress;
+
+  let effectiveFeeUlps: bigint;
+  $: effectiveFeeUlps = isBurnDestination
+    ? 0n
+    : toTokenAmountV2(transactionFee).toUlps();
+
   let max = 0;
   $: max = getMaxTransactionAmount({
     balance: selectedAccount?.balanceUlps,
-    fee: toTokenAmountV2(transactionFee).toUlps(),
+    fee: effectiveFeeUlps,
     maxAmount,
     token,
   });
@@ -113,7 +123,7 @@
       const tokens = TokenAmountV2.fromNumber({ amount, token });
       assertEnoughAccountFunds({
         account: selectedAccount,
-        amountUlps: tokens.toUlps() + toTokenAmountV2(transactionFee).toUlps(),
+        amountUlps: tokens.toUlps() + effectiveFeeUlps,
       });
       errorMessage = validateAmount({ amount, selectedAccount });
     } catch (error: unknown) {
@@ -328,6 +338,12 @@
     {/if}
   {/if}
 
+  {#if isBurnDestination}
+    <p class="burn-address-label" data-tid="burn-address-label">
+      {$i18n.accounts.burn_address}
+    </p>
+  {/if}
+
   {#if mustSelectNetwork}
     <TransactionFormItemNetwork
       bind:selectedNetwork
@@ -347,7 +363,7 @@
       {balance}
     />
 
-    {#if showLedgerFee}
+    {#if showLedgerFee && !isBurnDestination}
       <TransactionFormFee {transactionFee} />
     {/if}
 
@@ -416,6 +432,12 @@
         color: var(--text-description);
       }
     }
+  }
+
+  .burn-address-label {
+    font-size: var(--font-size-small);
+    color: var(--text-description);
+    margin: 0;
   }
 
   .manual-address-info {

--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -6,12 +6,18 @@
   import { formatUsdValue } from "$lib/utils/format.utils";
   import { getUsdValue } from "$lib/utils/token.utils";
   import { getLedgerCanisterIdFromUniverse } from "$lib/utils/universe.utils";
-  import { isNullish, type TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+  import {
+    isNullish,
+    nonNullish,
+    type TokenAmount,
+    TokenAmountV2,
+  } from "@dfinity/utils";
 
   type Props = {
     transactionFee: TokenAmount | TokenAmountV2;
+    description?: string;
   };
-  const { transactionFee }: Props = $props();
+  const { transactionFee, description = undefined }: Props = $props();
 
   const usdValueDisplay = $derived.by(() => {
     const ledgerCanisterId = getLedgerCanisterIdFromUniverse(
@@ -29,6 +35,11 @@
 <div data-tid="transaction-form-fee">
   <p class="fee label no-margin">
     {$i18n.accounts.transaction_fee}
+    {#if nonNullish(description)}
+      <span class="description" data-tid="transaction-form-fee-description"
+        >({description})</span
+      >
+    {/if}
   </p>
 
   <p class="value">
@@ -46,6 +57,10 @@
     padding: var(--padding-0_5x) 0;
     color: var(--text-description);
     @include fonts.small();
+
+    .description {
+      font-style: italic;
+    }
   }
 
   .value {

--- a/frontend/src/lib/components/transaction/TransactionReview.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReview.svelte
@@ -17,6 +17,7 @@
     description: Snippet;
     destinationInfo: Snippet;
     disableSubmit: boolean;
+    feeDescription?: string;
     handleGoBack: () => void;
     receivedAmount: Snippet;
     selectedNetwork?: TransactionNetwork;
@@ -32,6 +33,7 @@
     description,
     destinationInfo,
     disableSubmit,
+    feeDescription = undefined,
     handleGoBack,
     receivedAmount,
     selectedNetwork = undefined,
@@ -61,6 +63,7 @@
       {transactionFee}
       {showLedgerFee}
       {receivedAmount}
+      {feeDescription}
     />
 
     <TransactionDescription

--- a/frontend/src/lib/components/transaction/TransactionSummary.svelte
+++ b/frontend/src/lib/components/transaction/TransactionSummary.svelte
@@ -17,6 +17,7 @@
 
   type Props = {
     amount: number;
+    feeDescription?: string;
     receivedAmount: Snippet;
     showLedgerFee?: boolean;
     token: Token;
@@ -25,6 +26,7 @@
 
   const {
     amount,
+    feeDescription = undefined,
     receivedAmount,
     showLedgerFee = true,
     token,
@@ -94,7 +96,13 @@
 
   {#if showLedgerFee}
     <KeyValuePair testId="transaction-summary-fee">
-      {#snippet key()}<span class="label">{ledgerFeeLabel}</span>{/snippet}
+      {#snippet key()}<span class="label"
+          >{ledgerFeeLabel}{#if nonNullish(feeDescription)}&nbsp;<span
+              class="fee-description"
+              data-tid="transaction-summary-fee-description"
+              >({feeDescription})</span
+            >{/if}</span
+        >{/snippet}
       {#snippet value()}<div class="value">
           <AmountDisplay
             singleLine
@@ -170,6 +178,11 @@
 
   .subtitle {
     margin: 0 0 var(--padding-0_5x);
+  }
+
+  .fee-description {
+    font-style: italic;
+    color: var(--text-description);
   }
 
   .value {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -352,6 +352,7 @@
     "hardware_wallet_text": "Ledger device",
     "token_transaction_fee": "$tokenSymbol Ledger Fee",
     "transaction_fee": "Transaction Fee",
+    "burn_address": "Burn address",
     "review_transaction": "Review Transaction",
     "current_balance": "Current balance",
     "confirm_and_send": "Confirm and Send",

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -32,15 +32,20 @@
   let mintingAccountLoaded = false;
 
   onMount(async () => {
-    const mintingAccount = await queryIcrcMintingAccount({
-      identity: getCurrentIdentity(),
-      canisterId: ledgerCanisterId,
-      certified: false,
-    });
-    if (nonNullish(mintingAccount)) {
-      burnAddress = encodeIcrcAccount(mintingAccount);
+    try {
+      const mintingAccount = await queryIcrcMintingAccount({
+        identity: getCurrentIdentity(),
+        canisterId: ledgerCanisterId,
+        certified: false,
+      });
+      if (nonNullish(mintingAccount)) {
+        burnAddress = encodeIcrcAccount(mintingAccount);
+      }
+    } catch {
+      // Fall back to treating all addresses as regular (non-burn) transfers.
+    } finally {
+      mintingAccountLoaded = true;
     }
-    mintingAccountLoaded = true;
   });
 
   $: title =

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -58,7 +58,8 @@
       initiator: "accounts",
     });
 
-    const isBurn = nonNullish(burnAddress) && destinationAddress === burnAddress;
+    const isBurn =
+      nonNullish(burnAddress) && destinationAddress === burnAddress;
 
     const { blockIndex } = await transferTokens({
       source: sourceAccount,

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -29,6 +29,7 @@
 
   let currentStep: WizardStep | undefined;
   let burnAddress: string | undefined = undefined;
+  let mintingAccountLoaded = false;
 
   onMount(async () => {
     const mintingAccount = await queryIcrcMintingAccount({
@@ -39,6 +40,7 @@
     if (nonNullish(mintingAccount)) {
       burnAddress = encodeIcrcAccount(mintingAccount);
     }
+    mintingAccountLoaded = true;
   });
 
   $: title =
@@ -89,6 +91,7 @@
   {transactionFee}
   {transactionInit}
   {burnAddress}
+  disableContinue={!mintingAccountLoaded}
 >
   <svelte:fragment slot="title">{title ?? $i18n.accounts.send}</svelte:fragment>
   <p slot="description" class="value no-margin">

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { queryIcrcMintingAccount } from "$lib/api/icrc-ledger.api";
   import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
+  import { getCurrentIdentity } from "$lib/services/auth.services";
   import { transferTokens } from "$lib/services/icrc-accounts.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
@@ -11,7 +13,8 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import type { Principal } from "@icp-sdk/core/principal";
   import { TokenAmountV2, nonNullish, type Token } from "@dfinity/utils";
-  import { createEventDispatcher } from "svelte";
+  import { encodeIcrcAccount } from "@icp-sdk/canisters/ledger/icrc";
+  import { createEventDispatcher, onMount } from "svelte";
 
   export let selectedAccount: Account | undefined = undefined;
   export let ledgerCanisterId: Principal;
@@ -25,6 +28,18 @@
   };
 
   let currentStep: WizardStep | undefined;
+  let burnAddress: string | undefined = undefined;
+
+  onMount(async () => {
+    const mintingAccount = await queryIcrcMintingAccount({
+      identity: getCurrentIdentity(),
+      canisterId: ledgerCanisterId,
+      certified: false,
+    });
+    if (nonNullish(mintingAccount)) {
+      burnAddress = encodeIcrcAccount(mintingAccount);
+    }
+  });
 
   $: title =
     currentStep?.name === "Form"
@@ -43,12 +58,14 @@
       initiator: "accounts",
     });
 
+    const isBurn = nonNullish(burnAddress) && destinationAddress === burnAddress;
+
     const { blockIndex } = await transferTokens({
       source: sourceAccount,
       destinationAddress,
       amountUlps: numberToUlps({ amount, token }),
       ledgerCanisterId,
-      fee: transactionFee.toUlps(),
+      fee: isBurn ? 0n : transactionFee.toUlps(),
     });
 
     stopBusy("accounts");
@@ -70,6 +87,7 @@
   {token}
   {transactionFee}
   {transactionInit}
+  {burnAddress}
 >
   <svelte:fragment slot="title">{title ?? $i18n.accounts.send}</svelte:fragment>
   <p slot="description" class="value no-margin">

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -36,7 +36,7 @@
       const mintingAccount = await queryIcrcMintingAccount({
         identity: getCurrentIdentity(),
         canisterId: ledgerCanisterId,
-        certified: false,
+        certified: true,
       });
       if (nonNullish(mintingAccount)) {
         burnAddress = encodeIcrcAccount(mintingAccount);

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -29,7 +29,7 @@
 
   let currentStep: WizardStep | undefined;
   let burnAddress: string | undefined = undefined;
-  let mintingAccountLoaded = false;
+  let mintingAccountQueryAttempted = false;
 
   onMount(async () => {
     try {
@@ -44,7 +44,7 @@
     } catch {
       // Fall back to treating all addresses as regular (non-burn) transfers.
     } finally {
-      mintingAccountLoaded = true;
+      mintingAccountQueryAttempted = true;
     }
   });
 
@@ -96,7 +96,7 @@
   {transactionFee}
   {transactionInit}
   {burnAddress}
-  disableContinue={!mintingAccountLoaded}
+  disableContinue={!mintingAccountQueryAttempted}
 >
   <svelte:fragment slot="title">{title ?? $i18n.accounts.send}</svelte:fragment>
   <p slot="description" class="value no-margin">

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -18,6 +18,7 @@
     WizardStep,
     WizardSteps,
   } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
   import type { Principal } from "@icp-sdk/core/principal";
   import {
     ICPToken,
@@ -73,6 +74,11 @@
   let isBurnDestination: boolean;
   $: isBurnDestination =
     nonNullish(burnAddress) && selectedDestinationAddress === burnAddress;
+
+  let effectiveTransactionFee: TokenAmountV2 | TokenAmount;
+  $: effectiveTransactionFee = isBurnDestination
+    ? TokenAmountV2.fromUlps({ amount: 0n, token })
+    : transactionFee;
 
   let showManualAddress = selectDestinationMethods !== "dropdown";
 
@@ -184,11 +190,14 @@
         memo,
       }}
       handleGoBack={goBack}
-      {transactionFee}
+      transactionFee={effectiveTransactionFee}
       {disableSubmit}
       {token}
       {selectedNetwork}
-      showLedgerFee={showLedgerFee && !isBurnDestination}
+      {showLedgerFee}
+      feeDescription={isBurnDestination
+        ? $i18n.accounts.burn_address
+        : undefined}
       on:nnsSubmit
       on:nnsClose
       {withMemo}

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -60,6 +60,7 @@
 
   // Optional transaction memo to include in the submission payload
   export let withMemo: boolean = false;
+  export let burnAddress: string | undefined = undefined;
 
   // Init configuration only once when component is mounting. The configuration should not vary when user interact with the form.
   let canSelectDestination = isNullish(transactionInit.destinationAddress);
@@ -68,6 +69,10 @@
   let memo: string | undefined = undefined;
 
   let selectedDestinationAddress: string | undefined = destinationAddress;
+
+  let isBurnDestination: boolean;
+  $: isBurnDestination =
+    nonNullish(burnAddress) && selectedDestinationAddress === burnAddress;
 
   let showManualAddress = selectDestinationMethods !== "dropdown";
 
@@ -165,6 +170,7 @@
       {showLedgerFee}
       on:nnsOpenQRCodeReader={goQRCode}
       {withMemo}
+      {burnAddress}
     >
       <slot name="additional-info-form" slot="additional-info" />
     </TransactionForm>
@@ -182,7 +188,7 @@
       {disableSubmit}
       {token}
       {selectedNetwork}
-      {showLedgerFee}
+      showLedgerFee={showLedgerFee && !isBurnDestination}
       on:nnsSubmit
       on:nnsClose
       {withMemo}

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -364,6 +364,7 @@ interface I18nAccounts {
   hardware_wallet_text: string;
   token_transaction_fee: string;
   transaction_fee: string;
+  burn_address: string;
   review_transaction: string;
   current_balance: string;
   confirm_and_send: string;

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -68,6 +68,32 @@ describe("IcrcTokenTransactionModal", () => {
     );
   };
 
+  it("should disable continue until minting account is loaded", async () => {
+    setupAccount();
+    let resolveMintingAccount: (value: undefined) => void;
+    vi.spyOn(ledgerApi, "queryIcrcMintingAccount").mockReturnValue(
+      new Promise((resolve) => {
+        resolveMintingAccount = () => resolve(undefined);
+      })
+    );
+
+    const { container } = await renderModal({
+      component: IcrcTokenTransactionModal,
+      props: { ledgerCanisterId, universeId: ledgerCanisterId, token, transactionFee },
+    });
+
+    const po = IcrcTokenTransactionModalPo.under(
+      new JestPageObjectElement(container)
+    );
+
+    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(false);
+
+    resolveMintingAccount(undefined);
+    await runResolvedPromises();
+
+    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(false); // still disabled without amount/destination
+  });
+
   it("should render token in the modal title", async () => {
     const po = await renderModalComponent();
 

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -129,10 +129,13 @@ describe("IcrcTokenTransactionModal", () => {
 
     await runResolvedPromises();
 
-    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(
-      false
-    ); // still disabled without amount/destination, but no longer blocked by loading
-    expect(await po.getTransactionFormPo().hasBurnAddressLabel()).toBe(false);
+    // Loading flag cleared — entering valid inputs should now enable continue
+    const formPo = po.getTransactionFormPo();
+    await formPo.enterAddress(encodeIcrcAccount({ owner: principal(2) }));
+    await formPo.enterAmount(1);
+
+    expect(await formPo.isContinueButtonEnabled()).toBe(true);
+    expect(await formPo.hasBurnAddressLabel()).toBe(false);
   });
 
   it("should render token in the modal title", async () => {

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -103,6 +103,38 @@ describe("IcrcTokenTransactionModal", () => {
     ); // still disabled without amount/destination
   });
 
+  it("should enable continue if minting account query fails", async () => {
+    setupAccount();
+    vi.spyOn(ledgerApi, "queryIcrcMintingAccount").mockRejectedValue(
+      new Error("network error")
+    );
+
+    const { container } = await renderModal({
+      component: IcrcTokenTransactionModal,
+      props: {
+        ledgerCanisterId,
+        universeId: ledgerCanisterId,
+        token,
+        transactionFee,
+      },
+    });
+
+    const po = IcrcTokenTransactionModalPo.under(
+      new JestPageObjectElement(container)
+    );
+
+    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(
+      false
+    );
+
+    await runResolvedPromises();
+
+    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(
+      false
+    ); // still disabled without amount/destination, but no longer blocked by loading
+    expect(await po.getTransactionFormPo().hasBurnAddressLabel()).toBe(false);
+  });
+
   it("should render token in the modal title", async () => {
     const po = await renderModalComponent();
 

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -193,16 +193,18 @@ describe("IcrcTokenTransactionModal", () => {
       expect(await formPo.hasBurnAddressLabel()).toBe(false);
     });
 
-    it("should hide the fee when destination is the minting account", async () => {
+    it("should keep the fee visible and show burn description when destination is the minting account", async () => {
       setupAccount();
       const po = await renderModalComponent();
       const formPo = po.getTransactionFormPo();
 
-      expect(await formPo.hasFee()).toBe(true);
+      expect(await formPo.getTransactionFormFeePo().isPresent()).toBe(true);
+      expect(await formPo.hasBurnAddressLabel()).toBe(false);
 
       await formPo.enterAddress(mintingAccountAddress);
 
-      expect(await formPo.hasFee()).toBe(false);
+      expect(await formPo.getTransactionFormFeePo().isPresent()).toBe(true);
+      expect(await formPo.hasBurnAddressLabel()).toBe(true);
     });
 
     it("should transfer with fee 0 when destination is the minting account", async () => {

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -79,19 +79,28 @@ describe("IcrcTokenTransactionModal", () => {
 
     const { container } = await renderModal({
       component: IcrcTokenTransactionModal,
-      props: { ledgerCanisterId, universeId: ledgerCanisterId, token, transactionFee },
+      props: {
+        ledgerCanisterId,
+        universeId: ledgerCanisterId,
+        token,
+        transactionFee,
+      },
     });
 
     const po = IcrcTokenTransactionModalPo.under(
       new JestPageObjectElement(container)
     );
 
-    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(false);
+    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(
+      false
+    );
 
     resolveMintingAccount(undefined);
     await runResolvedPromises();
 
-    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(false); // still disabled without amount/destination
+    expect(await po.getTransactionFormPo().isContinueButtonEnabled()).toBe(
+      false
+    ); // still disabled without amount/destination
   });
 
   it("should render token in the modal title", async () => {

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -14,6 +14,7 @@ import { renderModal } from "$tests/mocks/modal.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransactionModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { encodeIcrcAccount } from "@icp-sdk/canisters/ledger/icrc";
 
@@ -26,6 +27,8 @@ describe("IcrcTokenTransactionModal", () => {
     amount: token.fee,
     token,
   });
+  const mintingAccount = { owner: principal(99) };
+  const mintingAccountAddress = encodeIcrcAccount(mintingAccount);
 
   beforeEach(() => {
     resetIdentity();
@@ -34,7 +37,18 @@ describe("IcrcTokenTransactionModal", () => {
       routeId: AppPath.Accounts,
     });
     vi.spyOn(ledgerApi, "icrcTransfer").mockResolvedValue(1234n);
+    vi.spyOn(ledgerApi, "queryIcrcMintingAccount").mockResolvedValue(undefined);
   });
+
+  const setupAccount = () => {
+    icrcAccountsStore.set({
+      ledgerCanisterId,
+      accounts: {
+        accounts: [{ ...mockIcrcMainAccount, balanceUlps: 1000n * 10n ** 18n }],
+        certified: true,
+      },
+    });
+  };
 
   const renderModalComponent = async () => {
     const { container } = await renderModal({
@@ -46,6 +60,8 @@ describe("IcrcTokenTransactionModal", () => {
         transactionFee,
       },
     });
+
+    await runResolvedPromises();
 
     return IcrcTokenTransactionModalPo.under(
       new JestPageObjectElement(container)
@@ -59,25 +75,11 @@ describe("IcrcTokenTransactionModal", () => {
   });
 
   it("should transfer tokens", async () => {
-    // Used to choose the source account
-    icrcAccountsStore.set({
-      ledgerCanisterId,
-      accounts: {
-        accounts: [
-          {
-            ...mockIcrcMainAccount,
-            balanceUlps: 1000n * 10n ** 18n,
-          },
-        ],
-        certified: true,
-      },
-    });
+    setupAccount();
 
     const po = await renderModalComponent();
 
-    const toAccount = {
-      owner: principal(2),
-    };
+    const toAccount = { owner: principal(2) };
     const amount = 10;
 
     await po.transferToAddress({
@@ -92,6 +94,80 @@ describe("IcrcTokenTransactionModal", () => {
       amount: BigInt(amount) * 10n ** 18n,
       to: toAccount,
       fee: token.fee,
+    });
+  });
+
+  describe("burn address", () => {
+    beforeEach(() => {
+      vi.spyOn(ledgerApi, "queryIcrcMintingAccount").mockResolvedValue(
+        mintingAccount
+      );
+    });
+
+    it("should show burn address label when destination is the minting account", async () => {
+      setupAccount();
+      const po = await renderModalComponent();
+      const formPo = po.getTransactionFormPo();
+
+      expect(await formPo.hasBurnAddressLabel()).toBe(false);
+
+      await formPo.enterAddress(mintingAccountAddress);
+
+      expect(await formPo.hasBurnAddressLabel()).toBe(true);
+    });
+
+    it("should not show burn address label for a regular address", async () => {
+      setupAccount();
+      const po = await renderModalComponent();
+      const formPo = po.getTransactionFormPo();
+
+      await formPo.enterAddress(encodeIcrcAccount({ owner: principal(2) }));
+
+      expect(await formPo.hasBurnAddressLabel()).toBe(false);
+    });
+
+    it("should hide the fee when destination is the minting account", async () => {
+      setupAccount();
+      const po = await renderModalComponent();
+      const formPo = po.getTransactionFormPo();
+
+      expect(await formPo.hasFee()).toBe(true);
+
+      await formPo.enterAddress(mintingAccountAddress);
+
+      expect(await formPo.hasFee()).toBe(false);
+    });
+
+    it("should transfer with fee 0 when destination is the minting account", async () => {
+      setupAccount();
+      const po = await renderModalComponent();
+
+      await po.transferToAddress({
+        destinationAddress: mintingAccountAddress,
+        amount: 1,
+      });
+
+      expect(ledgerApi.icrcTransfer).toHaveBeenCalledTimes(1);
+      expect(ledgerApi.icrcTransfer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fee: 0n,
+          to: mintingAccount,
+        })
+      );
+    });
+
+    it("should transfer with normal fee for a regular address", async () => {
+      setupAccount();
+      const po = await renderModalComponent();
+
+      await po.transferToAddress({
+        destinationAddress: encodeIcrcAccount({ owner: principal(2) }),
+        amount: 1,
+      });
+
+      expect(ledgerApi.icrcTransfer).toHaveBeenCalledWith(
+        expect.objectContaining({ fee: token.fee })
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -78,6 +78,9 @@ describe("SnsWallet", () => {
       balance: 0n,
     });
     vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(10n);
+    vi.spyOn(icrcLedgerApi, "queryIcrcMintingAccount").mockResolvedValue(
+      undefined
+    );
     vi.spyOn(
       workerTransactionsServices,
       "initTransactionsWorker"

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -153,10 +153,8 @@ export class TransactionFormPo extends BasePageObject {
   }
 
   hasBurnAddressLabel(): Promise<boolean> {
-    return this.root.byTestId("burn-address-label").isPresent();
-  }
-
-  async hasFee(): Promise<boolean> {
-    return this.getTransactionFormFeePo().isPresent();
+    return this.root
+      .byTestId("transaction-form-fee-description")
+      .isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -151,4 +151,12 @@ export class TransactionFormPo extends BasePageObject {
   async hasManualAddressLink(): Promise<boolean> {
     return this.getManualAddressLink().isPresent();
   }
+
+  hasBurnAddressLabel(): Promise<boolean> {
+    return this.root.byTestId("burn-address-label").isPresent();
+  }
+
+  async hasFee(): Promise<boolean> {
+    return this.getTransactionFormFeePo().isPresent();
+  }
 }

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -153,8 +153,6 @@ export class TransactionFormPo extends BasePageObject {
   }
 
   hasBurnAddressLabel(): Promise<boolean> {
-    return this.root
-      .byTestId("transaction-form-fee-description")
-      .isPresent();
+    return this.root.byTestId("transaction-form-fee-description").isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -152,7 +152,9 @@ export class TransactionFormPo extends BasePageObject {
     return this.getManualAddressLink().isPresent();
   }
 
-  hasBurnAddressLabel(): Promise<boolean> {
-    return this.root.byTestId("transaction-form-fee-description").isPresent();
+  async hasBurnAddressLabel(): Promise<boolean> {
+    const el = this.root.byTestId("transaction-form-fee-description");
+    if (!(await el.isPresent())) return false;
+    return (await el.getText()) === "(Burn address)";
   }
 }


### PR DESCRIPTION
# Motivation

SNS tokens can be burned by sending them to the minting account (burn address). When a user does this, no transaction fee is charged. The UI should recognize this scenario and reflect it clearly instead of displaying a regular fee.

# Changes

-  Added the `queryIcrcMintingAccount` API function to fetch the minting account for an ICRC ledger canister.
-  Retrieved the minting account on modal mount in `IcrcTokenTransactionModal` and encoded it as a burn address string.
-  Introduced the `burnAddress` prop in `TransactionModal` and `TransactionForm` to identify when the destination matches the burn address.
-  Displayed the transaction fee as 0 with a "Burn address" label when the destination is the burn address.
-  Passed `fee: 0n` to the transfer call when sending to the burn address.
-  Added tests to cover burn label visibility, fee display, and correct fee in the transfer call.

# Tests

- Added unit tests

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
