### PR TITLE
fix(release): verify wasm hash against the CI build log

### DIFF
--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -141,8 +141,32 @@ echo
 echo "Downloading wasm from CI..."
 "$SOURCE_DIR/nns-dapp/download-ci-wasm" --commit "$COMMIT" --dir "$WASM_DIR"
 
+# The Orbit request states this hash, so compare it with the hash in the CI build log.
+LOCAL_SHA="$(sha256sum "$WASM_PATH" | awk '{print $1}')"
+CI_SHA="$("$SOURCE_DIR/nns-dapp/get-hash-from-ci-log" --commit "$COMMIT")"
+if test -z "${CI_SHA:-}"; then
+  {
+    echo "ERROR: Found no nns-dapp.wasm.gz hash in the CI build log for $COMMIT."
+    echo "       The CI run may be too old, so a rebuild of the commit may be necessary."
+    exit 1
+  } >&2
+fi
+if test "$CI_SHA" != "$LOCAL_SHA"; then
+  {
+    echo "ERROR: The wasm hash differs from the hash in the CI build log."
+    echo "       CI build log: $CI_SHA"
+    echo "       $WASM_PATH: $LOCAL_SHA"
+    echo "       Please delete $WASM_PATH and run this again."
+    exit 1
+  } >&2
+fi
+
 TITLE="Install NNS dapp at commit ${COMMIT:0:10}"
 SUMMARY="Install NNS dapp at commit $COMMIT
+
+Wasm sha256 hash: $LOCAL_SHA
+
+The CI build log for this commit states the same hash.
 
 Verify the build before approving:
 

--- a/scripts/nns-dapp/release-beta
+++ b/scripts/nns-dapp/release-beta
@@ -143,8 +143,8 @@ echo "Downloading wasm from CI..."
 
 # The Orbit request states this hash, so compare it with the hash in the CI build log.
 LOCAL_SHA="$(sha256sum "$WASM_PATH" | awk '{print $1}')"
-CI_SHA="$("$SOURCE_DIR/nns-dapp/get-hash-from-ci-log" --commit "$COMMIT")"
-if test -z "${CI_SHA:-}"; then
+# The helper exits non-zero if the log holds no hash, so test the status here.
+if ! CI_SHA="$("$SOURCE_DIR/nns-dapp/get-hash-from-ci-log" --commit "$COMMIT")" || test -z "${CI_SHA:-}"; then
   {
     echo "ERROR: Found no nns-dapp.wasm.gz hash in the CI build log for $COMMIT."
     echo "       The CI run may be too old, so a rebuild of the commit may be necessary."

--- a/scripts/sns/aggregator/release
+++ b/scripts/sns/aggregator/release
@@ -28,6 +28,16 @@ ARG_SHA=$(sha256sum <"$ARG_PATH" | awk '{print $1}')
 
 PROPOSAL_TEXT="./release/AGGREGATOR_PROPOSAL.md"
 
+# Verifies that the proposal text states the hash of the wasm module.
+# The template checks this hash against the hash in the CI build log.
+grep -w "$SHA" "$PROPOSAL_TEXT" >/dev/null || {
+  echo "ERROR: The proposal text does not contain the hash of $WASM."
+  echo "       Wasm hash: $SHA"
+  echo "       Proposal text: $PROPOSAL_TEXT"
+  echo "       Please run scripts/sns/aggregator/release-template again."
+  exit 1
+} >&2
+
 # Verifies that the forum link placeholder has been replaced.
 FORUM_PLACEHOLDER="FORUM_LINK"
 # ... Verifies that the template contains the placeholder:

--- a/scripts/sns/aggregator/release
+++ b/scripts/sns/aggregator/release
@@ -30,7 +30,7 @@ PROPOSAL_TEXT="./release/AGGREGATOR_PROPOSAL.md"
 
 # Verifies that the proposal text states the hash of the wasm module.
 # The template checks this hash against the hash in the CI build log.
-grep -w "$SHA" "$PROPOSAL_TEXT" >/dev/null || {
+grep -qwF -- "$SHA" "$PROPOSAL_TEXT" || {
   echo "ERROR: The proposal text does not contain the hash of $WASM."
   echo "       Wasm hash: $SHA"
   echo "       Proposal text: $PROPOSAL_TEXT"

--- a/scripts/sns/aggregator/release-template
+++ b/scripts/sns/aggregator/release-template
@@ -2,15 +2,36 @@
 set -euo pipefail
 cd "$(dirname "$0")/../../.."
 
-WASM="release/ci/sns_aggregator.wasm.gz"
+WASM_FILENAME="sns_aggregator.wasm.gz"
+WASM="release/ci/$WASM_FILENAME"
+COMMIT="aggregator-release-candidate"
 mkdir -p release/ci
-./scripts/nns-dapp/download-ci-wasm --commit aggregator-release-candidate --wasm-filename sns_aggregator.wasm.gz
+./scripts/nns-dapp/download-ci-wasm --commit "$COMMIT" --wasm-filename "$WASM_FILENAME"
 
 if test -f "$WASM"; then
   SHA="$(sha256sum "$WASM" | awk '{print $1}')"
 else
   echo "Please populate ${WASM} and run this again."
   exit 0
+fi
+
+# The proposal states this hash, so compare it with the hash in the CI build log.
+CI_SHA="$(./scripts/nns-dapp/get-hash-from-ci-log --commit "$COMMIT" --filename "$WASM_FILENAME")"
+if test -z "${CI_SHA:-}"; then
+  {
+    echo "ERROR: Found no $WASM_FILENAME hash in the CI build log for $COMMIT."
+    echo "       GitHub deletes old logs, so a rebuild of the commit may be necessary."
+    exit 1
+  } >&2
+fi
+if test "$CI_SHA" != "$SHA"; then
+  {
+    echo "ERROR: The wasm hash differs from the hash in the CI build log."
+    echo "       CI build log: $CI_SHA"
+    echo "       $WASM: $SHA"
+    echo "       Please delete $WASM and run this again."
+    exit 1
+  } >&2
 fi
 
 cat <<EOF >release/AGGREGATOR_PROPOSAL.md

--- a/scripts/sns/aggregator/release-template
+++ b/scripts/sns/aggregator/release-template
@@ -16,8 +16,8 @@ else
 fi
 
 # The proposal states this hash, so compare it with the hash in the CI build log.
-CI_SHA="$(./scripts/nns-dapp/get-hash-from-ci-log --commit "$COMMIT" --filename "$WASM_FILENAME")"
-if test -z "${CI_SHA:-}"; then
+# The helper exits non-zero if the log holds no hash, so test the status here.
+if ! CI_SHA="$(./scripts/nns-dapp/get-hash-from-ci-log --commit "$COMMIT" --filename "$WASM_FILENAME")" || test -z "${CI_SHA:-}"; then
   {
     echo "ERROR: Found no $WASM_FILENAME hash in the CI build log for $COMMIT."
     echo "       The CI run may be too old, so a rebuild of the commit may be necessary."

--- a/scripts/sns/aggregator/release-template
+++ b/scripts/sns/aggregator/release-template
@@ -12,7 +12,7 @@ if test -f "$WASM"; then
   SHA="$(sha256sum "$WASM" | awk '{print $1}')"
 else
   echo "Please populate ${WASM} and run this again."
-  exit 0
+  exit 1
 fi
 
 # The proposal states this hash, so compare it with the hash in the CI build log.
@@ -20,7 +20,7 @@ CI_SHA="$(./scripts/nns-dapp/get-hash-from-ci-log --commit "$COMMIT" --filename 
 if test -z "${CI_SHA:-}"; then
   {
     echo "ERROR: Found no $WASM_FILENAME hash in the CI build log for $COMMIT."
-    echo "       GitHub deletes old logs, so a rebuild of the commit may be necessary."
+    echo "       The CI run may be too old, so a rebuild of the commit may be necessary."
     exit 1
   } >&2
 fi


### PR DESCRIPTION
# Motivation

The aggregator release template downloaded the wasm from CI. It computed the hash from that same file. The hash proved nothing about the file's origin. The beta release script had the same gap. It sent the CI wasm to Orbit with no hash check.

# Changes

- Added a hash check to `scripts/sns/aggregator/release-template`. It compares the local hash with the hash in the CI build log.
- Added a hash check to `scripts/sns/aggregator/release`. It confirms the proposal text states the wasm hash.
- Added a hash check to `scripts/nns-dapp/release-beta`. It compares the local hash with the hash in the CI build log, and states the hash in the Orbit request summary.
- Changed `release-template` to exit 1, not exit 0, when the wasm file is missing.

# Tests

- Ran `shellcheck` on the three changed files. All findings are pre-existing. They are not caused by this change.
- Ran `./scripts/lint-sh` on the three changed files. It passed.
- Ran `shfmt -i 2 -d` on the three changed files. It found no difference.
- Ran `./scripts/fmt` in full. It passed.
- Ran `./config.test`. It passed.
- Tested the new checks in a scratchpad script, with matching, differing, and empty hashes.
- Did not run `release-beta`, `release`, or `release-template`. Each script needs a live CI run, the HSM, or the Orbit `dfx` identity.

# Todos

- [ ] Accessibility (a11y) – no impact. The change touches only release scripts.
- [ ] Changelog – not needed. No user of nns-dapp can observe this change.
