### PR TITLE
fix(backend): bound Candid argument decoding

### DIFF
--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -110,6 +110,10 @@ pub fn http_request(req: assets::HttpRequest) -> assets::HttpResponse {
     assets::http_request(req)
 }
 
+// All structured argument methods below use the same decoding and skipping quotas.
+// Zero-argument methods do not decode argument bytes. `add_stable_asset` accepts a large blob whose
+// decoding cost is proportional to its byte length, so the ingress message limit already bounds it.
+
 fn get_caller() -> PrincipalId {
     let caller = ic_cdk::api::msg_caller();
     if caller == candid::Principal::anonymous() {
@@ -151,7 +155,11 @@ pub fn add_account() -> AccountIdentifier {
 /// user's principal (the fact that it is controlled by the same principal as the user's other
 /// ledger accounts is not derivable externally).
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn create_sub_account(sub_account_name: String) -> CreateSubAccountResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.create_sub_account(principal, sub_account_name))
@@ -161,7 +169,11 @@ pub fn create_sub_account(sub_account_name: String) -> CreateSubAccountResponse 
 ///
 /// These aliases are not visible externally or to anyone else.
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn rename_sub_account(request: RenameSubAccountRequest) -> RenameSubAccountResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.rename_sub_account(principal, request))
@@ -173,7 +185,11 @@ pub fn rename_sub_account(request: RenameSubAccountRequest) -> RenameSubAccountR
 /// the IC from the account, the user must use the hardware wallet to sign each request.
 /// Some read-only calls do not require signing, e.g. viewing the account's ICP balance.
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn register_hardware_wallet(request: RegisterHardwareWalletRequest) -> RegisterHardwareWalletResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.register_hardware_wallet(principal, request))
@@ -189,7 +205,11 @@ pub fn get_canisters() -> Vec<NamedCanister> {
 
 /// Attaches a canister to the user's account.
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn attach_canister(request: AttachCanisterRequest) -> AttachCanisterResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.attach_canister(principal, request))
@@ -197,7 +217,11 @@ pub fn attach_canister(request: AttachCanisterRequest) -> AttachCanisterResponse
 
 /// Renames a canister of the user.
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn rename_canister(request: RenameCanisterRequest) -> RenameCanisterResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.rename_canister(principal, request))
@@ -205,14 +229,22 @@ pub fn rename_canister(request: RenameCanisterRequest) -> RenameCanisterResponse
 
 /// Detaches a canister from the user's account.
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn detach_canister(request: DetachCanisterRequest) -> DetachCanisterResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.detach_canister(principal, request))
 }
 
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn set_imported_tokens(settings: ImportedTokens) -> SetImportedTokensResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.set_imported_tokens(principal, settings))
@@ -226,7 +258,11 @@ pub fn get_imported_tokens() -> GetImportedTokensResponse {
 }
 
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn set_fav_projects(settings: FavProjects) -> SetFavProjectsResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.set_fav_projects(principal, settings))
@@ -240,7 +276,11 @@ pub fn get_fav_projects() -> GetFavProjectsResponse {
 }
 
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn set_address_book(addresses: AddressBook) -> SetAddressBookResponse {
     let principal = get_caller();
     with_state_mut(|s| s.accounts_store.set_address_book(principal, addresses))
@@ -321,7 +361,11 @@ pub fn add_stable_asset(asset_bytes: Vec<u8>) {
 /// - If the requested number of accounts is too large, the call will run out of cycles and be killed.
 #[cfg(any(test, feature = "toy_data_gen"))]
 #[must_use]
-#[ic_cdk::update]
+#[candid_method(update)]
+#[ic_cdk::update(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn create_toy_accounts(num_accounts: u128) -> u64 {
     let caller = ic_cdk::api::msg_caller();
     if !ic_cdk::api::is_controller(&caller) {
@@ -338,7 +382,11 @@ pub fn create_toy_accounts(num_accounts: u128) -> u64 {
 /// Gets any toy account by toy account index.
 #[cfg(any(test, feature = "toy_data_gen"))]
 #[must_use]
-#[ic_cdk::query]
+#[candid_method(query)]
+#[ic_cdk::query(
+    hidden = true,
+    decode_with = "candid::utils::decode_one_with_decoding_and_skipping_quota::<10000,10000,_>"
+)]
 pub fn get_toy_account(toy_account_index: u64) -> GetAccountResponse {
     let caller = ic_cdk::api::msg_caller();
     if !ic_cdk::api::is_controller(&caller) {

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -110,10 +110,6 @@ pub fn http_request(req: assets::HttpRequest) -> assets::HttpResponse {
     assets::http_request(req)
 }
 
-// All structured argument methods below use the same decoding and skipping quotas.
-// Zero-argument methods do not decode argument bytes. `add_stable_asset` accepts a large blob whose
-// decoding cost is proportional to its byte length, so the ingress message limit already bounds it.
-
 fn get_caller() -> PrincipalId {
     let caller = ic_cdk::api::msg_caller();
     if caller == candid::Principal::anonymous() {


### PR DESCRIPTION
# Motivation

Structured Candid arguments need explicit decoding limits. These limits protect canister resources from expensive input types.

# Changes

- Applied decoding and skipping quotas to structured one-argument methods.
- Preserved the generated Candid interface for the changed methods.

# Tests

- `cargo fmt --all -- --check`
- `cargo check -p nns-dapp --tests`
- `cargo test -p nns-dapp candid_interface_test::test_implemented_interface_matches_declared_interface_exactly`
- `cargo test -p nns-dapp`

# Todos

- [x] Accessibility (a11y) – no frontend impact.
- [x] Changelog – no user-facing change.
