### PR TITLE
fix(ci): pin actions/checkout to commit SHA

### DIFF
--- a/.github/actions/checkout_snsdemo/action.yaml
+++ b/.github/actions/checkout_snsdemo/action.yaml
@@ -63,7 +63,7 @@ runs:
         fi
     - name: Get snsdemo
       if: ${{ steps.have_snsdemo.outputs.have_snsdemo == 'false' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         repository: 'dfinity/snsdemo'
         path: '${{ inputs.path }}'

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -51,7 +51,7 @@ runs:
         test -n "$URL" || URL="https://github.com/dfinity/snsdemo/releases/download/${{ steps.snsdemo_ref.outputs.ref }}/snsdemo_snapshot_ubuntu-22.04.tar.xz"
         echo "url=$URL" >> "$GITHUB_OUTPUT"
     - name: Get SNS scripts
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         repository: 'dfinity/snsdemo'
         path: 'snsdemo'

--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout nns-dapp
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Get node version
       shell: bash
       run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV

--- a/.github/actions/vitest/action.yml
+++ b/.github/actions/vitest/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout nns-dapp
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Get node version
       shell: bash
       run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV


### PR DESCRIPTION
# Motivation

Using `actions/checkout@v6` means CI tracks a mutable tag. If the tag is moved to a different commit — intentionally or via a supply chain attack — our pipelines silently change. Pinning to a SHA makes the reference immutable.

# Changes

- Replaced `actions/checkout@v6` with a pinned commit SHA in `checkout_snsdemo/action.yaml`.
- Replaced `actions/checkout@v6` with a pinned commit SHA in `start_dfx_snapshot/action.yaml`.
- Replaced `actions/checkout@v6` with a pinned commit SHA in `test-e2e/action.yml`.
- Replaced `actions/checkout@v6` with a pinned commit SHA in `vitest/action.yml`.