### PR TITLE
fix(release-sop): derive default test network and domain from DEVENV_USER

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -1,4 +1,4 @@
-82
+83
 Monterey
 IC
 ICP
@@ -33,6 +33,7 @@ Dapp
 Dependabot
 clippy
 dapp
+devenv
 dockerfile
 dockerfiles
 dockerized

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,4 +38,9 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- The `release-sop` script now derives its default test network and domain from
+  `DEVENV_USER` (falling back to `$USER`), so developers whose local username
+  differs from their devenv name can set it without overriding the system
+  `USER` variable.
+
 #### Security

--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -3,6 +3,11 @@ set -euo pipefail
 
 SOURCE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
+# The devenv username, used to derive the default test network and domain.
+# Defaults to $USER, but can be overridden for developers whose local username
+# does not match their devenv name (e.g. DEVENV_USER=jdoe).
+DEVENV_USER="${DEVENV_USER:-$USER}"
+
 print_help() {
   cat <<-EOF
 
@@ -27,8 +32,8 @@ source "$SOURCE_DIR/../clap.bash"
 clap.define long=new desc="Start a new release branch" variable=IS_NEW_RELEASE nargs=0 default="false"
 clap.define long=continue desc="Continue with an existing release branch" variable=CONTINUE nargs=0 default="false"
 clap.define long=name desc="The name of the new release branch" variable=BRANCH_NAME default=""
-clap.define long=test_network desc="The dfx network to deploy the release candidate to for testing" variable=TEST_NETWORK default="devenv_$USER"
-clap.define long=test_domain desc="The domain to use for the Release candidate URL" variable=TEST_DOMAIN default="${USER}-ingress.devenv.dfinity.network"
+clap.define long=test_network desc="The dfx network to deploy the release candidate to for testing" variable=TEST_NETWORK default="devenv_$DEVENV_USER"
+clap.define long=test_domain desc="The domain to use for the Release candidate URL" variable=TEST_DOMAIN default="${DEVENV_USER}-ingress.devenv.dfinity.network"
 clap.define long=mock-json desc="A json file with mock responses for commands during testing" variable=MOCK_JSON default=""
 # Source the output file ------------------------------------------------------
 source "$(clap.build)"


### PR DESCRIPTION
# Motivation

The `release-sop` script defaults its test network to `devenv_$USER` and its test domain to `${USER}-ingress.devenv.dfinity.network`. This only works when the local machine username matches the devenv name. When they differ, the only workaround was to override `USER` in the shell, which is a system variable other tools rely on. For example [Homebrew 6.0.0](https://brew.sh/2026/06/11/homebrew-6.0.0/)'s new [tap trust](https://docs.brew.sh/Tap-Trust) check calls `Dir.home(ENV["USER"])` and fails when `USER` is not a real account.

# Changes

- Added a `DEVENV_USER` variable (falling back to `$USER`) and used it to build the default test network and domain.
- Added an Operations changelog entry.

Backwards compatible: if `DEVENV_USER` is not set, the defaults are exactly `$USER` as before.