### PR TITLE
fix(ci): pin docker/build-push-action to commit SHA

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo "{}" > global-config.json
     - name: Build wasms
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         file: Dockerfile


### PR DESCRIPTION
# Motivation

Using `docker/build-push-action@v5` means CI tracks a mutable tag. If the tag is moved to a different commit — intentionally or via a supply chain attack — our builds silently change. Pinning to a SHA makes the reference immutable.

# Changes

- Replaced `docker/build-push-action@v5` with a pinned commit SHA in `build_nns_dapp/action.yaml`.