### PR TITLE
bot: Update rust version to 1.97.0

### DIFF
--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -202,7 +202,7 @@ pub fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
 
 /// Insert an asset into the state.
 pub fn insert_asset<S: Into<String> + Clone>(path: S, asset: Asset) {
-    crate::state::log(format!("Inserting asset {}", &path.clone().into()));
+    crate::state::log(format!("Inserting asset {}", path.clone().into()));
     STATE.with(|s| {
         let mut asset_hashes = s.asset_hashes.borrow_mut();
         let stable_memory = s.stable.borrow();

--- a/rs/sns_aggregator/src/fast_scheduler.rs
+++ b/rs/sns_aggregator/src/fast_scheduler.rs
@@ -181,7 +181,7 @@ impl FastScheduler {
     /// Starts the update timer using the global state.
     pub fn global_start() {
         let timer_interval = Duration::from_millis(STATE.with(|s| s.stable.borrow().config.borrow().fast_interval_ms));
-        crate::state::log(format!("Set interval to {}", &timer_interval.as_millis()));
+        crate::state::log(format!("Set interval to {}", timer_interval.as_millis()));
         STATE.with(|state| {
             state.fast_scheduler.borrow_mut().start(timer_interval);
         });

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -231,7 +231,7 @@ fn setup(config: Option<Config>) {
     ));
     // Set configuration, if provided
     if let Some(config) = config {
-        crate::state::log(format!("Setting config to: {:?}", &config));
+        crate::state::log(format!("Setting config to: {:?}", config));
         STATE.with(|state| {
             *state.stable.borrow().config.borrow_mut() = config;
         });
@@ -252,7 +252,7 @@ fn setup(config: Option<Config>) {
     //
     // Note: Timers are lost on upgrade, so a fresh timer needs to be started after upgrade.
     let timer_interval = Duration::from_millis(STATE.with(|s| s.stable.borrow().config.borrow().update_interval_ms));
-    crate::state::log(format!("Set interval to {}", &timer_interval.as_millis()));
+    crate::state::log(format!("Set interval to {}", timer_interval.as_millis()));
     STATE.with(|state| {
         let timer_id = set_timer_interval(timer_interval, crate::upstream::update_cache);
         let old_timer = state.timer_id.replace_with(|_| Some(timer_id));

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -231,7 +231,7 @@ fn setup(config: Option<Config>) {
     ));
     // Set configuration, if provided
     if let Some(config) = config {
-        crate::state::log(format!("Setting config to: {:?}", config));
+        crate::state::log(format!("Setting config to: {config:?}"));
         STATE.with(|state| {
             *state.stable.borrow().config.borrow_mut() = config;
         });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.96.1"
+channel = "1.97.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

The bot PR #7951 bumps Rust to 1.97.0, but 1.97.0 ships a stricter `clippy::useless_borrows_in_formatting` lint that fails the `cargo-tests` build under `-D warnings`. Since we shouldn't push commits to bot-generated PRs, this replaces it and fixes the lints too.

# Changes

- Updated the Rust toolchain to 1.97.0.
- Removed the redundant `&` in four `format!` arguments in the `sns_aggregator` crate that now trip `clippy::useless_borrows_in_formatting`.

Replaces #7951.
