### PR TITLE
refactor(housekeeping): remove proxy folder

### DIFF
--- a/proxy/.npmrc
+++ b/proxy/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
# Motivation

There is a legacy proxy folder that has not been used in a long time.

# Changes

- Removed folder and `.npmrc`.

# Tests

- Not necessary.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
