### PR TITLE
chore(frontend): bump @humanfs/node to 0.16.8

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -919,25 +919,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,6 +88,7 @@
     "cookie": "^0.7.0",
     "js-yaml": "^4.3.1",
     "postcss-selector-parser": "^6.1.3",
-    "browserslist": "^4.28.7"
+    "browserslist": "^4.28.7",
+    "@humanfs/node": "^0.16.8"
   }
 }


### PR DESCRIPTION
# Motivation

Dependabot alert 224 reports GHSA-p498-v437-472g in the humanfs/node package. The `copyAll()` function follows a symlink. It can copy a file from outside the source tree. The package is transitive through `eslint`, which is the only consumer in this repo.

# Changes

- Added an override for the humanfs/node package at `^0.16.8` in `frontend/package.json`, following PR 8015.
- Regenerated `frontend/package-lock.json` with `npm install`.

# Tests

- Ran `npm run check` in `frontend/`. It passed. svelte-check found 0 errors and 0 warnings. `eslint --max-warnings 0` passed, and eslint is the only consumer of this package.
- Ran `npm run test` in `frontend/`. It passed. 673 test files ran, with 5906 tests passed and 9 skipped.
- Ran `./scripts/check-relative-imports`. It passed.
- Ran `npx eslint --max-warnings 0` on a sample file as a spot check. It passed.
- Did not run the Rust gates (`./scripts/lint-rs`, `cargo test`, `cargo spellcheck`). The change touches no Rust file.
- Did not run the script and config gates (`shellcheck`, `./scripts/fmt`, `./config.test`). The change touches no script and no config file.
- Did not run a Playwright spec. The change touches no application source, and no browser bundle imports this package.

# Todos

- [ ] Accessibility (a11y) – no impact. This changes a locked dependency version only.
- [ ] Changelog – not needed. This is a dependency bump.
