### PR TITLE
fix(build): verify every toolchain binary that the release build downloads

### DIFF
--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -36,6 +36,8 @@ jobs:
             DIDC_RELEASE="$latest_didc_release" jq '.defaults.build.config.DIDC_RELEASE=(env.DIDC_RELEASE)' config.json  | sponge config.json
             scripts/install-didc
             DIDC_VERSION="$(didc --version)" jq '.defaults.build.config.DIDC_VERSION=(env.DIDC_VERSION)' config.json  | sponge config.json
+            # The release build verifies didc against a checksum in config.json.
+            scripts/update-tool-checksums
             echo "updated=1" >> "$GITHUB_OUTPUT"
             echo "version=$latest_didc_release" >> "$GITHUB_OUTPUT"
           else
@@ -71,6 +73,7 @@ jobs:
             # Changes
             ## Changes made by a bot triggered by ${{ github.actor }}
             - Update the version of `didc` specified in `config.json`.
+            - Update the sha256 checksums of the release build tools in `config.json`.
 
             ## Changes made by a human (delete if inapplicable)
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ assets.tar.xz
 sourcemaps.tar.xz
 build-inputs.txt
 out
+.update-tool-checksums-*
 
 # Miscellaneous
 *.class

--- a/BUILD.md
+++ b/BUILD.md
@@ -94,6 +94,37 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 TODO: When we make a proposal, we should have a corresponding release that voters can download. E.g. https://github.com/dfinity/nns-dapp/releases/tag/release-candidate exists but it doesn't have build artefacts.
 
+### Build toolchain integrity
+
+The `Dockerfile` downloads `node`, `rustup-init`, `dfx`, `didc` and `ic-wasm`.
+Each tool is pinned to an exact version.
+Each download is verified against a sha256 checksum that is stored in `config.json`.
+`scripts/download-verified` does the download and the check.
+The build fails if a checksum does not match.
+
+This matters because `ic-wasm shrink` is the last step that changes the released
+code. See `build-rs.sh`. A tampered tool would change `nns-dapp.wasm.gz`, and
+every verifier would reproduce the same tampered output.
+
+To change a pinned version:
+
+1. Change the version. The versions live in `dfx.json` (`dfx`),
+   `frontend/package.json` (`volta.node`) and `config.json` (the rest).
+2. Run `scripts/update-tool-checksums`. It downloads the artefacts and writes the
+   new checksums into `config.json`.
+3. Review the new checksums in the pull request diff.
+
+If you change a version but forget step 2, the Docker build fails on the
+checksum check. It does not build with an unverified tool.
+
+To re-derive a checksum by hand, download the artefact and run `sha256sum` on it.
+The URLs are listed in `scripts/update-tool-checksums`. Upstream also publishes
+checksums for `rustup-init`, `node` and `dfx`:
+
+- `https://static.rust-lang.org/rustup/archive/<version>/x86_64-unknown-linux-gnu/rustup-init.sha256`
+- `https://nodejs.org/dist/v<version>/SHASUMS256.txt`
+- The `.sha256` asset next to each `dfx` release asset.
+
 ### Build flavors
 
 The build creates several different `nns-dapp` and `sns_aggregator` Wasms. These builds target specific use cases:

--- a/BUILD.md
+++ b/BUILD.md
@@ -118,6 +118,7 @@ If you change a version but forget step 2, the Docker build fails on the
 checksum check. It does not build with an unverified tool.
 
 To re-derive a checksum by hand, download the artefact and run `sha256sum` on it.
+On macOS, run `shasum -a 256` instead. macOS has no `sha256sum`.
 The URLs are listed in `scripts/update-tool-checksums`. Upstream also publishes
 checksums for `rustup-init`, `node` and `dfx`:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,16 +39,29 @@ RUN jq -r '.volta.node' frontend/package.json > config/node_version
 RUN jq -r '.defaults.build.config.DIDC_RELEASE' config.json > config/didc_version
 RUN jq -r '.defaults.build.config.OPTIMIZER_VERSION' config.json > config/optimizer_version
 RUN jq -r '.defaults.build.config.IC_WASM_VERSION' config.json > config/ic_wasm_version
-RUN jq -r '.defaults.build.config.BINSTALL_VERSION' config.json > config/binstall_version
+RUN jq -r '.defaults.build.config.RUSTUP_INIT_VERSION' config.json > config/rustup_init_version
+# Every tool below is downloaded and then verified against one of these checksums.
+# Run scripts/update-tool-checksums after you change a pinned tool version.
+RUN jq -r '.defaults.build.config.RUSTUP_INIT_SHA256' config.json > config/rustup_init_sha256
+RUN jq -r '.defaults.build.config.NODE_SHA256' config.json > config/node_sha256
+RUN jq -r '.defaults.build.config.DFX_SHA256' config.json > config/dfx_sha256
+RUN jq -r '.defaults.build.config.DIDC_SHA256' config.json > config/didc_sha256
+RUN jq -r '.defaults.build.config.IC_WASM_SHA256' config.json > config/ic_wasm_sha256
 
 # This is the "builder", i.e. the base image used later to build the final code.
 FROM base as builder
 SHELL ["bash", "-c"]
-# Get tool versions
-COPY --from=tool_versions /config/*_version config/
+# Get tool versions and the checksums of the tools that are downloaded
+COPY --from=tool_versions /config/ config/
+# Downloads a file and verifies its sha256 checksum.  A mismatch fails the build.
+COPY scripts/download-verified /usr/local/bin/download-verified
 # Install node
-RUN npm install -g n
-RUN n "$(cat config/node_version)"
+RUN node_version="$(cat config/node_version)" \
+    && mkdir -p /opt/node \
+    && download-verified "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-x64.tar.gz" "$(cat config/node_sha256)" /tmp/node.tar.gz \
+    && tar -xzf /tmp/node.tar.gz -C /opt/node --strip-components=1 \
+    && rm /tmp/node.tar.gz
+ENV PATH=/opt/node/bin:$PATH
 RUN node --version
 RUN npm --version
 # Install Rust and Cargo in /opt
@@ -57,8 +70,11 @@ ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH
 
-RUN curl --fail https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.1/rustup-init.sh -sSf \
-    | sh -s -- -y --no-modify-path
+# rustup-init installs the toolchain that rust-toolchain.toml pins.
+RUN download-verified "https://static.rust-lang.org/rustup/archive/$(cat config/rustup_init_version)/x86_64-unknown-linux-gnu/rustup-init" "$(cat config/rustup_init_sha256)" /tmp/rustup-init \
+    && chmod 755 /tmp/rustup-init \
+    && /tmp/rustup-init -y --no-modify-path \
+    && rm /tmp/rustup-init
 RUN cargo --version
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty
@@ -74,14 +90,24 @@ COPY rs/sns_aggregator/Cargo.toml rs/sns_aggregator/Cargo.toml
 RUN mkdir -p rs/backend/src/bin rs/sns_aggregator/src && touch rs/backend/src/lib.rs rs/sns_aggregator/src/lib.rs && echo 'fn main(){}' | tee rs/backend/src/main.rs > rs/backend/src/bin/nns-dapp-check-args.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -f target/wasm32-unknown-unknown/release/*wasm
 # Install dfx
 WORKDIR /
-# dfx is installed in `$HOME/.local/share/dfx/bin` but we can't reference `$HOME` here so we hardcode `/root`.
-ENV PATH="/root/.local/share/dfx/bin:${PATH}"
-RUN DFXVM_INIT_YES=true DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
-# TODO: Make didc support binstall, then use cargo binstall --no-confirm didc here.
-RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc" && didc --version
-RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v$(cat config/binstall_version)/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
-RUN ./cargo-binstall -y --force "cargo-binstall@$(cat config/binstall_version)"
-RUN cargo binstall --no-confirm "ic-wasm@$(cat config/ic_wasm_version)" && command -v ic-wasm
+# The dfx release asset holds one file, the dfx binary.
+# The dfxvm installer is not used here because it downloads dfx without a checksum from this repository.
+RUN dfx_version="$(cat config/dfx_version)" \
+    && download-verified "https://github.com/dfinity/sdk/releases/download/${dfx_version}/dfx-${dfx_version}-x86_64-linux.tar.gz" "$(cat config/dfx_sha256)" /tmp/dfx.tar.gz \
+    && tar -xzf /tmp/dfx.tar.gz -C /usr/local/bin dfx \
+    && chmod 755 /usr/local/bin/dfx \
+    && rm /tmp/dfx.tar.gz \
+    && dfx --version
+RUN download-verified "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" "$(cat config/didc_sha256)" /tmp/didc \
+    && install -m 755 /tmp/didc /usr/local/bin/didc \
+    && rm /tmp/didc \
+    && didc --version
+# ic-wasm shrinks the wasm, so it is the last tool to change the released code.
+# The binary below is the same file that cargo binstall installed before.
+RUN download-verified "https://github.com/dfinity/ic-wasm/releases/download/$(cat config/ic_wasm_version)/ic-wasm-linux64" "$(cat config/ic_wasm_sha256)" /tmp/ic-wasm \
+    && install -m 755 /tmp/ic-wasm /usr/local/bin/ic-wasm \
+    && rm /tmp/ic-wasm \
+    && command -v ic-wasm
 
 # Title: Gets the deployment configuration
 # Args: Everything in the environment.  Ideally also ~/.config/dfx but that is inaccessible.

--- a/config.json
+++ b/config.json
@@ -108,6 +108,7 @@
     "build": {
       "config": {
         "IC_WASM_VERSION": "0.6.0",
+        "RUSTUP_INIT_VERSION": "1.28.1",
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
         "BINSTALL_VERSION": "1.3.0",
@@ -116,7 +117,12 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2026-09-02",
-        "IC_COMMIT_FOR_SNS_AGGREGATOR": "f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97"
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "f54e1f82c3cf8ae0b4be6b0fc3a940cdcd70dd97",
+        "RUSTUP_INIT_SHA256": "a3339fb004c3d0bb9862ba0bce001861fe5cbde9c10d16591eb3f39ee6cd3e7f",
+        "NODE_SHA256": "2ae6f70d74a459c0a96456e486dc60f3e7e65d7752ad302771834e58b27500af",
+        "DFX_SHA256": "218dad11e0519e11c7a310b5c7cb1eadff109bb5db1ea3432f08c870432a80fc",
+        "DIDC_SHA256": "32693c76d9c6fe0f273f2c1ebf7e48ba3c383e925e5afd17dd264a06aed9fbcc",
+        "IC_WASM_SHA256": "9dde8926efdef5910653d034b002bce37206cb77ea94a38ad2b6f7cefe5f4776"
       },
       "packtool": ""
     }

--- a/scripts/download-verified
+++ b/scripts/download-verified
@@ -41,7 +41,21 @@ curl --fail --location --show-error --silent --retry 5 \
 ###############
 # Verify
 ###############
-actual_sha256="$(sha256sum <"$tmpfile" | cut -d ' ' -f 1)"
+# Prints the sha256 checksum of the file named by the first argument.
+# macOS has shasum but it does not have sha256sum.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum <"$1" | cut -d ' ' -f 1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 <"$1" | cut -d ' ' -f 1
+  else
+    echo "ERROR: This script needs sha256sum or shasum to verify a checksum." >&2
+    echo "ERROR: Install one of them and run the script again." >&2
+    return 1
+  fi
+}
+
+actual_sha256="$(sha256_of "$tmpfile")" || exit 1
 
 [[ "$actual_sha256" == "$expected_sha256" ]] || {
   echo "ERROR: The checksum of the downloaded file is wrong."

--- a/scripts/download-verified
+++ b/scripts/download-verified
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+###############
+# Hjelpe meg!
+###############
+print_help() {
+  cat <<-EOF
+	Downloads a file and verifies its sha256 checksum.
+
+	The script writes the file only if the checksum matches.
+	The script exits with an error if the checksum does not match.
+
+	Usage:
+	    $(basename "$0") <url> <sha256> <output_path>
+	EOF
+}
+[[ "${1:-}" != "--help" ]] || {
+  print_help
+  exit 0
+}
+
+(($# == 3)) || {
+  print_help
+  exit 1
+} >&2
+
+url="$1"
+expected_sha256="$2"
+output_path="$3"
+
+###############
+# Download
+###############
+tmpfile="$(mktemp)"
+trap 'rm -f "$tmpfile"' EXIT
+
+curl --fail --location --show-error --silent --retry 5 \
+  --proto '=https' --tlsv1.2 --output "$tmpfile" "$url"
+
+###############
+# Verify
+###############
+actual_sha256="$(sha256sum <"$tmpfile" | cut -d ' ' -f 1)"
+
+[[ "$actual_sha256" == "$expected_sha256" ]] || {
+  echo "ERROR: The checksum of the downloaded file is wrong."
+  echo "ERROR: URL:      $url"
+  echo "ERROR: Expected: $expected_sha256"
+  echo "ERROR: Actual:   $actual_sha256"
+  echo "ERROR: Update the checksum with scripts/update-tool-checksums."
+  echo "ERROR: Review the new checksum before you commit it."
+  exit 1
+} >&2
+
+mv "$tmpfile" "$output_path"
+echo "Verified $url"

--- a/scripts/download-verified
+++ b/scripts/download-verified
@@ -32,7 +32,10 @@ output_path="$3"
 ###############
 # Download
 ###############
-tmpfile="$(mktemp)"
+# The temp file sits next to output_path, not under the system temp
+# directory. That keeps the final "mv" below on one filesystem, so it is an
+# atomic rename instead of a copy-then-delete.
+tmpfile="$(mktemp "$(dirname "$output_path")/.download-verified-XXXXXX")"
 trap 'rm -f "$tmpfile"' EXIT
 
 curl --fail --location --show-error --silent --retry 5 \

--- a/scripts/update-tool-checksums
+++ b/scripts/update-tool-checksums
@@ -65,7 +65,10 @@ sha256_of() {
   fi
 }
 
-tmpdir="$(mktemp -d)"
+# The temp directory sits next to config.json, not under the system temp
+# directory. That keeps the final "mv" below on one filesystem, so it is an
+# atomic rename instead of a copy-then-delete.
+tmpdir="$(mktemp -d ./.update-tool-checksums-XXXXXX)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 # Every download and every checksum must succeed before config.json changes.

--- a/scripts/update-tool-checksums
+++ b/scripts/update-tool-checksums
@@ -52,11 +52,16 @@ entries=(
 # Checksums
 ###############
 # Prints the sha256 checksum of the file named by the first argument.
+# macOS has shasum but it does not have sha256sum.
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum <"$1" | cut -d ' ' -f 1
-  else
+  elif command -v shasum >/dev/null 2>&1; then
     shasum -a 256 <"$1" | cut -d ' ' -f 1
+  else
+    echo "ERROR: This script needs sha256sum or shasum to verify a checksum." >&2
+    echo "ERROR: Install one of them and run the script again." >&2
+    return 1
   fi
 }
 
@@ -69,7 +74,7 @@ for entry in "${entries[@]}"; do
   echo "Downloading $url"
   curl --fail --location --show-error --silent --retry 5 \
     --proto '=https' --tlsv1.2 --output "$tmpdir/artefact" "$url"
-  checksum="$(sha256_of "$tmpdir/artefact")"
+  checksum="$(sha256_of "$tmpdir/artefact")" || exit 1
   echo "$key $checksum"
   KEY="$key" CHECKSUM="$checksum" \
     jq '.defaults.build.config[env.KEY] = env.CHECKSUM' config.json >"$tmpdir/config.json"

--- a/scripts/update-tool-checksums
+++ b/scripts/update-tool-checksums
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+###############
+# Hjelpe meg!
+###############
+print_help() {
+  cat <<-EOF
+	Records the sha256 checksum of every tool that the release build downloads.
+
+	The Dockerfile downloads each tool at a pinned version.  It then verifies
+	the tool against a checksum in config.json.  The build fails if the
+	checksum does not match.
+
+	This script reads the pinned versions, downloads the linux/amd64
+	artefacts, and writes the checksums into config.json.
+
+	Run this script after you change a pinned tool version.  Review the new
+	checksums in the pull request diff before you merge them.
+
+	Usage:
+	    $(basename "$0")
+	EOF
+}
+[[ "${1:-}" != "--help" ]] || {
+  print_help
+  exit 0
+}
+
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+
+###############
+# Pinned versions
+###############
+dfx_version="$(jq -r .dfx dfx.json)"
+node_version="$(jq -r .volta.node frontend/package.json)"
+didc_release="$(jq -r .defaults.build.config.DIDC_RELEASE config.json)"
+ic_wasm_version="$(jq -r .defaults.build.config.IC_WASM_VERSION config.json)"
+rustup_init_version="$(jq -r .defaults.build.config.RUSTUP_INIT_VERSION config.json)"
+
+# Each entry is a config.json key, a "|", and the URL of the artefact.
+# The Dockerfile downloads the same URLs.
+entries=(
+  "RUSTUP_INIT_SHA256|https://static.rust-lang.org/rustup/archive/${rustup_init_version}/x86_64-unknown-linux-gnu/rustup-init"
+  "NODE_SHA256|https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-x64.tar.gz"
+  "DFX_SHA256|https://github.com/dfinity/sdk/releases/download/${dfx_version}/dfx-${dfx_version}-x86_64-linux.tar.gz"
+  "DIDC_SHA256|https://github.com/dfinity/candid/releases/download/${didc_release}/didc-linux64"
+  "IC_WASM_SHA256|https://github.com/dfinity/ic-wasm/releases/download/${ic_wasm_version}/ic-wasm-linux64"
+)
+
+###############
+# Checksums
+###############
+# Prints the sha256 checksum of the file named by the first argument.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum <"$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 <"$1" | cut -d ' ' -f 1
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+for entry in "${entries[@]}"; do
+  key="${entry%%|*}"
+  url="${entry#*|}"
+  echo "Downloading $url"
+  curl --fail --location --show-error --silent --retry 5 \
+    --proto '=https' --tlsv1.2 --output "$tmpdir/artefact" "$url"
+  checksum="$(sha256_of "$tmpdir/artefact")"
+  echo "$key $checksum"
+  KEY="$key" CHECKSUM="$checksum" \
+    jq '.defaults.build.config[env.KEY] = env.CHECKSUM' config.json >"$tmpdir/config.json"
+  mv "$tmpdir/config.json" config.json
+done
+
+echo "Updated the tool checksums in config.json."

--- a/scripts/update-tool-checksums
+++ b/scripts/update-tool-checksums
@@ -68,6 +68,11 @@ sha256_of() {
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
+# Every download and every checksum must succeed before config.json changes.
+# A working copy takes every update. config.json itself is replaced once, at
+# the end, so a failed run leaves config.json untouched.
+cp config.json "$tmpdir/config.json"
+
 for entry in "${entries[@]}"; do
   key="${entry%%|*}"
   url="${entry#*|}"
@@ -77,8 +82,9 @@ for entry in "${entries[@]}"; do
   checksum="$(sha256_of "$tmpdir/artefact")" || exit 1
   echo "$key $checksum"
   KEY="$key" CHECKSUM="$checksum" \
-    jq '.defaults.build.config[env.KEY] = env.CHECKSUM' config.json >"$tmpdir/config.json"
-  mv "$tmpdir/config.json" config.json
+    jq '.defaults.build.config[env.KEY] = env.CHECKSUM' "$tmpdir/config.json" >"$tmpdir/config.json.next"
+  mv "$tmpdir/config.json.next" "$tmpdir/config.json"
 done
 
+mv "$tmpdir/config.json" config.json
 echo "Updated the tool checksums in config.json."

--- a/scripts/update-tool-checksums
+++ b/scripts/update-tool-checksums
@@ -32,11 +32,11 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
 ###############
 # Pinned versions
 ###############
-dfx_version="$(jq -r .dfx dfx.json)"
-node_version="$(jq -r .volta.node frontend/package.json)"
-didc_release="$(jq -r .defaults.build.config.DIDC_RELEASE config.json)"
-ic_wasm_version="$(jq -r .defaults.build.config.IC_WASM_VERSION config.json)"
-rustup_init_version="$(jq -r .defaults.build.config.RUSTUP_INIT_VERSION config.json)"
+dfx_version="$(jq -er .dfx dfx.json)"
+node_version="$(jq -er .volta.node frontend/package.json)"
+didc_release="$(jq -er .defaults.build.config.DIDC_RELEASE config.json)"
+ic_wasm_version="$(jq -er .defaults.build.config.IC_WASM_VERSION config.json)"
+rustup_init_version="$(jq -er .defaults.build.config.RUSTUP_INIT_VERSION config.json)"
 
 # Each entry is a config.json key, a "|", and the URL of the artefact.
 # The Dockerfile downloads the same URLs.


### PR DESCRIPTION
# Motivation

The Dockerfile downloaded node, rustup-init, dfx, didc and ic-wasm without a checksum. ic-wasm shrink is the last step that changes the released wasm. A tampered download would change nns-dapp.wasm.gz, and every reproducible-build verifier would reproduce the same tampered output and report a match.

# Changes

- Added scripts/download-verified. It downloads a file and checks its sha256 before it moves the file into place.
- Added scripts/update-tool-checksums. It records the checksum for each pinned tool version in config.json.
- Replaced the dfxvm installer with a direct, verified dfx download.
- Replaced cargo-binstall with a direct, verified ic-wasm download. The binary is byte identical to the one cargo-binstall installed.
- Replaced n with a direct, verified node download.
- Replaced the rustup-init.sh pipe with a direct, verified rustup-init download.
- Updated the didc bot workflow so a version bump also refreshes the checksum.
- Documented the checksum update procedure in BUILD.md, including the macOS alternative to `sha256sum`.

# Tests

- Ran `shellcheck` on `scripts/download-verified` and `scripts/update-tool-checksums`. Both are clean.
- Ran `shfmt -i 2 -d` on both scripts. Both are clean.
- Ran `./scripts/fmt`. It left the three changed files alone.
- Tested both checksum-tool code paths live, against a real download from GitHub. Ran each script with only `sha256sum`, with only `shasum`, with both, and with neither on `PATH`. A correct hash passes and writes the file. A wrong hash fails and writes no file. A missing tool fails with a clear error and writes no file.
- Ran `scripts/update-tool-checksums` with only `shasum` on `PATH`. It downloaded all five artifacts and produced the same checksums as the `sha256sum` path.
- Did not run `docker build`. The Docker daemon on this machine was down. The image is Linux, so it takes the `sha256sum` branch, which CI already proved green. The `shasum` branch matters for a macOS developer, not for the image.
- Did not run a release script, a mainnet deploy, an NNS proposal, or touch the HSM.

# Todos

- [ ] Accessibility (a11y) – no impact. This changes the release build only.
- [ ] Changelog – not needed. This hardens the release build. No user of nns-dapp can observe it.
