### PR TITLE
fix(backend): impose Candid decoding quota on http_request query

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -1,4 +1,4 @@
-60
+82
 Monterey
 IC
 ICP
@@ -80,3 +80,4 @@ dropdowns
 params
 APY
 APYs
+DoS

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,7 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
-- Impose a Candid decoding quota on the public `http_request` query to limit the DoS surface from oversized or adversarially encoded payloads.
+- Impose a Candid decoding quota on the public `http_request` query to limit the DoS surface from oversized or maliciously encoded payloads.
 
 #### Not Published
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,7 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
-- Impose a Candid decoding quota on the public `http_request` query to limit the DoS surface from oversized or maliciously encoded payloads.
+- Impose a Candid decoding quota on the public `http_request` query to limit the DoS surface from large or maliciously encoded payloads.
 
 #### Not Published
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Impose a Candid decoding quota on the public `http_request` query to limit the DoS surface from oversized or adversarially encoded payloads.
+
 #### Not Published
 
 ### Operations

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -12,7 +12,7 @@ use crate::perf::PerformanceCount;
 use crate::state::{init_state, restore_state, save_state, with_state, with_state_mut, StableState};
 use crate::tvl::TvlResponse;
 
-pub use candid::{CandidType, Deserialize};
+pub use candid::{candid_method, CandidType, Deserialize};
 use ic_cdk::println;
 use ic_cdk::{init, post_upgrade, pre_upgrade};
 use icp_ledger::AccountIdentifier;
@@ -87,12 +87,25 @@ fn post_upgrade(args_maybe: Option<CanisterArguments>) {
     println!("END   post-upgrade");
 }
 
-// TODO: add a `decode_with` argument decoder that imposes a Candid decoding
-// quota (see `http_request_decode_arg` in sns_aggregator/src/lib.rs). The
-// previous `decoding_quota` query attribute was removed in ic-cdk 0.19, and
-// this endpoint has no equivalent bound on attacker-controlled payloads.
+/// Decodes the `http_request` argument with a tight Candid quota to limit the
+/// `DoS` surface from oversized attacker-controlled payloads. ic-cdk 0.19 removed
+/// the `decoding_quota` query attribute, so we re-impose it via `decode_with`.
+#[allow(clippy::needless_pass_by_value)] // signature required by ic_cdk::query(decode_with = ...)
+fn http_request_decode_arg(arg_bytes: Vec<u8>) -> assets::HttpRequest {
+    let mut decoder_config = candid::DecoderConfig::new();
+    decoder_config.set_decoding_quota(10_000);
+    decoder_config.set_skipping_quota(10_000);
+    let (req,): (assets::HttpRequest,) = candid::utils::decode_args_with_config(&arg_bytes, &decoder_config)
+        .unwrap_or_else(|e| ic_cdk::api::trap(format!("Failed to decode http_request argument: {e}")));
+    req
+}
+
+// `hidden = true` suppresses ic-cdk's auto-generated Candid registration, which
+// (because of `decode_with`) would otherwise export the argument as raw `blob`.
+// The explicit `candid_method` below keeps the published interface as `HttpRequest`.
 #[must_use]
-#[ic_cdk::query]
+#[candid_method(query)]
+#[ic_cdk::query(hidden = true, decode_with = "http_request_decode_arg")]
 pub fn http_request(req: assets::HttpRequest) -> assets::HttpResponse {
     assets::http_request(req)
 }


### PR DESCRIPTION
# Motivation

The public `http_request` query decoded its argument with the default Candid decoder, with no bound on attacker-controlled payloads. An anonymous caller could send oversized or adversarially encoded input to consume excessive instructions and degrade availability. The `sns_aggregator` already guards this; the backend had a TODO for it since the ic-cdk 0.19 bump removed the old `decoding_quota` query attribute.

# Changes

- Added `http_request_decode_arg`, a `decode_with` decoder that caps decoding and skipping work via a Candid `DecoderConfig` (quota 10_000 each), mirroring `sns_aggregator`.
- Wired it into the `http_request` query and removed the TODO.
- Set `hidden = true` on the query plus an explicit `candid_method` so the published interface stays `HttpRequest` instead of ic-cdk exporting the argument as raw `blob`.
- Added a changelog entry under Security.