### PR TITLE
chore(deps): bump svelte and transitive dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2055,7 +2055,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
       "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3066,9 +3066,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -3396,12 +3396,20 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
-      "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.8.tgz",
+      "integrity": "sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -5314,9 +5322,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.53.5",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.5.tgz",
-      "integrity": "sha512-YkqERnF05g8KLdDZwZrF8/i1eSbj6Eoat8Jjr2IfruZz9StLuBqo8sfCSzjosNKd+ZrQ8DkKZDjpO5y3ht1Pow==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -5328,9 +5336,9 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.4",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",


### PR DESCRIPTION
# Motivation

```
# npm audit report

devalue  5.6.3 - 5.8.0
Severity: high
Svelte devalue: DoS via sparse array deserialization - https://github.com/advisories/GHSA-77vg-94rm-hx3p
fix available via `npm audit fix`
node_modules/devalue

svelte  <=5.55.6
Severity: moderate
Svelte SSR vulnerable to cross-site scripting via spread attributes - https://github.com/advisories/GHSA-pr6f-5x2q-rwfp
Svelte: SSR XSS via Insecure Promise Serialization in hydratable - https://github.com/advisories/GHSA-f3cj-j4f6-wq85
Svelte Vulnerable to XSS via DOM Clobbering of Internal Framework State - https://github.com/advisories/GHSA-rcqx-6q8c-2c42
Svelte: ReDoS in `<svelte:element>` Tag Validation - https://github.com/advisories/GHSA-9rmh-mm8f-r9h6
fix available via `npm audit fix`
node_modules/svelte

2 vulnerabilities (1 moderate, 1 high)

To address all issues, run:
  npm audit fix
```

# Changes

- Ran `npm audit fix` and updated the lock file with the bumps.

# Tests

- CI should be green.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
