### PR TITLE
chore(deps): bump postcss-selector-parser to 6.1.4 to fix recursion DoS

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4761,9 +4761,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,7 @@
   "overrides": {
     "semver": "^7.5.3",
     "cookie": "^0.7.0",
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.1",
+    "postcss-selector-parser": "^6.1.3"
   }
 }


### PR DESCRIPTION
# Motivation

Dependabot flagged a low severity vuln (GHSA-w9m9-85wc-3x92) in postcss-selector-parser. Versions before 6.1.3 can hit uncontrolled recursion when the AST serializer walks a crafted selector, so a malicious input can cause a DoS. It's a transitive dev dependency pulled in through `eslint-plugin-svelte`.

# Changes

- Added a `postcss-selector-parser` override in `frontend/package.json` pinned to `^6.1.3`.
- Regenerated `frontend/package-lock.json`, which now resolves to 6.1.4.

Closes the alert at https://github.com/dfinity/nns-dapp/security/dependabot/221
