### PR TITLE
fix(ci): pin dfinity/setup-dfx to commit SHA

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -49,7 +49,7 @@ runs:
       shell: bash
       run: echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
     - name: Install dfx
-      uses: dfinity/setup-dfx@main
+      uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
     - name: Install tools
       shell: bash
       run: |

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -63,7 +63,7 @@ runs:
     - name: Install cargo binstall
       uses: ./.github/actions/install_binstall
     - name: Install dfx
-      uses: dfinity/setup-dfx@main
+      uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
     - name: Install SNS script dependencies
       shell: bash
       run: |


### PR DESCRIPTION
# Motivation

Using `dfinity/setup-dfx@main` means CI always fetches whatever is at the tip of `main`. A future commit there — including a compromised one — could silently change what runs in our pipelines. Pinning to a SHA makes the reference immutable.

# Changes

- Replaced `dfinity/setup-dfx@main` with a pinned commit SHA in `build_nns_dapp/action.yaml`.
- Replaced `dfinity/setup-dfx@main` with a pinned commit SHA in `start_dfx_snapshot/action.yaml`.