### PR TITLE
fix(canisters): terminate cycles workers to stop memory leak

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,10 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- Terminate the per-canister cycles Web Workers when leaving the canisters
+  page, fixing a memory leak that could crash the tab ("Aw, Snap!") after
+  repeatedly navigating in and out of the canisters list with a large fleet.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/canisters/CanisterCardCycles.svelte
+++ b/frontend/src/lib/components/canisters/CanisterCardCycles.svelte
@@ -19,6 +19,13 @@
   export let canister: CanisterDetails;
 
   let worker: CyclesWorker | undefined;
+  // Set once the component is destroyed. `initWorker` is async, so the card can
+  // be destroyed while `initCyclesWorker()` is still pending (this happens on
+  // every visit to the canisters list, which briefly clears the store and
+  // remounts the cards). Without this flag `onDestroy` runs while `worker` is
+  // still undefined, and the worker that arrives afterwards is assigned to a
+  // dead component and never terminated - leaking one worker per card per visit.
+  let destroyed = false;
 
   const stopAndTerminate = () => {
     worker?.stopCyclesTimer();
@@ -29,7 +36,10 @@
     worker = undefined;
   };
 
-  onDestroy(stopAndTerminate);
+  onDestroy(() => {
+    destroyed = true;
+    stopAndTerminate();
+  });
 
   // The canister currently handled by the worker. Used to avoid re-creating a
   // worker when the `canister` prop changes but still points to the same
@@ -42,9 +52,9 @@
 
     const newWorker = await initCyclesWorker();
 
-    // A newer init superseded this one while we were awaiting: discard the
-    // just-created worker instead of leaking it.
-    if (canisterId !== currentCanisterId) {
+    // The component was destroyed, or a newer init superseded this one, while
+    // we were awaiting: discard the just-created worker instead of leaking it.
+    if (destroyed || canisterId !== currentCanisterId) {
       newWorker.terminate();
       return;
     }

--- a/frontend/src/lib/components/canisters/CanisterCardCycles.svelte
+++ b/frontend/src/lib/components/canisters/CanisterCardCycles.svelte
@@ -20,20 +20,50 @@
 
   let worker: CyclesWorker | undefined;
 
-  onDestroy(() => worker?.stopCyclesTimer());
-
-  const initWorker = async () => {
+  const stopAndTerminate = () => {
     worker?.stopCyclesTimer();
+    // Terminate the Web Worker, otherwise it keeps running (and holding memory)
+    // after the card is destroyed, leaking one worker per canister on every
+    // visit to the canisters page.
+    worker?.terminate();
+    worker = undefined;
+  };
 
-    worker = await initCyclesWorker();
+  onDestroy(stopAndTerminate);
 
-    worker.startCyclesTimer({
-      canisterId: canister.canister_id.toText(),
+  // The canister currently handled by the worker. Used to avoid re-creating a
+  // worker when the `canister` prop changes but still points to the same
+  // canister (e.g. when the list is reloaded), and to detect races when a new
+  // init supersedes a pending one.
+  let currentCanisterId: string | undefined;
+
+  const initWorker = async (canisterId: string) => {
+    stopAndTerminate();
+
+    const newWorker = await initCyclesWorker();
+
+    // A newer init superseded this one while we were awaiting: discard the
+    // just-created worker instead of leaking it.
+    if (canisterId !== currentCanisterId) {
+      newWorker.terminate();
+      return;
+    }
+
+    worker = newWorker;
+
+    newWorker.startCyclesTimer({
+      canisterId,
       callback: syncCanisterCallback,
     });
   };
 
-  $: (canister, (async () => await initWorker())());
+  $: {
+    const canisterId = canister.canister_id.toText();
+    if (canisterId !== currentCanisterId) {
+      currentCanisterId = canisterId;
+      initWorker(canisterId);
+    }
+  }
 
   let canisterSync: CanisterSync | undefined = undefined;
 

--- a/frontend/src/lib/services/worker-cycles.services.ts
+++ b/frontend/src/lib/services/worker-cycles.services.ts
@@ -14,6 +14,7 @@ export interface CyclesWorker {
     } & Pick<PostMessageDataRequestCycles, "canisterId">
   ) => void;
   stopCyclesTimer: () => void;
+  terminate: () => void;
 }
 
 export const initCyclesWorker = async (): Promise<CyclesWorker> => {
@@ -53,6 +54,9 @@ export const initCyclesWorker = async (): Promise<CyclesWorker> => {
       cyclesWorker.postMessage({
         msg: "nnsStopCyclesTimer",
       });
+    },
+    terminate: () => {
+      cyclesWorker.terminate();
     },
   };
 };

--- a/frontend/src/tests/lib/components/canisters/CanisterCard.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/CanisterCard.spec.ts
@@ -11,6 +11,9 @@ vitest.mock("$lib/services/worker-cycles.services", () => ({
       stopCyclesTimer: () => {
         // Do nothing
       },
+      terminate: () => {
+        // Do nothing
+      },
     })
   ),
 }));

--- a/frontend/src/tests/lib/components/canisters/CanisterCardCycles.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/CanisterCardCycles.spec.ts
@@ -1,6 +1,10 @@
 import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
 import CanisterCardCycles from "$lib/components/canisters/CanisterCardCycles.svelte";
-import type { CyclesCallback } from "$lib/services/worker-cycles.services";
+import {
+  initCyclesWorker,
+  type CyclesCallback,
+  type CyclesWorker,
+} from "$lib/services/worker-cycles.services";
 import type { CanisterSync } from "$lib/types/canister";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCanister } from "$tests/mocks/canisters.mock";
@@ -154,5 +158,34 @@ describe("CanisterCardCycles", () => {
     unmount();
 
     expect(terminateSpy).toBeCalledTimes(1);
+  });
+
+  it("should terminate a worker that resolves after the component is destroyed", async () => {
+    // Reproduces the leak seen on the canisters list: the store is briefly
+    // cleared on every visit, so a card can be destroyed while
+    // `initCyclesWorker()` is still pending. The worker that arrives afterwards
+    // must be terminated instead of leaked.
+    let resolveWorker: (worker: CyclesWorker) => void = () => undefined;
+    vi.mocked(initCyclesWorker).mockImplementationOnce(
+      () =>
+        new Promise<CyclesWorker>((resolve) => {
+          resolveWorker = resolve;
+        })
+    );
+
+    const { unmount } = render(CanisterCardCycles, props);
+
+    // The worker init is still pending; destroy the component first.
+    unmount();
+    expect(terminateSpy).not.toBeCalled();
+
+    // The worker resolves only now, after destroy.
+    resolveWorker({
+      startCyclesTimer: () => undefined,
+      stopCyclesTimer: () => undefined,
+      terminate: terminateSpy,
+    });
+
+    await waitFor(() => expect(terminateSpy).toBeCalledTimes(1));
   });
 });

--- a/frontend/src/tests/lib/components/canisters/CanisterCardCycles.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/CanisterCardCycles.spec.ts
@@ -9,6 +9,8 @@ import { render, waitFor } from "@testing-library/svelte";
 
 let cyclesCallback: CyclesCallback | undefined;
 
+const { terminateSpy } = vi.hoisted(() => ({ terminateSpy: vi.fn() }));
+
 vitest.mock("$lib/services/worker-cycles.services", () => ({
   initCyclesWorker: vitest.fn(() =>
     Promise.resolve({
@@ -18,6 +20,7 @@ vitest.mock("$lib/services/worker-cycles.services", () => ({
       stopCyclesTimer: () => {
         // Do nothing
       },
+      terminate: terminateSpy,
     })
   ),
 }));
@@ -25,6 +28,7 @@ vitest.mock("$lib/services/worker-cycles.services", () => ({
 describe("CanisterCardCycles", () => {
   beforeEach(() => {
     cyclesCallback = undefined;
+    terminateSpy.mockClear();
   });
 
   const props = { props: { canister: mockCanister } };
@@ -138,5 +142,17 @@ describe("CanisterCardCycles", () => {
     await waitFor(() =>
       expect(getAllByTestId("skeleton-text").length).toEqual(3)
     );
+  });
+
+  it("should terminate the worker when destroyed to avoid leaking it", async () => {
+    const { unmount } = render(CanisterCardCycles, props);
+
+    await waitFor(() => expect(cyclesCallback).toBeDefined());
+
+    expect(terminateSpy).not.toBeCalled();
+
+    unmount();
+
+    expect(terminateSpy).toBeCalledTimes(1);
   });
 });

--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -37,6 +37,9 @@ vi.mock("$lib/services/worker-cycles.services", () => ({
       stopCyclesTimer: () => {
         // Do nothing
       },
+      terminate: () => {
+        // Do nothing
+      },
     })
   ),
 }));

--- a/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
+++ b/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
@@ -6,11 +6,13 @@ vi.mock("$lib/workers/cycles.worker?worker");
 
 describe("initCyclesWorker", () => {
   const postMessage = vi.fn();
+  const terminate = vi.fn();
   beforeEach(async () => {
     const module = await import("$lib/workers/cycles.worker?worker");
     // In Vitest 4, we need to mock default as a constructor (class)
     module.default = class {
       postMessage = postMessage;
+      terminate = terminate;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
   });
@@ -33,5 +35,15 @@ describe("initCyclesWorker", () => {
         fetchRootKey: FETCH_ROOT_KEY,
       },
     });
+  });
+
+  it("terminate terminates the underlying worker", async () => {
+    const cyclesWorker = await initCyclesWorker();
+
+    expect(terminate).not.toBeCalled();
+
+    cyclesWorker.terminate();
+
+    expect(terminate).toBeCalledTimes(1);
   });
 });

--- a/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
+++ b/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
@@ -8,6 +8,8 @@ describe("initCyclesWorker", () => {
   const postMessage = vi.fn();
   const terminate = vi.fn();
   beforeEach(async () => {
+    postMessage.mockClear();
+    terminate.mockClear();
     const module = await import("$lib/workers/cycles.worker?worker");
     // In Vitest 4, we need to mock default as a constructor (class)
     module.default = class {


### PR DESCRIPTION
# Motivation

A user reported the tab crashing ("Aw, Snap!") when managing canisters on nns.ic0.app: clicking into a canister, going back to the list, and the tab crashes once the list finishes loading. It happens repeatedly and gets worse with a larger fleet.

The cause is a Web Worker leak. Each canister card spawns its own cycles worker, but the worker was never terminated - `onDestroy` only stopped its timer. So every visit to the canisters list leaks one worker per canister, and navigating in and out keeps piling them up until the renderer runs out of memory and crashes.

# Changes

- Added `terminate()` to the `CyclesWorker` interface and call it on card destroy, so workers no longer outlive the card.
- Gated worker re-init on the canister id actually changing, instead of re-creating a worker on every prop update from list reloads.
- Discarded a superseded async init instead of orphaning its worker.
- Added tests covering terminate-on-destroy and worker termination.
