### PR TITLE
fix(address-book): base mutations on certified data

### DIFF
--- a/frontend/src/lib/modals/address-book/AddAddressModal.svelte
+++ b/frontend/src/lib/modals/address-book/AddAddressModal.svelte
@@ -97,6 +97,7 @@
   const disableSave = $derived(
     nickname === "" ||
       address === "" ||
+      $addressBookStore.certified !== true ||
       nonNullish(nicknameError) ||
       nonNullish(addressError) ||
       $busy ||
@@ -119,6 +120,10 @@
   const handleSubmit = async (event: SubmitEvent) => {
     event.preventDefault();
     normalizeNickname();
+
+    if ($addressBookStore.certified !== true) {
+      return;
+    }
 
     // Check if fields are empty after normalizing
     if (nickname === "" || address === "") {
@@ -144,29 +149,21 @@
       address: addressType,
     };
 
-    // Create temporary array with the updated addresses
-    const currentAddresses = $addressBookStore.namedAddresses ?? [];
-    let updatedAddresses: NamedAddress[];
-
-    if (isEditMode) {
-      // In edit mode, find and replace the existing entry
-      updatedAddresses = currentAddresses.map((entry) =>
-        normalizeName(entry.name) === normalizeName(namedAddress?.name ?? "")
-          ? updatedAddress
-          : entry
-      );
-    } else {
-      // In add mode, append the new address
-      updatedAddresses = [...currentAddresses, updatedAddress];
-    }
-
     const initiator = isEditMode
       ? "edit-address-book-entry"
       : "add-address-book-entry";
     startBusy({ initiator });
 
     try {
-      const result = await saveAddressBook(updatedAddresses);
+      const result = await saveAddressBook(
+        isEditMode
+          ? {
+              type: "update",
+              previousName: namedAddress?.name ?? "",
+              address: updatedAddress,
+            }
+          : { type: "add", address: updatedAddress }
+      );
 
       if (!result?.err) {
         toastsSuccess({

--- a/frontend/src/lib/modals/address-book/RemoveAddressModal.svelte
+++ b/frontend/src/lib/modals/address-book/RemoveAddressModal.svelte
@@ -8,7 +8,6 @@
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { IconErrorOutline } from "@dfinity/gix-components";
-  import { isNullish } from "@dfinity/utils";
 
   interface Props {
     onClose: () => void;
@@ -18,19 +17,18 @@
   const { onClose, namedAddress }: Props = $props();
 
   const handleDeleteConfirm = async () => {
-    if (isNullish($addressBookStore.namedAddresses)) {
+    if ($addressBookStore.certified !== true) {
       return;
     }
-
-    const updatedAddresses = $addressBookStore.namedAddresses.filter(
-      (entry) => entry.name !== namedAddress.name
-    );
 
     const initiator = "delete-address-book-entry";
     startBusy({ initiator });
 
     try {
-      const result = await saveAddressBook(updatedAddresses);
+      const result = await saveAddressBook({
+        type: "remove",
+        name: namedAddress.name,
+      });
 
       if (!result?.err) {
         toastsSuccess({
@@ -47,7 +45,11 @@
   };
 </script>
 
-<ConfirmationModal on:nnsClose={onClose} on:nnsConfirm={handleDeleteConfirm}>
+<ConfirmationModal
+  on:nnsClose={onClose}
+  on:nnsConfirm={handleDeleteConfirm}
+  disabledConfirm={$addressBookStore.certified !== true}
+>
   <div data-tid="remove-address-confirmation" class="wrapper">
     <h4>
       {replacePlaceholders($i18n.address_book.remove_address_title, {

--- a/frontend/src/lib/modals/common/ConfirmationModal.svelte
+++ b/frontend/src/lib/modals/common/ConfirmationModal.svelte
@@ -5,6 +5,7 @@
 
   export let testId = "confirmation-modal-component";
   export let yesLabel: string | undefined = undefined;
+  export let disabledConfirm = false;
 
   const dispatch = createEventDispatcher();
 
@@ -27,7 +28,7 @@
       </button>
       <button
         data-tid="confirm-yes"
-        disabled={$busy}
+        disabled={$busy || disabledConfirm}
         class="primary"
         on:click={() => dispatch("nnsConfirm")}
       >

--- a/frontend/src/lib/services/address-book.services.ts
+++ b/frontend/src/lib/services/address-book.services.ts
@@ -67,18 +67,66 @@ export const loadAddressBook = async ({
   });
 };
 
+export type AddressBookMutation =
+  | { type: "add"; address: NamedAddress }
+  | { type: "update"; previousName: string; address: NamedAddress }
+  | { type: "remove"; name: string };
+
+const normalizeName = (name: string): string => name.trim().toLowerCase();
+
+const applyMutation = ({
+  namedAddresses,
+  mutation,
+}: {
+  namedAddresses: NamedAddress[];
+  mutation: AddressBookMutation;
+}): NamedAddress[] => {
+  switch (mutation.type) {
+    case "add":
+      return [...namedAddresses, mutation.address];
+    case "update": {
+      const previousName = normalizeName(mutation.previousName);
+      const addressExists = namedAddresses.some(
+        ({ name }) => normalizeName(name) === previousName
+      );
+      if (!addressExists) {
+        throw new Error("The address book entry no longer exists.");
+      }
+      return namedAddresses.map((address) =>
+        normalizeName(address.name) === previousName
+          ? mutation.address
+          : address
+      );
+    }
+    case "remove": {
+      const addresses = namedAddresses.filter(
+        ({ name }) => name !== mutation.name
+      );
+      if (addresses.length === namedAddresses.length) {
+        throw new Error("The address book entry no longer exists.");
+      }
+      return addresses;
+    }
+  }
+};
+
 /**
- * Save the entire address book to the `nns-dapp` backend and reload to update the `addressBookStore`.
- * - This method always saves the complete address book (replaces the existing one).
- * - The UI is responsible for manipulating the array (add/update/remove) before calling this method.
- * - Displays appropriate error toasts based on the error type.
- * - Returns an error if the operation fails.
+ * Applies one mutation to a certified address book and reloads the store.
+ * Uncertified store data is never used as the base of the backend write.
  */
 export const saveAddressBook = async (
-  namedAddresses: NamedAddress[]
+  mutation: AddressBookMutation
 ): Promise<{ err?: Error } | undefined> => {
   try {
     const identity = await getAuthenticatedIdentity();
+    const { named_addresses: certifiedAddresses } = await getAddressBook({
+      identity,
+      certified: true,
+    });
+    const namedAddresses = applyMutation({
+      namedAddresses: certifiedAddresses,
+      mutation,
+    });
     await setAddressBook({ identity, namedAddresses });
     await loadAddressBook();
   } catch (err) {

--- a/frontend/src/tests/lib/modals/address-book/AddAddressModal.spec.ts
+++ b/frontend/src/tests/lib/modals/address-book/AddAddressModal.spec.ts
@@ -20,7 +20,7 @@ describe("AddAddressModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    addressBookStore.reset();
+    addressBookStore.set({ namedAddresses: [], certified: true });
   });
 
   it("should display modal", async () => {
@@ -52,6 +52,24 @@ describe("AddAddressModal", () => {
 
     const saveButton = queryByTestId("save-address-button");
     expect(saveButton?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("should disable save while the address book is uncertified", async () => {
+    addressBookStore.set({ namedAddresses: [], certified: false });
+
+    const { container, queryByTestId } = await renderModal({
+      component: AddAddressModal,
+      props: { onClose: vi.fn() },
+    });
+
+    await fireEvent.input(container.querySelector("input[name='nickname']"), {
+      target: { value: "MyAddress" },
+    });
+    await fireEvent.input(container.querySelector("input[name='address']"), {
+      target: { value: validIcpAddress },
+    });
+
+    expect(queryByTestId("save-address-button")).toBeDisabled();
   });
 
   it("should display error if nickname is too short on submit", async () => {
@@ -312,12 +330,13 @@ describe("AddAddressModal", () => {
     const saveButton = queryByTestId("save-address-button");
     await fireEvent.click(saveButton);
 
-    expect(saveAddressBookSpy).toHaveBeenCalledWith([
-      {
+    expect(saveAddressBookSpy).toHaveBeenCalledWith({
+      type: "add",
+      address: {
         name: "MyAddress",
         address: { Icp: validIcpAddress },
       },
-    ]);
+    });
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -350,12 +369,13 @@ describe("AddAddressModal", () => {
     const saveButton = queryByTestId("save-address-button");
     await fireEvent.click(saveButton);
 
-    expect(saveAddressBookSpy).toHaveBeenCalledWith([
-      {
+    expect(saveAddressBookSpy).toHaveBeenCalledWith({
+      type: "add",
+      address: {
         name: "MyICRC1",
         address: { Icrc1: validIcrc1Address },
       },
-    ]);
+    });
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -389,13 +409,13 @@ describe("AddAddressModal", () => {
     const saveButton = queryByTestId("save-address-button");
     await fireEvent.click(saveButton);
 
-    expect(saveAddressBookSpy).toHaveBeenCalledWith([
-      mockNamedAddressIcp,
-      {
+    expect(saveAddressBookSpy).toHaveBeenCalledWith({
+      type: "add",
+      address: {
         name: "NewAddress",
         address: { Icrc1: validIcrc1Address },
       },
-    ]);
+    });
   });
 
   it("should not close modal on error", async () => {
@@ -680,12 +700,14 @@ describe("AddAddressModal", () => {
       const saveButton = queryByTestId("save-address-button");
       await fireEvent.click(saveButton);
 
-      expect(saveAddressBookSpy).toHaveBeenCalledWith([
-        {
+      expect(saveAddressBookSpy).toHaveBeenCalledWith({
+        type: "update",
+        previousName: mockNamedAddressIcp.name,
+        address: {
           name: "UpdatedNickname",
           address: mockNamedAddressIcp.address,
         },
-      ]);
+      });
 
       expect(onClose).toHaveBeenCalled();
     });
@@ -718,13 +740,14 @@ describe("AddAddressModal", () => {
       const saveButton = queryByTestId("save-address-button");
       await fireEvent.click(saveButton);
 
-      expect(saveAddressBookSpy).toHaveBeenCalledWith([
-        {
+      expect(saveAddressBookSpy).toHaveBeenCalledWith({
+        type: "update",
+        previousName: mockNamedAddressIcp.name,
+        address: {
           name: mockNamedAddressIcp.name,
           address: { Icrc1: validIcrc1Address },
         },
-        mockNamedAddressIcrc1,
-      ]);
+      });
     });
   });
 
@@ -791,12 +814,13 @@ describe("AddAddressModal", () => {
       const saveButton = queryByTestId("save-address-button");
       await fireEvent.click(saveButton);
 
-      expect(saveAddressBookSpy).toHaveBeenCalledWith([
-        {
+      expect(saveAddressBookSpy).toHaveBeenCalledWith({
+        type: "add",
+        address: {
           name: "My Test Address",
           address: { Icp: validIcpAddress },
         },
-      ]);
+      });
 
       expect(onClose).toHaveBeenCalled();
     });

--- a/frontend/src/tests/lib/modals/address-book/RemoveAddressModal.spec.ts
+++ b/frontend/src/tests/lib/modals/address-book/RemoveAddressModal.spec.ts
@@ -1,0 +1,52 @@
+import RemoveAddressModal from "$lib/modals/address-book/RemoveAddressModal.svelte";
+import * as addressBookServices from "$lib/services/address-book.services";
+import { addressBookStore } from "$lib/stores/address-book.store";
+import { mockNamedAddressIcp } from "$tests/mocks/address-book.mock";
+import { renderModal } from "$tests/mocks/modal.mock";
+import { fireEvent } from "@testing-library/svelte";
+
+vi.mock("$lib/services/address-book.services");
+
+describe("RemoveAddressModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addressBookStore.set({
+      namedAddresses: [mockNamedAddressIcp],
+      certified: true,
+    });
+  });
+
+  it("removes an address through a mutation", async () => {
+    const saveAddressBookSpy = vi
+      .spyOn(addressBookServices, "saveAddressBook")
+      .mockResolvedValue({});
+    const onClose = vi.fn();
+    const { queryByTestId } = await renderModal({
+      component: RemoveAddressModal,
+      props: { namedAddress: mockNamedAddressIcp, onClose },
+    });
+
+    await fireEvent.click(queryByTestId("confirm-yes"));
+
+    expect(saveAddressBookSpy).toHaveBeenCalledWith({
+      type: "remove",
+      name: mockNamedAddressIcp.name,
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("disables removal while the address book is uncertified", async () => {
+    addressBookStore.set({
+      namedAddresses: [mockNamedAddressIcp],
+      certified: false,
+    });
+    const saveAddressBookSpy = vi.spyOn(addressBookServices, "saveAddressBook");
+    const { queryByTestId } = await renderModal({
+      component: RemoveAddressModal,
+      props: { namedAddress: mockNamedAddressIcp, onClose: vi.fn() },
+    });
+
+    expect(queryByTestId("confirm-yes")).toBeDisabled();
+    expect(saveAddressBookSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/lib/services/address-book.services.spec.ts
+++ b/frontend/src/tests/lib/services/address-book.services.spec.ts
@@ -1,0 +1,86 @@
+import * as addressBookApi from "$lib/api/address-book.api";
+import { saveAddressBook } from "$lib/services/address-book.services";
+import { addressBookStore } from "$lib/stores/address-book.store";
+import {
+  mockNamedAddressIcp,
+  mockNamedAddressIcrc1,
+} from "$tests/mocks/address-book.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+
+describe("address-book services", () => {
+  beforeEach(() => {
+    resetIdentity();
+    addressBookStore.reset();
+    vi.spyOn(console, "error").mockReturnValue();
+  });
+
+  it("adds an address to certified backend data", async () => {
+    addressBookStore.set({
+      namedAddresses: [mockNamedAddressIcrc1],
+      certified: false,
+    });
+    vi.spyOn(addressBookApi, "getAddressBook").mockResolvedValue({
+      named_addresses: [mockNamedAddressIcp],
+    });
+    const setAddressBookSpy = vi
+      .spyOn(addressBookApi, "setAddressBook")
+      .mockResolvedValue();
+
+    await saveAddressBook({
+      type: "add",
+      address: mockNamedAddressIcrc1,
+    });
+
+    expect(addressBookApi.getAddressBook).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      certified: true,
+    });
+    expect(setAddressBookSpy).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      namedAddresses: [mockNamedAddressIcp, mockNamedAddressIcrc1],
+    });
+  });
+
+  it("updates an address in certified backend data", async () => {
+    vi.spyOn(addressBookApi, "getAddressBook").mockResolvedValue({
+      named_addresses: [mockNamedAddressIcp, mockNamedAddressIcrc1],
+    });
+    const setAddressBookSpy = vi
+      .spyOn(addressBookApi, "setAddressBook")
+      .mockResolvedValue();
+    const updatedAddress = {
+      ...mockNamedAddressIcp,
+      name: "Updated address",
+    };
+
+    await saveAddressBook({
+      type: "update",
+      previousName: mockNamedAddressIcp.name,
+      address: updatedAddress,
+    });
+
+    expect(setAddressBookSpy).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      namedAddresses: [updatedAddress, mockNamedAddressIcrc1],
+    });
+  });
+
+  it("removes an address from certified backend data", async () => {
+    vi.spyOn(addressBookApi, "getAddressBook").mockResolvedValue({
+      named_addresses: [mockNamedAddressIcp, mockNamedAddressIcrc1],
+    });
+    const setAddressBookSpy = vi
+      .spyOn(addressBookApi, "setAddressBook")
+      .mockResolvedValue();
+
+    await saveAddressBook({
+      type: "remove",
+      name: mockNamedAddressIcp.name,
+    });
+
+    expect(setAddressBookSpy).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      namedAddresses: [mockNamedAddressIcrc1],
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Address-book writes used local query data as their base. A later valid edit could save entries from an uncertified response.

# Changes

- Applied each address-book mutation to fresh certified backend data.
- Changed add, edit, and remove flows to send explicit mutations.
- Disabled mutation actions until certified data is available.
- Added regression tests for certified mutations and disabled controls.

# Tests

- `npm run check`
- `npx tsc --noEmit -p tsconfig.spec.json`
- 37 focused address-book Vitest tests.

# Todos

- [x] Accessibility (a11y) – native buttons expose the disabled state.
- [x] Changelog – no user-facing feature change.
