### PR TITLE
fix(address-book): build address book saves from certified data

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,10 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+* Build the address book replacement from certified data when the user
+  adds, edits or removes an entry. A save no longer writes back a query
+  response.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1154,6 +1154,8 @@
   "error__address_book": {
     "load_address_book": "There was an unexpected issue while loading the address book.",
     "update_address": "There was an unexpected issue while updating the address.",
+    "not_certified": "We could not verify your address book, so nothing was saved. Please reload the page and try again.",
+    "entry_not_found": "\"$name\" is not in your verified address book, so nothing was saved. Please reload the page and try again.",
     "too_many": "You can't add more than $limit addresses.",
     "invalid_icp": "Invalid ICP address: $error.",
     "invalid_icrc1": "Invalid ICRC1 address: $error.",

--- a/frontend/src/lib/modals/address-book/AddAddressModal.svelte
+++ b/frontend/src/lib/modals/address-book/AddAddressModal.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
   import InputWithError from "$lib/components/ui/InputWithError.svelte";
   import type { NamedAddress } from "$lib/canisters/nns-dapp/nns-dapp.types";
-  import { saveAddressBook } from "$lib/services/address-book.services";
+  import {
+    getCertifiedNamedAddresses,
+    saveAddressBook,
+  } from "$lib/services/address-book.services";
   import { addressBookStore } from "$lib/stores/address-book.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { toastsSuccess } from "$lib/stores/toasts.store";
+  import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
   import {
     invalidIcpAddress,
     invalidIcrcAddress,
   } from "$lib/utils/accounts.utils";
   import { getAddressString } from "$lib/utils/address-book.utils";
   import { Modal, busy } from "@dfinity/gix-components";
-  import { nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
 
   interface Props {
     onClose: () => void;
@@ -144,28 +147,49 @@
       address: addressType,
     };
 
-    // Create temporary array with the updated addresses
-    const currentAddresses = $addressBookStore.namedAddresses ?? [];
-    let updatedAddresses: NamedAddress[];
-
-    if (isEditMode) {
-      // In edit mode, find and replace the existing entry
-      updatedAddresses = currentAddresses.map((entry) =>
-        normalizeName(entry.name) === normalizeName(namedAddress?.name ?? "")
-          ? updatedAddress
-          : entry
-      );
-    } else {
-      // In add mode, append the new address
-      updatedAddresses = [...currentAddresses, updatedAddress];
-    }
-
     const initiator = isEditMode
       ? "edit-address-book-entry"
       : "add-address-book-entry";
     startBusy({ initiator });
 
     try {
+      // The save replaces the whole address book. Build the replacement from
+      // certified entries only. A single replica can forge or drop entries in a
+      // query response, and a write would make that response permanent.
+      const currentAddresses = await getCertifiedNamedAddresses();
+
+      if (isNullish(currentAddresses)) {
+        toastsError({ labelKey: "error__address_book.not_certified" });
+        return;
+      }
+
+      let updatedAddresses: NamedAddress[];
+
+      if (isEditMode) {
+        const previousName = normalizeName(namedAddress?.name ?? "");
+        const isPresent = currentAddresses.some(
+          (entry) => normalizeName(entry.name) === previousName
+        );
+
+        // The certified address book no longer holds the entry to edit.
+        // Report it instead of saving an unchanged address book.
+        if (!isPresent) {
+          toastsError({
+            labelKey: "error__address_book.entry_not_found",
+            substitutions: { $name: namedAddress?.name ?? "" },
+          });
+          return;
+        }
+
+        // In edit mode, find and replace the existing entry
+        updatedAddresses = currentAddresses.map((entry) =>
+          normalizeName(entry.name) === previousName ? updatedAddress : entry
+        );
+      } else {
+        // In add mode, append the new address
+        updatedAddresses = [...currentAddresses, updatedAddress];
+      }
+
       const result = await saveAddressBook(updatedAddresses);
 
       if (!result?.err) {

--- a/frontend/src/lib/modals/address-book/AddAddressModal.svelte
+++ b/frontend/src/lib/modals/address-book/AddAddressModal.svelte
@@ -55,7 +55,11 @@
       return $i18n.address_book.nickname_too_long;
     }
 
-    // Check uniqueness: normalize both sides (trim + lowercase) for comparison
+    // Check uniqueness: normalize both sides (trim + lowercase) for comparison.
+    // This check reads the store, which can hold a query response. A query
+    // response can hide a duplicate. The backend then rejects the save with
+    // `DuplicateAddressNameError` and the user gets a toast. The save itself
+    // always builds on certified entries, so this check is a hint only.
     const isNicknameAlreadyUsed = $addressBookStore.namedAddresses?.some(
       (entry) => {
         if (

--- a/frontend/src/lib/modals/address-book/RemoveAddressModal.svelte
+++ b/frontend/src/lib/modals/address-book/RemoveAddressModal.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import type { NamedAddress } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
-  import { saveAddressBook } from "$lib/services/address-book.services";
-  import { addressBookStore } from "$lib/stores/address-book.store";
+  import {
+    getCertifiedNamedAddresses,
+    saveAddressBook,
+  } from "$lib/services/address-book.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { toastsSuccess } from "$lib/stores/toasts.store";
+  import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { IconErrorOutline } from "@dfinity/gix-components";
   import { isNullish } from "@dfinity/utils";
@@ -18,18 +20,34 @@
   const { onClose, namedAddress }: Props = $props();
 
   const handleDeleteConfirm = async () => {
-    if (isNullish($addressBookStore.namedAddresses)) {
-      return;
-    }
-
-    const updatedAddresses = $addressBookStore.namedAddresses.filter(
-      (entry) => entry.name !== namedAddress.name
-    );
-
     const initiator = "delete-address-book-entry";
     startBusy({ initiator });
 
     try {
+      // The save replaces the whole address book. Build the replacement from
+      // certified entries only. A single replica can forge or drop entries in a
+      // query response, and a write would make that response permanent.
+      const currentAddresses = await getCertifiedNamedAddresses();
+
+      if (isNullish(currentAddresses)) {
+        toastsError({ labelKey: "error__address_book.not_certified" });
+        return;
+      }
+
+      const updatedAddresses = currentAddresses.filter(
+        (entry) => entry.name !== namedAddress.name
+      );
+
+      // The certified address book no longer holds the entry to remove.
+      // Report it instead of saving an unchanged address book.
+      if (updatedAddresses.length === currentAddresses.length) {
+        toastsError({
+          labelKey: "error__address_book.entry_not_found",
+          substitutions: { $name: namedAddress.name },
+        });
+        return;
+      }
+
       const result = await saveAddressBook(updatedAddresses);
 
       if (!result?.err) {

--- a/frontend/src/lib/services/address-book.services.ts
+++ b/frontend/src/lib/services/address-book.services.ts
@@ -14,7 +14,10 @@ import type {
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
-import { queryAndUpdate } from "$lib/services/utils.services";
+import {
+  queryAndUpdate,
+  type QueryAndUpdateStrategy,
+} from "$lib/services/utils.services";
 import { addressBookStore } from "$lib/stores/address-book.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { isAddressBookCertified } from "$lib/utils/address-book.utils";
@@ -25,15 +28,21 @@ import { get } from "svelte/store";
 /**
  * Load address book from the `nns-dapp` backend and update the `addressBookStore` store.
  * - Displays an error toast if the operation fails.
+ * - `strategy` selects the calls to make. The default makes a query call and an
+ *   update call, and the returned promise settles on the first response.
+ *   `"update"` makes only the update call, so the returned promise settles on
+ *   the certified response.
  */
 export const loadAddressBook = async ({
   ignoreAccountNotFoundError,
+  strategy = FORCE_CALL_STRATEGY,
 }: {
   ignoreAccountNotFoundError?: boolean;
+  strategy?: QueryAndUpdateStrategy;
 } = {}) => {
   return queryAndUpdate<AddressBook, unknown>({
     request: getAddressBook,
-    strategy: FORCE_CALL_STRATEGY,
+    strategy,
     onLoad: ({ response: { named_addresses: namedAddresses }, certified }) => {
       addressBookStore.set({
         namedAddresses,
@@ -77,13 +86,26 @@ export const loadAddressBook = async ({
  * from a query response, because a single replica can forge or drop entries.
  * If the store holds a query response, reload the address book first.
  *
+ * The reload uses the `"update"` strategy. A `"query_and_update"` reload
+ * settles on the query response, which leaves the store uncertified and blocks
+ * a normal save. A session that forces the `query` strategy never reaches the
+ * reload, because `isAddressBookCertified` accepts its query response.
+ *
  * Return `undefined` when certified entries are not available.
  */
 export const getCertifiedNamedAddresses = async (): Promise<
   NamedAddress[] | undefined
 > => {
   if (!isAddressBookCertified(get(addressBookStore).certified)) {
-    await loadAddressBook({ ignoreAccountNotFoundError: true });
+    try {
+      await loadAddressBook({
+        ignoreAccountNotFoundError: true,
+        strategy: "update",
+      });
+    } catch (err) {
+      console.error(err);
+      return undefined;
+    }
   }
 
   const { namedAddresses, certified } = get(addressBookStore);
@@ -108,7 +130,10 @@ export const saveAddressBook = async (
   try {
     const identity = await getAuthenticatedIdentity();
     await setAddressBook({ identity, namedAddresses });
-    await loadAddressBook();
+    // Reload with the `"update"` strategy. A query call can still return the
+    // address book from before this write. The `"update"` strategy also leaves
+    // the store certified, so the next save needs no extra reload.
+    await loadAddressBook({ strategy: "update" });
   } catch (err) {
     const error = err as Error;
 

--- a/frontend/src/lib/services/address-book.services.ts
+++ b/frontend/src/lib/services/address-book.services.ts
@@ -27,17 +27,24 @@ import { get } from "svelte/store";
 
 /**
  * Load address book from the `nns-dapp` backend and update the `addressBookStore` store.
- * - Displays an error toast if the operation fails.
- * - `strategy` selects the calls to make. The default makes a query call and an
- *   update call, and the returned promise settles on the first response.
- *   `"update"` makes only the update call, so the returned promise settles on
+ * - Displays an error toast if the operation fails. `silentErrorMessages`
+ *   suppresses that toast, so the caller can show its own message.
+ * - `strategy` selects the calls to make. The default is `FORCE_CALL_STRATEGY`.
+ *   That constant is `undefined` for a normal session, which makes a query
+ *   call and an update call. It is `"query"` for a forced-query session, which
+ *   makes only a query call. So the default can give uncertified data.
+ * - `"update"` makes only the update call. The returned promise then settles on
  *   the certified response.
+ * - For the other strategies the returned promise settles on the first
+ *   response, which is normally the query response.
  */
 export const loadAddressBook = async ({
   ignoreAccountNotFoundError,
+  silentErrorMessages,
   strategy = FORCE_CALL_STRATEGY,
 }: {
   ignoreAccountNotFoundError?: boolean;
+  silentErrorMessages?: boolean;
   strategy?: QueryAndUpdateStrategy;
 } = {}) => {
   return queryAndUpdate<AddressBook, unknown>({
@@ -70,6 +77,10 @@ export const loadAddressBook = async ({
       // Explicitly handle only UPDATE errors
       addressBookStore.reset();
 
+      if (silentErrorMessages === true) {
+        return;
+      }
+
       toastsError({
         labelKey: "error__address_book.load_address_book",
         err,
@@ -84,12 +95,17 @@ export const loadAddressBook = async ({
  *
  * A write replaces the whole address book. It must never build the replacement
  * from a query response, because a single replica can forge or drop entries.
- * If the store holds a query response, reload the address book first.
+ * If the store does not hold a certified response, reload the address book
+ * first.
  *
- * The reload uses the `"update"` strategy. A `"query_and_update"` reload
- * settles on the query response, which leaves the store uncertified and blocks
- * a normal save. A session that forces the `query` strategy never reaches the
- * reload, because `isAddressBookCertified` accepts its query response.
+ * The reload always uses the `"update"` strategy. Only an update call gives
+ * certified data. A `"query_and_update"` reload settles on the query response
+ * and leaves the store uncertified. A forced-query session gets no certified
+ * data from its own loads. Such a session takes this path on every save. One
+ * update call per save keeps the address book usable there.
+ *
+ * The reload shows no error toast. The caller shows one message for the whole
+ * failed save instead.
  *
  * Return `undefined` when certified entries are not available.
  */
@@ -100,6 +116,7 @@ export const getCertifiedNamedAddresses = async (): Promise<
     try {
       await loadAddressBook({
         ignoreAccountNotFoundError: true,
+        silentErrorMessages: true,
         strategy: "update",
       });
     } catch (err) {

--- a/frontend/src/lib/services/address-book.services.ts
+++ b/frontend/src/lib/services/address-book.services.ts
@@ -17,7 +17,10 @@ import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { addressBookStore } from "$lib/stores/address-book.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import { isAddressBookCertified } from "$lib/utils/address-book.utils";
 import { isLastCall } from "$lib/utils/env.utils";
+import { isNullish } from "@dfinity/utils";
+import { get } from "svelte/store";
 
 /**
  * Load address book from the `nns-dapp` backend and update the `addressBookStore` store.
@@ -65,6 +68,31 @@ export const loadAddressBook = async ({
     },
     logMessage: "Get Address Book",
   });
+};
+
+/**
+ * Return the address book entries that a certified call produced.
+ *
+ * A write replaces the whole address book. It must never build the replacement
+ * from a query response, because a single replica can forge or drop entries.
+ * If the store holds a query response, reload the address book first.
+ *
+ * Return `undefined` when certified entries are not available.
+ */
+export const getCertifiedNamedAddresses = async (): Promise<
+  NamedAddress[] | undefined
+> => {
+  if (!isAddressBookCertified(get(addressBookStore).certified)) {
+    await loadAddressBook({ ignoreAccountNotFoundError: true });
+  }
+
+  const { namedAddresses, certified } = get(addressBookStore);
+
+  if (!isAddressBookCertified(certified) || isNullish(namedAddresses)) {
+    return undefined;
+  }
+
+  return namedAddresses;
 };
 
 /**

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1204,6 +1204,8 @@ interface I18nError__fav_projects {
 interface I18nError__address_book {
   load_address_book: string;
   update_address: string;
+  not_certified: string;
+  entry_not_found: string;
   too_many: string;
   invalid_icp: string;
   invalid_icrc1: string;

--- a/frontend/src/lib/utils/address-book.utils.ts
+++ b/frontend/src/lib/utils/address-book.utils.ts
@@ -1,5 +1,17 @@
 import type { NamedAddress } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { isForceCallStrategy } from "$lib/utils/call.utils";
 import { ICPToken, isNullish, type Token } from "@dfinity/utils";
+
+/**
+ * Tell if the address book in the store comes from a certified call.
+ *
+ * A session that forces the `query` strategy never gets certified data.
+ * Such a session accepts the query response instead.
+ */
+export const isAddressBookCertified = (
+  certified: boolean | undefined
+): boolean =>
+  certified === true || (certified === false && isForceCallStrategy());
 
 /**
  * Helper function to extract address string from AddressType

--- a/frontend/src/lib/utils/address-book.utils.ts
+++ b/frontend/src/lib/utils/address-book.utils.ts
@@ -1,17 +1,15 @@
 import type { NamedAddress } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { isForceCallStrategy } from "$lib/utils/call.utils";
 import { ICPToken, isNullish, type Token } from "@dfinity/utils";
 
 /**
  * Tell if the address book in the store comes from a certified call.
  *
- * A session that forces the `query` strategy never gets certified data.
- * Such a session accepts the query response instead.
+ * Only an update call gives certified data. A query response is never
+ * certified, whatever call strategy the session uses.
  */
 export const isAddressBookCertified = (
   certified: boolean | undefined
-): boolean =>
-  certified === true || (certified === false && isForceCallStrategy());
+): boolean => certified === true;
 
 /**
  * Helper function to extract address string from AddressType

--- a/frontend/src/tests/e2e/address-book-certified.spec.ts
+++ b/frontend/src/tests/e2e/address-book-certified.spec.ts
@@ -1,0 +1,136 @@
+import { mockNamedAddressIcp } from "$tests/mocks/address-book.mock";
+import type { AddAddressModalPo } from "$tests/page-objects/AddAddressModal.page-object";
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import type { ToastsPo } from "$tests/page-objects/Toasts.page-object";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test, type Page } from "@playwright/test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// A save replaces the whole address book. It must build the replacement from
+// certified entries only. The store keeps a `certified` flag: the query
+// response sets it to false, and the update response sets it to true.
+//
+// This test holds back the update response of the nns-dapp canister. The store
+// then keeps the query response. The save must still go through, and it must
+// still write certified data.
+const UPDATE_CALL_DELAY_MS = 10_000;
+
+// `./config.sh` writes the nns-dapp canister id into `frontend/.env`.
+// `dfx canister id` is not usable here, because a git worktree holds no
+// `.dfx/local/canister_ids.json`.
+const nnsDappCanisterIdFromEnv = (): string => {
+  const env = readFileSync(resolve(process.cwd(), ".env"), "utf8");
+  const match = env.match(/^VITE_OWN_CANISTER_ID=(.*)$/m);
+  if (match === null) {
+    throw new Error("VITE_OWN_CANISTER_ID is missing from frontend/.env");
+  }
+  return match[1].trim();
+};
+
+// Hold back every update call to the nns-dapp canister. Query calls stay fast.
+const delayUpdateCalls = ({
+  page,
+  canisterId,
+}: {
+  page: Page;
+  canisterId: string;
+}): Promise<void> =>
+  page.route(`**/canister/${canisterId}/call`, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, UPDATE_CALL_DELAY_MS));
+    await route.continue();
+  });
+
+// The modal closes only after the save goes through. A blocked save keeps the
+// modal open and shows an error toast. Report that toast, so a failure says
+// what the user saw.
+const waitForSave = async ({
+  addAddressModalPo,
+  toastsPo,
+  timeoutMs,
+}: {
+  addAddressModalPo: AddAddressModalPo;
+  toastsPo: ToastsPo;
+  timeoutMs: number;
+}): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!(await addAddressModalPo.isPresent())) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  const messages = await toastsPo.getMessages();
+  throw new Error(
+    `The save did not go through. The modal is still open. Toasts: ${JSON.stringify(messages)}`
+  );
+};
+
+test("Address book saves build on certified data", async ({
+  page,
+  context,
+}) => {
+  const nnsDappCanisterId = nnsDappCanisterIdFromEnv();
+  const icpAddress = (mockNamedAddressIcp.address as { Icp: string }).Icp;
+
+  await page.goto("/address-book");
+  await disableCssAnimations(page);
+  await expect(page).toHaveTitle("Address Book | Network Nervous System");
+
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const addressBookPo = appPo.getAddressBookPo();
+  const addAddressModalPo = appPo.getAddAddressModalPo();
+  const toastsPo = appPo.getToastsPo();
+
+  step("A new user adds the first entry");
+  await addressBookPo.waitForContentLoaded();
+  await addressBookPo.clickAddAddress();
+  await addAddressModalPo.waitFor();
+  await addAddressModalPo.addAddress("Alice", icpAddress);
+
+  step("The save goes through and the modal closes");
+  await waitForSave({ addAddressModalPo, toastsPo, timeoutMs: 30_000 });
+
+  const rowsAfterAdd = await addressBookPo.getTableRowsData();
+  expect(rowsAfterAdd).toHaveLength(1);
+  expect(rowsAfterAdd[0].nickname).toBe("Alice");
+
+  step("Hold back the update call, then reload the page");
+  await delayUpdateCalls({ page, canisterId: nnsDappCanisterId });
+  await page.reload();
+  await disableCssAnimations(page);
+
+  step("The table renders the query response, so the store is uncertified");
+  await addressBookPo.waitForContentLoaded();
+  const rowsAfterReload = await addressBookPo.getTableRowsData();
+  expect(rowsAfterReload).toHaveLength(1);
+  expect(rowsAfterReload[0].nickname).toBe("Alice");
+
+  step("Add a second entry while the store holds the query response");
+  await addressBookPo.clickAddAddress();
+  await addAddressModalPo.waitFor();
+  await addAddressModalPo.addAddress("Bob", icpAddress);
+
+  step("The save is slower, but it still goes through and shows no error");
+  await waitForSave({ addAddressModalPo, toastsPo, timeoutMs: 90_000 });
+
+  step("Let the update calls through again and reload");
+  await page.unroute(`**/canister/${nnsDappCanisterId}/call`);
+  await page.reload();
+  await disableCssAnimations(page);
+  await addressBookPo.waitForContentLoaded();
+
+  step("The stored address book holds both entries");
+  const finalRows = await addressBookPo.getTableRowsData();
+  expect(finalRows.map((row) => row.nickname).sort()).toEqual(["Alice", "Bob"]);
+});

--- a/frontend/src/tests/lib/modals/address-book/AddAddressModal.spec.ts
+++ b/frontend/src/tests/lib/modals/address-book/AddAddressModal.spec.ts
@@ -2,13 +2,16 @@ import AddAddressModal from "$lib/modals/address-book/AddAddressModal.svelte";
 import * as addressBookServices from "$lib/services/address-book.services";
 import { addressBookStore } from "$lib/stores/address-book.store";
 import {
+  mockForgedNamedAddress,
   mockNamedAddressIcp,
   mockNamedAddressIcrc1,
 } from "$tests/mocks/address-book.mock";
 import en from "$tests/mocks/i18n.mock";
 
 import { renderModal } from "$tests/mocks/modal.mock";
-import { fireEvent } from "@testing-library/svelte";
+import { toastsStore } from "@dfinity/gix-components";
+import { fireEvent, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
 
 vi.mock("$lib/services/address-book.services");
 
@@ -21,6 +24,18 @@ describe("AddAddressModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     addressBookStore.reset();
+    addressBookStore.set({ namedAddresses: [], certified: true });
+
+    // The real service returns the entries only when the store holds certified
+    // data. The mock keeps that link, so the tests below can drop the
+    // certified flag and see the modal refuse to save.
+    vi.spyOn(
+      addressBookServices,
+      "getCertifiedNamedAddresses"
+    ).mockImplementation(async () => {
+      const { namedAddresses, certified } = get(addressBookStore);
+      return certified === true ? namedAddresses : undefined;
+    });
   });
 
   it("should display modal", async () => {
@@ -826,6 +841,152 @@ describe("AddAddressModal", () => {
 
       const saveButton = queryByTestId("save-address-button");
       await fireEvent.click(saveButton);
+      expect(saveAddressBookSpy).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+  describe("certified data", () => {
+    const fillForm = async (
+      container: HTMLElement,
+      nickname: string,
+      addressValue: string
+    ) => {
+      await fireEvent.input(container.querySelector("input[name='nickname']"), {
+        target: { value: nickname },
+      });
+      await fireEvent.input(container.querySelector("input[name='address']"), {
+        target: { value: addressValue },
+      });
+    };
+
+    it("should not write back an uncertified address book when adding", async () => {
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcp],
+        certified: false,
+      });
+
+      const saveAddressBookSpy = vi
+        .spyOn(addressBookServices, "saveAddressBook")
+        .mockResolvedValue({});
+      const onClose = vi.fn();
+
+      const { container, queryByTestId } = await renderModal({
+        component: AddAddressModal,
+        props: { onClose },
+      });
+
+      await fillForm(container, "Carol", validIcrc1Address);
+      await fireEvent.click(queryByTestId("save-address-button"));
+
+      await waitFor(() =>
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: en.error__address_book.not_certified,
+          },
+        ])
+      );
+
+      expect(saveAddressBookSpy).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should not write back an uncertified address book when editing", async () => {
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcp],
+        certified: false,
+      });
+
+      const saveAddressBookSpy = vi
+        .spyOn(addressBookServices, "saveAddressBook")
+        .mockResolvedValue({});
+      const onClose = vi.fn();
+
+      const { container, queryByTestId } = await renderModal({
+        component: AddAddressModal,
+        props: { onClose, namedAddress: mockNamedAddressIcp },
+      });
+
+      await fillForm(container, "Alice renamed", validIcrc1Address);
+      await fireEvent.click(queryByTestId("save-address-button"));
+
+      await waitFor(() =>
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: en.error__address_book.not_certified,
+          },
+        ])
+      );
+
+      expect(saveAddressBookSpy).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should write back the certified address book, not the store snapshot the modal opened with", async () => {
+      // The modal opens on a query response that holds a forged entry.
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcp, mockForgedNamedAddress],
+        certified: false,
+      });
+
+      const saveAddressBookSpy = vi
+        .spyOn(addressBookServices, "saveAddressBook")
+        .mockResolvedValue({});
+
+      const { container, queryByTestId } = await renderModal({
+        component: AddAddressModal,
+        props: { onClose: vi.fn() },
+      });
+
+      // The certified response arrives and drops the forged entry.
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcp],
+        certified: true,
+      });
+
+      await fillForm(container, "Carol", validIcrc1Address);
+      await fireEvent.click(queryByTestId("save-address-button"));
+
+      await waitFor(() => expect(saveAddressBookSpy).toHaveBeenCalledTimes(1));
+
+      expect(saveAddressBookSpy).toHaveBeenCalledWith([
+        mockNamedAddressIcp,
+        { name: "Carol", address: { Icrc1: validIcrc1Address } },
+      ]);
+    });
+
+    it("should not save when the entry to edit is absent from the certified address book", async () => {
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcrc1],
+        certified: true,
+      });
+
+      const saveAddressBookSpy = vi
+        .spyOn(addressBookServices, "saveAddressBook")
+        .mockResolvedValue({});
+      const onClose = vi.fn();
+
+      const { container, queryByTestId } = await renderModal({
+        component: AddAddressModal,
+        props: { onClose, namedAddress: mockNamedAddressIcp },
+      });
+
+      await fillForm(container, "Alice renamed", validIcrc1Address);
+      await fireEvent.click(queryByTestId("save-address-button"));
+
+      await waitFor(() =>
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: en.error__address_book.entry_not_found.replace(
+              "$name",
+              mockNamedAddressIcp.name
+            ),
+          },
+        ])
+      );
+
       expect(saveAddressBookSpy).not.toHaveBeenCalled();
       expect(onClose).not.toHaveBeenCalled();
     });

--- a/frontend/src/tests/lib/modals/address-book/RemoveAddressModal.spec.ts
+++ b/frontend/src/tests/lib/modals/address-book/RemoveAddressModal.spec.ts
@@ -1,0 +1,156 @@
+import RemoveAddressModal from "$lib/modals/address-book/RemoveAddressModal.svelte";
+import * as addressBookServices from "$lib/services/address-book.services";
+import { addressBookStore } from "$lib/stores/address-book.store";
+import {
+  mockForgedNamedAddress,
+  mockNamedAddressIcp,
+  mockNamedAddressIcrc1,
+} from "$tests/mocks/address-book.mock";
+import en from "$tests/mocks/i18n.mock";
+import { renderModal } from "$tests/mocks/modal.mock";
+import { toastsStore } from "@dfinity/gix-components";
+import { fireEvent, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+vi.mock("$lib/services/address-book.services");
+
+describe("RemoveAddressModal", () => {
+  const renderRemoveModal = (onClose = vi.fn()) =>
+    renderModal({
+      component: RemoveAddressModal,
+      props: { onClose, namedAddress: mockNamedAddressIcp },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addressBookStore.reset();
+    addressBookStore.set({
+      namedAddresses: [mockNamedAddressIcp, mockNamedAddressIcrc1],
+      certified: true,
+    });
+
+    // The real service returns the entries only when the store holds certified
+    // data. The mock keeps that link, so the tests below can drop the
+    // certified flag and see the modal refuse to save.
+    vi.spyOn(
+      addressBookServices,
+      "getCertifiedNamedAddresses"
+    ).mockImplementation(async () => {
+      const { namedAddresses, certified } = get(addressBookStore);
+      return certified === true ? namedAddresses : undefined;
+    });
+  });
+
+  it("should display the entry name", async () => {
+    const { queryByTestId } = await renderRemoveModal();
+
+    expect(queryByTestId("remove-address-confirmation")?.textContent).toContain(
+      mockNamedAddressIcp.name
+    );
+  });
+
+  it("should remove the entry from the certified address book", async () => {
+    const saveAddressBookSpy = vi
+      .spyOn(addressBookServices, "saveAddressBook")
+      .mockResolvedValue({});
+    const onClose = vi.fn();
+
+    const { queryByTestId } = await renderRemoveModal(onClose);
+
+    await fireEvent.click(queryByTestId("confirm-yes"));
+
+    await waitFor(() => expect(saveAddressBookSpy).toHaveBeenCalledTimes(1));
+
+    expect(saveAddressBookSpy).toHaveBeenCalledWith([mockNamedAddressIcrc1]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should not write back an uncertified address book", async () => {
+    addressBookStore.set({
+      namedAddresses: [mockNamedAddressIcp, mockNamedAddressIcrc1],
+      certified: false,
+    });
+
+    const saveAddressBookSpy = vi
+      .spyOn(addressBookServices, "saveAddressBook")
+      .mockResolvedValue({});
+    const onClose = vi.fn();
+
+    const { queryByTestId } = await renderRemoveModal(onClose);
+
+    await fireEvent.click(queryByTestId("confirm-yes"));
+
+    await waitFor(() =>
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: en.error__address_book.not_certified,
+        },
+      ])
+    );
+
+    expect(saveAddressBookSpy).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("should write back the certified address book, not the store snapshot the modal opened with", async () => {
+    // The modal opens on a query response that holds a forged entry.
+    addressBookStore.set({
+      namedAddresses: [
+        mockNamedAddressIcp,
+        mockNamedAddressIcrc1,
+        mockForgedNamedAddress,
+      ],
+      certified: false,
+    });
+
+    const saveAddressBookSpy = vi
+      .spyOn(addressBookServices, "saveAddressBook")
+      .mockResolvedValue({});
+
+    const { queryByTestId } = await renderRemoveModal();
+
+    // The certified response arrives and drops the forged entry.
+    addressBookStore.set({
+      namedAddresses: [mockNamedAddressIcp, mockNamedAddressIcrc1],
+      certified: true,
+    });
+
+    await fireEvent.click(queryByTestId("confirm-yes"));
+
+    await waitFor(() => expect(saveAddressBookSpy).toHaveBeenCalledTimes(1));
+
+    expect(saveAddressBookSpy).toHaveBeenCalledWith([mockNamedAddressIcrc1]);
+  });
+
+  it("should not save when the entry to remove is absent from the certified address book", async () => {
+    addressBookStore.set({
+      namedAddresses: [mockNamedAddressIcrc1],
+      certified: true,
+    });
+
+    const saveAddressBookSpy = vi
+      .spyOn(addressBookServices, "saveAddressBook")
+      .mockResolvedValue({});
+    const onClose = vi.fn();
+
+    const { queryByTestId } = await renderRemoveModal(onClose);
+
+    await fireEvent.click(queryByTestId("confirm-yes"));
+
+    await waitFor(() =>
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: en.error__address_book.entry_not_found.replace(
+            "$name",
+            mockNamedAddressIcp.name
+          ),
+        },
+      ])
+    );
+
+    expect(saveAddressBookSpy).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/lib/services/address-book.services.spec.ts
+++ b/frontend/src/tests/lib/services/address-book.services.spec.ts
@@ -1,5 +1,9 @@
 import * as addressBookApi from "$lib/api/address-book.api";
-import { getCertifiedNamedAddresses } from "$lib/services/address-book.services";
+import { AccountNotFoundError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
+import {
+  getCertifiedNamedAddresses,
+  saveAddressBook,
+} from "$lib/services/address-book.services";
 import { addressBookStore } from "$lib/stores/address-book.store";
 import {
   mockForgedNamedAddress,
@@ -8,6 +12,29 @@ import {
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import * as dfinityUtils from "@dfinity/utils";
 import { get } from "svelte/store";
+
+// The query response of a single replica can hold a forged entry. The certified
+// response always lands later than the query response in production, because
+// an update call runs consensus. Reproduce that order here.
+const QUERY_RESPONSE_DELAY_MS = 0;
+const CERTIFIED_RESPONSE_DELAY_MS = 50;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// The query response holds a forged entry. The certified response does not.
+const mockSlowCertifiedGetAddressBook = () =>
+  vi
+    .spyOn(addressBookApi, "getAddressBook")
+    .mockImplementation(async ({ certified }) => {
+      if (certified) {
+        await delay(CERTIFIED_RESPONSE_DELAY_MS);
+        return { named_addresses: [mockNamedAddressIcp] };
+      }
+
+      await delay(QUERY_RESPONSE_DELAY_MS);
+      return { named_addresses: [mockNamedAddressIcp, mockForgedNamedAddress] };
+    });
 
 describe("address-book-services", () => {
   beforeEach(() => {
@@ -37,12 +64,39 @@ describe("address-book-services", () => {
         certified: false,
       });
 
-      vi.spyOn(addressBookApi, "getAddressBook").mockResolvedValue({
-        named_addresses: [mockNamedAddressIcp],
-      });
+      mockSlowCertifiedGetAddressBook();
 
       expect(await getCertifiedNamedAddresses()).toEqual([mockNamedAddressIcp]);
       expect(get(addressBookStore).certified).toBe(true);
+    });
+
+    it("should reload with the update strategy and make no query call", async () => {
+      addressBookStore.set({
+        namedAddresses: [mockForgedNamedAddress],
+        certified: false,
+      });
+
+      const getAddressBookSpy = mockSlowCertifiedGetAddressBook();
+
+      await getCertifiedNamedAddresses();
+
+      expect(getAddressBookSpy).toHaveBeenCalledTimes(1);
+      expect(getAddressBookSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ certified: true })
+      );
+    });
+
+    it("should return an empty address book for a user who has no account yet", async () => {
+      // A new user has no account in the nns-dapp canister until the first
+      // write. The certified call then fails with `AccountNotFoundError`.
+      vi.spyOn(addressBookApi, "getAddressBook").mockImplementation(
+        async () => {
+          await delay(CERTIFIED_RESPONSE_DELAY_MS);
+          throw new AccountNotFoundError("Account not found");
+        }
+      );
+
+      expect(await getCertifiedNamedAddresses()).toEqual([]);
     });
 
     it("should return undefined when the reload fails", async () => {
@@ -64,6 +118,20 @@ describe("address-book-services", () => {
       );
 
       expect(await getCertifiedNamedAddresses()).toBeUndefined();
+    });
+  });
+
+  describe("saveAddressBook", () => {
+    it("should leave the store certified after a save", async () => {
+      vi.spyOn(addressBookApi, "setAddressBook").mockResolvedValue(undefined);
+      mockSlowCertifiedGetAddressBook();
+
+      expect(await saveAddressBook([mockNamedAddressIcp])).toBeUndefined();
+
+      expect(get(addressBookStore)).toEqual({
+        namedAddresses: [mockNamedAddressIcp],
+        certified: true,
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/services/address-book.services.spec.ts
+++ b/frontend/src/tests/lib/services/address-book.services.spec.ts
@@ -1,0 +1,69 @@
+import * as addressBookApi from "$lib/api/address-book.api";
+import { getCertifiedNamedAddresses } from "$lib/services/address-book.services";
+import { addressBookStore } from "$lib/stores/address-book.store";
+import {
+  mockForgedNamedAddress,
+  mockNamedAddressIcp,
+} from "$tests/mocks/address-book.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import * as dfinityUtils from "@dfinity/utils";
+import { get } from "svelte/store";
+
+describe("address-book-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+    vi.spyOn(console, "error").mockReturnValue();
+    vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);
+    addressBookStore.reset();
+  });
+
+  describe("getCertifiedNamedAddresses", () => {
+    it("should return the entries without reloading when the store is certified", async () => {
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcp],
+        certified: true,
+      });
+
+      const getAddressBookSpy = vi.spyOn(addressBookApi, "getAddressBook");
+
+      expect(await getCertifiedNamedAddresses()).toEqual([mockNamedAddressIcp]);
+      expect(getAddressBookSpy).not.toHaveBeenCalled();
+    });
+
+    it("should discard an uncertified snapshot and return the certified entries", async () => {
+      // The store holds a query response with a forged entry.
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcp, mockForgedNamedAddress],
+        certified: false,
+      });
+
+      vi.spyOn(addressBookApi, "getAddressBook").mockResolvedValue({
+        named_addresses: [mockNamedAddressIcp],
+      });
+
+      expect(await getCertifiedNamedAddresses()).toEqual([mockNamedAddressIcp]);
+      expect(get(addressBookStore).certified).toBe(true);
+    });
+
+    it("should return undefined when the reload fails", async () => {
+      addressBookStore.set({
+        namedAddresses: [mockForgedNamedAddress],
+        certified: false,
+      });
+
+      vi.spyOn(addressBookApi, "getAddressBook").mockRejectedValue(
+        new Error("test")
+      );
+
+      expect(await getCertifiedNamedAddresses()).toBeUndefined();
+    });
+
+    it("should return undefined when the address book was never loaded", async () => {
+      vi.spyOn(addressBookApi, "getAddressBook").mockRejectedValue(
+        new Error("test")
+      );
+
+      expect(await getCertifiedNamedAddresses()).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/address-book.services.spec.ts
+++ b/frontend/src/tests/lib/services/address-book.services.spec.ts
@@ -2,6 +2,7 @@ import * as addressBookApi from "$lib/api/address-book.api";
 import { AccountNotFoundError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import {
   getCertifiedNamedAddresses,
+  loadAddressBook,
   saveAddressBook,
 } from "$lib/services/address-book.services";
 import { addressBookStore } from "$lib/stores/address-book.store";
@@ -10,6 +11,8 @@ import {
   mockNamedAddressIcp,
 } from "$tests/mocks/address-book.mock";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
+import { toastsStore } from "@dfinity/gix-components";
 import * as dfinityUtils from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -99,6 +102,27 @@ describe("address-book-services", () => {
       expect(await getCertifiedNamedAddresses()).toEqual([]);
     });
 
+    it("should reload with the update strategy when the session forces the query strategy", async () => {
+      // A forced-query session never gets certified data from its own loads.
+      // A save must still build on certified entries, so it makes one update
+      // call of its own.
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      addressBookStore.set({
+        namedAddresses: [mockNamedAddressIcp, mockForgedNamedAddress],
+        certified: false,
+      });
+
+      const getAddressBookSpy = mockSlowCertifiedGetAddressBook();
+
+      expect(await getCertifiedNamedAddresses()).toEqual([mockNamedAddressIcp]);
+
+      expect(getAddressBookSpy).toHaveBeenCalledTimes(1);
+      expect(getAddressBookSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ certified: true })
+      );
+    });
+
     it("should return undefined when the reload fails", async () => {
       addressBookStore.set({
         namedAddresses: [mockForgedNamedAddress],
@@ -112,12 +136,61 @@ describe("address-book-services", () => {
       expect(await getCertifiedNamedAddresses()).toBeUndefined();
     });
 
+    it("should show no toast when the reload fails", async () => {
+      // The caller shows one message for the whole failed save. The reload must
+      // not add a second toast.
+      addressBookStore.set({
+        namedAddresses: [mockForgedNamedAddress],
+        certified: false,
+      });
+
+      vi.spyOn(addressBookApi, "getAddressBook").mockRejectedValue(
+        new Error("test")
+      );
+
+      expect(get(toastsStore)).toHaveLength(0);
+
+      await getCertifiedNamedAddresses();
+
+      expect(get(toastsStore)).toHaveLength(0);
+    });
+
     it("should return undefined when the address book was never loaded", async () => {
       vi.spyOn(addressBookApi, "getAddressBook").mockRejectedValue(
         new Error("test")
       );
 
       expect(await getCertifiedNamedAddresses()).toBeUndefined();
+    });
+  });
+
+  describe("loadAddressBook", () => {
+    it("should show an error toast when the load fails", async () => {
+      vi.spyOn(addressBookApi, "getAddressBook").mockRejectedValue(
+        new Error("test")
+      );
+
+      expect(get(toastsStore)).toHaveLength(0);
+
+      await loadAddressBook({ strategy: "update" });
+
+      expect(get(toastsStore)).toHaveLength(1);
+      expect(get(toastsStore)[0]).toMatchObject({
+        level: "error",
+      });
+    });
+
+    it("should show no error toast when the caller asks for silent errors", async () => {
+      vi.spyOn(addressBookApi, "getAddressBook").mockRejectedValue(
+        new Error("test")
+      );
+
+      await loadAddressBook({
+        silentErrorMessages: true,
+        strategy: "update",
+      });
+
+      expect(get(toastsStore)).toHaveLength(0);
     });
   });
 

--- a/frontend/src/tests/lib/utils/address-book.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/address-book.utils.spec.ts
@@ -15,10 +15,16 @@ describe("address-book.utils", () => {
       expect(isAddressBookCertified(undefined)).toBe(false);
     });
 
-    it("should accept a query response when the session forces the query strategy", () => {
+    it("should reject a query response when the session forces the query strategy", () => {
       mockedConstants.FORCE_CALL_STRATEGY = "query";
 
-      expect(isAddressBookCertified(false)).toBe(true);
+      expect(isAddressBookCertified(false)).toBe(false);
+    });
+
+    it("should accept a certified response when the session forces the query strategy", () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      expect(isAddressBookCertified(true)).toBe(true);
     });
 
     it("should reject an address book that was never loaded when the session forces the query strategy", () => {

--- a/frontend/src/tests/lib/utils/address-book.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/address-book.utils.spec.ts
@@ -1,0 +1,30 @@
+import { isAddressBookCertified } from "$lib/utils/address-book.utils";
+import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
+
+describe("address-book.utils", () => {
+  describe("isAddressBookCertified", () => {
+    it("should accept a certified response", () => {
+      expect(isAddressBookCertified(true)).toBe(true);
+    });
+
+    it("should reject a query response", () => {
+      expect(isAddressBookCertified(false)).toBe(false);
+    });
+
+    it("should reject an address book that was never loaded", () => {
+      expect(isAddressBookCertified(undefined)).toBe(false);
+    });
+
+    it("should accept a query response when the session forces the query strategy", () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      expect(isAddressBookCertified(false)).toBe(true);
+    });
+
+    it("should reject an address book that was never loaded when the session forces the query strategy", () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      expect(isAddressBookCertified(undefined)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/mocks/address-book.mock.ts
+++ b/frontend/src/tests/mocks/address-book.mock.ts
@@ -13,3 +13,14 @@ export const mockNamedAddressIcrc1: NamedAddress = {
     Icrc1: "h4a5i-5vcfo-5rusv-fmb6m-vrkia-mjnkc-jpoow-h5mam-nthnm-ldqlr-bqe",
   },
 };
+
+/**
+ * An entry that only a query response holds.
+ * It stands for an entry that a single replica forged.
+ */
+export const mockForgedNamedAddress: NamedAddress = {
+  name: "Mallory",
+  address: {
+    Icrc1: "aaaaa-aa",
+  },
+};


### PR DESCRIPTION
# Motivation

An address-book save built the replacement list from the store as it was at submit time. That store can hold an uncertified query response. A forged or missing entry in that response got written back through the certified update call, so an attacker entry could persist under a trusted nickname.

# Changes

- Added `getCertifiedNamedAddresses`, which returns entries only when the store holds certified data, and reloads once with the update strategy first.
- Changed `AddAddressModal` and `RemoveAddressModal` to build the saved list only from `getCertifiedNamedAddresses`, never from the raw store.
- Blocked the save with a clear error toast when certified data is not available, or when the entry to edit or remove is missing from it.
- Added a `strategy` parameter to `loadAddressBook`, so a reload can wait for the certified response instead of racing the query response.
- Added `silentErrorMessages` to `loadAddressBook`, so a failed reload raises one toast, not two.
- Corrected `isAddressBookCertified` to accept only `certified === true`, so a forced-query session can no longer skip the certified reload.
- Added unit tests for the new helper, both modals, and `isAddressBookCertified`.
- Kept an e2e spec, `address-book-certified.spec.ts`, that proves a save on an uncertified store still succeeds and writes only certified data.

# Tests

- Ran `npm run check`. It passed. svelte-check found 0 errors and 0 warnings.
- Ran `npm run test`. It passed. 676 test files ran, with 5932 tests passed and 9 skipped.
- Ran `./scripts/check-relative-imports`. It passed.
- Ran the e2e spec `address-book-certified.spec.ts` against a local replica. It passed, 1 test in about 58 seconds. The spec covers a normal first save, a save while the store holds a query response, and a final read that shows both entries as certified.
- Ran a control experiment: restored the old, permissive predicate and re-ran the two changed spec files. Two tests failed, which confirms the new tests catch the security hole.
- Did not run the Rust gates. The change touches no Rust file.
- Did not run the script and config gates. The change touches no script and no config file.
- Did not run the full `./scripts/e2e-tests` suite. The machine's disk was nearly full, and a full run holds the replica for a long time. Ran the spec that covers this change instead.

# Todos

- [x] Accessibility (a11y) – no impact. The change alters no markup. It only changes which data a save uses.
- [x] Changelog – added, under `### Application` / `#### Security` in `CHANGELOG-Nns-Dapp-unreleased.md`.
