### PR TITLE
chore(ci): pin remaining GitHub Action references to commit SHAs

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up docker buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
     - name: Create global config
       shell: bash
       run: echo "{}" > global-config.json

--- a/.github/actions/install_ic_wasm/action.yaml
+++ b/.github/actions/install_ic_wasm/action.yaml
@@ -12,7 +12,7 @@ runs:
         echo "IC_WASM_PATH=/home/runner/.cargo/bin/ic-wasm" >> "$GITHUB_OUTPUT"
     - name: Cache ic-wasm
       id: cache-ic-wasm
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.ic-wasm-version.outputs.IC_WASM_PATH }}
         key: ${{ runner.os }}-${{ steps.ic-wasm-version.outputs.IC_WASM_VERSION }}-ic-wasm

--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -22,15 +22,15 @@ runs:
     - name: Get node version
       shell: bash
       run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Get nns-dapp
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: nns-dapp
     - name: Get sns_aggregator_dev
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: sns_aggregator_dev
     - name: Start snapshot environment
@@ -67,7 +67,7 @@ runs:
       run: |
         find frontend/playwright-*
     - name: Upload Playwright results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: ${{ failure() }}
       with:
         name: playwright-failure-results-${{ inputs.shard_number }}
@@ -90,7 +90,7 @@ runs:
         fi
     - name: Upload screenshots
       if: ${{ steps.check-screenshots.outputs.screenshots }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: updated-screenshots
         path: |

--- a/.github/actions/vitest/action.yml
+++ b/.github/actions/vitest/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Get node version
       shell: bash
       run: jq -r '"NODE_VERSION=\(.volta.node)"' frontend/package.json >> $GITHUB_ENV
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Install dependencies


### PR DESCRIPTION
# Motivation

Most actions in the composite actions are already pinned to a full commit SHA, but a few were still using floating major tags like `@v4` and `@v3`. Floating tags can move to new code, which makes builds unpredictable and is a supply-chain risk. This finishes the job so all external actions are pinned.

# Changes

- Pinned `docker/setup-buildx-action` to a commit SHA (v3.12.0) in the build action.
- Pinned `actions/cache` to a commit SHA (v4.3.0) in the install-ic-wasm action.
- Pinned `actions/setup-node` to a commit SHA (v4.4.0) in the vitest and test-e2e actions.
- Pinned `actions/download-artifact` and `actions/upload-artifact` to commit SHAs (v4.3.0 / v4.6.2) in the test-e2e action.

Kept the same versions, so no behavior change -- just pinning.