### PR TITLE
Add AGENTS.md with Cloud agent development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# NNS Dapp
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is the NNS Dapp (Network Nervous System Decentralized Application) for the Internet Computer. The primary development target is the **frontend** SvelteKit application in `frontend/`.
+
+### Node.js version
+
+The project requires **Node.js 25.x** (pinned to 25.8.0 via Volta). The update script installs this via nvm. Verify with `node --version` in `frontend/`.
+
+### Frontend development commands
+
+All commands run from `frontend/`:
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm ci` |
+| Dev server | `npm run dev` (serves on http://localhost:5173) |
+| Lint | `npm run lint` (prettier + eslint) |
+| Type + lint check | `npm run check` (svelte-check + lint) |
+| Unit tests | `npm run test` (tsc + vitest, ~670 test files) |
+| Build | `npm run build` |
+
+### `.env` file requirement
+
+The dev server requires a `frontend/.env` file with `VITE_*` variables (canister IDs, host, feature flags). Without it the server returns HTTP 500. The `.env` is gitignored.
+
+To generate it with a running local replica: `DFX_NETWORK=local ./config.sh` from repo root.
+
+For frontend-only development (no local IC replica), create `frontend/.env` with placeholder canister IDs. See `frontend/src/tests/lib/utils/env-vars.utils.spec.ts` for valid example values.
+
+### Running without a local IC replica
+
+The frontend dev server will start and render all pages, but:
+- Authentication (Internet Identity) will not work
+- Canister calls will fail with network errors
+- The SNS aggregator JSON fetch will return HTML errors (benign)
+
+This is sufficient for UI development, component testing, and running the full vitest suite.
+
+### Full local environment (optional)
+
+For end-to-end testing with canisters, follow `HACKING.md`: install dfx, create a snapshot via [snsdemo](https://github.com/dfinity/snsdemo/), start the replica with `scripts/dfx-snapshot-start`, then generate `.env` with `config.sh`.
+
+### Test suite notes
+
+- Unit tests (`npm run test`) run entirely in jsdom/node - no network or replica needed.
+- Tests take ~5-6 minutes to complete (~5900 tests across ~670 files).
+- E2E tests (Playwright) are in `frontend/src/tests/e2e/` and require a running replica.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ The project requires **Node.js 25.x** (pinned to 25.8.0 via Volta). The update s
 
 All commands run from `frontend/`:
 
-| Task | Command |
-|------|---------|
-| Install deps | `npm ci` |
-| Dev server | `npm run dev` (serves on http://localhost:5173) |
-| Lint | `npm run lint` (prettier + eslint) |
-| Type + lint check | `npm run check` (svelte-check + lint) |
-| Unit tests | `npm run test` (tsc + vitest, ~670 test files) |
-| Build | `npm run build` |
+| Task              | Command                                         |
+| ----------------- | ----------------------------------------------- |
+| Install deps      | `npm ci`                                        |
+| Dev server        | `npm run dev` (serves on http://localhost:5173) |
+| Lint              | `npm run lint` (prettier + eslint)              |
+| Type + lint check | `npm run check` (svelte-check + lint)           |
+| Unit tests        | `npm run test` (tsc + vitest, ~670 test files)  |
+| Build             | `npm run build`                                 |
 
 ### `.env` file requirement
 
@@ -34,6 +34,7 @@ For frontend-only development (no local IC replica), create `frontend/.env` with
 ### Running without a local IC replica
 
 The frontend dev server will start and render all pages, but:
+
 - Authentication (Internet Identity) will not work
 - Canister calls will fail with network errors
 - The SNS aggregator JSON fetch will return HTML errors (benign)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working on this codebase.

## What's included

- Node.js version requirements (25.x via nvm)
- Frontend development commands table (dev, lint, test, build)
- `.env` file requirement and how to generate it
- Notes on running without a local IC replica
- Full local environment setup reference (pointing to HACKING.md)
- Test suite timing and configuration notes

## Demo

[nns_dapp_navigation_demo.mp4](https://cursor.com/agents/bc-b76e8f69-1687-4318-ab7c-0dc60e15b7aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnns_dapp_navigation_demo.mp4)

Frontend dev server running at localhost:5173, showing navigation through Portfolio, Tokens, Neuron Staking, Voting, and Launchpad pages.

[NNS Dapp Portfolio page](https://cursor.com/agents/bc-b76e8f69-1687-4318-ab7c-0dc60e15b7aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnns_dapp_portfolio.webp)
[NNS Dapp Tokens page](https://cursor.com/agents/bc-b76e8f69-1687-4318-ab7c-0dc60e15b7aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnns_dapp_tokens.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b76e8f69-1687-4318-ab7c-0dc60e15b7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b76e8f69-1687-4318-ab7c-0dc60e15b7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

