### PR TITLE
chore(rs): bump tar to 0.4.46 to address security advisories

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Bump `tar` to 0.4.46 to address RUSTSEC-2026-0067 and RUSTSEC-2026-0068.
+
 #### Not Published
 
 ### Operations

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,8 +24,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
-- Bump `tar` to 0.4.46 to address RUSTSEC-2026-0067 and RUSTSEC-2026-0068.
-
 #### Not Published
 
 ### Operations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5835,9 +5835,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -19,7 +19,7 @@ serde_cbor = "0.11.2"
 sha2 = "0.10.8"
 strum = "0.27.1"
 strum_macros = "0.27.1"
-tar = "0.4.40"
+tar = "0.4.46"
 
 cycles-minting-canister = { workspace = true }
 dfn_candid = { workspace = true }


### PR DESCRIPTION
# Motivation

`cargo audit` flags two medium-severity advisories on `tar` 0.4.44 (RUSTSEC-2026-0067 and RUSTSEC-2026-0068). Both are fixed in 0.4.45+, so bumping our pin to 0.4.46 clears them.

# Changes

- Bumped `tar` from 0.4.40 to 0.4.46 in `rs/backend/Cargo.toml`.
- Updated `Cargo.lock` accordingly.