### PR TITLE
fix(dissolve-delay): fix "2 years, 12 hours" shown at max dissolve delay

### DIFF
--- a/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
@@ -25,12 +25,11 @@
     </div>
     <div>
       {#if delayInSeconds > 0}
-        <!-- Math.round guards against BigInt() throwing on non-integer numbers -->
-        <p class="label"
-          >{formatDissolveDelay(BigInt(Math.round(delayInSeconds)))}</p
+        <p class="label" data-tid="dissolve-delay-label"
+          >{formatDissolveDelay(BigInt(delayInSeconds))}</p
         >
       {:else}
-        <p class="label">{$i18n.neurons.no_delay}</p>
+        <p class="label" data-tid="dissolve-delay-label">{$i18n.neurons.no_delay}</p>
       {/if}
       <p>{$i18n.neurons.dissolve_delay_title}</p>
     </div>

--- a/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
@@ -25,6 +25,7 @@
     </div>
     <div>
       {#if delayInSeconds > 0}
+        <!-- Math.round guards against BigInt() throwing on non-integer numbers -->
         <p class="label"
           >{formatDissolveDelay(BigInt(Math.round(delayInSeconds)))}</p
         >

--- a/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
@@ -29,7 +29,9 @@
           >{formatDissolveDelay(BigInt(delayInSeconds))}</p
         >
       {:else}
-        <p class="label" data-tid="dissolve-delay-label">{$i18n.neurons.no_delay}</p>
+        <p class="label" data-tid="dissolve-delay-label"
+          >{$i18n.neurons.no_delay}</p
+        >
       {/if}
       <p>{$i18n.neurons.dissolve_delay_title}</p>
     </div>

--- a/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { daysToDuration, secondsToDays } from "$lib/utils/date.utils";
+  import { formatDissolveDelay } from "$lib/utils/date.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import { ProgressBar } from "@dfinity/gix-components";
 
   export let delayInSeconds: number;
   export let maxDelayInSeconds: number;
   export let votingPower: number;
-
-  let delayInDays: number;
-  $: delayInDays = secondsToDays(delayInSeconds);
 </script>
 
 <TestIdWrapper testId="range-dissolve-delay-component">
@@ -28,7 +25,9 @@
     </div>
     <div>
       {#if delayInSeconds > 0}
-        <p class="label">{daysToDuration(delayInDays)}</p>
+        <p class="label"
+          >{formatDissolveDelay(BigInt(Math.round(delayInSeconds)))}</p
+        >
       {:else}
         <p class="label">{$i18n.neurons.no_delay}</p>
       {/if}

--- a/frontend/src/tests/lib/components/neurons/RangeDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/RangeDissolveDelay.spec.ts
@@ -1,0 +1,23 @@
+import RangeDissolveDelay from "$lib/components/neurons/RangeDissolveDelay.svelte";
+import { NNS_MAXIMUM_DISSOLVE_DELAY } from "$lib/constants/neurons.constants";
+import { RangeDissolveDelayPo } from "$tests/page-objects/RangeDissolveDelay.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+const renderComponent = (delayInSeconds: number) => {
+  const { container } = render(RangeDissolveDelay, {
+    props: {
+      delayInSeconds,
+      maxDelayInSeconds: NNS_MAXIMUM_DISSOLVE_DELAY,
+      votingPower: 0,
+    },
+  });
+  return RangeDissolveDelayPo.under(new JestPageObjectElement(container));
+};
+
+describe("RangeDissolveDelay", () => {
+  it("should display '2 years' (not '2 years, 12 hours') at max dissolve delay", async () => {
+    const po = renderComponent(NNS_MAXIMUM_DISSOLVE_DELAY);
+    expect(await po.getDissolveDelayLabel()).toBe("2 years");
+  });
+});

--- a/frontend/src/tests/page-objects/RangeDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/RangeDissolveDelay.page-object.ts
@@ -13,4 +13,8 @@ export class RangeDissolveDelayPo extends BasePageObject {
       await this.root.querySelector("progress").getAttribute("value")
     );
   }
+
+  getDissolveDelayLabel(): Promise<string> {
+    return this.getText("dissolve-delay-label");
+  }
 }


### PR DESCRIPTION
# Motivation

When a user selects the maximum dissolve delay of 2 years, the range component displays "2 years, 12 hours" instead of just "2 years." This issue arises from a mismatch in the year model: `NNS_MAXIMUM_DISSOLVE_DELAY` uses a 365.25-day year (31,557,600 seconds), while `daysToDuration` relies on `secondsToDuration` from `@dfinity/utils`, which uses a 365-day year (31,536,000 seconds). Dividing 2 × 365.25 days by 365-day years results in a remainder of 43,200 seconds (12 hours).

<img width="721" height="877" alt="Screenshot 2026-04-22 at 18 19 43" src="https://github.com/user-attachments/assets/c039f22f-86a6-453c-82d8-cf3f4272c70f" />


# Changes

-  Replaced `daysToDuration` with `formatDissolveDelay` in `RangeDissolveDelay.svelte`, which uses the same 365.25-day year model as `SECONDS_IN_TWO_YEARS`, ensuring the maximum value formats correctly as "2 years."
-  Removed the now-unused `delayInDays` intermediate variable and the `secondsToDays` import.

# Tests

- Visually tested

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
