### PR TITLE
feat(canisters): allow canister names up to 64 characters

### DIFF
--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -104,6 +104,7 @@ export const attachCanister = async ({
   if (isNameTooLong(name)) {
     throw new CanisterNameTooLongError("error__canister.name_too_long", {
       $name: name,
+      $max: String(MAX_CANISTER_NAME_LENGTH),
     });
   }
 
@@ -133,6 +134,7 @@ export const renameCanister = async ({
   if (isNameTooLong(name)) {
     throw new CanisterNameTooLongError("error__canister.name_too_long", {
       $name: name,
+      $max: String(MAX_CANISTER_NAME_LENGTH),
     });
   }
 
@@ -235,6 +237,7 @@ export const createCanister = async ({
   if (isNameTooLong(name)) {
     throw new CanisterNameTooLongError("error__canister.name_too_long", {
       $name: name,
+      $max: String(MAX_CANISTER_NAME_LENGTH),
     });
   }
 

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -38,6 +38,7 @@ import type {
   RenameSubAccountResponse,
   SubAccountDetails,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import { toNullable } from "@dfinity/utils";
 import { AccountIdentifier } from "@icp-sdk/canisters/ledger/icp";
 import { Actor } from "@icp-sdk/core/agent";
@@ -255,6 +256,7 @@ export class NNSDappCanister {
     if ("NameTooLong" in response) {
       throw new CanisterNameTooLongError("error__canister.name_too_long", {
         $name: name,
+        $max: String(MAX_CANISTER_NAME_LENGTH),
       });
     }
     if ("CanisterLimitExceeded" in response) {
@@ -286,6 +288,7 @@ export class NNSDappCanister {
     if ("NameTooLong" in response) {
       throw new CanisterNameTooLongError("error__canister.name_too_long", {
         $name: name,
+        $max: String(MAX_CANISTER_NAME_LENGTH),
       });
     }
     if ("CanisterNotFound" in response) {

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -43,6 +43,8 @@
     // Needed if the canister id is very long for mobile and uses multiple lines.
     text-align: center;
     margin: 0;
+    // A canister name can be one long word without spaces.
+    overflow-wrap: anywhere;
   }
 
   .skeleton {

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
@@ -21,7 +21,9 @@
   />
   <svelte:fragment slot="subtitle">
     {#if canister.name.length > 0 && isController}
-      <HeadingSubtitle testId="subtitle">{canister.name}</HeadingSubtitle>
+      <HeadingSubtitle testId="subtitle" breakLongWords
+        >{canister.name}</HeadingSubtitle
+      >
     {/if}
   </svelte:fragment>
   <svelte:fragment slot="tags">

--- a/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -32,7 +32,7 @@
   {#if nonNullish(name) && name !== ""}
     <KeyValuePair>
       {#snippet key()}<span>{$i18n.canisters.name}</span>{/snippet}
-      {#snippet value()}<span class="name">{name}</span>{/snippet}
+      {#snippet value()}<span class="canister-name">{name}</span>{/snippet}
     </KeyValuePair>
   {/if}
   <p class="conversion">
@@ -86,7 +86,7 @@
     @include fonts.h3;
   }
 
-  .name {
+  .canister-name {
     // A canister name can be one long word without spaces.
     overflow-wrap: anywhere;
     text-align: right;

--- a/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -32,7 +32,7 @@
   {#if nonNullish(name) && name !== ""}
     <KeyValuePair>
       {#snippet key()}<span>{$i18n.canisters.name}</span>{/snippet}
-      {#snippet value()}<span>{name}</span>{/snippet}
+      {#snippet value()}<span class="name">{name}</span>{/snippet}
     </KeyValuePair>
   {/if}
   <p class="conversion">
@@ -84,6 +84,12 @@
 
   .value {
     @include fonts.h3;
+  }
+
+  .name {
+    // A canister name can be one long word without spaces.
+    overflow-wrap: anywhere;
+    text-align: right;
   }
 
   .conversion {

--- a/frontend/src/lib/components/common/HeadingSubtitle.svelte
+++ b/frontend/src/lib/components/common/HeadingSubtitle.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
   export let testId: string | undefined = undefined;
+  // Opt in when the subtitle can be one long word without spaces.
+  export let breakLongWords = false;
 </script>
 
-<h4 data-tid={testId} class="description"><slot /></h4>
+<h4
+  data-tid={testId}
+  class="description"
+  class:break-long-words={breakLongWords}
+>
+  <slot />
+</h4>
 
 <style lang="scss">
   h4 {
     margin: 0;
     font-weight: normal;
-    overflow-wrap: anywhere;
+
+    &.break-long-words {
+      overflow-wrap: anywhere;
+    }
   }
 </style>

--- a/frontend/src/lib/components/common/HeadingSubtitle.svelte
+++ b/frontend/src/lib/components/common/HeadingSubtitle.svelte
@@ -8,5 +8,6 @@
   h4 {
     margin: 0;
     font-weight: normal;
+    overflow-wrap: anywhere;
   }
 </style>

--- a/frontend/src/lib/constants/canisters.constants.ts
+++ b/frontend/src/lib/constants/canisters.constants.ts
@@ -7,4 +7,4 @@ export const NEW_CANISTER_MIN_T_CYCLES = 2;
 export const SYNC_CYCLES_TIMER_INTERVAL = SECONDS_IN_MINUTE * 1000; // 1 minute
 
 // Constraint coming from the backend
-export const MAX_CANISTER_NAME_LENGTH = 24;
+export const MAX_CANISTER_NAME_LENGTH = 64;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1128,7 +1128,7 @@
   "error__canister": {
     "already_attached": "Canister ($canisterId) is already linked",
     "name_taken": "The name $name is already in use. Names must be unique.",
-    "name_too_long": "The name $name is too long (max. 64 characters). Please, choose a shorter name.",
+    "name_too_long": "The name $name is too long (max. $max characters). Please, choose a shorter name.",
     "limit_exceeded": "The limit of canisters that can be linked has been exceeded.",
     "unlink_not_found": "Error unlinking, canister ($canisterId) not found.",
     "unknown_link": "Error linking canister.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1128,7 +1128,7 @@
   "error__canister": {
     "already_attached": "Canister ($canisterId) is already linked",
     "name_taken": "The name $name is already in use. Names must be unique.",
-    "name_too_long": "The name $name is too long (max. 24 characters). Please, choose a shorter name.",
+    "name_too_long": "The name $name is too long (max. 64 characters). Please, choose a shorter name.",
     "limit_exceeded": "The limit of canisters that can be linked has been exceeded.",
     "unlink_not_found": "Error unlinking, canister ($canisterId) not found.",
     "unknown_link": "Error linking canister.",

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -121,6 +121,7 @@ describe("canisters-api", () => {
       await expect(call).rejects.toThrowError(
         new CanisterNameTooLongError("error__canister.name_too_long", {
           $name: longName,
+          $max: String(MAX_CANISTER_NAME_LENGTH),
         })
       );
       expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
@@ -150,6 +151,7 @@ describe("canisters-api", () => {
       await expect(call).rejects.toThrowError(
         new CanisterNameTooLongError("error__canister.name_too_long", {
           $name: longName,
+          $max: String(MAX_CANISTER_NAME_LENGTH),
         })
       );
       expect(mockNNSDappCanister.renameCanister).not.toBeCalled();
@@ -352,6 +354,7 @@ describe("canisters-api", () => {
       await expect(call).rejects.toThrowError(
         new CanisterNameTooLongError("error__canister.name_too_long", {
           $name: longName,
+          $max: String(MAX_CANISTER_NAME_LENGTH),
         })
       );
       expect(mockCmcCanister.notifyCreateCanister).not.toBeCalled();

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -133,7 +133,7 @@ describe("LinkCanisterModal", () => {
     nameInputElement && (await fireEvent.blur(nameInputElement));
 
     expect(
-      queryByText("Canister name too long. Maximum of 24 characters allowed.")
+      queryByText("Canister name too long. Maximum of 64 characters allowed.")
     ).toBeInTheDocument();
     expect(
       queryByTestId("link-canister-button")?.hasAttribute("disabled")

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -133,7 +133,9 @@ describe("LinkCanisterModal", () => {
     nameInputElement && (await fireEvent.blur(nameInputElement));
 
     expect(
-      queryByText("Canister name too long. Maximum of 64 characters allowed.")
+      queryByText(
+        `Canister name too long. Maximum of ${MAX_CANISTER_NAME_LENGTH} characters allowed.`
+      )
     ).toBeInTheDocument();
     expect(
       queryByTestId("link-canister-button")?.hasAttribute("disabled")

--- a/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
@@ -54,7 +54,7 @@ describe("RenameCanisterModal", () => {
     expect(await po.getRenameButton().isDisabled()).toBe(false);
   });
 
-  it("shows disabled button when input is longer than 24 characters", async () => {
+  it("shows disabled button when input is longer than the maximum length", async () => {
     const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH + 1);
     const po = renderComponent({ canisterId: mockCanisterId, name: "name" });
 

--- a/frontend/src/tests/lib/utils/canisters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/canisters.utils.spec.ts
@@ -195,12 +195,12 @@ describe("canister-utils", () => {
     it("returns an error message if canister name longer than max", () => {
       expect(
         errorCanisterNameMessage(
-          "My favorite dapp with a super duper long name"
+          "My favorite dapp with a name so long that it does not fit in the limit"
         )
-      ).toBe("Canister name too long. Maximum of 24 characters allowed.");
+      ).toBe("Canister name too long. Maximum of 64 characters allowed.");
       expect(
         errorCanisterNameMessage("a".repeat(MAX_CANISTER_NAME_LENGTH + 1))
-      ).toBe("Canister name too long. Maximum of 24 characters allowed.");
+      ).toBe("Canister name too long. Maximum of 64 characters allowed.");
     });
   });
 

--- a/frontend/src/tests/lib/utils/canisters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/canisters.utils.spec.ts
@@ -193,14 +193,15 @@ describe("canister-utils", () => {
     });
 
     it("returns an error message if canister name longer than max", () => {
+      const expectedMessage = `Canister name too long. Maximum of ${MAX_CANISTER_NAME_LENGTH} characters allowed.`;
       expect(
         errorCanisterNameMessage(
           "My favorite dapp with a name so long that it does not fit in the limit"
         )
-      ).toBe("Canister name too long. Maximum of 64 characters allowed.");
+      ).toBe(expectedMessage);
       expect(
         errorCanisterNameMessage("a".repeat(MAX_CANISTER_NAME_LENGTH + 1))
-      ).toBe("Canister name too long. Maximum of 64 characters allowed.");
+      ).toBe(expectedMessage);
     });
   });
 


### PR DESCRIPTION
# Motivation

The backend accepts canister names up to 64 characters since #8012. The frontend still validates against the old 24-character limit. A 64-character name can also be one long word, so the detail page and the top-up confirm screen need a wrap rule for it.

# Changes

- Raised `MAX_CANISTER_NAME_LENGTH` from 24 to 64.
- Updated the `error__canister.name_too_long` message to state 64 characters.
- Added `overflow-wrap: anywhere` to the canister heading title, the heading subtitle, and the name on the cycles confirm screen.
- Updated the tests that hardcoded the old limit in names and messages.

---

Prev. #8012