### PR TITLE
fix(deps): bump dompurify to 3.4.13 to fix IN_PLACE XSS

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3090,9 +3090,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
# Motivation

Dependabot flagged dompurify 3.4.12, pulled in transitively through @dfinity/gix-components, for GHSA-55q2-fjhq-7xh7. A hook that removes an element during IN_PLACE sanitization can leave a detached descendant executable, allowing XSS after sanitize() returns. Fixes https://github.com/dfinity/nns-dapp/security/dependabot/218.

# Changes

- Bumped dompurify from 3.4.12 to 3.4.13 in frontend/package-lock.json.