### PR TITLE
chore(sns_aggregator): rebaseline candid bindings to didc 0.5.4

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,6 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
 //! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
+#![allow(clippy::pedantic)]
 #![allow(deprecated)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -76,6 +76,7 @@ pub struct NervousSystemFunction {
 pub struct Subaccount {
     pub subaccount: serde_bytes::ByteBuf,
 }
+/// ! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/governance/canister/governance.did>
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Account {
     pub owner: Option<Principal>,
@@ -83,17 +84,24 @@ pub struct Account {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TreasuryMetrics {
+    /// A human-readable identified for this treasury, e.g., "ICP".
     pub name: Option<String>,
+    /// The amount of tokens in this treasury at the end of swap finalization.
     pub original_amount_e8s: Option<u64>,
+    /// The regularly updated amount of tokens in this treasury.
     pub amount_e8s: Option<u64>,
     pub account: Option<Account>,
+    /// The source of truth for the treasury balance is this ledger canister / account.
     pub ledger_canister_id: Option<Principal>,
+    /// Same as, e.g., `TransferSnsTreasuryFunds.from_treasury`.
     pub treasury: i32,
+    /// When the metrics were last updated.
     pub timestamp_seconds: Option<u64>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct VotingPowerMetrics {
     pub governance_total_potential_voting_power: Option<u64>,
+    /// When the metrics were last updated.
     pub timestamp_seconds: Option<u64>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -334,6 +342,20 @@ pub struct ManageDappCanisterSettings {
     pub memory_allocation: Option<u64>,
     pub compute_allocation: Option<u64>,
 }
+/// This type is equivalant to `ICRC3Value`, but we give it another name since it is used here not
+/// in the context of the ICRC-3 ledger standard. The justification is the same: The candid format
+/// supports sharing information even when the client and the server involved do not have the same
+/// schema (see the Upgrading and subtyping section of the candid spec). While this mechanism allows
+/// to evolve services and clients independently without breaking them, it also means that a client
+/// may not receive all the information that the server is sending, e.g. in case the client schema
+/// lacks some fields that the server schema has.
+///
+/// This loss of information is not an option for SNS voters deciding if an extension with particular
+/// init args should be installed or if an extension function with particular arguments should be
+/// called. The client must receive the same exact data the server sent in order to verify it.
+///
+/// Verification of a priorly installed extension is done by hashing the extension's init arg data
+/// and checking that the result is consistent with what has been certified by the SNS.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum PreciseValue {
     Int(i64),
@@ -739,11 +761,7 @@ pub struct SwapNeuron {
 pub struct ClaimedSwapNeurons {
     pub swap_neurons: Vec<SwapNeuron>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum ClaimSwapNeuronsResult {
-    Ok(ClaimedSwapNeurons),
-    Err(i32),
-}
+pub type ClaimSwapNeuronsResult = std::result::Result<ClaimedSwapNeurons, i32>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ClaimSwapNeuronsResponse {
     pub claim_swap_neurons_result: Option<ClaimSwapNeuronsResult>,
@@ -773,6 +791,7 @@ pub struct GetMetricsRequest {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Metrics {
+    /// The metrics below are cached (albeit this is an implementation detail).
     pub treasury_metrics: Option<Vec<TreasuryMetrics>>,
     pub voting_power_metrics: Option<VotingPowerMetrics>,
     pub last_ledger_block_timestamp: Option<u64>,
@@ -780,11 +799,7 @@ pub struct Metrics {
     pub num_recently_submitted_proposals: Option<u64>,
     pub genesis_timestamp_seconds: Option<u64>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum GetMetricsResult {
-    Ok(Metrics),
-    Err(GovernanceError),
-}
+pub type GetMetricsResult = std::result::Result<Metrics, GovernanceError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetMetricsResponse {
     pub get_metrics_result: Option<GetMetricsResult>,
@@ -800,13 +815,13 @@ pub struct GetNeuron {
     pub neuron_id: Option<NeuronId>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result_ {
+pub enum Result {
     Error(GovernanceError),
     Neuron(Neuron),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetNeuronResponse {
-    pub result: Option<Result_>,
+    pub result: Option<Result>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetProposal {
@@ -1066,12 +1081,12 @@ pub struct SetModeRet {}
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn claim_swap_neurons(&self, arg0: ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {
+    pub async fn claim_swap_neurons(&self, arg0: &ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {
         ic_cdk::call(self.0, "claim_swap_neurons", (arg0,)).await
     }
     pub async fn fail_stuck_upgrade_in_progress(
         &self,
-        arg0: FailStuckUpgradeInProgressArg,
+        arg0: &FailStuckUpgradeInProgressArg,
     ) -> CallResult<(FailStuckUpgradeInProgressRet,)> {
         ic_cdk::call(self.0, "fail_stuck_upgrade_in_progress", (arg0,)).await
     }
@@ -1083,74 +1098,74 @@ impl Service {
     }
     pub async fn get_maturity_modulation(
         &self,
-        arg0: GetMaturityModulationArg,
+        arg0: &GetMaturityModulationArg,
     ) -> CallResult<(GetMaturityModulationResponse,)> {
         ic_cdk::call(self.0, "get_maturity_modulation", (arg0,)).await
     }
-    pub async fn get_metadata(&self, arg0: GetMetadataArg) -> CallResult<(GetMetadataResponse,)> {
+    pub async fn get_metadata(&self, arg0: &GetMetadataArg) -> CallResult<(GetMetadataResponse,)> {
         ic_cdk::call(self.0, "get_metadata", (arg0,)).await
     }
-    pub async fn get_metrics(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
+    pub async fn get_metrics(&self, arg0: &GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
         ic_cdk::call(self.0, "get_metrics", (arg0,)).await
     }
-    pub async fn get_metrics_replicated(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
+    pub async fn get_metrics_replicated(&self, arg0: &GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
         ic_cdk::call(self.0, "get_metrics_replicated", (arg0,)).await
     }
-    pub async fn get_mode(&self, arg0: GetModeArg) -> CallResult<(GetModeResponse,)> {
+    pub async fn get_mode(&self, arg0: &GetModeArg) -> CallResult<(GetModeResponse,)> {
         ic_cdk::call(self.0, "get_mode", (arg0,)).await
     }
-    pub async fn get_nervous_system_parameters(&self, arg0: ()) -> CallResult<(NervousSystemParameters,)> {
+    pub async fn get_nervous_system_parameters(&self, arg0: &()) -> CallResult<(NervousSystemParameters,)> {
         ic_cdk::call(self.0, "get_nervous_system_parameters", (arg0,)).await
     }
-    pub async fn get_neuron(&self, arg0: GetNeuron) -> CallResult<(GetNeuronResponse,)> {
+    pub async fn get_neuron(&self, arg0: &GetNeuron) -> CallResult<(GetNeuronResponse,)> {
         ic_cdk::call(self.0, "get_neuron", (arg0,)).await
     }
-    pub async fn get_proposal(&self, arg0: GetProposal) -> CallResult<(GetProposalResponse,)> {
+    pub async fn get_proposal(&self, arg0: &GetProposal) -> CallResult<(GetProposalResponse,)> {
         ic_cdk::call(self.0, "get_proposal", (arg0,)).await
     }
-    pub async fn get_root_canister_status(&self, arg0: ()) -> CallResult<(CanisterStatusResultV2,)> {
+    pub async fn get_root_canister_status(&self, arg0: &()) -> CallResult<(CanisterStatusResultV2,)> {
         ic_cdk::call(self.0, "get_root_canister_status", (arg0,)).await
     }
     pub async fn get_running_sns_version(
         &self,
-        arg0: GetRunningSnsVersionArg,
+        arg0: &GetRunningSnsVersionArg,
     ) -> CallResult<(GetRunningSnsVersionResponse,)> {
         ic_cdk::call(self.0, "get_running_sns_version", (arg0,)).await
     }
     pub async fn get_sns_initialization_parameters(
         &self,
-        arg0: GetSnsInitializationParametersArg,
+        arg0: &GetSnsInitializationParametersArg,
     ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
         ic_cdk::call(self.0, "get_sns_initialization_parameters", (arg0,)).await
     }
-    pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
+    pub async fn get_timers(&self, arg0: &GetTimersArg) -> CallResult<(GetTimersResponse,)> {
         ic_cdk::call(self.0, "get_timers", (arg0,)).await
     }
     pub async fn get_upgrade_journal(
         &self,
-        arg0: GetUpgradeJournalRequest,
+        arg0: &GetUpgradeJournalRequest,
     ) -> CallResult<(GetUpgradeJournalResponse,)> {
         ic_cdk::call(self.0, "get_upgrade_journal", (arg0,)).await
     }
     pub async fn list_nervous_system_functions(&self) -> CallResult<(ListNervousSystemFunctionsResponse,)> {
         ic_cdk::call(self.0, "list_nervous_system_functions", ()).await
     }
-    pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<(ListNeuronsResponse,)> {
+    pub async fn list_neurons(&self, arg0: &ListNeurons) -> CallResult<(ListNeuronsResponse,)> {
         ic_cdk::call(self.0, "list_neurons", (arg0,)).await
     }
-    pub async fn list_proposals(&self, arg0: ListProposals) -> CallResult<(ListProposalsResponse,)> {
+    pub async fn list_proposals(&self, arg0: &ListProposals) -> CallResult<(ListProposalsResponse,)> {
         ic_cdk::call(self.0, "list_proposals", (arg0,)).await
     }
-    pub async fn list_topics(&self, arg0: ListTopicsRequest) -> CallResult<(ListTopicsResponse,)> {
+    pub async fn list_topics(&self, arg0: &ListTopicsRequest) -> CallResult<(ListTopicsResponse,)> {
         ic_cdk::call(self.0, "list_topics", (arg0,)).await
     }
-    pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
+    pub async fn manage_neuron(&self, arg0: &ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
         ic_cdk::call(self.0, "manage_neuron", (arg0,)).await
     }
-    pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
+    pub async fn reset_timers(&self, arg0: &ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
         ic_cdk::call(self.0, "reset_timers", (arg0,)).await
     }
-    pub async fn set_mode(&self, arg0: SetMode) -> CallResult<(SetModeRet,)> {
+    pub async fn set_mode(&self, arg0: &SetMode) -> CallResult<(SetModeRet,)> {
         ic_cdk::call(self.0, "set_mode", (arg0,)).await
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -76,6 +76,7 @@ pub struct NervousSystemFunction {
 pub struct Subaccount {
     pub subaccount: serde_bytes::ByteBuf,
 }
+/// ! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/governance/canister/governance.did>
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Account {
     pub owner: Option<Principal>,
@@ -83,17 +84,24 @@ pub struct Account {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TreasuryMetrics {
+    /// A human-readable identified for this treasury, e.g., "ICP".
     pub name: Option<String>,
+    /// The amount of tokens in this treasury at the end of swap finalization.
     pub original_amount_e8s: Option<u64>,
+    /// The regularly updated amount of tokens in this treasury.
     pub amount_e8s: Option<u64>,
     pub account: Option<Account>,
+    /// The source of truth for the treasury balance is this ledger canister / account.
     pub ledger_canister_id: Option<Principal>,
+    /// Same as, e.g., `TransferSnsTreasuryFunds.from_treasury`.
     pub treasury: i32,
+    /// When the metrics were last updated.
     pub timestamp_seconds: Option<u64>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct VotingPowerMetrics {
     pub governance_total_potential_voting_power: Option<u64>,
+    /// When the metrics were last updated.
     pub timestamp_seconds: Option<u64>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -334,6 +342,20 @@ pub struct ManageDappCanisterSettings {
     pub memory_allocation: Option<u64>,
     pub compute_allocation: Option<u64>,
 }
+/// This type is equivalant to `ICRC3Value`, but we give it another name since it is used here not
+/// in the context of the ICRC-3 ledger standard. The justification is the same: The candid format
+/// supports sharing information even when the client and the server involved do not have the same
+/// schema (see the Upgrading and subtyping section of the candid spec). While this mechanism allows
+/// to evolve services and clients independently without breaking them, it also means that a client
+/// may not receive all the information that the server is sending, e.g. in case the client schema
+/// lacks some fields that the server schema has.
+///
+/// This loss of information is not an option for SNS voters deciding if an extension with particular
+/// init args should be installed or if an extension function with particular arguments should be
+/// called. The client must receive the same exact data the server sent in order to verify it.
+///
+/// Verification of a priorly installed extension is done by hashing the extension's init arg data
+/// and checking that the result is consistent with what has been certified by the SNS.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum PreciseValue {
     Int(i64),
@@ -739,11 +761,7 @@ pub struct SwapNeuron {
 pub struct ClaimedSwapNeurons {
     pub swap_neurons: Vec<SwapNeuron>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum ClaimSwapNeuronsResult {
-    Ok(ClaimedSwapNeurons),
-    Err(i32),
-}
+pub type ClaimSwapNeuronsResult = std::result::Result<ClaimedSwapNeurons, i32>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ClaimSwapNeuronsResponse {
     pub claim_swap_neurons_result: Option<ClaimSwapNeuronsResult>,
@@ -773,6 +791,7 @@ pub struct GetMetricsRequest {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Metrics {
+    /// The metrics below are cached (albeit this is an implementation detail).
     pub treasury_metrics: Option<Vec<TreasuryMetrics>>,
     pub voting_power_metrics: Option<VotingPowerMetrics>,
     pub last_ledger_block_timestamp: Option<u64>,
@@ -780,11 +799,7 @@ pub struct Metrics {
     pub num_recently_submitted_proposals: Option<u64>,
     pub genesis_timestamp_seconds: Option<u64>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum GetMetricsResult {
-    Ok(Metrics),
-    Err(GovernanceError),
-}
+pub type GetMetricsResult = std::result::Result<Metrics, GovernanceError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetMetricsResponse {
     pub get_metrics_result: Option<GetMetricsResult>,
@@ -800,13 +815,13 @@ pub struct GetNeuron {
     pub neuron_id: Option<NeuronId>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result_ {
+pub enum Result {
     Error(GovernanceError),
     Neuron(Neuron),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetNeuronResponse {
-    pub result: Option<Result_>,
+    pub result: Option<Result>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetProposal {
@@ -1066,7 +1081,7 @@ pub struct SetModeRet {}
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn claim_swap_neurons(&self, arg0: ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {
+    pub async fn claim_swap_neurons(&self, arg0: &ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "claim_swap_neurons")
             .with_arg(arg0)
             .await
@@ -1075,7 +1090,7 @@ impl Service {
     }
     pub async fn fail_stuck_upgrade_in_progress(
         &self,
-        arg0: FailStuckUpgradeInProgressArg,
+        arg0: &FailStuckUpgradeInProgressArg,
     ) -> CallResult<(FailStuckUpgradeInProgressRet,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "fail_stuck_upgrade_in_progress")
             .with_arg(arg0)
@@ -1097,7 +1112,7 @@ impl Service {
     }
     pub async fn get_maturity_modulation(
         &self,
-        arg0: GetMaturityModulationArg,
+        arg0: &GetMaturityModulationArg,
     ) -> CallResult<(GetMaturityModulationResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_maturity_modulation")
             .with_arg(arg0)
@@ -1105,56 +1120,56 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_metadata(&self, arg0: GetMetadataArg) -> CallResult<(GetMetadataResponse,)> {
+    pub async fn get_metadata(&self, arg0: &GetMetadataArg) -> CallResult<(GetMetadataResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_metadata")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_metrics(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
+    pub async fn get_metrics(&self, arg0: &GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_metrics")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_metrics_replicated(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
+    pub async fn get_metrics_replicated(&self, arg0: &GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_metrics_replicated")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_mode(&self, arg0: GetModeArg) -> CallResult<(GetModeResponse,)> {
+    pub async fn get_mode(&self, arg0: &GetModeArg) -> CallResult<(GetModeResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_mode")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_nervous_system_parameters(&self, arg0: ()) -> CallResult<(NervousSystemParameters,)> {
+    pub async fn get_nervous_system_parameters(&self, arg0: &()) -> CallResult<(NervousSystemParameters,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_nervous_system_parameters")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_neuron(&self, arg0: GetNeuron) -> CallResult<(GetNeuronResponse,)> {
+    pub async fn get_neuron(&self, arg0: &GetNeuron) -> CallResult<(GetNeuronResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_neuron")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_proposal(&self, arg0: GetProposal) -> CallResult<(GetProposalResponse,)> {
+    pub async fn get_proposal(&self, arg0: &GetProposal) -> CallResult<(GetProposalResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_proposal")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_root_canister_status(&self, arg0: ()) -> CallResult<(CanisterStatusResultV2,)> {
+    pub async fn get_root_canister_status(&self, arg0: &()) -> CallResult<(CanisterStatusResultV2,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_root_canister_status")
             .with_arg(arg0)
             .await
@@ -1163,7 +1178,7 @@ impl Service {
     }
     pub async fn get_running_sns_version(
         &self,
-        arg0: GetRunningSnsVersionArg,
+        arg0: &GetRunningSnsVersionArg,
     ) -> CallResult<(GetRunningSnsVersionResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_running_sns_version")
             .with_arg(arg0)
@@ -1173,7 +1188,7 @@ impl Service {
     }
     pub async fn get_sns_initialization_parameters(
         &self,
-        arg0: GetSnsInitializationParametersArg,
+        arg0: &GetSnsInitializationParametersArg,
     ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_sns_initialization_parameters")
             .with_arg(arg0)
@@ -1181,7 +1196,7 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
+    pub async fn get_timers(&self, arg0: &GetTimersArg) -> CallResult<(GetTimersResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_timers")
             .with_arg(arg0)
             .await
@@ -1190,7 +1205,7 @@ impl Service {
     }
     pub async fn get_upgrade_journal(
         &self,
-        arg0: GetUpgradeJournalRequest,
+        arg0: &GetUpgradeJournalRequest,
     ) -> CallResult<(GetUpgradeJournalResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_upgrade_journal")
             .with_arg(arg0)
@@ -1204,42 +1219,42 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<(ListNeuronsResponse,)> {
+    pub async fn list_neurons(&self, arg0: &ListNeurons) -> CallResult<(ListNeuronsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_neurons")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn list_proposals(&self, arg0: ListProposals) -> CallResult<(ListProposalsResponse,)> {
+    pub async fn list_proposals(&self, arg0: &ListProposals) -> CallResult<(ListProposalsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_proposals")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn list_topics(&self, arg0: ListTopicsRequest) -> CallResult<(ListTopicsResponse,)> {
+    pub async fn list_topics(&self, arg0: &ListTopicsRequest) -> CallResult<(ListTopicsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_topics")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
+    pub async fn manage_neuron(&self, arg0: &ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "manage_neuron")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
+    pub async fn reset_timers(&self, arg0: &ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "reset_timers")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn set_mode(&self, arg0: SetMode) -> CallResult<(SetModeRet,)> {
+    pub async fn set_mode(&self, arg0: &SetMode) -> CallResult<(SetModeRet,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "set_mode")
             .with_arg(arg0)
             .await

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,31 +1,29 @@
-diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 7566582df..00c91ff35 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -129,7 +129,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
-     pub start: BlockIndex,
+@@ -154,7 +154,7 @@
      pub length: candid::Nat,
  }
+ /// The result of a "get_blocks" call.
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetBlocksResponse {
-     pub certificate: Option<serde_bytes::ByteBuf>,
-     pub first_index: BlockIndex,
-@@ -205,7 +205,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
-     pub start: TxIndex,
+     /// System certificate for the hash of the latest block in the chain.
+     /// Only present if `get_blocks` is called in a non-replicated query context.
+@@ -299,7 +299,7 @@
+     /// The number of transactions you can fetch using the callback.
      pub length: candid::Nat,
  }
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetTransactionsResponse {
-     pub first_index: TxIndex,
-     pub log_length: candid::Nat,
-@@ -339,7 +339,7 @@ pub struct GetBlocksResultArchivedBlocksItem {
+     /// The index of the first transaction in [transactions].
+     /// If the transaction vector is empty, the exact value of this field is not specified.
+@@ -567,7 +567,7 @@
      pub args: Vec<GetBlocksArgs>,
      pub callback: GetBlocksResultArchivedBlocksItemCallback,
  }
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetBlocksResult {
-     pub log_length: candid::Nat,
-     pub blocks: Vec<GetBlocksResultBlocksItem>,
+     /// Total number of blocks in the
+     /// block log

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -28,6 +28,7 @@ pub struct ChangeArchiveOptions {
     pub node_max_memory_size_bytes: Option<u64>,
     pub controller_id: Option<Principal>,
 }
+/// The value returned from the [icrc1_metadata] endpoint.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum MetadataValue {
     Int(candid::Int),
@@ -74,6 +75,7 @@ pub struct InitArgsArchiveOptions {
     pub node_max_memory_size_bytes: Option<u64>,
     pub controller_id: Principal,
 }
+/// The initialization parameters of the Ledger
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InitArgs {
     pub decimals: Option<u8>,
@@ -94,6 +96,7 @@ pub enum LedgerArg {
     Upgrade(Option<UpgradeArgs>),
     Init(InitArgs),
 }
+/// ! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/ledger_suite/icrc1/ledger/ledger.did>
 pub type BlockIndex = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ArchiveInfo {
@@ -103,7 +106,9 @@ pub struct ArchiveInfo {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksArgs {
+    /// The index of the first block to fetch.
     pub start: BlockIndex,
+    /// Max number of blocks to fetch.
     pub length: candid::Nat,
 }
 pub type Map = Vec<(String, Box<Value>)>;
@@ -118,25 +123,60 @@ pub enum Value {
     Array(Vec<Box<Value>>),
 }
 pub type Block = Box<Value>;
+/// A prefix of the block range specified in the [GetBlocksArgs] request.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct BlockRange {
+    /// A prefix of the requested block range.
+    /// The index of the first block is equal to [GetBlocksArgs.start].
+    ///
+    /// Note that the number of blocks might be less than the requested
+    /// [GetBlocksArgs.length] for various reasons, for example:
+    ///
+    /// 1. The query might have hit the replica with an outdated state
+    /// that doesn't have the whole range yet.
+    /// 2. The requested range is too large to fit into a single reply.
+    ///
+    /// NOTE: the list of blocks can be empty if:
+    ///
+    /// 1. [GetBlocksArgs.length] was zero.
+    /// 2. [GetBlocksArgs.start] was larger than the last block known to
+    /// the canister.
     pub blocks: Vec<Block>,
 }
 pub type QueryBlockArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponseArchivedBlocksItem {
+    /// Callback to fetch the archived blocks.
     pub callback: QueryBlockArchiveFn,
+    /// The index of the first archived block.
     pub start: BlockIndex,
+    /// The number of blocks that can be fetched.
     pub length: candid::Nat,
 }
+/// The result of a "get_blocks" call.
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse {
+    /// System certificate for the hash of the latest block in the chain.
+    /// Only present if `get_blocks` is called in a non-replicated query context.
     pub certificate: Option<serde_bytes::ByteBuf>,
+    /// The index of the first block in "blocks".
+    /// If the blocks vector is empty, the exact value of this field is not specified.
     pub first_index: BlockIndex,
+    /// List of blocks that were available in the ledger when it processed the call.
+    ///
+    /// The blocks form a contiguous range, with the first block having index
+    /// [first_block_index] (see below), and the last block having index
+    /// [first_block_index] + len(blocks) - 1.
+    ///
+    /// The block range can be an arbitrary sub-range of the originally requested range.
     pub blocks: Vec<Block>,
+    /// The total number of blocks in the chain.
+    /// If the chain length is positive, the index of the last block is `chain_len - 1`.
     pub chain_length: u64,
+    /// Encoding of instructions for fetching archived blocks.
     pub archived_blocks: Vec<GetBlocksResponseArchivedBlocksItem>,
 }
+/// Certificate for the block at `block_index`.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DataCertificate {
     pub certificate: Option<serde_bytes::ByteBuf>,
@@ -145,9 +185,12 @@ pub struct DataCertificate {
 pub type TxIndex = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetTransactionsRequest {
+    /// The index of the first tx to fetch.
     pub start: TxIndex,
+    /// The number of transactions to fetch.
     pub length: candid::Nat,
 }
+/// Number of nanoseconds since the UNIX epoch in UTC timezone.
 pub type Timestamp = u64;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Burn {
@@ -224,22 +267,58 @@ pub struct Transaction {
     pub timestamp: Timestamp,
     pub transfer: Option<Transfer>,
 }
+/// A prefix of the transaction range specified in the [GetTransactionsRequest] request.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransactionRange {
+    /// A prefix of the requested transaction range.
+    /// The index of the first transaction is equal to [GetTransactionsRequest.from].
+    ///
+    /// Note that the number of transactions might be less than the requested
+    /// [GetTransactionsRequest.length] for various reasons, for example:
+    ///
+    /// 1. The query might have hit the replica with an outdated state
+    /// that doesn't have the whole range yet.
+    /// 2. The requested range is too large to fit into a single reply.
+    ///
+    /// NOTE: the list of transactions can be empty if:
+    ///
+    /// 1. [GetTransactionsRequest.length] was zero.
+    /// 2. [GetTransactionsRequest.from] was larger than the last transaction known to
+    /// the canister.
     pub transactions: Vec<Transaction>,
 }
 pub type QueryArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponseArchivedTransactionsItem {
+    /// The function you should call to fetch the archived transactions.
+    /// The range of the transaction accessible using this function is given by [from]
+    /// and [len] fields above.
     pub callback: QueryArchiveFn,
+    /// The index of the first archived transaction you can fetch using the [callback].
     pub start: TxIndex,
+    /// The number of transactions you can fetch using the callback.
     pub length: candid::Nat,
 }
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponse {
+    /// The index of the first transaction in [transactions].
+    /// If the transaction vector is empty, the exact value of this field is not specified.
     pub first_index: TxIndex,
+    /// The total number of transactions in the log.
     pub log_length: candid::Nat,
+    /// List of transaction that were available in the ledger when it processed the call.
+    ///
+    /// The transactions form a contiguous range, with the first transaction having index
+    /// [first_index] (see below), and the last transaction having index
+    /// [first_index] + len(transactions) - 1.
+    ///
+    /// The transaction range can be an arbitrary sub-range of the originally requested range.
     pub transactions: Vec<Transaction>,
+    /// Encoding of instructions for fetching archived transactions whose indices fall into the
+    /// requested range.
+    ///
+    /// For each entry `e` in [archived_transactions], `[e.from, e.from + len)` is a sub-range
+    /// of the originally requested transaction range.
     pub archived_transactions: Vec<GetTransactionsResponseArchivedTransactionsItem>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -260,24 +339,17 @@ pub enum GetAllowancesError {
     GenericError { message: String, error_code: candid::Nat },
     AccessDenied { reason: String },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc103GetAllowancesResponse {
-    Ok(Vec<Allowance103>),
-    Err(GetAllowancesError),
-}
+pub type Icrc103GetAllowancesResponse = std::result::Result<Vec<Allowance103>, GetAllowancesError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum GetIndexPrincipalError {
+    /// Any error not covered by the above variants.
     GenericError {
         description: String,
         error_code: candid::Nat,
     },
     IndexPrincipalNotSet,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum GetIndexPrincipalResult {
-    Ok(Principal),
-    Err(GetIndexPrincipalError),
-}
+pub type GetIndexPrincipalResult = std::result::Result<Principal, GetIndexPrincipalError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc10SupportedStandardsRetItem {
     pub url: String,
@@ -298,11 +370,7 @@ pub enum Icrc152BurnError {
     InsufficientBalance { balance: candid::Nat },
     Unauthorized(String),
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc152BurnResult {
-    Ok(candid::Nat),
-    Err(Icrc152BurnError),
-}
+pub type Icrc152BurnResult = std::result::Result<candid::Nat, Icrc152BurnError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc152MintArgs {
     pub to: Account,
@@ -317,11 +385,7 @@ pub enum Icrc152MintError {
     Duplicate { duplicate_of: candid::Nat },
     Unauthorized(String),
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc152MintResult {
-    Ok(candid::Nat),
-    Err(Icrc152MintError),
-}
+pub type Icrc152MintResult = std::result::Result<candid::Nat, Icrc152MintError>;
 pub type Tokens = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct StandardRecord {
@@ -348,11 +412,7 @@ pub enum TransferError {
     TooOld,
     InsufficientFunds { balance: Tokens },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum TransferResult {
-    Ok(BlockIndex),
-    Err(TransferError),
-}
+pub type TransferResult = std::result::Result<BlockIndex, TransferError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc21ConsentMessageMetadata {
     pub utc_offset_minutes: Option<i16>,
@@ -402,6 +462,7 @@ pub struct Icrc21ErrorInfo {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Icrc21Error {
+    /// Any error not covered by the above variants.
     GenericError {
         description: String,
         error_code: candid::Nat,
@@ -410,11 +471,7 @@ pub enum Icrc21Error {
     UnsupportedCanisterCall(Icrc21ErrorInfo),
     ConsentMessageUnavailable(Icrc21ErrorInfo),
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc21ConsentMessageResponse {
-    Ok(Icrc21ConsentInfo),
-    Err(Icrc21Error),
-}
+pub type Icrc21ConsentMessageResponse = std::result::Result<Icrc21ConsentInfo, Icrc21Error>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AllowanceArgs {
     pub account: Account,
@@ -448,11 +505,7 @@ pub enum ApproveError {
     Expired { ledger_time: Timestamp },
     InsufficientFunds { balance: candid::Nat },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum ApproveResult {
-    Ok(BlockIndex),
-    Err(ApproveError),
-}
+pub type ApproveResult = std::result::Result<BlockIndex, ApproveError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransferFromArgs {
     pub to: Account,
@@ -475,35 +528,38 @@ pub enum TransferFromError {
     TooOld,
     InsufficientFunds { balance: Tokens },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum TransferFromResult {
-    Ok(BlockIndex),
-    Err(TransferFromError),
-}
+pub type TransferFromResult = std::result::Result<BlockIndex, TransferFromError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetArchivesArgs {
+    /// The last archive seen by the client.
+    /// The Ledger will return archives coming
+    /// after this one if set, otherwise it
+    /// will return the first archives.
     pub from: Option<Principal>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetArchivesResultItem {
+    /// The last block in the archive
     pub end: candid::Nat,
+    /// The id of the archive
     pub canister_id: Principal,
+    /// The first block in the archive
     pub start: candid::Nat,
 }
 pub type GetArchivesResult = Vec<GetArchivesResultItem>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc3Value {
+pub enum ICRC3Value {
     Int(candid::Int),
-    Map(Vec<(String, Box<Icrc3Value>)>),
+    Map(Vec<(String, Box<ICRC3Value>)>),
     Nat(candid::Nat),
     Blob(serde_bytes::ByteBuf),
     Text(String),
-    Array(Vec<Box<Icrc3Value>>),
+    Array(Vec<Box<ICRC3Value>>),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksResultBlocksItem {
     pub id: candid::Nat,
-    pub block: Box<Icrc3Value>,
+    pub block: Box<ICRC3Value>,
 }
 pub type GetBlocksResultArchivedBlocksItemCallback = candid::Func;
 #[derive(CandidType, Deserialize)]
@@ -513,13 +569,17 @@ pub struct GetBlocksResultArchivedBlocksItem {
 }
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResult {
+    /// Total number of blocks in the
+    /// block log
     pub log_length: candid::Nat,
     pub blocks: Vec<GetBlocksResultBlocksItem>,
     pub archived_blocks: Vec<GetBlocksResultArchivedBlocksItem>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct Icrc3DataCertificate {
+pub struct ICRC3DataCertificate {
+    /// See https://internetcomputer.org/docs/current/references/ic-interface-spec#certification
     pub certificate: serde_bytes::ByteBuf,
+    /// CBOR encoded hash_tree
     pub hash_tree: serde_bytes::ByteBuf,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -533,88 +593,88 @@ impl Service {
     pub async fn archives(&self) -> CallResult<(Vec<ArchiveInfo>,)> {
         ic_cdk::call(self.0, "archives", ()).await
     }
-    pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<(GetBlocksResponse,)> {
+    pub async fn get_blocks(&self, arg0: &GetBlocksArgs) -> CallResult<(GetBlocksResponse,)> {
         ic_cdk::call(self.0, "get_blocks", (arg0,)).await
     }
     pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
         ic_cdk::call(self.0, "get_data_certificate", ()).await
     }
-    pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> CallResult<(GetTransactionsResponse,)> {
+    pub async fn get_transactions(&self, arg0: &GetTransactionsRequest) -> CallResult<(GetTransactionsResponse,)> {
         ic_cdk::call(self.0, "get_transactions", (arg0,)).await
     }
-    pub async fn icrc_103_get_allowances(
+    pub async fn icrc103_get_allowances(
         &self,
-        arg0: GetAllowancesArgs,
+        arg0: &GetAllowancesArgs,
     ) -> CallResult<(Icrc103GetAllowancesResponse,)> {
         ic_cdk::call(self.0, "icrc103_get_allowances", (arg0,)).await
     }
-    pub async fn icrc_106_get_index_principal(&self) -> CallResult<(GetIndexPrincipalResult,)> {
+    pub async fn icrc106_get_index_principal(&self) -> CallResult<(GetIndexPrincipalResult,)> {
         ic_cdk::call(self.0, "icrc106_get_index_principal", ()).await
     }
-    pub async fn icrc_10_supported_standards(&self) -> CallResult<(Vec<Icrc10SupportedStandardsRetItem>,)> {
+    pub async fn icrc10_supported_standards(&self) -> CallResult<(Vec<Icrc10SupportedStandardsRetItem>,)> {
         ic_cdk::call(self.0, "icrc10_supported_standards", ()).await
     }
-    pub async fn icrc_152_burn(&self, arg0: Icrc152BurnArgs) -> CallResult<(Icrc152BurnResult,)> {
+    pub async fn icrc152_burn(&self, arg0: &Icrc152BurnArgs) -> CallResult<(Icrc152BurnResult,)> {
         ic_cdk::call(self.0, "icrc152_burn", (arg0,)).await
     }
-    pub async fn icrc_152_mint(&self, arg0: Icrc152MintArgs) -> CallResult<(Icrc152MintResult,)> {
+    pub async fn icrc152_mint(&self, arg0: &Icrc152MintArgs) -> CallResult<(Icrc152MintResult,)> {
         ic_cdk::call(self.0, "icrc152_mint", (arg0,)).await
     }
-    pub async fn icrc_1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
+    pub async fn icrc1_balance_of(&self, arg0: &Account) -> CallResult<(Tokens,)> {
         ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
     }
-    pub async fn icrc_1_decimals(&self) -> CallResult<(u8,)> {
+    pub async fn icrc1_decimals(&self) -> CallResult<(u8,)> {
         ic_cdk::call(self.0, "icrc1_decimals", ()).await
     }
-    pub async fn icrc_1_fee(&self) -> CallResult<(Tokens,)> {
+    pub async fn icrc1_fee(&self) -> CallResult<(Tokens,)> {
         ic_cdk::call(self.0, "icrc1_fee", ()).await
     }
-    pub async fn icrc_1_metadata(&self) -> CallResult<(Vec<(String, MetadataValue)>,)> {
+    pub async fn icrc1_metadata(&self) -> CallResult<(Vec<(String, MetadataValue)>,)> {
         ic_cdk::call(self.0, "icrc1_metadata", ()).await
     }
-    pub async fn icrc_1_minting_account(&self) -> CallResult<(Option<Account>,)> {
+    pub async fn icrc1_minting_account(&self) -> CallResult<(Option<Account>,)> {
         ic_cdk::call(self.0, "icrc1_minting_account", ()).await
     }
-    pub async fn icrc_1_name(&self) -> CallResult<(String,)> {
+    pub async fn icrc1_name(&self) -> CallResult<(String,)> {
         ic_cdk::call(self.0, "icrc1_name", ()).await
     }
-    pub async fn icrc_1_supported_standards(&self) -> CallResult<(Vec<StandardRecord>,)> {
+    pub async fn icrc1_supported_standards(&self) -> CallResult<(Vec<StandardRecord>,)> {
         ic_cdk::call(self.0, "icrc1_supported_standards", ()).await
     }
-    pub async fn icrc_1_symbol(&self) -> CallResult<(String,)> {
+    pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
         ic_cdk::call(self.0, "icrc1_symbol", ()).await
     }
-    pub async fn icrc_1_total_supply(&self) -> CallResult<(Tokens,)> {
+    pub async fn icrc1_total_supply(&self) -> CallResult<(Tokens,)> {
         ic_cdk::call(self.0, "icrc1_total_supply", ()).await
     }
-    pub async fn icrc_1_transfer(&self, arg0: TransferArg) -> CallResult<(TransferResult,)> {
+    pub async fn icrc1_transfer(&self, arg0: &TransferArg) -> CallResult<(TransferResult,)> {
         ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await
     }
-    pub async fn icrc_21_canister_call_consent_message(
+    pub async fn icrc21_canister_call_consent_message(
         &self,
-        arg0: Icrc21ConsentMessageRequest,
+        arg0: &Icrc21ConsentMessageRequest,
     ) -> CallResult<(Icrc21ConsentMessageResponse,)> {
         ic_cdk::call(self.0, "icrc21_canister_call_consent_message", (arg0,)).await
     }
-    pub async fn icrc_2_allowance(&self, arg0: AllowanceArgs) -> CallResult<(Allowance,)> {
+    pub async fn icrc2_allowance(&self, arg0: &AllowanceArgs) -> CallResult<(Allowance,)> {
         ic_cdk::call(self.0, "icrc2_allowance", (arg0,)).await
     }
-    pub async fn icrc_2_approve(&self, arg0: ApproveArgs) -> CallResult<(ApproveResult,)> {
+    pub async fn icrc2_approve(&self, arg0: &ApproveArgs) -> CallResult<(ApproveResult,)> {
         ic_cdk::call(self.0, "icrc2_approve", (arg0,)).await
     }
-    pub async fn icrc_2_transfer_from(&self, arg0: TransferFromArgs) -> CallResult<(TransferFromResult,)> {
+    pub async fn icrc2_transfer_from(&self, arg0: &TransferFromArgs) -> CallResult<(TransferFromResult,)> {
         ic_cdk::call(self.0, "icrc2_transfer_from", (arg0,)).await
     }
-    pub async fn icrc_3_get_archives(&self, arg0: GetArchivesArgs) -> CallResult<(GetArchivesResult,)> {
+    pub async fn icrc3_get_archives(&self, arg0: &GetArchivesArgs) -> CallResult<(GetArchivesResult,)> {
         ic_cdk::call(self.0, "icrc3_get_archives", (arg0,)).await
     }
-    pub async fn icrc_3_get_blocks(&self, arg0: Vec<GetBlocksArgs>) -> CallResult<(GetBlocksResult,)> {
+    pub async fn icrc3_get_blocks(&self, arg0: &Vec<GetBlocksArgs>) -> CallResult<(GetBlocksResult,)> {
         ic_cdk::call(self.0, "icrc3_get_blocks", (arg0,)).await
     }
-    pub async fn icrc_3_get_tip_certificate(&self) -> CallResult<(Option<Icrc3DataCertificate>,)> {
+    pub async fn icrc3_get_tip_certificate(&self) -> CallResult<(Option<ICRC3DataCertificate>,)> {
         ic_cdk::call(self.0, "icrc3_get_tip_certificate", ()).await
     }
-    pub async fn icrc_3_supported_block_types(&self) -> CallResult<(Vec<Icrc3SupportedBlockTypesRetItem>,)> {
+    pub async fn icrc3_supported_block_types(&self) -> CallResult<(Vec<Icrc3SupportedBlockTypesRetItem>,)> {
         ic_cdk::call(self.0, "icrc3_supported_block_types", ()).await
     }
     pub async fn is_ledger_ready(&self) -> CallResult<(bool,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,6 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
 //! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/ledger_suite/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
+#![allow(clippy::pedantic)]
 #![allow(deprecated)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -28,6 +28,7 @@ pub struct ChangeArchiveOptions {
     pub node_max_memory_size_bytes: Option<u64>,
     pub controller_id: Option<Principal>,
 }
+/// The value returned from the [icrc1_metadata] endpoint.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum MetadataValue {
     Int(candid::Int),
@@ -74,6 +75,7 @@ pub struct InitArgsArchiveOptions {
     pub node_max_memory_size_bytes: Option<u64>,
     pub controller_id: Principal,
 }
+/// The initialization parameters of the Ledger
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InitArgs {
     pub decimals: Option<u8>,
@@ -94,6 +96,7 @@ pub enum LedgerArg {
     Upgrade(Option<UpgradeArgs>),
     Init(InitArgs),
 }
+/// ! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/ledger_suite/icrc1/ledger/ledger.did>
 pub type BlockIndex = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ArchiveInfo {
@@ -103,7 +106,9 @@ pub struct ArchiveInfo {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksArgs {
+    /// The index of the first block to fetch.
     pub start: BlockIndex,
+    /// Max number of blocks to fetch.
     pub length: candid::Nat,
 }
 pub type Map = Vec<(String, Box<Value>)>;
@@ -118,25 +123,60 @@ pub enum Value {
     Array(Vec<Box<Value>>),
 }
 pub type Block = Box<Value>;
+/// A prefix of the block range specified in the [GetBlocksArgs] request.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct BlockRange {
+    /// A prefix of the requested block range.
+    /// The index of the first block is equal to [GetBlocksArgs.start].
+    ///
+    /// Note that the number of blocks might be less than the requested
+    /// [GetBlocksArgs.length] for various reasons, for example:
+    ///
+    /// 1. The query might have hit the replica with an outdated state
+    /// that doesn't have the whole range yet.
+    /// 2. The requested range is too large to fit into a single reply.
+    ///
+    /// NOTE: the list of blocks can be empty if:
+    ///
+    /// 1. [GetBlocksArgs.length] was zero.
+    /// 2. [GetBlocksArgs.start] was larger than the last block known to
+    /// the canister.
     pub blocks: Vec<Block>,
 }
 pub type QueryBlockArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponseArchivedBlocksItem {
+    /// Callback to fetch the archived blocks.
     pub callback: QueryBlockArchiveFn,
+    /// The index of the first archived block.
     pub start: BlockIndex,
+    /// The number of blocks that can be fetched.
     pub length: candid::Nat,
 }
+/// The result of a "get_blocks" call.
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse {
+    /// System certificate for the hash of the latest block in the chain.
+    /// Only present if `get_blocks` is called in a non-replicated query context.
     pub certificate: Option<serde_bytes::ByteBuf>,
+    /// The index of the first block in "blocks".
+    /// If the blocks vector is empty, the exact value of this field is not specified.
     pub first_index: BlockIndex,
+    /// List of blocks that were available in the ledger when it processed the call.
+    ///
+    /// The blocks form a contiguous range, with the first block having index
+    /// [first_block_index] (see below), and the last block having index
+    /// [first_block_index] + len(blocks) - 1.
+    ///
+    /// The block range can be an arbitrary sub-range of the originally requested range.
     pub blocks: Vec<Block>,
+    /// The total number of blocks in the chain.
+    /// If the chain length is positive, the index of the last block is `chain_len - 1`.
     pub chain_length: u64,
+    /// Encoding of instructions for fetching archived blocks.
     pub archived_blocks: Vec<GetBlocksResponseArchivedBlocksItem>,
 }
+/// Certificate for the block at `block_index`.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DataCertificate {
     pub certificate: Option<serde_bytes::ByteBuf>,
@@ -145,9 +185,12 @@ pub struct DataCertificate {
 pub type TxIndex = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetTransactionsRequest {
+    /// The index of the first tx to fetch.
     pub start: TxIndex,
+    /// The number of transactions to fetch.
     pub length: candid::Nat,
 }
+/// Number of nanoseconds since the UNIX epoch in UTC timezone.
 pub type Timestamp = u64;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Burn {
@@ -224,22 +267,58 @@ pub struct Transaction {
     pub timestamp: Timestamp,
     pub transfer: Option<Transfer>,
 }
+/// A prefix of the transaction range specified in the [GetTransactionsRequest] request.
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransactionRange {
+    /// A prefix of the requested transaction range.
+    /// The index of the first transaction is equal to [GetTransactionsRequest.from].
+    ///
+    /// Note that the number of transactions might be less than the requested
+    /// [GetTransactionsRequest.length] for various reasons, for example:
+    ///
+    /// 1. The query might have hit the replica with an outdated state
+    /// that doesn't have the whole range yet.
+    /// 2. The requested range is too large to fit into a single reply.
+    ///
+    /// NOTE: the list of transactions can be empty if:
+    ///
+    /// 1. [GetTransactionsRequest.length] was zero.
+    /// 2. [GetTransactionsRequest.from] was larger than the last transaction known to
+    /// the canister.
     pub transactions: Vec<Transaction>,
 }
 pub type QueryArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponseArchivedTransactionsItem {
+    /// The function you should call to fetch the archived transactions.
+    /// The range of the transaction accessible using this function is given by [from]
+    /// and [len] fields above.
     pub callback: QueryArchiveFn,
+    /// The index of the first archived transaction you can fetch using the [callback].
     pub start: TxIndex,
+    /// The number of transactions you can fetch using the callback.
     pub length: candid::Nat,
 }
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponse {
+    /// The index of the first transaction in [transactions].
+    /// If the transaction vector is empty, the exact value of this field is not specified.
     pub first_index: TxIndex,
+    /// The total number of transactions in the log.
     pub log_length: candid::Nat,
+    /// List of transaction that were available in the ledger when it processed the call.
+    ///
+    /// The transactions form a contiguous range, with the first transaction having index
+    /// [first_index] (see below), and the last transaction having index
+    /// [first_index] + len(transactions) - 1.
+    ///
+    /// The transaction range can be an arbitrary sub-range of the originally requested range.
     pub transactions: Vec<Transaction>,
+    /// Encoding of instructions for fetching archived transactions whose indices fall into the
+    /// requested range.
+    ///
+    /// For each entry `e` in [archived_transactions], `[e.from, e.from + len)` is a sub-range
+    /// of the originally requested transaction range.
     pub archived_transactions: Vec<GetTransactionsResponseArchivedTransactionsItem>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -260,24 +339,17 @@ pub enum GetAllowancesError {
     GenericError { message: String, error_code: candid::Nat },
     AccessDenied { reason: String },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc103GetAllowancesResponse {
-    Ok(Vec<Allowance103>),
-    Err(GetAllowancesError),
-}
+pub type Icrc103GetAllowancesResponse = std::result::Result<Vec<Allowance103>, GetAllowancesError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum GetIndexPrincipalError {
+    /// Any error not covered by the above variants.
     GenericError {
         description: String,
         error_code: candid::Nat,
     },
     IndexPrincipalNotSet,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum GetIndexPrincipalResult {
-    Ok(Principal),
-    Err(GetIndexPrincipalError),
-}
+pub type GetIndexPrincipalResult = std::result::Result<Principal, GetIndexPrincipalError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc10SupportedStandardsRetItem {
     pub url: String,
@@ -298,11 +370,7 @@ pub enum Icrc152BurnError {
     InsufficientBalance { balance: candid::Nat },
     Unauthorized(String),
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc152BurnResult {
-    Ok(candid::Nat),
-    Err(Icrc152BurnError),
-}
+pub type Icrc152BurnResult = std::result::Result<candid::Nat, Icrc152BurnError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc152MintArgs {
     pub to: Account,
@@ -317,11 +385,7 @@ pub enum Icrc152MintError {
     Duplicate { duplicate_of: candid::Nat },
     Unauthorized(String),
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc152MintResult {
-    Ok(candid::Nat),
-    Err(Icrc152MintError),
-}
+pub type Icrc152MintResult = std::result::Result<candid::Nat, Icrc152MintError>;
 pub type Tokens = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct StandardRecord {
@@ -348,11 +412,7 @@ pub enum TransferError {
     TooOld,
     InsufficientFunds { balance: Tokens },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum TransferResult {
-    Ok(BlockIndex),
-    Err(TransferError),
-}
+pub type TransferResult = std::result::Result<BlockIndex, TransferError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc21ConsentMessageMetadata {
     pub utc_offset_minutes: Option<i16>,
@@ -402,6 +462,7 @@ pub struct Icrc21ErrorInfo {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Icrc21Error {
+    /// Any error not covered by the above variants.
     GenericError {
         description: String,
         error_code: candid::Nat,
@@ -410,11 +471,7 @@ pub enum Icrc21Error {
     UnsupportedCanisterCall(Icrc21ErrorInfo),
     ConsentMessageUnavailable(Icrc21ErrorInfo),
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc21ConsentMessageResponse {
-    Ok(Icrc21ConsentInfo),
-    Err(Icrc21Error),
-}
+pub type Icrc21ConsentMessageResponse = std::result::Result<Icrc21ConsentInfo, Icrc21Error>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AllowanceArgs {
     pub account: Account,
@@ -448,11 +505,7 @@ pub enum ApproveError {
     Expired { ledger_time: Timestamp },
     InsufficientFunds { balance: candid::Nat },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum ApproveResult {
-    Ok(BlockIndex),
-    Err(ApproveError),
-}
+pub type ApproveResult = std::result::Result<BlockIndex, ApproveError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransferFromArgs {
     pub to: Account,
@@ -475,35 +528,38 @@ pub enum TransferFromError {
     TooOld,
     InsufficientFunds { balance: Tokens },
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum TransferFromResult {
-    Ok(BlockIndex),
-    Err(TransferFromError),
-}
+pub type TransferFromResult = std::result::Result<BlockIndex, TransferFromError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetArchivesArgs {
+    /// The last archive seen by the client.
+    /// The Ledger will return archives coming
+    /// after this one if set, otherwise it
+    /// will return the first archives.
     pub from: Option<Principal>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetArchivesResultItem {
+    /// The last block in the archive
     pub end: candid::Nat,
+    /// The id of the archive
     pub canister_id: Principal,
+    /// The first block in the archive
     pub start: candid::Nat,
 }
 pub type GetArchivesResult = Vec<GetArchivesResultItem>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Icrc3Value {
+pub enum ICRC3Value {
     Int(candid::Int),
-    Map(Vec<(String, Box<Icrc3Value>)>),
+    Map(Vec<(String, Box<ICRC3Value>)>),
     Nat(candid::Nat),
     Blob(serde_bytes::ByteBuf),
     Text(String),
-    Array(Vec<Box<Icrc3Value>>),
+    Array(Vec<Box<ICRC3Value>>),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksResultBlocksItem {
     pub id: candid::Nat,
-    pub block: Box<Icrc3Value>,
+    pub block: Box<ICRC3Value>,
 }
 pub type GetBlocksResultArchivedBlocksItemCallback = candid::Func;
 #[derive(CandidType, Deserialize)]
@@ -513,13 +569,17 @@ pub struct GetBlocksResultArchivedBlocksItem {
 }
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResult {
+    /// Total number of blocks in the
+    /// block log
     pub log_length: candid::Nat,
     pub blocks: Vec<GetBlocksResultBlocksItem>,
     pub archived_blocks: Vec<GetBlocksResultArchivedBlocksItem>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct Icrc3DataCertificate {
+pub struct ICRC3DataCertificate {
+    /// See https://internetcomputer.org/docs/current/references/ic-interface-spec#certification
     pub certificate: serde_bytes::ByteBuf,
+    /// CBOR encoded hash_tree
     pub hash_tree: serde_bytes::ByteBuf,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -536,7 +596,7 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<(GetBlocksResponse,)> {
+    pub async fn get_blocks(&self, arg0: &GetBlocksArgs) -> CallResult<(GetBlocksResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_blocks")
             .with_arg(arg0)
             .await
@@ -549,16 +609,16 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> CallResult<(GetTransactionsResponse,)> {
+    pub async fn get_transactions(&self, arg0: &GetTransactionsRequest) -> CallResult<(GetTransactionsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_transactions")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_103_get_allowances(
+    pub async fn icrc103_get_allowances(
         &self,
-        arg0: GetAllowancesArgs,
+        arg0: &GetAllowancesArgs,
     ) -> CallResult<(Icrc103GetAllowancesResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc103_get_allowances")
             .with_arg(arg0)
@@ -566,97 +626,97 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_106_get_index_principal(&self) -> CallResult<(GetIndexPrincipalResult,)> {
+    pub async fn icrc106_get_index_principal(&self) -> CallResult<(GetIndexPrincipalResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc106_get_index_principal")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_10_supported_standards(&self) -> CallResult<(Vec<Icrc10SupportedStandardsRetItem>,)> {
+    pub async fn icrc10_supported_standards(&self) -> CallResult<(Vec<Icrc10SupportedStandardsRetItem>,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc10_supported_standards")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_152_burn(&self, arg0: Icrc152BurnArgs) -> CallResult<(Icrc152BurnResult,)> {
+    pub async fn icrc152_burn(&self, arg0: &Icrc152BurnArgs) -> CallResult<(Icrc152BurnResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc152_burn")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_152_mint(&self, arg0: Icrc152MintArgs) -> CallResult<(Icrc152MintResult,)> {
+    pub async fn icrc152_mint(&self, arg0: &Icrc152MintArgs) -> CallResult<(Icrc152MintResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc152_mint")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
+    pub async fn icrc1_balance_of(&self, arg0: &Account) -> CallResult<(Tokens,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_balance_of")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_decimals(&self) -> CallResult<(u8,)> {
+    pub async fn icrc1_decimals(&self) -> CallResult<(u8,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_decimals")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_fee(&self) -> CallResult<(Tokens,)> {
+    pub async fn icrc1_fee(&self) -> CallResult<(Tokens,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_fee")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_metadata(&self) -> CallResult<(Vec<(String, MetadataValue)>,)> {
+    pub async fn icrc1_metadata(&self) -> CallResult<(Vec<(String, MetadataValue)>,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_metadata")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_minting_account(&self) -> CallResult<(Option<Account>,)> {
+    pub async fn icrc1_minting_account(&self) -> CallResult<(Option<Account>,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_minting_account")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_name(&self) -> CallResult<(String,)> {
+    pub async fn icrc1_name(&self) -> CallResult<(String,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_name")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_supported_standards(&self) -> CallResult<(Vec<StandardRecord>,)> {
+    pub async fn icrc1_supported_standards(&self) -> CallResult<(Vec<StandardRecord>,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_supported_standards")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_symbol(&self) -> CallResult<(String,)> {
+    pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_symbol")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_total_supply(&self) -> CallResult<(Tokens,)> {
+    pub async fn icrc1_total_supply(&self) -> CallResult<(Tokens,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_total_supply")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_1_transfer(&self, arg0: TransferArg) -> CallResult<(TransferResult,)> {
+    pub async fn icrc1_transfer(&self, arg0: &TransferArg) -> CallResult<(TransferResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_transfer")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_21_canister_call_consent_message(
+    pub async fn icrc21_canister_call_consent_message(
         &self,
-        arg0: Icrc21ConsentMessageRequest,
+        arg0: &Icrc21ConsentMessageRequest,
     ) -> CallResult<(Icrc21ConsentMessageResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc21_canister_call_consent_message")
             .with_arg(arg0)
@@ -664,48 +724,48 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_2_allowance(&self, arg0: AllowanceArgs) -> CallResult<(Allowance,)> {
+    pub async fn icrc2_allowance(&self, arg0: &AllowanceArgs) -> CallResult<(Allowance,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc2_allowance")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_2_approve(&self, arg0: ApproveArgs) -> CallResult<(ApproveResult,)> {
+    pub async fn icrc2_approve(&self, arg0: &ApproveArgs) -> CallResult<(ApproveResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc2_approve")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_2_transfer_from(&self, arg0: TransferFromArgs) -> CallResult<(TransferFromResult,)> {
+    pub async fn icrc2_transfer_from(&self, arg0: &TransferFromArgs) -> CallResult<(TransferFromResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc2_transfer_from")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_3_get_archives(&self, arg0: GetArchivesArgs) -> CallResult<(GetArchivesResult,)> {
+    pub async fn icrc3_get_archives(&self, arg0: &GetArchivesArgs) -> CallResult<(GetArchivesResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_get_archives")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_3_get_blocks(&self, arg0: Vec<GetBlocksArgs>) -> CallResult<(GetBlocksResult,)> {
+    pub async fn icrc3_get_blocks(&self, arg0: &Vec<GetBlocksArgs>) -> CallResult<(GetBlocksResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_get_blocks")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_3_get_tip_certificate(&self) -> CallResult<(Option<Icrc3DataCertificate>,)> {
+    pub async fn icrc3_get_tip_certificate(&self) -> CallResult<(Option<ICRC3DataCertificate>,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_get_tip_certificate")
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn icrc_3_supported_block_types(&self) -> CallResult<(Vec<Icrc3SupportedBlockTypesRetItem>,)> {
+    pub async fn icrc3_supported_block_types(&self) -> CallResult<(Vec<Icrc3SupportedBlockTypesRetItem>,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_supported_block_types")
             .await
             .map_err(ic_cdk::call::Error::from)

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -131,15 +131,15 @@ pub struct CleanUpFailedRegisterExtensionRequest {
     pub canister_id: Option<Principal>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct CleanUpFailedRegisterExtensionResultOk {}
+/// ! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/root/canister/root.did>
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterCallError {
     pub code: Option<i32>,
     pub description: String,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum CleanUpFailedRegisterExtensionResult {
-    Ok(EmptyRecord),
-    Err(CanisterCallError),
-}
+pub type CleanUpFailedRegisterExtensionResult =
+    std::result::Result<CleanUpFailedRegisterExtensionResultOk, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CleanUpFailedRegisterExtensionResponse {
     pub result: Option<CleanUpFailedRegisterExtensionResult>,
@@ -235,10 +235,8 @@ pub struct RegisterExtensionRequest {
     pub canister_id: Option<Principal>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum RegisterExtensionResult {
-    Ok(EmptyRecord),
-    Err(CanisterCallError),
-}
+pub struct RegisterExtensionResultOk {}
+pub type RegisterExtensionResult = std::result::Result<RegisterExtensionResultOk, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterExtensionResponse {
     pub result: Option<RegisterExtensionResult>,
@@ -264,15 +262,15 @@ pub struct SetDappControllersResponse {
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {
+    pub async fn canister_status(&self, arg0: &CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {
         ic_cdk::call(self.0, "canister_status", (arg0,)).await
     }
-    pub async fn change_canister(&self, arg0: ChangeCanisterRequest) -> CallResult<()> {
+    pub async fn change_canister(&self, arg0: &ChangeCanisterRequest) -> CallResult<()> {
         ic_cdk::call(self.0, "change_canister", (arg0,)).await
     }
     pub async fn clean_up_failed_register_extension(
         &self,
-        arg0: CleanUpFailedRegisterExtensionRequest,
+        arg0: &CleanUpFailedRegisterExtensionRequest,
     ) -> CallResult<(CleanUpFailedRegisterExtensionResponse,)> {
         ic_cdk::call(self.0, "clean_up_failed_register_extension", (arg0,)).await
     }
@@ -281,43 +279,46 @@ impl Service {
     }
     pub async fn get_sns_canisters_summary(
         &self,
-        arg0: GetSnsCanistersSummaryRequest,
+        arg0: &GetSnsCanistersSummaryRequest,
     ) -> CallResult<(GetSnsCanistersSummaryResponse,)> {
         ic_cdk::call(self.0, "get_sns_canisters_summary", (arg0,)).await
     }
-    pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
+    pub async fn get_timers(&self, arg0: &GetTimersArg) -> CallResult<(GetTimersResponse,)> {
         ic_cdk::call(self.0, "get_timers", (arg0,)).await
     }
-    pub async fn list_sns_canisters(&self, arg0: ListSnsCanistersArg) -> CallResult<(ListSnsCanistersResponse,)> {
+    pub async fn list_sns_canisters(&self, arg0: &ListSnsCanistersArg) -> CallResult<(ListSnsCanistersResponse,)> {
         ic_cdk::call(self.0, "list_sns_canisters", (arg0,)).await
     }
     pub async fn manage_dapp_canister_settings(
         &self,
-        arg0: ManageDappCanisterSettingsRequest,
+        arg0: &ManageDappCanisterSettingsRequest,
     ) -> CallResult<(ManageDappCanisterSettingsResponse,)> {
         ic_cdk::call(self.0, "manage_dapp_canister_settings", (arg0,)).await
     }
     pub async fn register_dapp_canister(
         &self,
-        arg0: RegisterDappCanisterRequest,
+        arg0: &RegisterDappCanisterRequest,
     ) -> CallResult<(RegisterDappCanisterRet,)> {
         ic_cdk::call(self.0, "register_dapp_canister", (arg0,)).await
     }
     pub async fn register_dapp_canisters(
         &self,
-        arg0: RegisterDappCanistersRequest,
+        arg0: &RegisterDappCanistersRequest,
     ) -> CallResult<(RegisterDappCanistersRet,)> {
         ic_cdk::call(self.0, "register_dapp_canisters", (arg0,)).await
     }
-    pub async fn register_extension(&self, arg0: RegisterExtensionRequest) -> CallResult<(RegisterExtensionResponse,)> {
+    pub async fn register_extension(
+        &self,
+        arg0: &RegisterExtensionRequest,
+    ) -> CallResult<(RegisterExtensionResponse,)> {
         ic_cdk::call(self.0, "register_extension", (arg0,)).await
     }
-    pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
+    pub async fn reset_timers(&self, arg0: &ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
         ic_cdk::call(self.0, "reset_timers", (arg0,)).await
     }
     pub async fn set_dapp_controllers(
         &self,
-        arg0: SetDappControllersRequest,
+        arg0: &SetDappControllersRequest,
     ) -> CallResult<(SetDappControllersResponse,)> {
         ic_cdk::call(self.0, "set_dapp_controllers", (arg0,)).await
     }

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,6 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
 //! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
+#![allow(clippy::pedantic)]
 #![allow(deprecated)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -131,15 +131,15 @@ pub struct CleanUpFailedRegisterExtensionRequest {
     pub canister_id: Option<Principal>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct CleanUpFailedRegisterExtensionResultOk {}
+/// ! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/root/canister/root.did>
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterCallError {
     pub code: Option<i32>,
     pub description: String,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum CleanUpFailedRegisterExtensionResult {
-    Ok(EmptyRecord),
-    Err(CanisterCallError),
-}
+pub type CleanUpFailedRegisterExtensionResult =
+    std::result::Result<CleanUpFailedRegisterExtensionResultOk, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CleanUpFailedRegisterExtensionResponse {
     pub result: Option<CleanUpFailedRegisterExtensionResult>,
@@ -235,10 +235,8 @@ pub struct RegisterExtensionRequest {
     pub canister_id: Option<Principal>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum RegisterExtensionResult {
-    Ok(EmptyRecord),
-    Err(CanisterCallError),
-}
+pub struct RegisterExtensionResultOk {}
+pub type RegisterExtensionResult = std::result::Result<RegisterExtensionResultOk, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterExtensionResponse {
     pub result: Option<RegisterExtensionResult>,
@@ -264,14 +262,14 @@ pub struct SetDappControllersResponse {
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {
+    pub async fn canister_status(&self, arg0: &CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "canister_status")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn change_canister(&self, arg0: ChangeCanisterRequest) -> CallResult<()> {
+    pub async fn change_canister(&self, arg0: &ChangeCanisterRequest) -> CallResult<()> {
         ic_cdk::call::Call::unbounded_wait(self.0, "change_canister")
             .with_arg(arg0)
             .await
@@ -280,7 +278,7 @@ impl Service {
     }
     pub async fn clean_up_failed_register_extension(
         &self,
-        arg0: CleanUpFailedRegisterExtensionRequest,
+        arg0: &CleanUpFailedRegisterExtensionRequest,
     ) -> CallResult<(CleanUpFailedRegisterExtensionResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "clean_up_failed_register_extension")
             .with_arg(arg0)
@@ -296,7 +294,7 @@ impl Service {
     }
     pub async fn get_sns_canisters_summary(
         &self,
-        arg0: GetSnsCanistersSummaryRequest,
+        arg0: &GetSnsCanistersSummaryRequest,
     ) -> CallResult<(GetSnsCanistersSummaryResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_sns_canisters_summary")
             .with_arg(arg0)
@@ -304,14 +302,14 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
+    pub async fn get_timers(&self, arg0: &GetTimersArg) -> CallResult<(GetTimersResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_timers")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn list_sns_canisters(&self, arg0: ListSnsCanistersArg) -> CallResult<(ListSnsCanistersResponse,)> {
+    pub async fn list_sns_canisters(&self, arg0: &ListSnsCanistersArg) -> CallResult<(ListSnsCanistersResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_sns_canisters")
             .with_arg(arg0)
             .await
@@ -320,7 +318,7 @@ impl Service {
     }
     pub async fn manage_dapp_canister_settings(
         &self,
-        arg0: ManageDappCanisterSettingsRequest,
+        arg0: &ManageDappCanisterSettingsRequest,
     ) -> CallResult<(ManageDappCanisterSettingsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "manage_dapp_canister_settings")
             .with_arg(arg0)
@@ -330,7 +328,7 @@ impl Service {
     }
     pub async fn register_dapp_canister(
         &self,
-        arg0: RegisterDappCanisterRequest,
+        arg0: &RegisterDappCanisterRequest,
     ) -> CallResult<(RegisterDappCanisterRet,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "register_dapp_canister")
             .with_arg(arg0)
@@ -340,7 +338,7 @@ impl Service {
     }
     pub async fn register_dapp_canisters(
         &self,
-        arg0: RegisterDappCanistersRequest,
+        arg0: &RegisterDappCanistersRequest,
     ) -> CallResult<(RegisterDappCanistersRet,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "register_dapp_canisters")
             .with_arg(arg0)
@@ -348,14 +346,17 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn register_extension(&self, arg0: RegisterExtensionRequest) -> CallResult<(RegisterExtensionResponse,)> {
+    pub async fn register_extension(
+        &self,
+        arg0: &RegisterExtensionRequest,
+    ) -> CallResult<(RegisterExtensionResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "register_extension")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
+    pub async fn reset_timers(&self, arg0: &ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "reset_timers")
             .with_arg(arg0)
             .await
@@ -364,7 +365,7 @@ impl Service {
     }
     pub async fn set_dapp_controllers(
         &self,
-        arg0: SetDappControllersRequest,
+        arg0: &SetDappControllersRequest,
     ) -> CallResult<(SetDappControllersResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "set_dapp_controllers")
             .with_arg(arg0)

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -86,14 +86,10 @@ pub struct Err {
     pub description: Option<String>,
     pub error_type: Option<i32>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result_ {
-    Ok(Ok),
-    Err(Err),
-}
+pub type Result = std::result::Result<Ok, Err>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ErrorRefundIcpResponse {
-    pub result: Option<Result_>,
+    pub result: Option<Result>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FinalizeSwapArg {}
@@ -111,11 +107,7 @@ pub struct FailedUpdate {
 pub struct SetDappControllersResponse {
     pub failed_updates: Vec<FailedUpdate>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility {
-    Ok(SetDappControllersResponse),
-    Err(CanisterCallError),
-}
+pub type Possibility = std::result::Result<SetDappControllersResponse, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDappControllersCallResult {
     pub possibility: Option<Possibility>,
@@ -137,11 +129,7 @@ pub struct GovernanceError {
 pub struct Response {
     pub governance_error: Option<GovernanceError>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility1 {
-    Ok(Response),
-    Err(CanisterCallError),
-}
+pub type Possibility1 = std::result::Result<Response, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SettleCommunityFundParticipationResult {
     pub possibility: Option<Possibility1>,
@@ -155,20 +143,14 @@ pub struct Ok1 {
 pub struct Error {
     pub message: Option<String>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility2 {
-    Ok(Ok1),
-    Err(Error),
-}
+pub type Possibility2 = std::result::Result<Ok1, Error>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SettleNeuronsFundParticipationResult {
     pub possibility: Option<Possibility2>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility3 {
-    Ok(EmptyRecord),
-    Err(CanisterCallError),
-}
+pub struct Possibility3Ok {}
+pub type Possibility3 = std::result::Result<Possibility3Ok, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetModeCallResult {
     pub possibility: Option<Possibility3>,
@@ -205,6 +187,7 @@ pub struct TransferableAmount {
     pub amount_transferred_e8s: Option<u64>,
     pub transfer_success_timestamp_seconds: u64,
 }
+/// ! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/swap/canister/swap.did>
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct BuyerState {
     pub icp: Option<TransferableAmount>,
@@ -317,11 +300,7 @@ pub struct Ok2 {
 pub struct Err1 {
     pub error_type: Option<i32>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result1 {
-    Ok(Ok2),
-    Err(Err1),
-}
+pub type Result1 = std::result::Result<Ok2, Err1>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetOpenTicketResponse {
     pub result: Option<Result1>,
@@ -494,11 +473,7 @@ pub struct Err2 {
     pub existing_ticket: Option<Ticket>,
     pub error_type: i32,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result2 {
-    Ok(Ok2),
-    Err(Err2),
-}
+pub type Result2 = std::result::Result<Ok2, Err2>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NewSaleTicketResponse {
     pub result: Option<Result2>,
@@ -522,79 +497,79 @@ pub struct ResetTimersRet {}
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {
+    pub async fn error_refund_icp(&self, arg0: &ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {
         ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await
     }
-    pub async fn finalize_swap(&self, arg0: FinalizeSwapArg) -> CallResult<(FinalizeSwapResponse,)> {
+    pub async fn finalize_swap(&self, arg0: &FinalizeSwapArg) -> CallResult<(FinalizeSwapResponse,)> {
         ic_cdk::call(self.0, "finalize_swap", (arg0,)).await
     }
     pub async fn get_auto_finalization_status(
         &self,
-        arg0: GetAutoFinalizationStatusArg,
+        arg0: &GetAutoFinalizationStatusArg,
     ) -> CallResult<(GetAutoFinalizationStatusResponse,)> {
         ic_cdk::call(self.0, "get_auto_finalization_status", (arg0,)).await
     }
-    pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<(GetBuyerStateResponse,)> {
+    pub async fn get_buyer_state(&self, arg0: &GetBuyerStateRequest) -> CallResult<(GetBuyerStateResponse,)> {
         ic_cdk::call(self.0, "get_buyer_state", (arg0,)).await
     }
-    pub async fn get_buyers_total(&self, arg0: GetBuyersTotalArg) -> CallResult<(GetBuyersTotalResponse,)> {
+    pub async fn get_buyers_total(&self, arg0: &GetBuyersTotalArg) -> CallResult<(GetBuyersTotalResponse,)> {
         ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await
     }
-    pub async fn get_canister_status(&self, arg0: GetCanisterStatusArg) -> CallResult<(CanisterStatusResultV2,)> {
+    pub async fn get_canister_status(&self, arg0: &GetCanisterStatusArg) -> CallResult<(CanisterStatusResultV2,)> {
         ic_cdk::call(self.0, "get_canister_status", (arg0,)).await
     }
-    pub async fn get_derived_state(&self, arg0: GetDerivedStateArg) -> CallResult<(GetDerivedStateResponse,)> {
+    pub async fn get_derived_state(&self, arg0: &GetDerivedStateArg) -> CallResult<(GetDerivedStateResponse,)> {
         ic_cdk::call(self.0, "get_derived_state", (arg0,)).await
     }
-    pub async fn get_init(&self, arg0: GetInitArg) -> CallResult<(GetInitResponse,)> {
+    pub async fn get_init(&self, arg0: &GetInitArg) -> CallResult<(GetInitResponse,)> {
         ic_cdk::call(self.0, "get_init", (arg0,)).await
     }
-    pub async fn get_lifecycle(&self, arg0: GetLifecycleArg) -> CallResult<(GetLifecycleResponse,)> {
+    pub async fn get_lifecycle(&self, arg0: &GetLifecycleArg) -> CallResult<(GetLifecycleResponse,)> {
         ic_cdk::call(self.0, "get_lifecycle", (arg0,)).await
     }
-    pub async fn get_open_ticket(&self, arg0: GetOpenTicketArg) -> CallResult<(GetOpenTicketResponse,)> {
+    pub async fn get_open_ticket(&self, arg0: &GetOpenTicketArg) -> CallResult<(GetOpenTicketResponse,)> {
         ic_cdk::call(self.0, "get_open_ticket", (arg0,)).await
     }
-    pub async fn get_sale_parameters(&self, arg0: GetSaleParametersArg) -> CallResult<(GetSaleParametersResponse,)> {
+    pub async fn get_sale_parameters(&self, arg0: &GetSaleParametersArg) -> CallResult<(GetSaleParametersResponse,)> {
         ic_cdk::call(self.0, "get_sale_parameters", (arg0,)).await
     }
-    pub async fn get_state(&self, arg0: GetStateArg) -> CallResult<(GetStateResponse,)> {
+    pub async fn get_state(&self, arg0: &GetStateArg) -> CallResult<(GetStateResponse,)> {
         ic_cdk::call(self.0, "get_state", (arg0,)).await
     }
-    pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
+    pub async fn get_timers(&self, arg0: &GetTimersArg) -> CallResult<(GetTimersResponse,)> {
         ic_cdk::call(self.0, "get_timers", (arg0,)).await
     }
     pub async fn list_community_fund_participants(
         &self,
-        arg0: ListCommunityFundParticipantsRequest,
+        arg0: &ListCommunityFundParticipantsRequest,
     ) -> CallResult<(ListCommunityFundParticipantsResponse,)> {
         ic_cdk::call(self.0, "list_community_fund_participants", (arg0,)).await
     }
     pub async fn list_direct_participants(
         &self,
-        arg0: ListDirectParticipantsRequest,
+        arg0: &ListDirectParticipantsRequest,
     ) -> CallResult<(ListDirectParticipantsResponse,)> {
         ic_cdk::call(self.0, "list_direct_participants", (arg0,)).await
     }
     pub async fn list_sns_neuron_recipes(
         &self,
-        arg0: ListSnsNeuronRecipesRequest,
+        arg0: &ListSnsNeuronRecipesRequest,
     ) -> CallResult<(ListSnsNeuronRecipesResponse,)> {
         ic_cdk::call(self.0, "list_sns_neuron_recipes", (arg0,)).await
     }
-    pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<(NewSaleTicketResponse,)> {
+    pub async fn new_sale_ticket(&self, arg0: &NewSaleTicketRequest) -> CallResult<(NewSaleTicketResponse,)> {
         ic_cdk::call(self.0, "new_sale_ticket", (arg0,)).await
     }
-    pub async fn notify_payment_failure(&self, arg0: NotifyPaymentFailureArg) -> CallResult<(Ok2,)> {
+    pub async fn notify_payment_failure(&self, arg0: &NotifyPaymentFailureArg) -> CallResult<(Ok2,)> {
         ic_cdk::call(self.0, "notify_payment_failure", (arg0,)).await
     }
     pub async fn refresh_buyer_tokens(
         &self,
-        arg0: RefreshBuyerTokensRequest,
+        arg0: &RefreshBuyerTokensRequest,
     ) -> CallResult<(RefreshBuyerTokensResponse,)> {
         ic_cdk::call(self.0, "refresh_buyer_tokens", (arg0,)).await
     }
-    pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
+    pub async fn reset_timers(&self, arg0: &ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
         ic_cdk::call(self.0, "reset_timers", (arg0,)).await
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,6 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
 //! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
+#![allow(clippy::pedantic)]
 #![allow(deprecated)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -86,14 +86,10 @@ pub struct Err {
     pub description: Option<String>,
     pub error_type: Option<i32>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result_ {
-    Ok(Ok),
-    Err(Err),
-}
+pub type Result = std::result::Result<Ok, Err>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ErrorRefundIcpResponse {
-    pub result: Option<Result_>,
+    pub result: Option<Result>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FinalizeSwapArg {}
@@ -111,11 +107,7 @@ pub struct FailedUpdate {
 pub struct SetDappControllersResponse {
     pub failed_updates: Vec<FailedUpdate>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility {
-    Ok(SetDappControllersResponse),
-    Err(CanisterCallError),
-}
+pub type Possibility = std::result::Result<SetDappControllersResponse, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDappControllersCallResult {
     pub possibility: Option<Possibility>,
@@ -137,11 +129,7 @@ pub struct GovernanceError {
 pub struct Response {
     pub governance_error: Option<GovernanceError>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility1 {
-    Ok(Response),
-    Err(CanisterCallError),
-}
+pub type Possibility1 = std::result::Result<Response, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SettleCommunityFundParticipationResult {
     pub possibility: Option<Possibility1>,
@@ -155,20 +143,14 @@ pub struct Ok1 {
 pub struct Error {
     pub message: Option<String>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility2 {
-    Ok(Ok1),
-    Err(Error),
-}
+pub type Possibility2 = std::result::Result<Ok1, Error>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SettleNeuronsFundParticipationResult {
     pub possibility: Option<Possibility2>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Possibility3 {
-    Ok(EmptyRecord),
-    Err(CanisterCallError),
-}
+pub struct Possibility3Ok {}
+pub type Possibility3 = std::result::Result<Possibility3Ok, CanisterCallError>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetModeCallResult {
     pub possibility: Option<Possibility3>,
@@ -205,6 +187,7 @@ pub struct TransferableAmount {
     pub amount_transferred_e8s: Option<u64>,
     pub transfer_success_timestamp_seconds: u64,
 }
+/// ! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/sns/swap/canister/swap.did>
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct BuyerState {
     pub icp: Option<TransferableAmount>,
@@ -317,11 +300,7 @@ pub struct Ok2 {
 pub struct Err1 {
     pub error_type: Option<i32>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result1 {
-    Ok(Ok2),
-    Err(Err1),
-}
+pub type Result1 = std::result::Result<Ok2, Err1>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetOpenTicketResponse {
     pub result: Option<Result1>,
@@ -494,11 +473,7 @@ pub struct Err2 {
     pub existing_ticket: Option<Ticket>,
     pub error_type: i32,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result2 {
-    Ok(Ok2),
-    Err(Err2),
-}
+pub type Result2 = std::result::Result<Ok2, Err2>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NewSaleTicketResponse {
     pub result: Option<Result2>,
@@ -522,14 +497,14 @@ pub struct ResetTimersRet {}
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {
+    pub async fn error_refund_icp(&self, arg0: &ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "error_refund_icp")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn finalize_swap(&self, arg0: FinalizeSwapArg) -> CallResult<(FinalizeSwapResponse,)> {
+    pub async fn finalize_swap(&self, arg0: &FinalizeSwapArg) -> CallResult<(FinalizeSwapResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "finalize_swap")
             .with_arg(arg0)
             .await
@@ -538,7 +513,7 @@ impl Service {
     }
     pub async fn get_auto_finalization_status(
         &self,
-        arg0: GetAutoFinalizationStatusArg,
+        arg0: &GetAutoFinalizationStatusArg,
     ) -> CallResult<(GetAutoFinalizationStatusResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_auto_finalization_status")
             .with_arg(arg0)
@@ -546,70 +521,70 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<(GetBuyerStateResponse,)> {
+    pub async fn get_buyer_state(&self, arg0: &GetBuyerStateRequest) -> CallResult<(GetBuyerStateResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_buyer_state")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_buyers_total(&self, arg0: GetBuyersTotalArg) -> CallResult<(GetBuyersTotalResponse,)> {
+    pub async fn get_buyers_total(&self, arg0: &GetBuyersTotalArg) -> CallResult<(GetBuyersTotalResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_buyers_total")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_canister_status(&self, arg0: GetCanisterStatusArg) -> CallResult<(CanisterStatusResultV2,)> {
+    pub async fn get_canister_status(&self, arg0: &GetCanisterStatusArg) -> CallResult<(CanisterStatusResultV2,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_canister_status")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_derived_state(&self, arg0: GetDerivedStateArg) -> CallResult<(GetDerivedStateResponse,)> {
+    pub async fn get_derived_state(&self, arg0: &GetDerivedStateArg) -> CallResult<(GetDerivedStateResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_derived_state")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_init(&self, arg0: GetInitArg) -> CallResult<(GetInitResponse,)> {
+    pub async fn get_init(&self, arg0: &GetInitArg) -> CallResult<(GetInitResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_init")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_lifecycle(&self, arg0: GetLifecycleArg) -> CallResult<(GetLifecycleResponse,)> {
+    pub async fn get_lifecycle(&self, arg0: &GetLifecycleArg) -> CallResult<(GetLifecycleResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_lifecycle")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_open_ticket(&self, arg0: GetOpenTicketArg) -> CallResult<(GetOpenTicketResponse,)> {
+    pub async fn get_open_ticket(&self, arg0: &GetOpenTicketArg) -> CallResult<(GetOpenTicketResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_open_ticket")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_sale_parameters(&self, arg0: GetSaleParametersArg) -> CallResult<(GetSaleParametersResponse,)> {
+    pub async fn get_sale_parameters(&self, arg0: &GetSaleParametersArg) -> CallResult<(GetSaleParametersResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_sale_parameters")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_state(&self, arg0: GetStateArg) -> CallResult<(GetStateResponse,)> {
+    pub async fn get_state(&self, arg0: &GetStateArg) -> CallResult<(GetStateResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_state")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
+    pub async fn get_timers(&self, arg0: &GetTimersArg) -> CallResult<(GetTimersResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_timers")
             .with_arg(arg0)
             .await
@@ -618,7 +593,7 @@ impl Service {
     }
     pub async fn list_community_fund_participants(
         &self,
-        arg0: ListCommunityFundParticipantsRequest,
+        arg0: &ListCommunityFundParticipantsRequest,
     ) -> CallResult<(ListCommunityFundParticipantsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_community_fund_participants")
             .with_arg(arg0)
@@ -628,7 +603,7 @@ impl Service {
     }
     pub async fn list_direct_participants(
         &self,
-        arg0: ListDirectParticipantsRequest,
+        arg0: &ListDirectParticipantsRequest,
     ) -> CallResult<(ListDirectParticipantsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_direct_participants")
             .with_arg(arg0)
@@ -638,7 +613,7 @@ impl Service {
     }
     pub async fn list_sns_neuron_recipes(
         &self,
-        arg0: ListSnsNeuronRecipesRequest,
+        arg0: &ListSnsNeuronRecipesRequest,
     ) -> CallResult<(ListSnsNeuronRecipesResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_sns_neuron_recipes")
             .with_arg(arg0)
@@ -646,14 +621,14 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<(NewSaleTicketResponse,)> {
+    pub async fn new_sale_ticket(&self, arg0: &NewSaleTicketRequest) -> CallResult<(NewSaleTicketResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "new_sale_ticket")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn notify_payment_failure(&self, arg0: NotifyPaymentFailureArg) -> CallResult<(Ok2,)> {
+    pub async fn notify_payment_failure(&self, arg0: &NotifyPaymentFailureArg) -> CallResult<(Ok2,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "notify_payment_failure")
             .with_arg(arg0)
             .await
@@ -662,7 +637,7 @@ impl Service {
     }
     pub async fn refresh_buyer_tokens(
         &self,
-        arg0: RefreshBuyerTokensRequest,
+        arg0: &RefreshBuyerTokensRequest,
     ) -> CallResult<(RefreshBuyerTokensResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "refresh_buyer_tokens")
             .with_arg(arg0)
@@ -670,7 +645,7 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
+    pub async fn reset_timers(&self, arg0: &ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "reset_timers")
             .with_arg(arg0)
             .await

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -29,6 +29,7 @@ pub struct SnsWasm {
     pub proposal_id: Option<u64>,
     pub canister_type: i32,
 }
+/// ! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/nns/sns-wasm/canister/sns-wasm.did>
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddWasmRequest {
     pub hash: serde_bytes::ByteBuf,
@@ -40,13 +41,13 @@ pub struct SnsWasmError {
     pub message: String,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result_ {
+pub enum Result {
     Error(SnsWasmError),
     Hash(serde_bytes::ByteBuf),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddWasmResponse {
-    pub result: Option<Result_>,
+    pub result: Option<Result>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronBasketConstructionParameters {
@@ -346,69 +347,69 @@ pub struct UpdateSnsSubnetListResponse {
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
+    pub async fn add_wasm(&self, arg0: &AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
         ic_cdk::call(self.0, "add_wasm", (arg0,)).await
     }
-    pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<(DeployNewSnsResponse,)> {
+    pub async fn deploy_new_sns(&self, arg0: &DeployNewSnsRequest) -> CallResult<(DeployNewSnsResponse,)> {
         ic_cdk::call(self.0, "deploy_new_sns", (arg0,)).await
     }
     pub async fn get_allowed_principals(
         &self,
-        arg0: GetAllowedPrincipalsArg,
+        arg0: &GetAllowedPrincipalsArg,
     ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
         ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
     }
     pub async fn get_deployed_sns_by_proposal_id(
         &self,
-        arg0: GetDeployedSnsByProposalIdRequest,
+        arg0: &GetDeployedSnsByProposalIdRequest,
     ) -> CallResult<(GetDeployedSnsByProposalIdResponse,)> {
         ic_cdk::call(self.0, "get_deployed_sns_by_proposal_id", (arg0,)).await
     }
-    pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<(Vec<(String, String)>,)> {
+    pub async fn get_latest_sns_version_pretty(&self, arg0: &()) -> CallResult<(Vec<(String, String)>,)> {
         ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await
     }
     pub async fn get_next_sns_version(
         &self,
-        arg0: GetNextSnsVersionRequest,
+        arg0: &GetNextSnsVersionRequest,
     ) -> CallResult<(GetNextSnsVersionResponse,)> {
         ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
     }
     pub async fn get_proposal_id_that_added_wasm(
         &self,
-        arg0: GetProposalIdThatAddedWasmRequest,
+        arg0: &GetProposalIdThatAddedWasmRequest,
     ) -> CallResult<(GetProposalIdThatAddedWasmResponse,)> {
         ic_cdk::call(self.0, "get_proposal_id_that_added_wasm", (arg0,)).await
     }
-    pub async fn get_sns_subnet_ids(&self, arg0: GetSnsSubnetIdsArg) -> CallResult<(GetSnsSubnetIdsResponse,)> {
+    pub async fn get_sns_subnet_ids(&self, arg0: &GetSnsSubnetIdsArg) -> CallResult<(GetSnsSubnetIdsResponse,)> {
         ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await
     }
-    pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
+    pub async fn get_wasm(&self, arg0: &GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
         ic_cdk::call(self.0, "get_wasm", (arg0,)).await
     }
-    pub async fn get_wasm_metadata(&self, arg0: GetWasmMetadataRequest) -> CallResult<(GetWasmMetadataResponse,)> {
+    pub async fn get_wasm_metadata(&self, arg0: &GetWasmMetadataRequest) -> CallResult<(GetWasmMetadataResponse,)> {
         ic_cdk::call(self.0, "get_wasm_metadata", (arg0,)).await
     }
     pub async fn insert_upgrade_path_entries(
         &self,
-        arg0: InsertUpgradePathEntriesRequest,
+        arg0: &InsertUpgradePathEntriesRequest,
     ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
         ic_cdk::call(self.0, "insert_upgrade_path_entries", (arg0,)).await
     }
-    pub async fn list_deployed_snses(&self, arg0: ListDeployedSnsesArg) -> CallResult<(ListDeployedSnsesResponse,)> {
+    pub async fn list_deployed_snses(&self, arg0: &ListDeployedSnsesArg) -> CallResult<(ListDeployedSnsesResponse,)> {
         ic_cdk::call(self.0, "list_deployed_snses", (arg0,)).await
     }
-    pub async fn list_upgrade_steps(&self, arg0: ListUpgradeStepsRequest) -> CallResult<(ListUpgradeStepsResponse,)> {
+    pub async fn list_upgrade_steps(&self, arg0: &ListUpgradeStepsRequest) -> CallResult<(ListUpgradeStepsResponse,)> {
         ic_cdk::call(self.0, "list_upgrade_steps", (arg0,)).await
     }
     pub async fn update_allowed_principals(
         &self,
-        arg0: UpdateAllowedPrincipalsRequest,
+        arg0: &UpdateAllowedPrincipalsRequest,
     ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
         ic_cdk::call(self.0, "update_allowed_principals", (arg0,)).await
     }
     pub async fn update_sns_subnet_list(
         &self,
-        arg0: UpdateSnsSubnetListRequest,
+        arg0: &UpdateSnsSubnetListRequest,
     ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
         ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
     }

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,6 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
 //! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
+#![allow(clippy::pedantic)]
 #![allow(deprecated)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -29,6 +29,7 @@ pub struct SnsWasm {
     pub proposal_id: Option<u64>,
     pub canister_type: i32,
 }
+/// ! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97/rs/nns/sns-wasm/canister/sns-wasm.did>
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddWasmRequest {
     pub hash: serde_bytes::ByteBuf,
@@ -40,13 +41,13 @@ pub struct SnsWasmError {
     pub message: String,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub enum Result_ {
+pub enum Result {
     Error(SnsWasmError),
     Hash(serde_bytes::ByteBuf),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddWasmResponse {
-    pub result: Option<Result_>,
+    pub result: Option<Result>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronBasketConstructionParameters {
@@ -346,14 +347,14 @@ pub struct UpdateSnsSubnetListResponse {
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
+    pub async fn add_wasm(&self, arg0: &AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "add_wasm")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<(DeployNewSnsResponse,)> {
+    pub async fn deploy_new_sns(&self, arg0: &DeployNewSnsRequest) -> CallResult<(DeployNewSnsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "deploy_new_sns")
             .with_arg(arg0)
             .await
@@ -362,7 +363,7 @@ impl Service {
     }
     pub async fn get_allowed_principals(
         &self,
-        arg0: GetAllowedPrincipalsArg,
+        arg0: &GetAllowedPrincipalsArg,
     ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_allowed_principals")
             .with_arg(arg0)
@@ -372,7 +373,7 @@ impl Service {
     }
     pub async fn get_deployed_sns_by_proposal_id(
         &self,
-        arg0: GetDeployedSnsByProposalIdRequest,
+        arg0: &GetDeployedSnsByProposalIdRequest,
     ) -> CallResult<(GetDeployedSnsByProposalIdResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_deployed_sns_by_proposal_id")
             .with_arg(arg0)
@@ -380,7 +381,7 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<(Vec<(String, String)>,)> {
+    pub async fn get_latest_sns_version_pretty(&self, arg0: &()) -> CallResult<(Vec<(String, String)>,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_latest_sns_version_pretty")
             .with_arg(arg0)
             .await
@@ -389,7 +390,7 @@ impl Service {
     }
     pub async fn get_next_sns_version(
         &self,
-        arg0: GetNextSnsVersionRequest,
+        arg0: &GetNextSnsVersionRequest,
     ) -> CallResult<(GetNextSnsVersionResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_next_sns_version")
             .with_arg(arg0)
@@ -399,7 +400,7 @@ impl Service {
     }
     pub async fn get_proposal_id_that_added_wasm(
         &self,
-        arg0: GetProposalIdThatAddedWasmRequest,
+        arg0: &GetProposalIdThatAddedWasmRequest,
     ) -> CallResult<(GetProposalIdThatAddedWasmResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_proposal_id_that_added_wasm")
             .with_arg(arg0)
@@ -407,21 +408,21 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_sns_subnet_ids(&self, arg0: GetSnsSubnetIdsArg) -> CallResult<(GetSnsSubnetIdsResponse,)> {
+    pub async fn get_sns_subnet_ids(&self, arg0: &GetSnsSubnetIdsArg) -> CallResult<(GetSnsSubnetIdsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_sns_subnet_ids")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
+    pub async fn get_wasm(&self, arg0: &GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_wasm")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn get_wasm_metadata(&self, arg0: GetWasmMetadataRequest) -> CallResult<(GetWasmMetadataResponse,)> {
+    pub async fn get_wasm_metadata(&self, arg0: &GetWasmMetadataRequest) -> CallResult<(GetWasmMetadataResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "get_wasm_metadata")
             .with_arg(arg0)
             .await
@@ -430,7 +431,7 @@ impl Service {
     }
     pub async fn insert_upgrade_path_entries(
         &self,
-        arg0: InsertUpgradePathEntriesRequest,
+        arg0: &InsertUpgradePathEntriesRequest,
     ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "insert_upgrade_path_entries")
             .with_arg(arg0)
@@ -438,14 +439,14 @@ impl Service {
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn list_deployed_snses(&self, arg0: ListDeployedSnsesArg) -> CallResult<(ListDeployedSnsesResponse,)> {
+    pub async fn list_deployed_snses(&self, arg0: &ListDeployedSnsesArg) -> CallResult<(ListDeployedSnsesResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_deployed_snses")
             .with_arg(arg0)
             .await
             .map_err(ic_cdk::call::Error::from)
             .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
-    pub async fn list_upgrade_steps(&self, arg0: ListUpgradeStepsRequest) -> CallResult<(ListUpgradeStepsResponse,)> {
+    pub async fn list_upgrade_steps(&self, arg0: &ListUpgradeStepsRequest) -> CallResult<(ListUpgradeStepsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "list_upgrade_steps")
             .with_arg(arg0)
             .await
@@ -454,7 +455,7 @@ impl Service {
     }
     pub async fn update_allowed_principals(
         &self,
-        arg0: UpdateAllowedPrincipalsRequest,
+        arg0: &UpdateAllowedPrincipalsRequest,
     ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "update_allowed_principals")
             .with_arg(arg0)
@@ -464,7 +465,7 @@ impl Service {
     }
     pub async fn update_sns_subnet_list(
         &self,
-        arg0: UpdateSnsSubnetListRequest,
+        arg0: &UpdateSnsSubnetListRequest,
     ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
         ic_cdk::call::Call::unbounded_wait(self.0, "update_sns_subnet_list")
             .with_arg(arg0)

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -264,7 +264,7 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
             .or(existing_data.nervous_system_parameters);
 
     let list_topics_response = sns_gov::Service(governance_canister_id)
-        .list_topics(ListTopicsRequest {})
+        .list_topics(&ListTopicsRequest {})
         .await
         .map_err(|err| crate::state::log(format!("Call to Swap.list_topics failed: {err:?}")))
         .map(|response: (_,)| response.0)

--- a/scripts/sns/aggregator/did2rs.header
+++ b/scripts/sns/aggregator/did2rs.header
@@ -1,4 +1,5 @@
 #![allow(clippy::all)]
+#![allow(clippy::pedantic)]
 #![allow(deprecated)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]


### PR DESCRIPTION
# Motivation

The daily aggregator-update workflow has been failing since the didc 0.4.0 → 0.5.4 bump in #7812. The committed bindings were never regenerated under the new didc, so the codegen output drifted from the checked-in files and `ic_sns_ledger.patch` no longer applied cleanly.

# Changes

- Regenerated all five `ic_sns_*.rs` candid bindings under `didc 0.5.4`.
- Re-derived `ic_sns_ledger.patch` against the new baseline (same 3 derive-stripping hunks, updated context).
- Updated the `list_topics` call in `upstream.rs` to pass `&ListTopicsRequest` to match the new by-reference canister-method signatures.