### PR TITLE
chore(deps): bump ic-cdk to 0.20.2 with API migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
  "candid",
  "dfn_protobuf",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-crypto-tree-hash",
  "ic-dummy-getrandom-for-wasm",
  "ic-http-types",
@@ -1033,6 +1033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1071,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -1989,7 +2023,7 @@ checksum = "818d6d5416a8f0212e1b132703b0da51e36c55f2b96677e96f2bbe7702e1bd85"
 dependencies = [
  "candid",
  "ic-cdk-executor",
- "ic-cdk-macros",
+ "ic-cdk-macros 0.19.0",
  "ic-error-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-management-canister-types 0.5.0",
  "ic0",
@@ -1997,6 +2031,22 @@ dependencies = [
  "serde",
  "serde_bytes",
  "slotmap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ic-cdk"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7971f4983db147afbbc4e7f87f60b09fcd60ac707af37ff3d2468dcddbf551"
+dependencies = [
+ "candid",
+ "ic-cdk-executor",
+ "ic-cdk-macros 0.20.2",
+ "ic-error-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic0",
+ "pin-project-lite",
+ "serde",
  "thiserror 2.0.18",
 ]
 
@@ -2019,6 +2069,19 @@ checksum = "66dad91a214945cb3605bc9ef6901b87e2ac41e3624284c2cabba49d43aa4f43"
 dependencies = [
  "candid",
  "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c20c002200c720958f321bb78b4d4987fc2c380bf9ef69ed4404730810f45f"
+dependencies = [
+ "candid",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2392,7 +2455,7 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canister-profiler",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-cdk-timers",
  "ic-crypto-sha2",
  "ic-http-types",
@@ -2420,7 +2483,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-cdk-timers",
  "ic-certification",
  "ic-http-types",
@@ -2470,7 +2533,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -2616,7 +2679,7 @@ dependencies = [
  "candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-error-types 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base)",
  "ic-ledger-core",
  "ic-management-canister-types-private",
@@ -2735,7 +2798,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#992628c4f26cc7320396b6b8be37133a666a4386"
 dependencies = [
  "candid",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -2759,7 +2822,7 @@ version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#992628c4f26cc7320396b6b8be37133a666a4386"
 dependencies = [
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
 ]
 
 [[package]]
@@ -2788,7 +2851,7 @@ dependencies = [
  "candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -2809,7 +2872,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
 ]
 
 [[package]]
@@ -2827,7 +2890,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#992628c4f26cc7320396b6b8be37133a666a4386"
 dependencies = [
- "ic-cdk",
+ "ic-cdk 0.19.0",
 ]
 
 [[package]]
@@ -2838,7 +2901,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -2867,7 +2930,7 @@ name = "ic-neurons-fund"
 version = "0.0.1"
 source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#992628c4f26cc7320396b6b8be37133a666a4386"
 dependencies = [
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-nervous-system-common",
  "lazy_static",
  "rust_decimal",
@@ -2884,7 +2947,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-nervous-system-canisters",
  "ic-nns-constants",
  "ic-protobuf",
@@ -2923,7 +2986,7 @@ dependencies = [
  "dyn-clone",
  "futures",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-cdk-timers",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
@@ -3068,7 +3131,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
  "ic-nervous-system-root",
@@ -3129,7 +3192,7 @@ name = "ic-registry-canister-chunkify"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#992628c4f26cc7320396b6b8be37133a666a4386"
 dependencies = [
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-nervous-system-chunks",
  "ic-registry-transport",
  "ic-stable-structures 0.6.9",
@@ -3155,7 +3218,7 @@ version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#992628c4f26cc7320396b6b8be37133a666a4386"
 dependencies = [
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-protobuf",
 ]
 
@@ -3256,7 +3319,7 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canister-profiler",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-cdk-timers",
  "ic-crypto-sha2",
  "ic-http-types",
@@ -3362,7 +3425,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -3415,7 +3478,7 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-cdk-timers",
  "ic-http-types",
  "ic-management-canister-types-private",
@@ -3445,7 +3508,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-cdk-timers",
  "ic-http-types",
  "ic-ledger-core",
@@ -3496,7 +3559,7 @@ dependencies = [
  "futures",
  "hex",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-crypto-sha2",
  "ic-http-types",
  "ic-management-canister-types-private",
@@ -3696,7 +3759,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -3739,7 +3802,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#99
 dependencies = [
  "async-trait",
  "candid",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "icrc-ledger-client",
 ]
 
@@ -4365,7 +4428,7 @@ dependencies = [
  "flate2",
  "hex",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.20.2",
  "ic-cdk-timers",
  "ic-certified-map 0.3.4",
  "ic-crypto-sha2",
@@ -5293,7 +5356,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-certified-map 0.3.4",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
@@ -5354,7 +5417,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2026-07-09_04-35-base#99
 dependencies = [
  "chrono",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.19.0",
  "ic-nns-constants",
  "ic-protobuf",
  "itertools 0.12.1",
@@ -5843,7 +5906,7 @@ dependencies = [
  "candid",
  "dfn_candid",
  "ic-base-types",
- "ic-cdk",
+ "ic-cdk 0.20.2",
  "ic-cdk-timers",
  "ic-certified-map 0.3.2",
  "ic-management-canister-types 0.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 version = "2.0.148"
 
 [workspace.dependencies]
-ic-cdk = "0.19.0"
+ic-cdk = "0.20.2"
 ic-cdk-timers = "1.0.0"
 ic-management-canister-types = "0.8.0"
 

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -80,13 +80,23 @@ struct CanisterStatusResultV2 {
     module_hash: Option<serde_bytes::ByteBuf>,
 }
 
+/// Argument for the management canister `canister_status` method.
+///
+/// Previously `ic_cdk::management_canister::CanisterIdRecord`, which moved to the
+/// separate `ic-cdk-management-canister` crate in ic-cdk 0.20.  We only need this
+/// one trivial record, so we mirror it locally as with the types above.
+#[derive(CandidType, Deserialize)]
+struct CanisterIdRecord {
+    canister_id: Principal,
+}
+
 /// API method to get cycle balance and burn rate.
 #[candid_method(update)]
 #[ic_cdk::update]
 #[allow(clippy::panic)] // This is a readonly function, only a rather arcane reason prevents it from being a query call.
 async fn get_canister_status() -> CanisterStatusResultV2 {
     let own_canister_id = ic_cdk::api::canister_self();
-    let canister_id_record = ic_cdk::management_canister::CanisterIdRecord {
+    let canister_id_record = CanisterIdRecord {
         canister_id: own_canister_id,
     };
 

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -10,7 +10,7 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use candid::Principal;
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
@@ -1067,90 +1067,183 @@ pub struct SetModeRet {}
 pub struct Service(pub Principal);
 impl Service {
     pub async fn claim_swap_neurons(&self, arg0: ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {
-        ic_cdk::call(self.0, "claim_swap_neurons", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "claim_swap_neurons")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn fail_stuck_upgrade_in_progress(
         &self,
         arg0: FailStuckUpgradeInProgressArg,
     ) -> CallResult<(FailStuckUpgradeInProgressRet,)> {
-        ic_cdk::call(self.0, "fail_stuck_upgrade_in_progress", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "fail_stuck_upgrade_in_progress")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
-        ic_cdk::call(self.0, "get_build_metadata", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_build_metadata")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_latest_reward_event(&self) -> CallResult<(RewardEvent,)> {
-        ic_cdk::call(self.0, "get_latest_reward_event", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_latest_reward_event")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_maturity_modulation(
         &self,
         arg0: GetMaturityModulationArg,
     ) -> CallResult<(GetMaturityModulationResponse,)> {
-        ic_cdk::call(self.0, "get_maturity_modulation", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_maturity_modulation")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_metadata(&self, arg0: GetMetadataArg) -> CallResult<(GetMetadataResponse,)> {
-        ic_cdk::call(self.0, "get_metadata", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_metadata")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_metrics(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
-        ic_cdk::call(self.0, "get_metrics", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_metrics")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_metrics_replicated(&self, arg0: GetMetricsRequest) -> CallResult<(GetMetricsResponse,)> {
-        ic_cdk::call(self.0, "get_metrics_replicated", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_metrics_replicated")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_mode(&self, arg0: GetModeArg) -> CallResult<(GetModeResponse,)> {
-        ic_cdk::call(self.0, "get_mode", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_mode")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_nervous_system_parameters(&self, arg0: ()) -> CallResult<(NervousSystemParameters,)> {
-        ic_cdk::call(self.0, "get_nervous_system_parameters", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_nervous_system_parameters")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_neuron(&self, arg0: GetNeuron) -> CallResult<(GetNeuronResponse,)> {
-        ic_cdk::call(self.0, "get_neuron", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_neuron")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_proposal(&self, arg0: GetProposal) -> CallResult<(GetProposalResponse,)> {
-        ic_cdk::call(self.0, "get_proposal", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_proposal")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_root_canister_status(&self, arg0: ()) -> CallResult<(CanisterStatusResultV2,)> {
-        ic_cdk::call(self.0, "get_root_canister_status", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_root_canister_status")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_running_sns_version(
         &self,
         arg0: GetRunningSnsVersionArg,
     ) -> CallResult<(GetRunningSnsVersionResponse,)> {
-        ic_cdk::call(self.0, "get_running_sns_version", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_running_sns_version")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_sns_initialization_parameters(
         &self,
         arg0: GetSnsInitializationParametersArg,
     ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
-        ic_cdk::call(self.0, "get_sns_initialization_parameters", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_sns_initialization_parameters")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
-        ic_cdk::call(self.0, "get_timers", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_timers")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_upgrade_journal(
         &self,
         arg0: GetUpgradeJournalRequest,
     ) -> CallResult<(GetUpgradeJournalResponse,)> {
-        ic_cdk::call(self.0, "get_upgrade_journal", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_upgrade_journal")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_nervous_system_functions(&self) -> CallResult<(ListNervousSystemFunctionsResponse,)> {
-        ic_cdk::call(self.0, "list_nervous_system_functions", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_nervous_system_functions")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<(ListNeuronsResponse,)> {
-        ic_cdk::call(self.0, "list_neurons", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_neurons")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_proposals(&self, arg0: ListProposals) -> CallResult<(ListProposalsResponse,)> {
-        ic_cdk::call(self.0, "list_proposals", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_proposals")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_topics(&self, arg0: ListTopicsRequest) -> CallResult<(ListTopicsResponse,)> {
-        ic_cdk::call(self.0, "list_topics", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_topics")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
-        ic_cdk::call(self.0, "manage_neuron", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "manage_neuron")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
-        ic_cdk::call(self.0, "reset_timers", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "reset_timers")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn set_mode(&self, arg0: SetMode) -> CallResult<(SetModeRet,)> {
-        ic_cdk::call(self.0, "set_mode", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "set_mode")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -10,7 +10,7 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use candid::Principal;
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
@@ -531,93 +531,190 @@ pub struct Icrc3SupportedBlockTypesRetItem {
 pub struct Service(pub Principal);
 impl Service {
     pub async fn archives(&self) -> CallResult<(Vec<ArchiveInfo>,)> {
-        ic_cdk::call(self.0, "archives", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "archives")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<(GetBlocksResponse,)> {
-        ic_cdk::call(self.0, "get_blocks", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_blocks")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
-        ic_cdk::call(self.0, "get_data_certificate", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_data_certificate")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> CallResult<(GetTransactionsResponse,)> {
-        ic_cdk::call(self.0, "get_transactions", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_transactions")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_103_get_allowances(
         &self,
         arg0: GetAllowancesArgs,
     ) -> CallResult<(Icrc103GetAllowancesResponse,)> {
-        ic_cdk::call(self.0, "icrc103_get_allowances", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc103_get_allowances")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_106_get_index_principal(&self) -> CallResult<(GetIndexPrincipalResult,)> {
-        ic_cdk::call(self.0, "icrc106_get_index_principal", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc106_get_index_principal")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_10_supported_standards(&self) -> CallResult<(Vec<Icrc10SupportedStandardsRetItem>,)> {
-        ic_cdk::call(self.0, "icrc10_supported_standards", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc10_supported_standards")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_152_burn(&self, arg0: Icrc152BurnArgs) -> CallResult<(Icrc152BurnResult,)> {
-        ic_cdk::call(self.0, "icrc152_burn", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc152_burn")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_152_mint(&self, arg0: Icrc152MintArgs) -> CallResult<(Icrc152MintResult,)> {
-        ic_cdk::call(self.0, "icrc152_mint", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc152_mint")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
-        ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_balance_of")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_decimals(&self) -> CallResult<(u8,)> {
-        ic_cdk::call(self.0, "icrc1_decimals", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_decimals")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_fee(&self) -> CallResult<(Tokens,)> {
-        ic_cdk::call(self.0, "icrc1_fee", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_fee")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_metadata(&self) -> CallResult<(Vec<(String, MetadataValue)>,)> {
-        ic_cdk::call(self.0, "icrc1_metadata", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_metadata")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_minting_account(&self) -> CallResult<(Option<Account>,)> {
-        ic_cdk::call(self.0, "icrc1_minting_account", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_minting_account")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_name(&self) -> CallResult<(String,)> {
-        ic_cdk::call(self.0, "icrc1_name", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_name")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_supported_standards(&self) -> CallResult<(Vec<StandardRecord>,)> {
-        ic_cdk::call(self.0, "icrc1_supported_standards", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_supported_standards")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_symbol(&self) -> CallResult<(String,)> {
-        ic_cdk::call(self.0, "icrc1_symbol", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_symbol")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_total_supply(&self) -> CallResult<(Tokens,)> {
-        ic_cdk::call(self.0, "icrc1_total_supply", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_total_supply")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_1_transfer(&self, arg0: TransferArg) -> CallResult<(TransferResult,)> {
-        ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc1_transfer")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_21_canister_call_consent_message(
         &self,
         arg0: Icrc21ConsentMessageRequest,
     ) -> CallResult<(Icrc21ConsentMessageResponse,)> {
-        ic_cdk::call(self.0, "icrc21_canister_call_consent_message", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc21_canister_call_consent_message")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_2_allowance(&self, arg0: AllowanceArgs) -> CallResult<(Allowance,)> {
-        ic_cdk::call(self.0, "icrc2_allowance", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc2_allowance")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_2_approve(&self, arg0: ApproveArgs) -> CallResult<(ApproveResult,)> {
-        ic_cdk::call(self.0, "icrc2_approve", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc2_approve")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_2_transfer_from(&self, arg0: TransferFromArgs) -> CallResult<(TransferFromResult,)> {
-        ic_cdk::call(self.0, "icrc2_transfer_from", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc2_transfer_from")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_3_get_archives(&self, arg0: GetArchivesArgs) -> CallResult<(GetArchivesResult,)> {
-        ic_cdk::call(self.0, "icrc3_get_archives", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_get_archives")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_3_get_blocks(&self, arg0: Vec<GetBlocksArgs>) -> CallResult<(GetBlocksResult,)> {
-        ic_cdk::call(self.0, "icrc3_get_blocks", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_get_blocks")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_3_get_tip_certificate(&self) -> CallResult<(Option<Icrc3DataCertificate>,)> {
-        ic_cdk::call(self.0, "icrc3_get_tip_certificate", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_get_tip_certificate")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn icrc_3_supported_block_types(&self) -> CallResult<(Vec<Icrc3SupportedBlockTypesRetItem>,)> {
-        ic_cdk::call(self.0, "icrc3_supported_block_types", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "icrc3_supported_block_types")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn is_ledger_ready(&self) -> CallResult<(bool,)> {
-        ic_cdk::call(self.0, "is_ledger_ready", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "is_ledger_ready")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -10,7 +10,7 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use candid::Principal;
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
@@ -265,60 +265,111 @@ pub struct SetDappControllersResponse {
 pub struct Service(pub Principal);
 impl Service {
     pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {
-        ic_cdk::call(self.0, "canister_status", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "canister_status")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn change_canister(&self, arg0: ChangeCanisterRequest) -> CallResult<()> {
-        ic_cdk::call(self.0, "change_canister", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "change_canister")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn clean_up_failed_register_extension(
         &self,
         arg0: CleanUpFailedRegisterExtensionRequest,
     ) -> CallResult<(CleanUpFailedRegisterExtensionResponse,)> {
-        ic_cdk::call(self.0, "clean_up_failed_register_extension", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "clean_up_failed_register_extension")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
-        ic_cdk::call(self.0, "get_build_metadata", ()).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_build_metadata")
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_sns_canisters_summary(
         &self,
         arg0: GetSnsCanistersSummaryRequest,
     ) -> CallResult<(GetSnsCanistersSummaryResponse,)> {
-        ic_cdk::call(self.0, "get_sns_canisters_summary", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_sns_canisters_summary")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
-        ic_cdk::call(self.0, "get_timers", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_timers")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_sns_canisters(&self, arg0: ListSnsCanistersArg) -> CallResult<(ListSnsCanistersResponse,)> {
-        ic_cdk::call(self.0, "list_sns_canisters", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_sns_canisters")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn manage_dapp_canister_settings(
         &self,
         arg0: ManageDappCanisterSettingsRequest,
     ) -> CallResult<(ManageDappCanisterSettingsResponse,)> {
-        ic_cdk::call(self.0, "manage_dapp_canister_settings", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "manage_dapp_canister_settings")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn register_dapp_canister(
         &self,
         arg0: RegisterDappCanisterRequest,
     ) -> CallResult<(RegisterDappCanisterRet,)> {
-        ic_cdk::call(self.0, "register_dapp_canister", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "register_dapp_canister")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn register_dapp_canisters(
         &self,
         arg0: RegisterDappCanistersRequest,
     ) -> CallResult<(RegisterDappCanistersRet,)> {
-        ic_cdk::call(self.0, "register_dapp_canisters", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "register_dapp_canisters")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn register_extension(&self, arg0: RegisterExtensionRequest) -> CallResult<(RegisterExtensionResponse,)> {
-        ic_cdk::call(self.0, "register_extension", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "register_extension")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
-        ic_cdk::call(self.0, "reset_timers", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "reset_timers")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn set_dapp_controllers(
         &self,
         arg0: SetDappControllersRequest,
     ) -> CallResult<(SetDappControllersResponse,)> {
-        ic_cdk::call(self.0, "set_dapp_controllers", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "set_dapp_controllers")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -10,7 +10,7 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use candid::Principal;
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
@@ -523,78 +523,158 @@ pub struct ResetTimersRet {}
 pub struct Service(pub Principal);
 impl Service {
     pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {
-        ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "error_refund_icp")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn finalize_swap(&self, arg0: FinalizeSwapArg) -> CallResult<(FinalizeSwapResponse,)> {
-        ic_cdk::call(self.0, "finalize_swap", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "finalize_swap")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_auto_finalization_status(
         &self,
         arg0: GetAutoFinalizationStatusArg,
     ) -> CallResult<(GetAutoFinalizationStatusResponse,)> {
-        ic_cdk::call(self.0, "get_auto_finalization_status", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_auto_finalization_status")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<(GetBuyerStateResponse,)> {
-        ic_cdk::call(self.0, "get_buyer_state", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_buyer_state")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_buyers_total(&self, arg0: GetBuyersTotalArg) -> CallResult<(GetBuyersTotalResponse,)> {
-        ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_buyers_total")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_canister_status(&self, arg0: GetCanisterStatusArg) -> CallResult<(CanisterStatusResultV2,)> {
-        ic_cdk::call(self.0, "get_canister_status", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_canister_status")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_derived_state(&self, arg0: GetDerivedStateArg) -> CallResult<(GetDerivedStateResponse,)> {
-        ic_cdk::call(self.0, "get_derived_state", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_derived_state")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_init(&self, arg0: GetInitArg) -> CallResult<(GetInitResponse,)> {
-        ic_cdk::call(self.0, "get_init", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_init")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_lifecycle(&self, arg0: GetLifecycleArg) -> CallResult<(GetLifecycleResponse,)> {
-        ic_cdk::call(self.0, "get_lifecycle", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_lifecycle")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_open_ticket(&self, arg0: GetOpenTicketArg) -> CallResult<(GetOpenTicketResponse,)> {
-        ic_cdk::call(self.0, "get_open_ticket", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_open_ticket")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_sale_parameters(&self, arg0: GetSaleParametersArg) -> CallResult<(GetSaleParametersResponse,)> {
-        ic_cdk::call(self.0, "get_sale_parameters", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_sale_parameters")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_state(&self, arg0: GetStateArg) -> CallResult<(GetStateResponse,)> {
-        ic_cdk::call(self.0, "get_state", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_state")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_timers(&self, arg0: GetTimersArg) -> CallResult<(GetTimersResponse,)> {
-        ic_cdk::call(self.0, "get_timers", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_timers")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_community_fund_participants(
         &self,
         arg0: ListCommunityFundParticipantsRequest,
     ) -> CallResult<(ListCommunityFundParticipantsResponse,)> {
-        ic_cdk::call(self.0, "list_community_fund_participants", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_community_fund_participants")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_direct_participants(
         &self,
         arg0: ListDirectParticipantsRequest,
     ) -> CallResult<(ListDirectParticipantsResponse,)> {
-        ic_cdk::call(self.0, "list_direct_participants", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_direct_participants")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_sns_neuron_recipes(
         &self,
         arg0: ListSnsNeuronRecipesRequest,
     ) -> CallResult<(ListSnsNeuronRecipesResponse,)> {
-        ic_cdk::call(self.0, "list_sns_neuron_recipes", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_sns_neuron_recipes")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<(NewSaleTicketResponse,)> {
-        ic_cdk::call(self.0, "new_sale_ticket", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "new_sale_ticket")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn notify_payment_failure(&self, arg0: NotifyPaymentFailureArg) -> CallResult<(Ok2,)> {
-        ic_cdk::call(self.0, "notify_payment_failure", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "notify_payment_failure")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn refresh_buyer_tokens(
         &self,
         arg0: RefreshBuyerTokensRequest,
     ) -> CallResult<(RefreshBuyerTokensResponse,)> {
-        ic_cdk::call(self.0, "refresh_buyer_tokens", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "refresh_buyer_tokens")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn reset_timers(&self, arg0: ResetTimersArg) -> CallResult<(ResetTimersRet,)> {
-        ic_cdk::call(self.0, "reset_timers", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "reset_timers")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -10,7 +10,7 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use candid::Principal;
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
@@ -347,69 +347,129 @@ pub struct UpdateSnsSubnetListResponse {
 pub struct Service(pub Principal);
 impl Service {
     pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
-        ic_cdk::call(self.0, "add_wasm", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "add_wasm")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<(DeployNewSnsResponse,)> {
-        ic_cdk::call(self.0, "deploy_new_sns", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "deploy_new_sns")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_allowed_principals(
         &self,
         arg0: GetAllowedPrincipalsArg,
     ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
-        ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_allowed_principals")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_deployed_sns_by_proposal_id(
         &self,
         arg0: GetDeployedSnsByProposalIdRequest,
     ) -> CallResult<(GetDeployedSnsByProposalIdResponse,)> {
-        ic_cdk::call(self.0, "get_deployed_sns_by_proposal_id", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_deployed_sns_by_proposal_id")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<(Vec<(String, String)>,)> {
-        ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_latest_sns_version_pretty")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_next_sns_version(
         &self,
         arg0: GetNextSnsVersionRequest,
     ) -> CallResult<(GetNextSnsVersionResponse,)> {
-        ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_next_sns_version")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_proposal_id_that_added_wasm(
         &self,
         arg0: GetProposalIdThatAddedWasmRequest,
     ) -> CallResult<(GetProposalIdThatAddedWasmResponse,)> {
-        ic_cdk::call(self.0, "get_proposal_id_that_added_wasm", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_proposal_id_that_added_wasm")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_sns_subnet_ids(&self, arg0: GetSnsSubnetIdsArg) -> CallResult<(GetSnsSubnetIdsResponse,)> {
-        ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_sns_subnet_ids")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
-        ic_cdk::call(self.0, "get_wasm", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_wasm")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn get_wasm_metadata(&self, arg0: GetWasmMetadataRequest) -> CallResult<(GetWasmMetadataResponse,)> {
-        ic_cdk::call(self.0, "get_wasm_metadata", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "get_wasm_metadata")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn insert_upgrade_path_entries(
         &self,
         arg0: InsertUpgradePathEntriesRequest,
     ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
-        ic_cdk::call(self.0, "insert_upgrade_path_entries", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "insert_upgrade_path_entries")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_deployed_snses(&self, arg0: ListDeployedSnsesArg) -> CallResult<(ListDeployedSnsesResponse,)> {
-        ic_cdk::call(self.0, "list_deployed_snses", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_deployed_snses")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn list_upgrade_steps(&self, arg0: ListUpgradeStepsRequest) -> CallResult<(ListUpgradeStepsResponse,)> {
-        ic_cdk::call(self.0, "list_upgrade_steps", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "list_upgrade_steps")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn update_allowed_principals(
         &self,
         arg0: UpdateAllowedPrincipalsRequest,
     ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
-        ic_cdk::call(self.0, "update_allowed_principals", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "update_allowed_principals")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
     pub async fn update_sns_subnet_list(
         &self,
         arg0: UpdateSnsSubnetListRequest,
     ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
-        ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
+        ic_cdk::call::Call::unbounded_wait(self.0, "update_sns_subnet_list")
+            .with_arg(arg0)
+            .await
+            .map_err(ic_cdk::call::Error::from)
+            .and_then(|resp| resp.candid_tuple().map_err(Into::into))
     }
 }

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -130,6 +130,12 @@ cd "$GIT_ROOT"
 	    # In the service, return CallResult instead of Result.
 	    /impl Service/,${s/-> Result/-> CallResult/g};
 
+	    # In the service, migrate the deprecated `ic_cdk::call()` function (removed in
+	    # ic-cdk 0.20) to the `ic_cdk::call::Call` builder API.  Two shapes are emitted
+	    # by didc: calls with a single argument `(arg0,)` and nullary calls `()`.
+	    /impl Service/,${s@ic_cdk::call\(self\.0, ("[a-z0-9_]+"), \(arg0,\)\)\.await@ic_cdk::call::Call::unbounded_wait(self.0, \1).with_arg(arg0).await.map_err(ic_cdk::call::Error::from).and_then(|resp| resp.candid_tuple().map_err(Into::into))@g};
+	    /impl Service/,${s@ic_cdk::call\(self\.0, ("[a-z0-9_]+"), \(\)\)\.await@ic_cdk::call::Call::unbounded_wait(self.0, \1).await.map_err(ic_cdk::call::Error::from).and_then(|resp| resp.candid_tuple().map_err(Into::into))@g};
+
 	    # Replace invalid "{}" in generated Rust code with "EmptyRecord":
 	    /^pub (struct|enum) /,/^}/{s/ *\{\},$/(EmptyRecord),/g};
 	    ' |

--- a/scripts/sns/aggregator/did2rs.header
+++ b/scripts/sns/aggregator/did2rs.header
@@ -8,4 +8,4 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use candid::Principal;
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::CallResult;


### PR DESCRIPTION
# Motivation

Dependabot #7910 bumps `ic-cdk` from 0.19 to 0.20.2 but fails to build, because 0.20 has two breaking changes the plain bump does not adapt to. This PR supersedes #7910 by doing the bump plus the migration.

The two breaking changes:
- The deprecated `ic_cdk::call()` free function was removed (`call` is now a module). This broke all 100 call sites in the candid-generated `rs/sns_aggregator/src/types/ic_*.rs` service bindings.
- The `management_canister` module moved to its own crate, breaking `ic_cdk::management_canister::CanisterIdRecord` in `lib.rs`.

# Changes

- Migrated the generated service methods to the `ic_cdk::call::Call` builder API, matching the style already used in `upstream.rs`, and fixed the `CallResult` import.
- Updated the `did2rs` codegen (`did2rs.sh` + `did2rs.header`) so regenerating these files emits the new API instead of the old one.
- Mirrored the trivial `CanisterIdRecord` locally in `lib.rs`, next to the other management-canister types already defined there, to avoid pulling in the new `ic-cdk-management-canister` crate for a single record.
- Bumped `ic-cdk` to 0.20.2. The lockfile keeps both 0.19.0 (required by the IC git deps) and 0.20.2 (our crates); this is expected.