### PR TITLE
fix(ci): pin snsdemo to a commit hash instead of a mutable tag

### DIFF
--- a/.github/actions/checkout_snsdemo/action.yaml
+++ b/.github/actions/checkout_snsdemo/action.yaml
@@ -1,6 +1,7 @@
 name: 'Clone the snsdemo repository'
 description: |
-  Ensures that the snsdemo repository is checked out at the commit specified in `config.json`.
+  Ensures that the snsdemo repository is checked out at the commit specified by
+  `SNSDEMO_COMMIT` in `config.json`.
 
   * If the snsdemo repository is already present: Checks that the repo is checked
     out at the expected commit.  If not, this fails with an error message.
@@ -14,7 +15,7 @@ inputs:
     default: "snsdemo"
 outputs:
   ref:
-    description: The snsdemo reference that was checked out
+    description: The snsdemo commit hash that was checked out
     value: ${{ steps.snsdemo_ref.outputs.ref }}
 runs:
   using: "composite"
@@ -29,12 +30,19 @@ runs:
         then echo have_snsdemo=true | tee -a "$GITHUB_OUTPUT"
         else echo have_snsdemo=false | tee -a "$GITHUB_OUTPUT"
         fi
-    - name: Determine snsdemo ref
+    - name: Determine snsdemo commit
       id: snsdemo_ref
       shell: bash
       run: |
-        SNSDEMO_RELEASE="$(jq -r .defaults.build.config.SNSDEMO_RELEASE config.json)"
-        echo "ref=$SNSDEMO_RELEASE" >> "$GITHUB_OUTPUT"
+        set -euo pipefail
+        # A commit hash is immutable. A tag is not. Check out the commit only.
+        SNSDEMO_COMMIT="$(jq -r .defaults.build.config.SNSDEMO_COMMIT config.json)"
+        [[ "$SNSDEMO_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+          echo "ERROR: SNSDEMO_COMMIT in config.json must be a full 40 character commit hash."
+          echo "Actual value: $SNSDEMO_COMMIT"
+          exit 1
+        } >&2
+        echo "ref=$SNSDEMO_COMMIT" >> "$GITHUB_OUTPUT"
     - name: Check that the existing repo has the expected commit.
       if: ${{ steps.have_snsdemo.outputs.have_snsdemo == 'true' }}
       shell: bash

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -4,7 +4,7 @@ description: |
   Optionally installs nns-dapp and sns_aggregator.
 inputs:
   snsdemo_ref:
-    description: "The git ref at which to use the snsdemo scripts.  Defaults to the SNSDEMO_COMMIT hash in config.json"
+    description: "The snsdemo commit hash to use for the snsdemo scripts. Must be a full 40 character hash. Defaults to the SNSDEMO_COMMIT hash in config.json"
     required: false
     default: ""
   snapshot_url:
@@ -42,16 +42,14 @@ runs:
       run: |
         set -euo pipefail
         SNSDEMO_REF="${{ inputs.snsdemo_ref }}"
-        if test -z "$SNSDEMO_REF"
-        then
-          # A commit hash is immutable. A tag is not. Check out the commit only.
-          SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_COMMIT config.json)"
-          [[ "$SNSDEMO_REF" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "ERROR: SNSDEMO_COMMIT in config.json must be a full 40 character commit hash."
-            echo "Actual value: $SNSDEMO_REF"
-            exit 1
-          } >&2
-        fi
+        test -n "$SNSDEMO_REF" || SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_COMMIT config.json)"
+        # A commit hash is immutable. A tag is not. Check out the commit only.
+        # Apply this check to the input too, so a caller cannot pass a mutable ref.
+        [[ "$SNSDEMO_REF" =~ ^[0-9a-f]{40}$ ]] || {
+          echo "ERROR: The snsdemo ref must be a full 40 character commit hash."
+          echo "Actual value: $SNSDEMO_REF"
+          exit 1
+        } >&2
         echo "ref=$SNSDEMO_REF" >> "$GITHUB_OUTPUT"
     - name: Determine snsdemo snapshot URL
       id: snsdemo_snapshot

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -4,11 +4,11 @@ description: |
   Optionally installs nns-dapp and sns_aggregator.
 inputs:
   snsdemo_ref:
-    description: "The git ref at which to use the snsdemo scripts.  Defaults to the release tag in config.json"
+    description: "The git ref at which to use the snsdemo scripts.  Defaults to the SNSDEMO_COMMIT hash in config.json"
     required: false
     default: ""
   snapshot_url:
-    description: "The URL of the snapshot to download and install.  Defaults to the URL of the release tag in config.json."
+    description: "The URL of the snapshot to download and install.  Defaults to the URL of the SNSDEMO_RELEASE tag in config.json."
     required: false
     default: ""
   nns_dapp_wasm:
@@ -40,15 +40,28 @@ runs:
       id: snsdemo_ref
       shell: bash
       run: |
+        set -euo pipefail
         SNSDEMO_REF="${{ inputs.snsdemo_ref }}"
-        test -n "$SNSDEMO_REF" || SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_RELEASE config.json)"
+        if test -z "$SNSDEMO_REF"
+        then
+          # A commit hash is immutable. A tag is not. Check out the commit only.
+          SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_COMMIT config.json)"
+          [[ "$SNSDEMO_REF" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "ERROR: SNSDEMO_COMMIT in config.json must be a full 40 character commit hash."
+            echo "Actual value: $SNSDEMO_REF"
+            exit 1
+          } >&2
+        fi
         echo "ref=$SNSDEMO_REF" >> "$GITHUB_OUTPUT"
     - name: Determine snsdemo snapshot URL
       id: snsdemo_snapshot
       shell: bash
       run: |
+        set -euo pipefail
         URL="${{ inputs.snapshot_url }}"
-        test -n "$URL" || URL="https://github.com/dfinity/snsdemo/releases/download/${{ steps.snsdemo_ref.outputs.ref }}/snsdemo_snapshot_ubuntu-24.04.tar.xz"
+        # The snapshot is a release asset, so the URL needs the release tag.
+        SNSDEMO_RELEASE="$(jq -r .defaults.build.config.SNSDEMO_RELEASE config.json)"
+        test -n "$URL" || URL="https://github.com/dfinity/snsdemo/releases/download/${SNSDEMO_RELEASE}/snsdemo_snapshot_ubuntu-24.04.tar.xz"
         echo "url=$URL" >> "$GITHUB_OUTPUT"
     - name: Get SNS scripts
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -46,12 +46,6 @@ jobs:
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
         with:
           dfx-version: ${{ env.DFX_VERSION }}
-      - name: Set credentials
-        run: |
-          printf "%s" "${{ secrets.DFX_IDENTITY_PEM }}" | dfx identity import --storage-mode=plaintext ci /dev/stdin
-          dfx identity use ci
-        env:
-          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
       - name: Get SNS scripts
         uses: ./.github/actions/checkout_snsdemo
         with:
@@ -62,6 +56,14 @@ jobs:
           sudo apt-get update -yy && sudo apt-get install -yy moreutils
           : Add scripts to the path
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+      # Import the deploy key as late as possible.
+      # The key is plaintext on disk from here on.
+      - name: Set credentials
+        run: |
+          printf "%s" "$DFX_IDENTITY_PEM" | dfx identity import --storage-mode=plaintext ci /dev/stdin
+          dfx identity use ci
+        env:
+          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
       - name: Verify identity
         run: |
           dfx identity whoami

--- a/config.json
+++ b/config.json
@@ -116,6 +116,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2026-09-02",
+        "SNSDEMO_COMMIT": "01a4552082630fbaacaed6d11c36fc18664cf125",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97"
       },
       "packtool": ""

--- a/scripts/update-snsdemo
+++ b/scripts/update-snsdemo
@@ -27,7 +27,8 @@ test -n "${SNSDEMO_RELEASE:-}" || {
 # Check that the SNSDEMO repo is checked out at the correct release
 pushd "$SNSDEMO_REPO"
 HEAD_COMMIT="$(git rev-parse HEAD)"
-RELEASE_COMMIT="$(git rev-parse "tags/$SNSDEMO_RELEASE")"
+# `^{commit}` makes this a commit hash, also for an annotated tag.
+RELEASE_COMMIT="$(git rev-parse "tags/$SNSDEMO_RELEASE^{commit}")"
 [[ "$HEAD_COMMIT" == "$RELEASE_COMMIT" ]] || {
   echo "ERROR: The repo should be checked out at the release tag."
   echo "SNSDEMO repo HEAD:      $HEAD_COMMIT"
@@ -53,8 +54,13 @@ done
 # Move to the root of the nns-dapp repository
 cd "$SOURCE_DIR/.."
 
-# Update the snsdemo commit in dfx.json
+# Update the snsdemo release tag in config.json.
+# The tag names the release. The snapshot download URL needs it.
 jq --arg c "$SNSDEMO_RELEASE" '.defaults.build.config.SNSDEMO_RELEASE |= $c' config.json | sponge config.json
+
+# Update the snsdemo commit in config.json.
+# CI checks out this commit. A commit hash is immutable, so it cannot be moved.
+jq --arg c "$RELEASE_COMMIT" '.defaults.build.config.SNSDEMO_COMMIT |= $c' config.json | sponge config.json
 
 # Update dfx to match snsdemo
 v="$DFX_VERSION" jq '.dfx |= env.v' dfx.json | sponge dfx.json


### PR DESCRIPTION
# Motivation

CI checked out the snsdemo repository at a mutable release tag. The mainnet deploy job imports the deploy identity before that checkout runs, so a moved tag could run attacker-controlled code while the key sits on disk.

# Changes

- Added `SNSDEMO_COMMIT` to `config.json`, pinned to the commit of tag `release-2026-08-26`.
- Made `checkout_snsdemo` and `start_dfx_snapshot` check out `SNSDEMO_COMMIT`, and reject a value that is not a 40 character hash.
- Kept `SNSDEMO_RELEASE` only for the snapshot release asset URL and the version bump comparison.
- Moved the deploy key import in `deploy-to-app.yaml` to after the snsdemo checkout, so the key never sits on disk before the checkout runs.
- Updated `scripts/update-snsdemo` to write both `SNSDEMO_RELEASE` and `SNSDEMO_COMMIT`, resolved with `^{commit}` so an annotated tag cannot write a tag object hash.
- Moved the 40-character-hash guard in `start_dfx_snapshot` outside the default-value branch, so it also checks a caller-supplied `snsdemo_ref` input.

# Tests

- Ran `shellcheck` on the changed shell snippets. It found no findings.
- Ran `./scripts/fmt`. It passed with no change to the edited files.
- Ran `./config.test`. It passed. The mainnet config and the app config both passed.
- Parsed the three edited YAML files with `js-yaml`. All three parsed.
- Ran `bash -n scripts/update-snsdemo`. It passed.
- Tested the hash guard directly, under the same shell that GitHub Actions uses, with nine bad inputs. These include a tag name, a branch name, an upper-case hash, and a short hash. Every bad input failed closed and wrote no output.
- Verified the pinned commit hash against the GitHub API. It matches the tag `release-2026-08-26`.
- Did not run the frontend gates (`npm run check`, `npm run test`, `./scripts/check-relative-imports`). The change touches no frontend file.
- Did not run the Rust gates. The change touches no Rust file.
- Did not run a local replica or a Playwright spec. A local replica cannot exercise a GitHub Actions composite action. CI on this pull request proves the change instead: every job that checks out snsdemo passed, with 28 checks passed and 5 skipped.

# Todos

- [ ] Accessibility (a11y) – no impact. This changes CI and release scripts only.
- [ ] Changelog – not needed. This hardens CI. No user of nns-dapp can observe it.
