### PR TITLE
fix(release): pick newest successful CI run for artifacts

### DIFF
--- a/scripts/nns-dapp/get-ci-build-run
+++ b/scripts/nns-dapp/get-ci-build-run
@@ -37,5 +37,5 @@ fi
 if [ "$ALL" = "true" ]; then
   echo "$ci_build_run_ids"
 else
-  echo "$ci_build_run_ids" | tail -1
+  echo "$ci_build_run_ids" | head -1
 fi


### PR DESCRIPTION
# Motivation

The release SOP downloads CI build artifacts by commit SHA, but `get-ci-build-run` picked the *oldest* successful run for that commit. When a commit is built several times across days, the oldest run's artifacts (`nns-dapp`, `sns_aggregator`) have short retention (~3 days) and get garbage-collected by GitHub, so `download-ci-wasm` fails with "no artifact matches any of the names or patterns provided" even though the build was fine.

# Changes

- Switched `get-ci-build-run` to pick the newest successful run (`head -1` instead of `tail -1`), which still has its artifacts. The build is reproducible, so the WASM hash is identical across runs.