### PR TITLE
chore(deps): bump js-yaml to 4.3.1 to fix quadratic CPU DoS

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3999,9 +3999,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,6 +85,7 @@
   },
   "overrides": {
     "semver": "^7.5.3",
-    "cookie": "^0.7.0"
+    "cookie": "^0.7.0",
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
# Motivation

Dependabot flagged a high severity vuln (GHSA-5p4m-2wfm-xmqj) in js-yaml. Versions before 4.3.1 resolve `!!omap` with an O(n²) scan, so a small YAML doc can block the event loop for seconds. It's a transitive dev dependency pulled in through `@eslint/eslintrc`.

# Changes

- Added a `js-yaml` override in `frontend/package.json` pinned to `^4.3.1`.
- Regenerated `frontend/package-lock.json` to pick up the patched version.

Closes the alert at https://github.com/dfinity/nns-dapp/security/dependabot/216