### PR TITLE
chore(build): migrate Node version management to Volta

### DIFF
--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/checkout@v6
     - name: Get node version
       shell: bash
-      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
+      run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}

--- a/.github/actions/vitest/action.yml
+++ b/.github/actions/vitest/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: actions/checkout@v6
     - name: Get node version
       shell: bash
-      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
+      run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get cargo sort version
         run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' config.json >> $GITHUB_ENV
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -212,7 +212,7 @@ jobs:
       - name: Install sponge
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -24,7 +24,7 @@ jobs:
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Update the SNS aggregator response files
         run: scripts/nns-dapp/replace-sns-aggregator-response.sh
       - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' config.json >> $GITHUB_ENV
+        run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ out
 .history
 .svn/
 .gradle/
-.nvmrc
 
 # IntelliJ related
 *.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,9 @@ SHELL ["bash", "-c"]
 RUN mkdir -p config
 COPY dfx.json dfx.json
 COPY config.json config.json
+COPY frontend/package.json frontend/package.json
 RUN jq -r .dfx dfx.json > config/dfx_version
-RUN jq -r '.defaults.build.config.NODE_VERSION' config.json > config/node_version
+RUN jq -r '.volta.node' frontend/package.json > config/node_version
 RUN jq -r '.defaults.build.config.DIDC_RELEASE' config.json > config/didc_version
 RUN jq -r '.defaults.build.config.OPTIMIZER_VERSION' config.json > config/optimizer_version
 RUN jq -r '.defaults.build.config.IC_WASM_VERSION' config.json > config/ic_wasm_version

--- a/config.json
+++ b/config.json
@@ -107,7 +107,6 @@
     },
     "build": {
       "config": {
-        "NODE_VERSION": "25.8.0",
         "IC_WASM_VERSION": "0.6.0",
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,7 +12,7 @@ All the Internet computer interactions are done through ic-js or the official [a
 
 ### Prerequisites
 
-We use [Volta](https://volta.sh/) to pin the Node.js and npm versions for this project. Volta reads the `volta` field in [`package.json`](./package.json) and automatically switches Node and npm when you `cd` into the `frontend/` directory.
+We use [Volta](https://volta.sh/) to pin the Node.js version for this project (npm follows whatever ships bundled with Node). Volta reads the `volta` field in [`package.json`](./package.json) and automatically switches Node when you `cd` into the `frontend/` directory.
 
 One-time install:
 
@@ -20,9 +20,9 @@ One-time install:
 curl https://get.volta.sh | bash
 ```
 
-Open a new terminal (or `source` your shell profile) so Volta's shims are on `PATH`. Then, from inside `frontend/`, run `node --version` and `npm --version` to confirm the pinned versions are active.
+Open a new terminal (or `source` your shell profile) so Volta's shims are on `PATH`. Then, from inside `frontend/`, run `node --version` to confirm the pinned version is active.
 
-If you prefer not to use Volta, install the Node and npm versions listed in the `volta` block of `frontend/package.json` manually.
+If you prefer not to use Volta, install the Node version listed in the `volta` block of `frontend/package.json` manually.
 
 Clone the project on your computer and install the libraries:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,14 +10,19 @@ All the Internet computer interactions are done through ic-js or the official [a
 
 ## Installation and local development
 
-Set the node version defined in [config.json](https://github.com/dfinity/nns-dapp/blob/main/config.json#L103).
+### Prerequisites
 
-If you use [nvm](https://github.com/nvm-sh/nvm), you can run the following commands to set up the correct Node.js version:
+We use [Volta](https://volta.sh/) to pin the Node.js and npm versions for this project. Volta reads the `volta` field in [`package.json`](./package.json) and automatically switches Node and npm when you `cd` into the repo.
+
+One-time install:
 
 ```bash
-npm run sync-node-version  # Creates .nvmrc with the required version
-nvm use                    # Switches to the specified version
+curl https://get.volta.sh | bash
 ```
+
+After installing, run `node --version` and `npm --version` from inside the repo to confirm the pinned versions are active.
+
+If you prefer not to use Volta, install the Node and npm versions listed in the `volta` block of `frontend/package.json` manually (e.g. via `nvm install <version>`).
 
 Clone the project on your computer and install the libraries:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,7 +12,7 @@ All the Internet computer interactions are done through ic-js or the official [a
 
 ### Prerequisites
 
-We use [Volta](https://volta.sh/) to pin the Node.js and npm versions for this project. Volta reads the `volta` field in [`package.json`](./package.json) and automatically switches Node and npm when you `cd` into the repo.
+We use [Volta](https://volta.sh/) to pin the Node.js and npm versions for this project. Volta reads the `volta` field in [`package.json`](./package.json) and automatically switches Node and npm when you `cd` into the `frontend/` directory.
 
 One-time install:
 
@@ -20,9 +20,9 @@ One-time install:
 curl https://get.volta.sh | bash
 ```
 
-After installing, run `node --version` and `npm --version` from inside the repo to confirm the pinned versions are active.
+Open a new terminal (or `source` your shell profile) so Volta's shims are on `PATH`. Then, from inside `frontend/`, run `node --version` and `npm --version` to confirm the pinned versions are active.
 
-If you prefer not to use Volta, install the Node and npm versions listed in the `volta` block of `frontend/package.json` manually (e.g. via `nvm install <version>`).
+If you prefer not to use Volta, install the Node and npm versions listed in the `volta` block of `frontend/package.json` manually.
 
 Clone the project on your computer and install the libraries:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,12 +24,15 @@
     "test-e2e": "tsc --noEmit -p src/tests/e2e/tsconfig.json && playwright test",
     "update:agent": "npm rm @icp-sdk/core @icp-sdk/auth @icp-sdk/canisters @dfinity/utils && npm i @icp-sdk/core @icp-sdk/auth @icp-sdk/canisters@next @dfinity/utils@next && ../scripts/revert-next.sh",
     "update:gix": "npm update @dfinity/gix-components",
-    "upgrade:next": "npm rm @icp-sdk/canisters @dfinity/utils && npm i @icp-sdk/canisters@next @dfinity/utils@next && ../scripts/revert-next.sh",
-    "sync-node-version": "./scripts/sync-node-version"
+    "upgrade:next": "npm rm @icp-sdk/canisters @dfinity/utils && npm i @icp-sdk/canisters@next @dfinity/utils@next && ../scripts/revert-next.sh"
   },
   "engines": {
     "npm": ">=11.11.0 <12.0.0",
     "node": ">=25.0.0 <26.0.0"
+  },
+  "volta": {
+    "node": "25.8.0",
+    "npm": "11.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,8 +31,7 @@
     "node": ">=25.0.0 <26.0.0"
   },
   "volta": {
-    "node": "25.8.0",
-    "npm": "11.13.0"
+    "node": "25.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/frontend/scripts/sync-node-version
+++ b/frontend/scripts/sync-node-version
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-ROOT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../.."
-
-NODE_VERSION=$(jq -r '.defaults.build.config.NODE_VERSION' "$ROOT_DIR"/config.json)
-echo "v$NODE_VERSION" >"$ROOT_DIR"/frontend/.nvmrc


### PR DESCRIPTION
# Motivation

The Node version was duplicated between `config.json` and a generated `.nvmrc`, and required running `npm run sync-node-version && nvm use` to pick up the right version locally. Aligns with the sister `governance-app` repo (dfinity/governance-app#390) and gives us a single source of truth that auto-switches Node and npm on `cd`.

# Changes

- Added a `volta` block to `frontend/package.json` pinning Node `25.8.0` and npm `11.13.0` as the single source of truth.
- Updated `Dockerfile` and the 5 CI workflows/actions to read the Node version from `frontend/package.json`'s `.volta.node` instead of `config.json`.
- Removed `NODE_VERSION` from `config.json`, deleted `frontend/scripts/sync-node-version`, and dropped the `.nvmrc` entry from `.gitignore`.
- Rewrote the prerequisites section of `frontend/README.md` to recommend Volta, with a fallback note for manual installs.