### PR TITLE
chore(deps): bump dfx to 0.32.0 (via snsdemo release-2026-06-10)

### DIFF
--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: |
         URL="${{ inputs.snapshot_url }}"
-        test -n "$URL" || URL="https://github.com/dfinity/snsdemo/releases/download/${{ steps.snsdemo_ref.outputs.ref }}/snsdemo_snapshot_ubuntu-22.04.tar.xz"
+        test -n "$URL" || URL="https://github.com/dfinity/snsdemo/releases/download/${{ steps.snsdemo_ref.outputs.ref }}/snsdemo_snapshot_ubuntu-24.04.tar.xz"
         echo "url=$URL" >> "$GITHUB_OUTPUT"
     - name: Get SNS scripts
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/config.json
+++ b/config.json
@@ -115,7 +115,7 @@
         "DIDC_VERSION": "didc 0.5.4",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2026-05-27",
+        "SNSDEMO_RELEASE": "release-2026-06-10",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97"
       },
       "packtool": ""

--- a/config.json
+++ b/config.json
@@ -115,7 +115,7 @@
         "DIDC_VERSION": "didc 0.5.4",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2026-06-10",
+        "SNSDEMO_RELEASE": "release-2026-06-17",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97"
       },
       "packtool": ""

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.31.0",
+  "dfx": "0.32.0",
   "canisters": {
     "nns-governance": {
       "type": "custom",


### PR DESCRIPTION
# Motivation

Bump `dfx` to `0.32.0`. dfx 0.32.0 reads a replica/pocket-ic state that the older snsdemo snapshot can't provide (CI fails with `Error: Cannot find canister id`), so the dfx bump has to come together with the matching snsdemo release.

`release-2026-06-10` is the first snsdemo release built on dfx 0.32.0 (see https://github.com/dfinity/snsdemo/pull/594), and it publishes its test snapshot as `ubuntu-24.04`.

Depends on #7905 (Linux runners / Docker base image on ubuntu 24.04), already merged.

# Changes

- `dfx.json`: `dfx` `0.31.0` → `0.32.0`.
- `config.json`: `SNSDEMO_RELEASE` → `release-2026-06-10` (brings the snapshot generated with dfx 0.32.0).
- `start_dfx_snapshot`: snapshot artifact `snsdemo_snapshot_ubuntu-22.04.tar.xz` → `…ubuntu-24.04.tar.xz`, to match how snsdemo now publishes snapshots (since release-2026-06-03).
- Regenerated the 4 e2e screenshot baselines for the new snapshot.

# Tests

- CI should pass.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
