### PR TITLE
feat(frontend): add atino canister to II alternative origins

### DIFF
--- a/frontend/src/lib/constants/origin.constants.ts
+++ b/frontend/src/lib/constants/origin.constants.ts
@@ -5,4 +5,5 @@ export const NNS_IC_ORG_ALTERNATIVE_ORIGINS = [
   "https://wallet.ic0.app",
   "https://beta.nns.internetcomputer.org",
   "https://beta.nns.ic0.app",
+  "https://atino-ciaaa-aaaae-agwjq-cai.icp0.io",
 ];

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -33,6 +33,9 @@ describe("env-utils", () => {
 
       setOrigin("https://beta.nns.ic0.app");
       expect(isNnsAlternativeOrigin()).toBeTruthy();
+
+      setOrigin("https://atino-ciaaa-aaaae-agwjq-cai.icp0.io");
+      expect(isNnsAlternativeOrigin()).toBeTruthy();
     });
 
     it("should not be an alternative origin", () => {

--- a/frontend/static/.well-known/ii-alternative-origins
+++ b/frontend/static/.well-known/ii-alternative-origins
@@ -1,1 +1,1 @@
-{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app", "https://sns.internetcomputer.org"]}
+{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app", "https://sns.internetcomputer.org", "https://atino-ciaaa-aaaae-agwjq-cai.icp0.io"]}


### PR DESCRIPTION
# Motivation

We want the ICVC redemption canister to share the same Internet Identity as `nns.ic0.app`, so users get the same account when they open it. For that the canister origin has to be a registered alternative origin.

# Changes

- Added `https://atino-ciaaa-aaaae-agwjq-cai.icp0.io` to the `ii-alternative-origins` manifest so II authorizes it to use `nns.ic0.app` as derivation origin.
- Added the same origin to `NNS_IC_ORG_ALTERNATIVE_ORIGINS` so the app requests the `nns.ic0.app` derivation origin when running there.
- Added a test case asserting the new origin is recognized as an alternative origin.
