### PR TITLE
chore(deps): bump dompurify

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3079,9 +3079,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
# Motivation

```
# npm audit report

dompurify  <=3.3.3
Severity: moderate
DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation - https://github.com/advisories/GHSA-39q2-94rc-95cp
fix available via `npm audit fix`
node_modules/dompurify

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix
```

# Changes

- Ran `npm audit fix`

# Tests

- CI should be green

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
