### PR TITLE
fix(aggregator): bound sns-controlled data before it enters the cache

### DIFF
--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -14,8 +14,9 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ### Removed
 ### Fixed
 ### Security
-- Limit the size of each SNS controlled field before the aggregator caches it. One SNS can no longer make a shared page too large to serve.
+- Limit the size of each SNS controlled field before the aggregator caches it. One SNS can no longer grow a cached record without limit. A field over its limit becomes empty, and the SNS keeps its place in the list.
 - Stop caching the swap buyers, the neuron recipes and the Neurons' Fund participants. The aggregator never serves these lists and they grow without limit.
+- Never serve `null` for `swap_state.swap`, `derived_state`, `init`, `swap_params` or `nervous_system_parameters`. The NNS dapp reads these fields without a check for `null`. One `null` made the NNS dapp show no SNS at all.
 
 ## [Proposal 137283](https://dashboard.internetcomputer.org/proposal/137283)
 ### Added

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -14,6 +14,8 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ### Removed
 ### Fixed
 ### Security
+- Limit the size of each SNS controlled field before the aggregator caches it. One SNS can no longer make a shared page too large to serve.
+- Stop caching the swap buyers, the neuron recipes and the Neurons' Fund participants. The aggregator never serves these lists and they grow without limit.
 
 ## [Proposal 137283](https://dashboard.internetcomputer.org/proposal/137283)
 ### Added

--- a/rs/sns_aggregator/src/types/ic_sns_governance.edit
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.edit
@@ -4,3 +4,4 @@ set -euxo pipefail
 # Commands to run after creating the rust file with didc:
 scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_governance.rs --type GetMetadataResponse --trait Default
 scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_governance.rs --type ListNervousSystemFunctionsResponse --trait Default
+scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_governance.rs --type NervousSystemParameters --trait Default

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -214,7 +214,7 @@ pub struct VotingRewardsParameters {
     pub reward_rate_transition_duration_seconds: Option<u64>,
     pub round_duration_seconds: Option<u64>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct NervousSystemParameters {
     pub default_followees: Option<DefaultFollowees>,
     pub max_dissolve_delay_seconds: Option<u64>,

--- a/rs/sns_aggregator/src/types/ic_sns_swap.edit
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.edit
@@ -3,3 +3,6 @@ set -euxo pipefail
 
 # Commands to run after creating the rust file with didc:
 scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type GetStateResponse --trait Default
+scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type Swap --trait Default
+scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type DerivedState --trait Default
+scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type GetDerivedStateResponse --trait Default

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -271,7 +271,7 @@ pub struct CanisterStatusResultV2 {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetDerivedStateArg {}
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct GetDerivedStateResponse {
     pub sns_tokens_per_icp: Option<f64>,
     pub buyer_total_icp_e8s: Option<u64>,
@@ -404,7 +404,7 @@ pub struct CfParticipant {
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct Swap {
     pub auto_finalize_swap_response: Option<FinalizeSwapResponse>,
     pub neuron_recipes: Vec<SnsNeuronRecipe>,
@@ -425,7 +425,7 @@ pub struct Swap {
     pub params: Option<Params>,
     pub open_sns_token_swap_proposal_id: Option<u64>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct DerivedState {
     pub sns_tokens_per_icp: f32,
     pub buyer_total_icp_e8s: u64,

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -16,9 +16,132 @@ use candid::Principal;
 use candid::Principal as CanisterId;
 use ic_cdk::api::time;
 use ic_cdk::call::CallResult;
+use serde::Serialize;
+
+#[cfg(test)]
+mod tests;
 
 /// default time window to get SNS metrics is 2 months.
 const TIME_WINDOW_SECONDS: u64 = 2 * 30 * 24 * 3600;
+
+/// The largest JSON size, in bytes, that the aggregator accepts for each SNS controlled field.
+///
+/// An SNS controls the content of every field below.  The aggregator caches the fields.  It also
+/// copies most of them into shared pages of ten SNSs.  The Internet Computer limits a reply to
+/// about two megabytes, so one huge field can make a shared page too large to serve.
+///
+/// Each limit is at least three times the largest value that mainnet SNSs use today.  The source
+/// is the mainnet snapshot in `frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json`, taken
+/// on 2026-08-28.  It holds 54 SNSs.  Each comment gives the observed maximum.  A limit that is
+/// too low would empty a field of a real SNS, so each limit keeps a large margin.
+pub mod limits {
+    /// Canister IDs from the SNS root canister.  Mainnet maximum: 1106 bytes.
+    /// The limit holds about 220 dapp canister IDs.
+    pub const LIST_SNS_CANISTERS: usize = 16 * 1024;
+    /// The project URL in the governance metadata.  Mainnet maximum: 48 bytes.
+    pub const META_URL: usize = 4 * 1024;
+    /// The project name in the governance metadata.  Mainnet maximum: 21 bytes.
+    pub const META_NAME: usize = 4 * 1024;
+    /// The project description in the governance metadata.  Mainnet maximum: 1534 bytes.
+    pub const META_DESCRIPTION: usize = 16 * 1024;
+    /// The project logo, as a data URL, in the governance metadata.
+    ///
+    /// The snapshot holds no governance logo, because the aggregator serves it as a separate
+    /// asset.  The largest logo in the snapshot is the ledger logo, at 291585 bytes.  The limit
+    /// gives that logo a margin of 1.8 times.
+    pub const META_LOGO: usize = 512 * 1024;
+    /// Governance metrics.  Mainnet maximum: 950 bytes.
+    pub const METRICS: usize = 16 * 1024;
+    /// The last voting reward event.  Mainnet maximum: 836 bytes.
+    /// The limit holds about 900 settled proposal IDs in one reward round.
+    pub const LATEST_REWARD_EVENT: usize = 16 * 1024;
+    /// The nervous system functions.  Mainnet maximum: 43148 bytes, for 121 functions.
+    pub const PARAMETERS: usize = 128 * 1024;
+    /// The nervous system parameters.  Mainnet maximum: 1059 bytes.
+    pub const NERVOUS_SYSTEM_PARAMETERS: usize = 16 * 1024;
+    /// The swap state, after the aggregator removes the lists that it never serves.
+    /// Mainnet maximum of the served part: 36958 bytes.
+    pub const SWAP_STATE: usize = 128 * 1024;
+    /// The ledger metadata.  Mainnet maximum: 291921 bytes.
+    ///
+    /// The token logo makes up almost all of that size.  The limit gives it a margin of 1.8
+    /// times.  This is the largest field that reaches a shared page.
+    pub const ICRC1_METADATA: usize = 512 * 1024;
+    /// The ledger transaction fee.  Mainnet maximum: 22 bytes.
+    /// A 128 bit number needs at most 39 digits.
+    pub const ICRC1_FEE: usize = 128;
+    /// The ledger total supply.  Mainnet maximum: 19 bytes.
+    pub const ICRC1_TOTAL_SUPPLY: usize = 128;
+    /// The swap parameters.  Mainnet maximum: 471 bytes.
+    pub const SWAP_PARAMS: usize = 8 * 1024;
+    /// The initialization parameters of the swap.  Mainnet maximum: 36294 bytes.
+    pub const INIT: usize = 128 * 1024;
+    /// The derived swap state.  Mainnet maximum: 258 bytes.
+    pub const DERIVED_STATE: usize = 4 * 1024;
+    /// The swap lifecycle.  Mainnet maximum: 138 bytes.
+    pub const LIFECYCLE: usize = 4 * 1024;
+    /// The governance topics.  Mainnet maximum: 44484 bytes.
+    /// Topics repeat the nervous system functions, so this limit matches `PARAMETERS`.
+    pub const TOPICS: usize = 128 * 1024;
+}
+
+/// Returns `value` if its JSON form fits in `max_bytes`, else an empty value and a reason.
+///
+/// An SNS controls the fields that the aggregator caches and serves.  A field that is too large
+/// makes a shared page too large to serve, and it makes the cache grow without limit.  The
+/// aggregator empties one field instead of dropping the whole SNS.  The SNS keeps its place in
+/// the list, so the launchpad still shows it.
+fn bound<T: Serialize + Default>(value: T, max_bytes: usize) -> (T, Option<String>) {
+    match serde_json::to_vec(&value) {
+        Ok(json) if json.len() <= max_bytes => (value, None),
+        Ok(json) => {
+            let size = json.len();
+            (
+                T::default(),
+                Some(format!("has {size} bytes and the limit is {max_bytes} bytes")),
+            )
+        }
+        Err(err) => (T::default(), Some(format!("cannot be measured: {err}"))),
+    }
+}
+
+/// Applies `bound` and writes any reason to the canister log.
+fn bounded<T: Serialize + Default>(index: u64, field: &str, value: T, max_bytes: usize) -> T {
+    let (value, reason) = bound(value, max_bytes);
+    if let Some(reason) = reason {
+        crate::state::log(format!(
+            "SNS index {index}: field '{field}' {reason}.  The aggregator empties the field."
+        ));
+    }
+    value
+}
+
+/// Limits the size of each part of the governance metadata.
+///
+/// The logo is much larger than the other parts, and the aggregator serves it as a separate
+/// asset.  Each part therefore gets its own limit.
+fn bounded_metadata(index: u64, meta: types::GetMetadataResponse) -> types::GetMetadataResponse {
+    types::GetMetadataResponse {
+        url: bounded(index, "meta.url", meta.url, limits::META_URL),
+        logo: bounded(index, "meta.logo", meta.logo, limits::META_LOGO),
+        name: bounded(index, "meta.name", meta.name, limits::META_NAME),
+        description: bounded(index, "meta.description", meta.description, limits::META_DESCRIPTION),
+    }
+}
+
+/// Removes the parts of the swap state that the aggregator never serves.
+///
+/// The swap canister returns every buyer, every neuron recipe and every Neurons' Fund
+/// participant.  The aggregator serves none of them.  These lists grow with the number of
+/// participants, so the aggregator clears them before it caches the record.
+fn strip_unserved_swap_state(mut swap_state: GetStateResponse) -> GetStateResponse {
+    if let Some(swap) = swap_state.swap.as_mut() {
+        swap.buyers = Vec::new();
+        swap.neuron_recipes = Vec::new();
+        swap.cf_participants = Vec::new();
+    }
+    swap_state
+}
 
 /// Updates one part of the cache:  Either the list of SNSs or one SNS.
 // TODO: overlapping invocations could race on `sns_to_get.pop()` /
@@ -271,6 +394,53 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
         .ok();
 
     crate::state::log("Yay, got an SNS status".to_string());
+
+    // Limit the size of every SNS controlled field before the aggregator caches it.
+    //
+    // The limit applies to the value that the aggregator is about to cache.  That value is the
+    // new response, or the previous cached value when the call failed.  A cache that an earlier
+    // release filled with oversized data therefore recovers on the next update.
+    let list_sns_canisters = bounded(
+        index,
+        "list_sns_canisters",
+        list_sns_canisters,
+        limits::LIST_SNS_CANISTERS,
+    );
+    let meta = bounded_metadata(index, meta);
+    let metrics = bounded(index, "metrics", metrics, limits::METRICS);
+    let latest_reward_event = bounded(
+        index,
+        "latest_reward_event",
+        latest_reward_event,
+        limits::LATEST_REWARD_EVENT,
+    );
+    let parameters = bounded(index, "parameters", parameters, limits::PARAMETERS);
+    let nervous_system_parameters = bounded(
+        index,
+        "nervous_system_parameters",
+        nervous_system_parameters,
+        limits::NERVOUS_SYSTEM_PARAMETERS,
+    );
+    let swap_state = bounded(
+        index,
+        "swap_state",
+        strip_unserved_swap_state(swap_state),
+        limits::SWAP_STATE,
+    );
+    let icrc1_metadata = bounded(index, "icrc1_metadata", icrc1_metadata, limits::ICRC1_METADATA);
+    let icrc1_fee = bounded(index, "icrc1_fee", icrc1_fee, limits::ICRC1_FEE);
+    let icrc1_total_supply = bounded(
+        index,
+        "icrc1_total_supply",
+        icrc1_total_supply,
+        limits::ICRC1_TOTAL_SUPPLY,
+    );
+    let swap_params_response = bounded(index, "swap_params", swap_params_response, limits::SWAP_PARAMS);
+    let init_response = bounded(index, "init", init_response, limits::INIT);
+    let derived_state_response = bounded(index, "derived_state", derived_state_response, limits::DERIVED_STATE);
+    let lifecycle_response = bounded(index, "lifecycle", lifecycle_response, limits::LIFECYCLE);
+    let list_topics_response = bounded(index, "topics", list_topics_response, limits::TOPICS);
+
     // If the SNS sale will open, collect data when it does.
     FastScheduler::global_schedule_sns(&swap_state);
     // Save the data in the state.

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -30,10 +30,29 @@ const TIME_WINDOW_SECONDS: u64 = 2 * 30 * 24 * 3600;
 /// copies most of them into shared pages of ten SNSs.  The Internet Computer limits a reply to
 /// about two megabytes, so one huge field can make a shared page too large to serve.
 ///
-/// Each limit is at least three times the largest value that mainnet SNSs use today.  The source
-/// is the mainnet snapshot in `frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json`, taken
-/// on 2026-08-28.  It holds 54 SNSs.  Each comment gives the observed maximum.  A limit that is
-/// too low would empty a field of a real SNS, so each limit keeps a large margin.
+/// Each limit is a round binary size above the largest value that mainnet SNSs use today.  The
+/// source is the mainnet snapshot in `frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json`,
+/// taken on 2026-08-28.  It holds 54 SNSs.  Each comment below gives the observed maximum.
+///
+/// The margin is not the same for every field.  It runs from 1.8 times to 195 times.  The margin
+/// follows the cost that the field puts on a shared page.
+///
+/// * A small field keeps a large margin, because a large limit costs almost nothing.  `META_NAME`
+///   keeps 195 times and `META_URL` keeps 85 times.
+/// * A large field that a page carries keeps a margin near three times.  `TOPICS` keeps 2.9 times,
+///   `PARAMETERS` 3.0 times, `SWAP_STATE` 3.5 times and `INIT` 3.6 times.
+/// * `ICRC1_METADATA` keeps the smallest margin, 1.8 times, and stops at 524288 bytes.  One real
+///   SNS already puts 291921 bytes in it, and a token logo makes up almost all of that size.  A
+///   limit of 1048576 bytes would let two such SNSs fill a whole page of ten.
+/// * `META_LOGO` keeps the same 1.8 times and the same 524288 bytes.  It reaches no shared page,
+///   because the aggregator serves the governance logo as a separate asset.  It has no
+///   measurement, so it copies the `ICRC1_METADATA` margin.
+///
+/// `mainnet_sns_data_is_within_the_limits` reads the snapshot and fails if a real SNS passes a
+/// limit.  That test guards the limits before the first release only.  After the release the
+/// aggregator empties a field over its limit before it serves the field.  The snapshot then never
+/// holds a value over a limit.  `tail_log` names each field that a limit empties, so the canister
+/// log is the signal after the release.
 pub mod limits {
     /// Canister IDs from the SNS root canister.  Mainnet maximum: 1106 bytes.
     /// The limit holds about 220 dapp canister IDs.

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -6,7 +6,7 @@ use crate::fast_scheduler::FastScheduler;
 use crate::state::{State, STATE};
 use crate::types::ic_sns_governance::{self as sns_gov, ListTopicsRequest, NervousSystemParameters};
 use crate::types::ic_sns_swap::{
-    GetDerivedStateResponse, GetInitResponse, GetLifecycleResponse, GetSaleParametersResponse,
+    DerivedState, GetDerivedStateResponse, GetInitResponse, GetLifecycleResponse, GetSaleParametersResponse, Swap,
 };
 use crate::types::ic_sns_wasm::{DeployedSns, ListDeployedSnsesResponse};
 use crate::types::upstream::UpstreamData;
@@ -47,8 +47,9 @@ pub mod limits {
     /// The project logo, as a data URL, in the governance metadata.
     ///
     /// The snapshot holds no governance logo, because the aggregator serves it as a separate
-    /// asset.  The largest logo in the snapshot is the ledger logo, at 291585 bytes.  The limit
-    /// gives that logo a margin of 1.8 times.
+    /// asset.  This limit therefore has no measurement behind it, and
+    /// `mainnet_sns_data_is_within_the_limits` cannot guard it.  The largest logo in the snapshot
+    /// is the ledger logo, at 291585 bytes.  The limit gives that logo a margin of 1.8 times.
     pub const META_LOGO: usize = 512 * 1024;
     /// Governance metrics.  Mainnet maximum: 950 bytes.
     pub const METRICS: usize = 16 * 1024;
@@ -73,6 +74,9 @@ pub mod limits {
     /// The ledger total supply.  Mainnet maximum: 19 bytes.
     pub const ICRC1_TOTAL_SUPPLY: usize = 128;
     /// The swap parameters.  Mainnet maximum: 471 bytes.
+    ///
+    /// `INIT` and `SWAP_STATE` are much larger because they hold lists.  `Params` holds only
+    /// numbers, so it cannot grow past about 600 bytes.  This limit stays small on purpose.
     pub const SWAP_PARAMS: usize = 8 * 1024;
     /// The initialization parameters of the swap.  Mainnet maximum: 36294 bytes.
     pub const INIT: usize = 128 * 1024;
@@ -90,7 +94,10 @@ pub mod limits {
 /// An SNS controls the fields that the aggregator caches and serves.  A field that is too large
 /// makes a shared page too large to serve, and it makes the cache grow without limit.  The
 /// aggregator empties one field instead of dropping the whole SNS.  The SNS keeps its place in
-/// the list, so the launchpad still shows it.
+/// the list, so no other SNS moves to a different page.
+///
+/// An empty value is `None` for an optional field.  `fill_unreadable_nulls` then replaces that
+/// `None` where the launchpad cannot read a `null`.
 fn bound<T: Serialize + Default>(value: T, max_bytes: usize) -> (T, Option<String>) {
     match serde_json::to_vec(&value) {
         Ok(json) if json.len() <= max_bytes => (value, None),
@@ -105,27 +112,49 @@ fn bound<T: Serialize + Default>(value: T, max_bytes: usize) -> (T, Option<Strin
     }
 }
 
-/// Applies `bound` and writes any reason to the canister log.
-fn bounded<T: Serialize + Default>(index: u64, field: &str, value: T, max_bytes: usize) -> T {
-    let (value, reason) = bound(value, max_bytes);
-    if let Some(reason) = reason {
-        crate::state::log(format!(
-            "SNS index {index}: field '{field}' {reason}.  The aggregator empties the field."
-        ));
-    }
-    value
+/// Applies the size limits for one SNS and collects a reason for each field that it empties.
+///
+/// The caller writes the reasons to the canister log.  The canister log needs a canister, so this
+/// split lets a test call the whole bounding pass outside a canister.
+struct Bounder {
+    /// The index of the SNS in the list from the nns-sns-wasm canister.
+    index: u64,
+    /// One line for each field that a limit emptied.
+    reasons: Vec<String>,
 }
 
-/// Limits the size of each part of the governance metadata.
-///
-/// The logo is much larger than the other parts, and the aggregator serves it as a separate
-/// asset.  Each part therefore gets its own limit.
-fn bounded_metadata(index: u64, meta: types::GetMetadataResponse) -> types::GetMetadataResponse {
-    types::GetMetadataResponse {
-        url: bounded(index, "meta.url", meta.url, limits::META_URL),
-        logo: bounded(index, "meta.logo", meta.logo, limits::META_LOGO),
-        name: bounded(index, "meta.name", meta.name, limits::META_NAME),
-        description: bounded(index, "meta.description", meta.description, limits::META_DESCRIPTION),
+impl Bounder {
+    /// Creates a bounder for one SNS.
+    fn new(index: u64) -> Self {
+        Bounder {
+            index,
+            reasons: Vec::new(),
+        }
+    }
+
+    /// Applies `bound` and keeps any reason.
+    fn bound<T: Serialize + Default>(&mut self, field: &str, value: T, max_bytes: usize) -> T {
+        let (value, reason) = bound(value, max_bytes);
+        if let Some(reason) = reason {
+            let index = self.index;
+            self.reasons.push(format!(
+                "SNS index {index}: field '{field}' {reason}.  The aggregator empties the field."
+            ));
+        }
+        value
+    }
+
+    /// Limits the size of each part of the governance metadata.
+    ///
+    /// The logo is much larger than the other parts, and the aggregator serves it as a separate
+    /// asset.  Each part therefore gets its own limit.
+    fn bound_metadata(&mut self, meta: types::GetMetadataResponse) -> types::GetMetadataResponse {
+        types::GetMetadataResponse {
+            url: self.bound("meta.url", meta.url, limits::META_URL),
+            logo: self.bound("meta.logo", meta.logo, limits::META_LOGO),
+            name: self.bound("meta.name", meta.name, limits::META_NAME),
+            description: self.bound("meta.description", meta.description, limits::META_DESCRIPTION),
+        }
     }
 }
 
@@ -141,6 +170,94 @@ fn strip_unserved_swap_state(mut swap_state: GetStateResponse) -> GetStateRespon
         swap.cf_participants = Vec::new();
     }
     swap_state
+}
+
+/// Replaces a `null` with a minimal object in each field that the launchpad reads without a check.
+///
+/// The launchpad reads `swap_state.swap`, `derived_state`, `init`, `swap_params` and
+/// `nervous_system_parameters` without a check for `null`.  It also converts
+/// `derived_state.buyer_total_icp_e8s` to a number without a check.  A `null` in any of them
+/// raises a `TypeError` inside a store that maps every SNS, so the launchpad then shows NO SNS at
+/// all.  One SNS would hide every other SNS.
+///
+/// A field becomes `null` in two cases:  A size limit emptied it, or the first call for a new SNS
+/// failed and the cache held nothing.  This function makes both cases safe.  The launchpad reads
+/// the minimal object, finds no swap parameters, and drops that one SNS.  Every other SNS keeps
+/// its card.
+///
+/// Each replacement is minimal on purpose.  It carries no value that the SNS did not supply,
+/// except the two numbers in `derived_state`, which the launchpad requires to be numbers.
+fn fill_unreadable_nulls(mut data: UpstreamData) -> UpstreamData {
+    if data.swap_state.swap.is_none() {
+        data.swap_state.swap = Some(Swap::default());
+    }
+    if data.swap_state.derived.is_none() {
+        data.swap_state.derived = Some(DerivedState::default());
+    }
+    let mut derived_state = data.derived_state.unwrap_or_default();
+    derived_state.sns_tokens_per_icp = Some(derived_state.sns_tokens_per_icp.unwrap_or(0.0));
+    derived_state.buyer_total_icp_e8s = Some(derived_state.buyer_total_icp_e8s.unwrap_or(0));
+    data.derived_state = Some(derived_state);
+    data.init = Some(data.init.unwrap_or(GetInitResponse { init: None }));
+    data.swap_params = Some(data.swap_params.unwrap_or(GetSaleParametersResponse { params: None }));
+    data.nervous_system_parameters = Some(data.nervous_system_parameters.unwrap_or_default());
+    data
+}
+
+/// Limits the size of every SNS controlled field, then makes the record safe for the launchpad.
+///
+/// The limit applies to the value that the aggregator is about to cache.  That value is the new
+/// response, or the previous cached value when the call failed.  A cache that an earlier release
+/// filled with data over a limit therefore recovers on the next update.
+///
+/// `fill_unreadable_nulls` runs after the limits.  It adds only fixed empty objects, never a
+/// value that the SNS supplied, so it adds at most a few hundred bytes to the record.
+///
+/// The second return value holds one line for each field that a limit emptied.  The caller writes
+/// those lines to the canister log.
+fn bound_upstream_data(data: UpstreamData) -> (UpstreamData, Vec<String>) {
+    let index = data.index;
+    let mut bounder = Bounder::new(index);
+    let bounded_data = UpstreamData {
+        index,
+        canister_ids: data.canister_ids,
+        list_sns_canisters: bounder.bound(
+            "list_sns_canisters",
+            data.list_sns_canisters,
+            limits::LIST_SNS_CANISTERS,
+        ),
+        meta: bounder.bound_metadata(data.meta),
+        metrics: bounder.bound("metrics", data.metrics, limits::METRICS),
+        latest_reward_event: bounder.bound(
+            "latest_reward_event",
+            data.latest_reward_event,
+            limits::LATEST_REWARD_EVENT,
+        ),
+        parameters: bounder.bound("parameters", data.parameters, limits::PARAMETERS),
+        nervous_system_parameters: bounder.bound(
+            "nervous_system_parameters",
+            data.nervous_system_parameters,
+            limits::NERVOUS_SYSTEM_PARAMETERS,
+        ),
+        swap_state: bounder.bound(
+            "swap_state",
+            strip_unserved_swap_state(data.swap_state),
+            limits::SWAP_STATE,
+        ),
+        icrc1_metadata: bounder.bound("icrc1_metadata", data.icrc1_metadata, limits::ICRC1_METADATA),
+        icrc1_fee: bounder.bound("icrc1_fee", data.icrc1_fee, limits::ICRC1_FEE),
+        icrc1_total_supply: bounder.bound(
+            "icrc1_total_supply",
+            data.icrc1_total_supply,
+            limits::ICRC1_TOTAL_SUPPLY,
+        ),
+        swap_params: bounder.bound("swap_params", data.swap_params, limits::SWAP_PARAMS),
+        init: bounder.bound("init", data.init, limits::INIT),
+        derived_state: bounder.bound("derived_state", data.derived_state, limits::DERIVED_STATE),
+        lifecycle: bounder.bound("lifecycle", data.lifecycle, limits::LIFECYCLE),
+        topics: bounder.bound("topics", data.topics, limits::TOPICS),
+    };
+    (fill_unreadable_nulls(bounded_data), bounder.reasons)
 }
 
 /// Updates one part of the cache:  Either the list of SNSs or one SNS.
@@ -395,56 +512,8 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
 
     crate::state::log("Yay, got an SNS status".to_string());
 
-    // Limit the size of every SNS controlled field before the aggregator caches it.
-    //
-    // The limit applies to the value that the aggregator is about to cache.  That value is the
-    // new response, or the previous cached value when the call failed.  A cache that an earlier
-    // release filled with oversized data therefore recovers on the next update.
-    let list_sns_canisters = bounded(
-        index,
-        "list_sns_canisters",
-        list_sns_canisters,
-        limits::LIST_SNS_CANISTERS,
-    );
-    let meta = bounded_metadata(index, meta);
-    let metrics = bounded(index, "metrics", metrics, limits::METRICS);
-    let latest_reward_event = bounded(
-        index,
-        "latest_reward_event",
-        latest_reward_event,
-        limits::LATEST_REWARD_EVENT,
-    );
-    let parameters = bounded(index, "parameters", parameters, limits::PARAMETERS);
-    let nervous_system_parameters = bounded(
-        index,
-        "nervous_system_parameters",
-        nervous_system_parameters,
-        limits::NERVOUS_SYSTEM_PARAMETERS,
-    );
-    let swap_state = bounded(
-        index,
-        "swap_state",
-        strip_unserved_swap_state(swap_state),
-        limits::SWAP_STATE,
-    );
-    let icrc1_metadata = bounded(index, "icrc1_metadata", icrc1_metadata, limits::ICRC1_METADATA);
-    let icrc1_fee = bounded(index, "icrc1_fee", icrc1_fee, limits::ICRC1_FEE);
-    let icrc1_total_supply = bounded(
-        index,
-        "icrc1_total_supply",
-        icrc1_total_supply,
-        limits::ICRC1_TOTAL_SUPPLY,
-    );
-    let swap_params_response = bounded(index, "swap_params", swap_params_response, limits::SWAP_PARAMS);
-    let init_response = bounded(index, "init", init_response, limits::INIT);
-    let derived_state_response = bounded(index, "derived_state", derived_state_response, limits::DERIVED_STATE);
-    let lifecycle_response = bounded(index, "lifecycle", lifecycle_response, limits::LIFECYCLE);
-    let list_topics_response = bounded(index, "topics", list_topics_response, limits::TOPICS);
-
-    // If the SNS sale will open, collect data when it does.
-    FastScheduler::global_schedule_sns(&swap_state);
-    // Save the data in the state.
-    let slow_data = UpstreamData {
+    // Limit the size of every SNS controlled field before the aggregator caches the record.
+    let (slow_data, reasons) = bound_upstream_data(UpstreamData {
         index,
         canister_ids: sns_canister_ids,
         list_sns_canisters,
@@ -462,7 +531,14 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
         derived_state: derived_state_response,
         lifecycle: lifecycle_response,
         topics: list_topics_response,
-    };
+    });
+    for reason in reasons {
+        crate::state::log(reason);
+    }
+
+    // If the SNS sale will open, collect data when it does.
+    FastScheduler::global_schedule_sns(&slow_data.swap_state);
+    // Save the data in the state.
     State::insert_sns(index, &slow_data)
         .map_err(|err| crate::state::log(format!("Failed to create certified assets: {err}")))
         .unwrap_or_default();

--- a/rs/sns_aggregator/src/upstream/tests.rs
+++ b/rs/sns_aggregator/src/upstream/tests.rs
@@ -3,8 +3,16 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
 
-use super::{bound, limits, strip_unserved_swap_state};
-use crate::types::ic_sns_swap::{BuyerState, CfParticipant, GetStateResponse, SnsNeuronRecipe, Swap};
+use super::{bound, bound_upstream_data, fill_unreadable_nulls, limits, strip_unserved_swap_state};
+use crate::types::ic_sns_governance::{GetMetadataResponse, NervousSystemParameters, NeuronPermissionList};
+use crate::types::ic_sns_swap::{
+    BuyerState, CfParticipant, DerivedState, GetDerivedStateResponse, GetInitResponse, GetSaleParametersResponse,
+    GetStateResponse, SnsNeuronRecipe, Swap,
+};
+use crate::types::slow::SlowSnsData;
+use crate::types::upstream::UpstreamData;
+use crate::Icrc1Value;
+use serde_bytes::ByteBuf;
 use serde_json::Value;
 use std::fs;
 use std::path::PathBuf;
@@ -234,4 +242,181 @@ fn mainnet_sns_data_is_within_the_limits() {
             );
         }
     }
+}
+
+/// The places in the served JSON that the launchpad reads without a check for `null`.
+///
+/// `frontend/src/lib/utils/sns-aggregator-converters.utils.ts` reads `swap_state.swap`,
+/// `derived_state`, `init` and `swap_params` without a check.  It converts
+/// `derived_state.buyer_total_icp_e8s` to a `BigInt`, which fails on `null`.
+/// `frontend/src/lib/derived/sns-parameters.derived.ts` reads the fields of
+/// `nervous_system_parameters` without a check.
+///
+/// Each of those reads happens inside a store that maps EVERY SNS.  A `null` in one SNS therefore
+/// empties the whole launchpad.
+const PLACES_THAT_MUST_NOT_BE_NULL: &[&[&str]] = &[
+    &["swap_state", "swap"],
+    &["derived_state"],
+    &["derived_state", "buyer_total_icp_e8s"],
+    &["derived_state", "sns_tokens_per_icp"],
+    &["init"],
+    &["swap_params"],
+    &["nervous_system_parameters"],
+];
+
+/// Converts the record to the JSON that the aggregator serves, and fails on an unreadable null.
+fn assert_the_launchpad_can_read(data: &UpstreamData) {
+    let served = serde_json::to_value(SlowSnsData::from(data)).expect("Failed to serialise the served record");
+    for path in PLACES_THAT_MUST_NOT_BE_NULL {
+        let mut value = &served;
+        for key in *path {
+            value = &value[*key];
+        }
+        assert!(
+            !value.is_null(),
+            "The served JSON holds null at '{}'.  One such null empties the whole launchpad.  The record is: {served}",
+            path.join(".")
+        );
+    }
+}
+
+/// A record in which four SNS controlled fields are far over their limits.
+///
+/// `swap_params`, `init` and `derived_state` hold only numbers, so no test can make them
+/// too large today.  `an_empty_record_serves_no_null_that_the_launchpad_cannot_read` covers the
+/// state that those three reach when a bound does trip.
+fn oversized_upstream_data() -> UpstreamData {
+    UpstreamData {
+        meta: GetMetadataResponse {
+            url: None,
+            logo: None,
+            name: None,
+            description: Some("d".repeat(limits::META_DESCRIPTION + 1)),
+        },
+        icrc1_metadata: vec![(
+            "icrc1:logo".to_string(),
+            Icrc1Value::Text("A".repeat(limits::ICRC1_METADATA + 1)),
+        )],
+        nervous_system_parameters: Some(NervousSystemParameters {
+            neuron_claimer_permissions: Some(NeuronPermissionList {
+                permissions: vec![1; limits::NERVOUS_SYSTEM_PARAMETERS],
+            }),
+            ..Default::default()
+        }),
+        swap_state: GetStateResponse {
+            swap: Some(Swap {
+                purge_old_tickets_next_principal: Some(ByteBuf::from(vec![7u8; limits::SWAP_STATE])),
+                ..Default::default()
+            }),
+            derived: None,
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn an_oversized_record_serves_no_null_that_the_launchpad_cannot_read() {
+    let (data, reasons) = bound_upstream_data(oversized_upstream_data());
+
+    // Each bound must have tripped, and each trip must be reported.
+    assert_eq!(reasons.len(), 4, "Expected four reports, got: {reasons:?}");
+    assert!(data.meta.description.is_none(), "The description must be emptied");
+    assert!(data.icrc1_metadata.is_empty(), "The ledger metadata must be emptied");
+    let parameters = data
+        .nervous_system_parameters
+        .as_ref()
+        .expect("The nervous system parameters must be an object");
+    assert!(
+        parameters.neuron_claimer_permissions.is_none(),
+        "The nervous system parameters must be emptied"
+    );
+    let swap = data.swap_state.swap.as_ref().expect("The swap must be an object");
+    assert!(
+        swap.purge_old_tickets_next_principal.is_none(),
+        "The swap state must be emptied"
+    );
+    assert!(swap.params.is_none(), "The emptied swap holds no parameters");
+
+    assert_the_launchpad_can_read(&data);
+}
+
+#[test]
+fn an_empty_record_serves_no_null_that_the_launchpad_cannot_read() {
+    // Every field of a default record is empty.  A field reaches this state when its bound trips,
+    // because `bound` replaces an oversized value with the default value of its type.
+    let (data, reasons) = bound_upstream_data(UpstreamData::default());
+    assert!(reasons.is_empty(), "An empty record trips no bound: {reasons:?}");
+    assert_the_launchpad_can_read(&data);
+}
+
+#[test]
+fn an_empty_record_serves_zero_for_the_two_derived_numbers() {
+    let (data, _reasons) = bound_upstream_data(UpstreamData::default());
+    let derived_state = data.derived_state.expect("The derived state must be an object");
+    assert_eq!(derived_state.buyer_total_icp_e8s, Some(0));
+    assert_eq!(derived_state.sns_tokens_per_icp, Some(0.0));
+}
+
+#[test]
+fn fill_unreadable_nulls_keeps_the_values_that_the_sns_supplied() {
+    let data = UpstreamData {
+        swap_state: GetStateResponse {
+            swap: Some(Swap {
+                lifecycle: 2,
+                ..Default::default()
+            }),
+            derived: Some(DerivedState {
+                buyer_total_icp_e8s: 7,
+                sns_tokens_per_icp: 3.0,
+                ..Default::default()
+            }),
+        },
+        derived_state: Some(GetDerivedStateResponse {
+            buyer_total_icp_e8s: Some(11),
+            sns_tokens_per_icp: Some(5.0),
+            ..Default::default()
+        }),
+        init: Some(GetInitResponse { init: None }),
+        swap_params: Some(GetSaleParametersResponse { params: None }),
+        nervous_system_parameters: Some(NervousSystemParameters {
+            reject_cost_e8s: Some(13),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let filled = fill_unreadable_nulls(data);
+    assert_eq!(filled.swap_state.swap.expect("A swap").lifecycle, 2);
+    assert_eq!(
+        filled.swap_state.derived.expect("A derived state").buyer_total_icp_e8s,
+        7
+    );
+    let derived_state = filled.derived_state.expect("A derived state response");
+    assert_eq!(derived_state.buyer_total_icp_e8s, Some(11));
+    assert_eq!(derived_state.sns_tokens_per_icp, Some(5.0));
+    assert_eq!(
+        filled
+            .nervous_system_parameters
+            .expect("Nervous system parameters")
+            .reject_cost_e8s,
+        Some(13)
+    );
+}
+
+#[test]
+fn bound_upstream_data_keeps_a_record_that_is_within_the_limits() {
+    let data = UpstreamData {
+        meta: GetMetadataResponse {
+            url: Some("https://example.com".to_string()),
+            logo: None,
+            name: Some("A name".to_string()),
+            description: Some("A description".to_string()),
+        },
+        icrc1_metadata: vec![("icrc1:symbol".to_string(), Icrc1Value::Text("TOK".to_string()))],
+        ..Default::default()
+    };
+    let (bounded_data, reasons) = bound_upstream_data(data);
+    assert!(reasons.is_empty(), "No bound must trip: {reasons:?}");
+    assert_eq!(bounded_data.meta.name.as_deref(), Some("A name"));
+    assert_eq!(bounded_data.meta.description.as_deref(), Some("A description"));
+    assert_eq!(bounded_data.icrc1_metadata.len(), 1);
 }

--- a/rs/sns_aggregator/src/upstream/tests.rs
+++ b/rs/sns_aggregator/src/upstream/tests.rs
@@ -1,0 +1,237 @@
+//! Tests for the size limits on SNS controlled data.
+#![allow(clippy::panic)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+use super::{bound, limits, strip_unserved_swap_state};
+use crate::types::ic_sns_swap::{BuyerState, CfParticipant, GetStateResponse, SnsNeuronRecipe, Swap};
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+
+/// The mainnet snapshot that the launchpad tests use.
+///
+/// A bot updates these files from mainnet.  They hold the aggregator response for every SNS, in
+/// the form that the aggregator serves.
+fn mainnet_snapshot_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../frontend/src/tests/workflows/Launchpad")
+}
+
+/// Reads every SNS record in the mainnet snapshot.
+fn mainnet_sns_records() -> Vec<Value> {
+    let dir = mainnet_snapshot_dir();
+    let mut records = Vec::new();
+    let entries = fs::read_dir(&dir).unwrap_or_else(|err| panic!("Failed to read {}: {err}", dir.display()));
+    for entry in entries {
+        let path = entry.expect("Failed to read a directory entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let text = fs::read_to_string(&path).unwrap_or_else(|err| panic!("Failed to read {}: {err}", path.display()));
+        let page: Value =
+            serde_json::from_str(&text).unwrap_or_else(|err| panic!("Failed to parse {}: {err}", path.display()));
+        let page = page
+            .as_array()
+            .unwrap_or_else(|| panic!("{} does not hold an array", path.display()))
+            .clone();
+        records.extend(page);
+    }
+    assert!(
+        records.len() > 10,
+        "Expected the mainnet snapshot to hold many SNSs, found {}",
+        records.len()
+    );
+    records
+}
+
+/// A buyer record, as the swap canister returns it.
+fn a_buyer() -> (String, BuyerState) {
+    (
+        "a buyer".to_string(),
+        BuyerState {
+            icp: None,
+            has_created_neuron_recipes: None,
+        },
+    )
+}
+
+/// A neuron recipe, as the swap canister returns it.
+fn a_neuron_recipe() -> SnsNeuronRecipe {
+    SnsNeuronRecipe {
+        sns: None,
+        claimed_status: None,
+        neuron_attributes: None,
+        investor: None,
+    }
+}
+
+/// A Neurons' Fund participant, as the swap canister returns it.
+fn a_cf_participant() -> CfParticipant {
+    CfParticipant {
+        controller: None,
+        hotkey_principal: "a principal".to_string(),
+        cf_neurons: Vec::new(),
+    }
+}
+
+#[test]
+fn bound_keeps_a_value_within_the_limit() {
+    let value = Some("a".repeat(100));
+    let (bounded_value, reason) = bound(value.clone(), limits::META_DESCRIPTION);
+    assert_eq!(bounded_value, value);
+    assert_eq!(reason, None);
+}
+
+#[test]
+fn bound_keeps_a_value_of_exactly_the_limit() {
+    // Two of the bytes are the JSON quotation marks.
+    let value = "a".repeat(limits::META_URL - 2);
+    let (bounded_value, reason) = bound(value.clone(), limits::META_URL);
+    assert_eq!(bounded_value, value);
+    assert_eq!(reason, None);
+}
+
+#[test]
+fn bound_empties_a_value_over_the_limit() {
+    let value = Some("a".repeat(limits::META_DESCRIPTION + 1));
+    let (bounded_value, reason) = bound(value, limits::META_DESCRIPTION);
+    assert_eq!(bounded_value, None, "An oversized description must be emptied");
+    assert!(reason.is_some(), "An oversized description must be reported");
+}
+
+#[test]
+fn bound_empties_an_oversized_logo() {
+    // A data URL for a logo of one megabyte.
+    let logo = Some(format!("data:image/png;base64,{}", "A".repeat(1024 * 1024)));
+    let (bounded_logo, reason) = bound(logo, limits::META_LOGO);
+    assert_eq!(bounded_logo, None);
+    assert!(reason.is_some());
+}
+
+#[test]
+fn bound_empties_an_oversized_list() {
+    let entries: Vec<String> = (0..100_000).map(|index| format!("entry {index}")).collect();
+    let (bounded_entries, reason) = bound(entries, limits::ICRC1_METADATA);
+    assert!(bounded_entries.is_empty(), "An oversized list must be emptied");
+    assert!(reason.is_some());
+}
+
+#[test]
+fn bound_keeps_the_largest_real_ledger_metadata() {
+    let largest = mainnet_sns_records()
+        .iter()
+        .map(|record| record["icrc1_metadata"].to_string().len())
+        .max()
+        .expect("The snapshot holds no SNS");
+    let value = "A".repeat(largest);
+    let (bounded_value, reason) = bound(value.clone(), limits::ICRC1_METADATA);
+    assert_eq!(bounded_value, value, "The largest real ledger metadata must survive");
+    assert_eq!(reason, None);
+}
+
+#[test]
+fn strip_unserved_swap_state_clears_the_participant_lists() {
+    let swap = Swap {
+        auto_finalize_swap_response: None,
+        neuron_recipes: vec![a_neuron_recipe(), a_neuron_recipe()],
+        next_ticket_id: Some(7),
+        decentralization_sale_open_timestamp_seconds: Some(1234),
+        finalize_swap_in_progress: None,
+        timers: None,
+        cf_participants: vec![a_cf_participant(), a_cf_participant()],
+        init: None,
+        already_tried_to_auto_finalize: None,
+        neurons_fund_participation_icp_e8s: None,
+        purge_old_tickets_last_completion_timestamp_nanoseconds: None,
+        direct_participation_icp_e8s: None,
+        lifecycle: 2,
+        purge_old_tickets_next_principal: None,
+        decentralization_swap_termination_timestamp_seconds: None,
+        buyers: vec![a_buyer(), a_buyer(), a_buyer()],
+        params: None,
+        open_sns_token_swap_proposal_id: Some(42),
+    };
+    let stripped = strip_unserved_swap_state(GetStateResponse {
+        swap: Some(swap),
+        derived: None,
+    });
+    let stripped_swap = stripped.swap.expect("The swap must survive");
+    assert!(stripped_swap.buyers.is_empty(), "The buyers must be cleared");
+    assert!(
+        stripped_swap.neuron_recipes.is_empty(),
+        "The neuron recipes must be cleared"
+    );
+    assert!(
+        stripped_swap.cf_participants.is_empty(),
+        "The Neurons' Fund participants must be cleared"
+    );
+    assert_eq!(stripped_swap.lifecycle, 2, "The lifecycle must survive");
+    assert_eq!(
+        stripped_swap.decentralization_sale_open_timestamp_seconds,
+        Some(1234),
+        "The sale start time must survive"
+    );
+    assert_eq!(
+        stripped_swap.open_sns_token_swap_proposal_id,
+        Some(42),
+        "The proposal ID must survive"
+    );
+}
+
+#[test]
+fn strip_unserved_swap_state_accepts_an_empty_state() {
+    let stripped = strip_unserved_swap_state(GetStateResponse::default());
+    assert!(stripped.swap.is_none());
+    assert!(stripped.derived.is_none());
+}
+
+/// Every SNS on mainnet must stay within the limits.
+///
+/// A limit that is too low empties a field of a real SNS.  The launchpad then shows that SNS
+/// without its data.  If this test fails, mainnet data has grown past a limit.  Raise the limit
+/// in `limits`.
+///
+/// The snapshot holds the data in the form that the aggregator serves.  It therefore holds no
+/// governance logo, because the aggregator serves the logo as a separate asset.  Its swap state
+/// is also the served subset, which is smaller than the cached swap state.
+#[test]
+fn mainnet_sns_data_is_within_the_limits() {
+    let field_limits: &[(&str, usize)] = &[
+        ("list_sns_canisters", limits::LIST_SNS_CANISTERS),
+        ("metrics", limits::METRICS),
+        ("latest_reward_event", limits::LATEST_REWARD_EVENT),
+        ("parameters", limits::PARAMETERS),
+        ("nervous_system_parameters", limits::NERVOUS_SYSTEM_PARAMETERS),
+        ("swap_state", limits::SWAP_STATE),
+        ("icrc1_metadata", limits::ICRC1_METADATA),
+        ("icrc1_fee", limits::ICRC1_FEE),
+        ("icrc1_total_supply", limits::ICRC1_TOTAL_SUPPLY),
+        ("swap_params", limits::SWAP_PARAMS),
+        ("init", limits::INIT),
+        ("derived_state", limits::DERIVED_STATE),
+        ("lifecycle", limits::LIFECYCLE),
+        ("topics", limits::TOPICS),
+    ];
+    let meta_limits: &[(&str, usize)] = &[
+        ("url", limits::META_URL),
+        ("name", limits::META_NAME),
+        ("description", limits::META_DESCRIPTION),
+    ];
+    for record in mainnet_sns_records() {
+        let index = record["index"].clone();
+        for &(field, limit) in field_limits {
+            let size = record[field].to_string().len();
+            assert!(
+                size <= limit,
+                "SNS index {index}: field '{field}' has {size} bytes and the limit is {limit} bytes"
+            );
+        }
+        for &(field, limit) in meta_limits {
+            let size = record["meta"][field].to_string().len();
+            assert!(
+                size <= limit,
+                "SNS index {index}: field 'meta.{field}' has {size} bytes and the limit is {limit} bytes"
+            );
+        }
+    }
+}


### PR DESCRIPTION
# Motivation

An SNS controls the content of about 13 responses the aggregator fetches for it, and the aggregator cached each one with no size check. One oversized field made a shared page of ten SNSs too large to serve, hiding those SNSs from the launchpad with no recovery until a code change.

# Changes

- Added a size limit for each SNS controlled field, applied to the value just before it enters the cache.
- Stopped caching the swap buyers, the neuron recipes, and the Neurons' Fund participants, since the aggregator never serves these lists.
- Replaced `null` with a minimal non-null value for `swap_state`, `derived_state`, `init`, `swap_params`, and `nervous_system_parameters` when a limit empties them, since the NNS dapp reads those fields with no null check.
- Added a test that checks the mainnet snapshot stays within every limit, so a future data shift fails the test before a release.
- Added tests that serialise a bounded record and fail if the served JSON holds a null the NNS dapp cannot read.

# Tests

- `cargo test` passes for the whole workspace, 16 tests in the aggregator crate, up from 11.
- `./scripts/lint-rs` and `cargo fmt --all --check` pass.
- No frontend source changed. The new Rust tests only read the frontend mainnet snapshot files.

# Todos

- [x] Accessibility (a11y) – no UI change. This ships in the SNS aggregator canister.
- [x] Changelog – added three `### Security` entries to `CHANGELOG-Sns_Aggregator.md`. This ships in the SNS aggregator canister, which has its own changelog and proposal.
