### PR TITLE
feat(canisters): raise the canister name limit to 64 characters

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+- Increase the maximum canister name length from 24 to 64 characters.
+
 #### Deprecated
 
 #### Removed

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -36,7 +36,7 @@ const MAX_IMPORTED_TOKENS: i32 = 20;
 // Conservatively limit the number of favorite projects to prevent using too much memory.
 const MAX_FAVORITE_PROJECTS: i32 = 20;
 
-// Maximum length for a canister name
+// Maximum length in UTF-8 bytes for a canister name
 const CANISTER_NAME_MAX_LENGTH: usize = 64;
 
 // Conservatively limit the number of named addresses to prevent using too much memory.

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -36,6 +36,9 @@ const MAX_IMPORTED_TOKENS: i32 = 20;
 // Conservatively limit the number of favorite projects to prevent using too much memory.
 const MAX_FAVORITE_PROJECTS: i32 = 20;
 
+// Maximum length for a canister name
+const CANISTER_NAME_MAX_LENGTH: usize = 64;
+
 // Conservatively limit the number of named addresses to prevent using too much memory.
 const MAX_NAMED_ADDRESSES: i32 = 20;
 
@@ -875,8 +878,6 @@ impl AccountsStore {
     }
 
     fn validate_canister_name(name: &str) -> bool {
-        const CANISTER_NAME_MAX_LENGTH: usize = 24;
-
         name.len() <= CANISTER_NAME_MAX_LENGTH
     }
 

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -293,7 +293,7 @@ fn attach_canister_name_too_long() {
     let result1 = store.attach_canister(
         principal,
         AttachCanisterRequest {
-            name: "ABCDEFGHIJKLMNOPQRSTUVWX".to_string(),
+            name: "A".repeat(CANISTER_NAME_MAX_LENGTH),
             canister_id: canister_id1,
             block_index: None,
         },
@@ -301,7 +301,7 @@ fn attach_canister_name_too_long() {
     let result2 = store.attach_canister(
         principal,
         AttachCanisterRequest {
-            name: "ABCDEFGHIJKLMNOPQRSTUVWXY".to_string(),
+            name: "A".repeat(CANISTER_NAME_MAX_LENGTH + 1),
             canister_id: canister_id2,
             block_index: None,
         },
@@ -754,7 +754,7 @@ fn rename_to_long_name_fails() {
 
     let canister_id = CanisterId::from_str(TEST_ICRC1_ACCOUNT_2).unwrap();
 
-    let long_name = "ABCDEFGHIJKLMNOPQRSTUVWXY".to_string();
+    let long_name = "A".repeat(CANISTER_NAME_MAX_LENGTH + 1);
     let name = "DEF".to_string();
     store.attach_canister(
         principal,


### PR DESCRIPTION
# Motivation

The Canisters page limits a canister name to 24 characters. This is too short in practice, and it is well below the 64-character limit for contact names. The backend enforces the limit, so it must change first. The frontend change follows in a separate PR.

# Changes

- Raised the canister name limit from 24 to 64 characters.
- Moved `CANISTER_NAME_MAX_LENGTH` out of `validate_canister_name` to a module-level constant.
- Updated the attach and rename tests to build names from the constant.