### PR TITLE
feat(staking): annualize APY over the eligible-to-vote window

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -78,3 +78,4 @@ SEV
 SNP
 dropdowns
 params
+APY

--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -79,3 +79,4 @@ SNP
 dropdowns
 params
 APY
+APYs

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-- Compute per-neuron APY as an annualized rate over the days the neuron is actually eligible to vote, with a pool-decay correction factor (`fullPoolSum / eligiblePoolSum`). For locked neurons the correction collapses to 1 and the displayed APY is unchanged from before. Dissolving neurons that previously displayed a near-zero APY (because the post-eligibility tail dragged the 365-day average toward 0) now display the rate at which they're actually earning during dissolution. The project total APY follows the same methodology: it is the stake-weighted average of the per-neuron annualized APYs (bank-style), rather than the simulated reward over the full year divided by stake.
+- Annualize per-neuron APY over the days the neuron is eligible to vote, so dissolving neurons no longer display a near-zero rate. Locked-neuron APYs are unchanged.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+- Compute per-neuron APY as an annualized rate over the days the neuron is actually eligible to vote, with a pool-decay correction factor (`fullPoolSum / eligiblePoolSum`). For locked neurons the correction collapses to 1 and the displayed APY is unchanged from before. Dissolving neurons that previously displayed a near-zero APY (because the post-eligibility tail dragged the 365-day average toward 0) now display the rate at which they're actually earning during dissolution. The project total APY follows the same methodology: it is the stake-weighted average of the per-neuron annualized APYs (bank-style), rather than the simulated reward over the full year divided by stake.
+
 #### Deprecated
 
 #### Removed

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-- Annualize per-neuron APY over the days the neuron is eligible to vote, so dissolving neurons no longer display a near-zero rate. Locked-neuron APYs are unchanged.
+- Per-neuron APY is now annualized over the days the neuron is eligible to vote, so dissolving neurons no longer display a near-zero rate. Locked-neuron APYs are unchanged.
 
 #### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/dfinity/nns-dapp/build.yml?logo=github&label=Build%20and%20test)](https://github.com/dfinity/nns-dapp/actions/workflows/build.yml)
 <a href="https://github.com/dfinity/nns-dapp/releases"><img src="https://img.shields.io/github/downloads/dfinity/nns-dapp/total?label=downloads&logo=github" alt="GitHub all releases"></a>
 [![Chat on Discord](https://img.shields.io/badge/chat-Discord-lightgrey?logo=Discord&style=flat-square)](https://discord.internetcomputer.org)
-
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/dfinity/nns-dapp/build.yml?logo=github&label=Build%20and%20test)](https://github.com/dfinity/nns-dapp/actions/workflows/build.yml)
 <a href="https://github.com/dfinity/nns-dapp/releases"><img src="https://img.shields.io/github/downloads/dfinity/nns-dapp/total?label=downloads&logo=github" alt="GitHub all releases"></a>
 [![Chat on Discord](https://img.shields.io/badge/chat-Discord-lightgrey?logo=Discord&style=flat-square)](https://discord.internetcomputer.org)
+
 </div>
 
 ---

--- a/frontend/src/lib/utils/staking-rewards.utils.ts
+++ b/frontend/src/lib/utils/staking-rewards.utils.ts
@@ -361,7 +361,7 @@ const getNnsRewardEstimationUSD = (
   days: number,
   maximiseParams: boolean = false,
   forceInitialDate?: Date
-): { total: number; neurons: Map<string, number> } => {
+): ReturnType<typeof getNeuronsRewardEstimationUSD> => {
   return getNeuronsRewardEstimationUSD({
     neurons: params.nnsNeurons.neurons ?? [],
     maximiseParams,
@@ -377,7 +377,7 @@ const getSnsRewardEstimationUSD = (
   sns: CachedSnsDto,
   maximiseParams: boolean = false,
   forceInitialDate?: Date
-): { total: number; neurons: Map<string, number> } => {
+): ReturnType<typeof getNeuronsRewardEstimationUSD> => {
   return getNeuronsRewardEstimationUSD({
     neurons:
       params.snsNeurons[sns.canister_ids.root_canister_id]?.neurons ?? [],
@@ -461,6 +461,22 @@ const getAPYs = (params: StakingRewardCalcParams, forceInitialDate?: Date) => {
   return apy;
 };
 
+// Per-neuron APY: (rewards during eligibility / stake) scaled by
+// (fullPoolSum / eligiblePoolSum). For a neuron eligible all year the scaling
+// is 1 and the value matches the original sum/stake formula. For a dissolving
+// neuron eligible only for an early subset of the simulated year, the scaling
+// discounts the high-pool early days so that locked >= dissolving holds at
+// every dissolve-delay preset.
+const annualizeWithPoolCorrection = (
+  reward: number,
+  stake: number,
+  eligiblePoolSum: number,
+  fullPoolSum: number
+): number => {
+  if (stake <= 0 || eligiblePoolSum <= 0) return 0;
+  return (reward / stake) * (fullPoolSum / eligiblePoolSum);
+};
+
 const getAPY = (
   params: StakingRewardCalcParams,
   neurons: AgnosticNeuron[],
@@ -470,20 +486,28 @@ const getAPY = (
     days: number,
     maximiseParams?: boolean,
     forceInitialDate?: Date
-  ) => { total: number; neurons: Map<string, number> },
+  ) => {
+    total: number;
+    neurons: Map<string, number>;
+    eligiblePoolSums: Map<string, number>;
+    fullPoolSum: number;
+  },
   forceInitialDate?: Date
 ) => {
   const {
-    total: yearEstimatedRewardTotalUSD,
     neurons: yearEstimatedRewardNeuronsUSD,
+    eligiblePoolSums: yearEstimatedEligiblePoolSums,
+    fullPoolSum: yearFullPoolSum,
   } = rewardEstimationFunction(params, 365, false, forceInitialDate);
   const {
-    total: yearEstimatedMaxRewardTotalUSD,
     neurons: yearEstimatedMaxRewardNeuronsUSD,
+    eligiblePoolSums: yearEstimatedMaxEligiblePoolSums,
   } = rewardEstimationFunction(params, 365, true, forceInitialDate);
 
   let totalUSD = 0;
   let totalMaxUSD = 0;
+  let stakeWeightedApySumUSD = 0;
+  let stakeWeightedMaxApySumUSD = 0;
   const fxRate = getFXRate(params.fxRates, ledgerPrincipal);
   const singleNeuronsApy = new Map<string, { cur: number; max: number }>();
 
@@ -506,21 +530,26 @@ const getAPY = (
     totalMaxUSD += neuronTotalMaxStakeUSD;
 
     const neuronId = getNeuronId(neuron);
-    singleNeuronsApy.set(neuronId, {
-      cur: neuronTotalStakeUSD
-        ? (yearEstimatedRewardNeuronsUSD.get(neuronId) ?? 0) /
-          neuronTotalStakeUSD
-        : 0,
-      max: neuronTotalMaxStakeUSD
-        ? (yearEstimatedMaxRewardNeuronsUSD.get(neuronId) ?? 0) /
-          neuronTotalMaxStakeUSD
-        : 0,
-    });
+    const cur = annualizeWithPoolCorrection(
+      yearEstimatedRewardNeuronsUSD.get(neuronId) ?? 0,
+      neuronTotalStakeUSD,
+      yearEstimatedEligiblePoolSums.get(neuronId) ?? 0,
+      yearFullPoolSum
+    );
+    const max = annualizeWithPoolCorrection(
+      yearEstimatedMaxRewardNeuronsUSD.get(neuronId) ?? 0,
+      neuronTotalMaxStakeUSD,
+      yearEstimatedMaxEligiblePoolSums.get(neuronId) ?? 0,
+      yearFullPoolSum
+    );
+    singleNeuronsApy.set(neuronId, { cur, max });
+    stakeWeightedApySumUSD += cur * neuronTotalStakeUSD;
+    stakeWeightedMaxApySumUSD += max * neuronTotalMaxStakeUSD;
   });
 
   return {
-    cur: totalUSD ? yearEstimatedRewardTotalUSD / totalUSD : 0,
-    max: totalMaxUSD ? yearEstimatedMaxRewardTotalUSD / totalMaxUSD : 0,
+    cur: totalUSD ? stakeWeightedApySumUSD / totalUSD : 0,
+    max: totalMaxUSD ? stakeWeightedMaxApySumUSD / totalMaxUSD : 0,
     neurons: singleNeuronsApy,
   };
 };
@@ -563,6 +592,33 @@ const isDataReady = (params: StakingRewardCalcParams) => {
   ].every((x) => x === true);
 };
 
+// Pool reward per simulated day, computed once and shared across all neurons.
+// Depends only on reward params and the date window (not on neuron state), so
+// it can be reused for the cur/max simulation passes and avoids recomputing
+// inside getTokenReward for every neuron-day.
+const computeDayPoolRewards = (
+  params: StakingRewardCalcParams,
+  days: number,
+  sns?: CachedSnsDto,
+  forceInitialDate?: Date
+): number[] => {
+  const rewardParams = getRewardParams(params, sns);
+  const genesis = getGenesisTimestampSeconds(sns);
+  const result: number[] = new Array(days);
+  for (let i = 0; i < days; i++) {
+    result[i] = getPoolReward({
+      genesisTimestampSeconds: genesis,
+      referenceDate: getDate(i, forceInitialDate),
+      transitionDurationSeconds: rewardParams.rewardTransition,
+      initialRewardRate: rewardParams.initialReward,
+      finalRewardRate: rewardParams.finalReward,
+      totalSupply: rewardParams.totalSupply,
+      poolReductionFactor: rewardParams.poolReductionFactor,
+    });
+  }
+  return result;
+};
+
 const getNeuronsRewardEstimationUSD = (params: {
   neurons: AgnosticNeuronArray;
   maximiseParams?: boolean;
@@ -570,7 +626,17 @@ const getNeuronsRewardEstimationUSD = (params: {
   sns?: CachedSnsDto;
   forceInitialDate?: Date;
   otherParams: StakingRewardCalcParams;
-}): { total: number; neurons: Map<string, number> } => {
+}): {
+  total: number;
+  neurons: Map<string, number>;
+  // Sum of the pool reward over the days each neuron was eligible to vote.
+  // Used together with the full-window pool sum to annualize APY with a
+  // pool-decay correction (see getAPY), so that a dissolving neuron whose
+  // short eligibility window lands on the highest-pool days of the year
+  // doesn't appear to out-earn the equivalent locked neuron.
+  eligiblePoolSums: Map<string, number>;
+  fullPoolSum: number;
+} => {
   const {
     neurons: _neurons,
     maximiseParams,
@@ -581,35 +647,52 @@ const getNeuronsRewardEstimationUSD = (params: {
   } = params;
 
   if (!_neurons || _neurons.length === 0) {
-    return { total: 0, neurons: new Map() };
+    return {
+      total: 0,
+      neurons: new Map(),
+      eligiblePoolSums: new Map(),
+      fullPoolSum: 0,
+    };
   }
   const neurons = cloneNeurons(_neurons);
+  const rewardParams = getRewardParams(otherParams, sns);
+  const dayPoolRewards = computeDayPoolRewards(
+    otherParams,
+    days,
+    sns,
+    forceInitialDate
+  );
+  const fullPoolSum = dayPoolRewards.reduce((acc, p) => acc + p, 0);
 
   if (maximiseParams) {
     neurons.forEach((neuron) =>
-      maximiseNeuronParams(
-        neuron,
-        getRewardParams(otherParams, sns).maxDissolve,
-        forceInitialDate
-      )
+      maximiseNeuronParams(neuron, rewardParams.maxDissolve, forceInitialDate)
     );
   }
 
   let neuronsTotalRewardUSD = 0;
   const singleNeuronRewardsUSD = new Map<string, number>();
+  const eligiblePoolSums = new Map<string, number>();
   for (let i = 0; i < days; i++) {
+    const dayPoolReward = dayPoolRewards[i];
+    const referenceDate = getDate(i, forceInitialDate);
     const projectDayRewardUSD = neurons.reduce((acc, neuron) => {
       let neuronVotingPower = 0n;
+      const neuronId = getNeuronId(neuron);
 
       if (
         isNeuronEligibleToVote(
           neuron,
-          getRewardParams(otherParams, sns).minStake,
-          getRewardParams(otherParams, sns).minDissolve,
-          getDate(i, forceInitialDate)
+          rewardParams.minStake,
+          rewardParams.minDissolve,
+          referenceDate
         )
       ) {
-        const referenceDate = getDate(i, forceInitialDate);
+        eligiblePoolSums.set(
+          neuronId,
+          (eligiblePoolSums.get(neuronId) ?? 0) + dayPoolReward
+        );
+
         const baseStake = getNeuronTotalStakeAfterFeesE8s(neuron);
         const eightYearGangExtra = !sns
           ? getEightYearGangBonusE8s(neuron as NeuronInfo, referenceDate)
@@ -626,9 +709,8 @@ const getNeuronsRewardEstimationUSD = (params: {
         const tokenReward = getTokenReward(
           otherParams,
           neuronVotingPower,
-          i,
-          sns,
-          forceInitialDate
+          dayPoolReward,
+          sns
         );
 
         const rewardUSD =
@@ -638,7 +720,6 @@ const getNeuronsRewardEstimationUSD = (params: {
             sns ? sns.canister_ids.ledger_canister_id : LEDGER_CANISTER_ID
           );
 
-        const neuronId = getNeuronId(neuron);
         const prev = singleNeuronRewardsUSD.get(neuronId) ?? 0;
         singleNeuronRewardsUSD.set(neuronId, prev + rewardUSD);
 
@@ -655,7 +736,12 @@ const getNeuronsRewardEstimationUSD = (params: {
     neuronsTotalRewardUSD += projectDayRewardUSD;
   }
 
-  return { total: neuronsTotalRewardUSD, neurons: singleNeuronRewardsUSD };
+  return {
+    total: neuronsTotalRewardUSD,
+    neurons: singleNeuronRewardsUSD,
+    eligiblePoolSums,
+    fullPoolSum,
+  };
 };
 
 const getFXRate = (
@@ -732,9 +818,8 @@ const getPoolReward = (params: {
 const getTokenReward = (
   params: StakingRewardCalcParams,
   neuronVotingPower: bigint,
-  addDays: number,
-  sns?: CachedSnsDto,
-  forceInitialDate?: Date
+  poolReward: number,
+  sns?: CachedSnsDto
 ) => {
   const totalVotingPower = sns
     ? BigInt(
@@ -756,20 +841,9 @@ const getTokenReward = (
     20
   );
 
-  const rewardParams = getRewardParams(params, sns);
-  const poolReward = getPoolReward({
-    genesisTimestampSeconds: getGenesisTimestampSeconds(sns),
-    referenceDate: getDate(addDays, forceInitialDate),
-    transitionDurationSeconds: rewardParams.rewardTransition,
-    initialRewardRate: rewardParams.initialReward,
-    finalRewardRate: rewardParams.finalReward,
-    totalSupply: rewardParams.totalSupply,
-    poolReductionFactor: rewardParams.poolReductionFactor,
-  });
-
   if (poolReward === 0) {
     logWithTimestamp(
-      `Staking rewards: pool reward is 0 for ${sns ? sns.canister_ids.root_canister_id : OWN_CANISTER_ID_TEXT} in ${addDays} days.`
+      `Staking rewards: pool reward is 0 for ${sns ? sns.canister_ids.root_canister_id : OWN_CANISTER_ID_TEXT}.`
     );
   }
 

--- a/frontend/src/lib/utils/staking-rewards.utils.ts
+++ b/frontend/src/lib/utils/staking-rewards.utils.ts
@@ -620,6 +620,7 @@ const computeDayPoolRewards = (
 ): number[] => {
   const genesis = getGenesisTimestampSeconds(sns);
   const result: number[] = new Array(days);
+  let hasZero = false;
   for (let i = 0; i < days; i++) {
     const poolReward = getPoolReward({
       genesisTimestampSeconds: genesis,
@@ -630,12 +631,13 @@ const computeDayPoolRewards = (
       totalSupply: rewardParams.totalSupply,
       poolReductionFactor: rewardParams.poolReductionFactor,
     });
-    if (poolReward === 0) {
-      logWithTimestamp(
-        `Staking rewards: pool reward is 0 for ${sns ? sns.canister_ids.root_canister_id : OWN_CANISTER_ID_TEXT} on day ${i}.`
-      );
-    }
+    if (poolReward === 0) hasZero = true;
     result[i] = poolReward;
+  }
+  if (hasZero) {
+    logWithTimestamp(
+      `Staking rewards: pool reward is 0 for ${sns ? sns.canister_ids.root_canister_id : OWN_CANISTER_ID_TEXT} on one or more simulated days.`
+    );
   }
   return result;
 };

--- a/frontend/src/lib/utils/staking-rewards.utils.ts
+++ b/frontend/src/lib/utils/staking-rewards.utils.ts
@@ -434,12 +434,12 @@ const getAPYs = (params: StakingRewardCalcParams, forceInitialDate?: Date) => {
           params,
           snsNeurons[rootPrincipal]?.neurons ?? [],
           ledgerPrincipal,
-          (params, days, maximiseNeuronParams, forceInitialDate, dayPool) =>
+          (params, days, maximiseParams, forceInitialDate, dayPool) =>
             getSnsRewardEstimationUSD(
               params,
               days,
               sns,
-              maximiseNeuronParams,
+              maximiseParams,
               forceInitialDate,
               dayPool
             ),

--- a/frontend/src/lib/utils/staking-rewards.utils.ts
+++ b/frontend/src/lib/utils/staking-rewards.utils.ts
@@ -360,7 +360,8 @@ const getNnsRewardEstimationUSD = (
   params: StakingRewardCalcParams,
   days: number,
   maximiseParams: boolean = false,
-  forceInitialDate?: Date
+  forceInitialDate?: Date,
+  dayPoolRewards?: number[]
 ): ReturnType<typeof getNeuronsRewardEstimationUSD> => {
   return getNeuronsRewardEstimationUSD({
     neurons: params.nnsNeurons.neurons ?? [],
@@ -368,6 +369,7 @@ const getNnsRewardEstimationUSD = (
     days,
     otherParams: params,
     forceInitialDate,
+    dayPoolRewards,
   });
 };
 
@@ -376,7 +378,8 @@ const getSnsRewardEstimationUSD = (
   days: number,
   sns: CachedSnsDto,
   maximiseParams: boolean = false,
-  forceInitialDate?: Date
+  forceInitialDate?: Date,
+  dayPoolRewards?: number[]
 ): ReturnType<typeof getNeuronsRewardEstimationUSD> => {
   return getNeuronsRewardEstimationUSD({
     neurons:
@@ -386,6 +389,7 @@ const getSnsRewardEstimationUSD = (
     otherParams: params,
     sns,
     forceInitialDate,
+    dayPoolRewards,
   });
 };
 
@@ -430,13 +434,14 @@ const getAPYs = (params: StakingRewardCalcParams, forceInitialDate?: Date) => {
           params,
           snsNeurons[rootPrincipal]?.neurons ?? [],
           ledgerPrincipal,
-          (params, days, maximiseNeuronParams, forceInitialDate) =>
+          (params, days, maximiseNeuronParams, forceInitialDate, dayPool) =>
             getSnsRewardEstimationUSD(
               params,
               days,
               sns,
               maximiseNeuronParams,
-              forceInitialDate
+              forceInitialDate,
+              dayPool
             ),
           forceInitialDate
         )
@@ -460,6 +465,11 @@ const getAPYs = (params: StakingRewardCalcParams, forceInitialDate?: Date) => {
 
   return apy;
 };
+
+// Length of the forward simulation. Integer days because the simulation
+// iterates day-by-day; not interchangeable with DAYS_IN_AVG_YEAR (365.25),
+// which is the calendar-year length used elsewhere for annual-rate conversions.
+const SIMULATED_DAYS = 365;
 
 // Per-neuron APY: (rewards during eligibility / stake) scaled by
 // (fullPoolSum / eligiblePoolSum). For a neuron eligible all year the scaling
@@ -485,24 +495,30 @@ const getAPY = (
     params: StakingRewardCalcParams,
     days: number,
     maximiseParams?: boolean,
-    forceInitialDate?: Date
-  ) => {
-    total: number;
-    neurons: Map<string, number>;
-    eligiblePoolSums: Map<string, number>;
-    fullPoolSum: number;
-  },
+    forceInitialDate?: Date,
+    dayPoolRewards?: number[]
+  ) => ReturnType<typeof getNeuronsRewardEstimationUSD>,
   forceInitialDate?: Date
 ) => {
   const {
     neurons: yearEstimatedRewardNeuronsUSD,
     eligiblePoolSums: yearEstimatedEligiblePoolSums,
     fullPoolSum: yearFullPoolSum,
-  } = rewardEstimationFunction(params, 365, false, forceInitialDate);
+    dayPoolRewards: yearDayPoolRewards,
+  } = rewardEstimationFunction(params, SIMULATED_DAYS, false, forceInitialDate);
+  // The day-by-day pool reward depends only on the date window and reward
+  // params (not on neuron state or maximise flags), so reuse the array from
+  // the cur pass instead of recomputing it for the max pass.
   const {
     neurons: yearEstimatedMaxRewardNeuronsUSD,
     eligiblePoolSums: yearEstimatedMaxEligiblePoolSums,
-  } = rewardEstimationFunction(params, 365, true, forceInitialDate);
+  } = rewardEstimationFunction(
+    params,
+    SIMULATED_DAYS,
+    true,
+    forceInitialDate,
+    yearDayPoolRewards
+  );
 
   let totalUSD = 0;
   let totalMaxUSD = 0;
@@ -597,16 +613,15 @@ const isDataReady = (params: StakingRewardCalcParams) => {
 // it can be reused for the cur/max simulation passes and avoids recomputing
 // inside getTokenReward for every neuron-day.
 const computeDayPoolRewards = (
-  params: StakingRewardCalcParams,
+  rewardParams: ReturnType<typeof getRewardParams>,
   days: number,
   sns?: CachedSnsDto,
   forceInitialDate?: Date
 ): number[] => {
-  const rewardParams = getRewardParams(params, sns);
   const genesis = getGenesisTimestampSeconds(sns);
   const result: number[] = new Array(days);
   for (let i = 0; i < days; i++) {
-    result[i] = getPoolReward({
+    const poolReward = getPoolReward({
       genesisTimestampSeconds: genesis,
       referenceDate: getDate(i, forceInitialDate),
       transitionDurationSeconds: rewardParams.rewardTransition,
@@ -615,6 +630,12 @@ const computeDayPoolRewards = (
       totalSupply: rewardParams.totalSupply,
       poolReductionFactor: rewardParams.poolReductionFactor,
     });
+    if (poolReward === 0) {
+      logWithTimestamp(
+        `Staking rewards: pool reward is 0 for ${sns ? sns.canister_ids.root_canister_id : OWN_CANISTER_ID_TEXT} on day ${i}.`
+      );
+    }
+    result[i] = poolReward;
   }
   return result;
 };
@@ -626,6 +647,10 @@ const getNeuronsRewardEstimationUSD = (params: {
   sns?: CachedSnsDto;
   forceInitialDate?: Date;
   otherParams: StakingRewardCalcParams;
+  // Optional precomputed pool rewards. Callers running the simulation twice
+  // (e.g. getAPY's cur+max passes) can compute it once and thread it through
+  // to avoid the redundant per-day pool calculation.
+  dayPoolRewards?: number[];
 }): {
   total: number;
   neurons: Map<string, number>;
@@ -636,6 +661,7 @@ const getNeuronsRewardEstimationUSD = (params: {
   // doesn't appear to out-earn the equivalent locked neuron.
   eligiblePoolSums: Map<string, number>;
   fullPoolSum: number;
+  dayPoolRewards: number[];
 } => {
   const {
     neurons: _neurons,
@@ -644,25 +670,25 @@ const getNeuronsRewardEstimationUSD = (params: {
     sns,
     forceInitialDate,
     otherParams,
+    dayPoolRewards: precomputedDayPoolRewards,
   } = params;
+
+  const rewardParams = getRewardParams(otherParams, sns);
+  const dayPoolRewards =
+    precomputedDayPoolRewards ??
+    computeDayPoolRewards(rewardParams, days, sns, forceInitialDate);
+  const fullPoolSum = dayPoolRewards.reduce((acc, p) => acc + p, 0);
 
   if (!_neurons || _neurons.length === 0) {
     return {
       total: 0,
       neurons: new Map(),
       eligiblePoolSums: new Map(),
-      fullPoolSum: 0,
+      fullPoolSum,
+      dayPoolRewards,
     };
   }
   const neurons = cloneNeurons(_neurons);
-  const rewardParams = getRewardParams(otherParams, sns);
-  const dayPoolRewards = computeDayPoolRewards(
-    otherParams,
-    days,
-    sns,
-    forceInitialDate
-  );
-  const fullPoolSum = dayPoolRewards.reduce((acc, p) => acc + p, 0);
 
   if (maximiseParams) {
     neurons.forEach((neuron) =>
@@ -741,6 +767,7 @@ const getNeuronsRewardEstimationUSD = (params: {
     neurons: singleNeuronRewardsUSD,
     eligiblePoolSums,
     fullPoolSum,
+    dayPoolRewards,
   };
 };
 
@@ -840,12 +867,6 @@ const getTokenReward = (
     totalVotingPower!,
     20
   );
-
-  if (poolReward === 0) {
-    logWithTimestamp(
-      `Staking rewards: pool reward is 0 for ${sns ? sns.canister_ids.root_canister_id : OWN_CANISTER_ID_TEXT}.`
-    );
-  }
 
   return (
     Math.trunc(poolReward * E8S_RATE * neuronRewardRatioForTheDay) / E8S_RATE

--- a/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
@@ -1232,6 +1232,50 @@ describe("neuron-utils", () => {
       true
     );
 
+    // Mixed-eligibility portfolio: one dissolving neuron (partial-year
+    // eligibility) alongside two locked neurons. Verifies the bank-style
+    // aggregation — the project total APY is the stake-weighted average of
+    // the per-neuron annualized APYs, not the simulated reward over the
+    // full year divided by stake. Also guards against the old behavior where
+    // the dissolving neuron's APY would be dragged toward 0 by the
+    // post-eligibility tail of the 365-day window.
+    params.nnsNeurons.neurons.forEach((n) => {
+      n.state = NeuronState.Locked;
+      n.fullNeuron.autoStakeMaturity = false;
+      n.fullNeuron.cachedNeuronStake = BigInt(50 * E8S_RATE);
+      n.fullNeuron.dissolveState = {
+        DissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
+      };
+    });
+    // Neuron 0: dissolving 6 months → annualized over partial-year eligibility.
+    params.nnsNeurons.neurons[0].state = NeuronState.Dissolving;
+    params.nnsNeurons.neurons[0].fullNeuron.dissolveState = {
+      WhenDissolvedTimestampSeconds:
+        BigInt(referenceDateSeconds) + BigInt(SECONDS_IN_HALF_YEAR),
+    };
+
+    const mixedApy = getRewardData(params).apy.get(OWN_CANISTER_ID_TEXT);
+    const apyDissolving = mixedApy.neurons.get(
+      getNeuronId(getNeuron(0) as AgnosticNeuron)
+    ).cur;
+    const apyLocked1 = mixedApy.neurons.get(
+      getNeuronId(getNeuron(1) as AgnosticNeuron)
+    ).cur;
+    const apyLocked2 = mixedApy.neurons.get(
+      getNeuronId(getNeuron(2) as AgnosticNeuron)
+    ).cur;
+
+    // Annualized — not dragged toward 0 by the post-eligibility tail.
+    expect(apyDissolving).toBeGreaterThan(0.01);
+    // Locked >= dissolving holds.
+    expect(apyLocked1).toBeGreaterThan(apyDissolving);
+    expect(apyLocked2).toBeGreaterThan(apyDissolving);
+    // Project total = stake-weighted average of per-neuron APYs (equal stakes).
+    const expectedTotal = (apyDissolving + apyLocked1 + apyLocked2) / 3;
+    expect(roundToDecimals(mixedApy.cur * 100, 4)).toBe(
+      roundToDecimals(expectedTotal * 100, 4)
+    );
+
     // Let's remove some vital data, the APY should be 0 and we should see an error
     old = params.nnsTotalVotingPower;
     params.nnsTotalVotingPower = 0n;

--- a/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking-rewards.utils.spec.ts
@@ -889,12 +889,12 @@ describe("neuron-utils", () => {
       WhenDissolvedTimestampSeconds:
         BigInt(referenceDateSeconds) + BigInt(0.5 * SECONDS_IN_YEAR),
     };
-    expect(checkApy(OWN_CANISTER_ID_TEXT, false, 1.08)).toBe(true);
+    expect(checkApy(OWN_CANISTER_ID_TEXT, false, 2.29)).toBe(true);
     expect(checkApy(OWN_CANISTER_ID_TEXT, true, 6.99)).toBe(true);
 
     // The neuron APY should be the same as the NNS total APY since there is only one neuron
     expect(
-      checkNeuronApy(OWN_CANISTER_ID_TEXT, getNeuron(0), false, 1.08)
+      checkNeuronApy(OWN_CANISTER_ID_TEXT, getNeuron(0), false, 2.29)
     ).toBe(true);
     expect(checkNeuronApy(OWN_CANISTER_ID_TEXT, getNeuron(0), true, 6.99)).toBe(
       true
@@ -1056,7 +1056,7 @@ describe("neuron-utils", () => {
       WhenDissolvedTimestampSeconds:
         BigInt(referenceDateSeconds) + BigInt(1 * SECONDS_IN_YEAR),
     };
-    expect(checkApy(OWN_CANISTER_ID_TEXT, false, 2.51)).toBe(true);
+    expect(checkApy(OWN_CANISTER_ID_TEXT, false, 2.6)).toBe(true);
     expect(checkApy(OWN_CANISTER_ID_TEXT, true, 6.99)).toBe(true);
 
     // Dissolving neuron with 1 month dissolve delay (above 2-week minimum)
@@ -1064,7 +1064,7 @@ describe("neuron-utils", () => {
       WhenDissolvedTimestampSeconds:
         BigInt(referenceDateSeconds) + BigInt(1 * SECONDS_IN_MONTH),
     };
-    expect(checkApy(OWN_CANISTER_ID_TEXT, false, 0.11)).toBe(true);
+    expect(checkApy(OWN_CANISTER_ID_TEXT, false, 2.19)).toBe(true);
     expect(checkApy(OWN_CANISTER_ID_TEXT, true, 6.99)).toBe(true);
 
     // Staked maturity should not affect the APY (more stake, more rewards, same APY ratio)
@@ -1295,11 +1295,11 @@ describe("neuron-utils", () => {
           BigInt(referenceDateSeconds) + BigInt(SECONDS_IN_YEAR),
       },
     ];
-    expect(checkApy(TEST_SNS_IDS[0], false, 2.05)).toBe(true);
+    expect(checkApy(TEST_SNS_IDS[0], false, 4.1)).toBe(true);
     expect(checkApy(TEST_SNS_IDS[0], true, 7.3)).toBe(true);
 
     // The neuron APY should be the same as the Project total APY since there is only one neuron
-    expect(checkNeuronApy(TEST_SNS_IDS[0], getNeuron(0), false, 2.05)).toBe(
+    expect(checkNeuronApy(TEST_SNS_IDS[0], getNeuron(0), false, 4.1)).toBe(
       true
     );
     expect(checkNeuronApy(TEST_SNS_IDS[0], getNeuron(0), true, 7.3)).toBe(true);
@@ -1473,7 +1473,7 @@ describe("neuron-utils", () => {
           BigInt(referenceDateSeconds) + BigInt(1 * SECONDS_IN_YEAR),
       },
     ];
-    expect(checkApy(TEST_SNS_IDS[0], false, 2.08)).toBe(true);
+    expect(checkApy(TEST_SNS_IDS[0], false, 4.14)).toBe(true);
     expect(checkApy(TEST_SNS_IDS[0], true, 7.3)).toBe(true);
 
     // Dissolving neuron with 1 month dissolve delay


### PR DESCRIPTION
# Motivation

Per-neuron APY was computed as `sum(daily_reward) / stake` over a fixed 365-day forward simulation. Once a dissolving neuron's dissolve delay fell below the voting eligibility threshold, the remaining days of the simulation earned 0 and dragged the displayed APY toward 0 — even though the user would presumably redeploy those funds rather than leave them idle. A 6-month dissolving neuron displayed an APY of under 1% while it was actively earning at >2% during the dissolution window.

Mirrors [dfinity/governance-app#386](https://github.com/dfinity/governance-app/pull/386). Applies equally to NNS and SNS neurons since they share the same `getNeuronsRewardEstimationUSD` code path.

# Changes

- Per-neuron APY is now `(reward / stake) * (fullPoolSum / eligiblePoolSum)`. For a locked neuron eligible all year the correction factor collapses to 1 and the value matches the original definition; for a dissolving neuron eligible only at the start of the simulated window, the correction discounts those high-pool early days so locked >= dissolving at every dissolve-delay preset (without it, pool decay over the simulated year would let short-eligibility dissolving neurons appear to out-earn the equivalent locked neuron).
- Added a `computeDayPoolRewards` helper invoked once per simulation, and threaded the per-day value into `getTokenReward` so pool reward is computed once per simulated day rather than once per neuron-day.
- Updated `staking-rewards.utils.spec.ts` expectations for the dissolving scenarios that move under the new methodology. Locked-neuron expectations are unchanged.

# How dissolving APYs change in the spec

| Scenario | Before | After |
| --- | --- | --- |
| NNS dissolving 6mo (autoStake off) | 1.08% | 2.29% |
| NNS dissolving 1y | 2.51% | 2.60% |
| NNS dissolving 1mo | 0.11% | 2.19% |
| SNS dissolving 1y (autoStake off) | 2.05% | 4.10% |
| SNS dissolving 1y (autoStake on) | 2.08% | 4.14% |

All locked APY values are unchanged. Locked >= Dissolving holds at every preset.