### PR TITLE
fix(imported-tokens): build write payload from certified data only

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,11 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Build the imported-token replacement from certified data when the user imports
+  a token, adds an index canister, or removes a token. A save no longer writes
+  back a query response, and a save can no longer clear the list because the
+  tokens were not loaded.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1140,6 +1140,8 @@
     "add_imported_token": "There was an unexpected issue while importing the token.",
     "remove_imported_token": "There was an unexpected issue while removing the imported token.",
     "update_imported_token": "There was an unexpected issue while updating the imported token.",
+    "not_certified": "We could not verify your imported tokens, so nothing was saved. Please reload the page and try again.",
+    "token_not_found": "This token is not in your verified token list, so nothing was saved. Please reload the page and try again.",
     "too_many": "You can't import more than $limit tokens.",
     "ledger_canister_loading": "Unable to load token details using the provided ledger canister ID.",
     "is_duplication": "You have already imported this token, you can find it in the token list.",

--- a/frontend/src/lib/modals/accounts/AddIndexCanisterModal.svelte
+++ b/frontend/src/lib/modals/accounts/AddIndexCanisterModal.svelte
@@ -4,7 +4,6 @@
   import { addIndexCanister } from "$lib/services/imported-tokens.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { Modal } from "@dfinity/gix-components";
   import type { Principal } from "@icp-sdk/core/principal";
   import { isNullish } from "@dfinity/utils";
@@ -20,11 +19,7 @@
 
   const nnsSubmit = async () => {
     // Just for type safety. This should never happen.
-    if (
-      isNullish(ledgerCanisterId) ||
-      isNullish(indexCanisterId) ||
-      isNullish($importedTokensStore.importedTokens)
-    ) {
+    if (isNullish(ledgerCanisterId) || isNullish(indexCanisterId)) {
       return;
     }
 
@@ -43,10 +38,10 @@
         return;
       }
 
+      // The service builds the replacement list from certified data.
       const { success } = await addIndexCanister({
         ledgerCanisterId,
         indexCanisterId,
-        importedTokens: $importedTokensStore.importedTokens,
       });
       if (success) {
         close();

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -202,10 +202,7 @@
 
   const onConfirm = async () => {
     // Just for type safety. This should never happen.
-    if (
-      isNullish(ledgerCanisterId) ||
-      isNullish($importedTokensStore.importedTokens)
-    ) {
+    if (isNullish(ledgerCanisterId)) {
       return;
     }
 
@@ -215,12 +212,12 @@
         labelKey: "import_token.importing",
       });
 
+      // The service builds the replacement list from certified data.
       const { success } = await addImportedToken({
         tokenToAdd: {
           ledgerCanisterId,
           indexCanisterId,
         },
-        importedTokens: $importedTokensStore.importedTokens,
       });
       if (success) {
         close();

--- a/frontend/src/lib/services/imported-tokens.services.ts
+++ b/frontend/src/lib/services/imported-tokens.services.ts
@@ -37,17 +37,24 @@ import type { Principal } from "@icp-sdk/core/principal";
 import { get } from "svelte/store";
 
 /** Load imported tokens from the `nns-dapp` backend and update the `importedTokensStore` store.
- * - Displays an error toast if the operation fails.
- * - `strategy` selects the calls to make. The default makes a query call and an
- *   update call, and the returned promise settles on the first response.
- *   `"update"` makes only the update call, so the returned promise settles on
+ * - Displays an error toast if the operation fails. `silentErrorMessages`
+ *   suppresses that toast, so the caller can show its own message.
+ * - `strategy` selects the calls to make. The default is `FORCE_CALL_STRATEGY`.
+ *   That constant is `undefined` for a normal session, which makes a query
+ *   call and an update call. It is `"query"` for a forced-query session, which
+ *   makes only a query call. So the default can give uncertified data.
+ * - `"update"` makes only the update call. The returned promise then settles on
  *   the certified response.
+ * - For the other strategies the returned promise settles on the first
+ *   response, which is normally the query response.
  */
 export const loadImportedTokens = async ({
   ignoreAccountNotFoundError,
+  silentErrorMessages,
   strategy = FORCE_CALL_STRATEGY,
 }: {
   ignoreAccountNotFoundError?: boolean;
+  silentErrorMessages?: boolean;
   strategy?: QueryAndUpdateStrategy;
 } = {}) => {
   return queryAndUpdate<ImportedTokens, unknown>({
@@ -82,6 +89,10 @@ export const loadImportedTokens = async ({
       importedTokensStore.reset();
       failedImportedTokenLedgerIdsStore.reset();
 
+      if (silentErrorMessages === true) {
+        return;
+      }
+
       toastsError({
         labelKey: "error__imported_tokens.load_imported_tokens",
         err,
@@ -96,13 +107,17 @@ export const loadImportedTokens = async ({
  *
  * A write replaces the whole imported-token list. It must never build the
  * replacement from a query response, because a single replica can forge or drop
- * entries. If the store holds a query response, reload the imported tokens
- * first.
+ * entries. If the store does not hold a certified response, reload the imported
+ * tokens first.
  *
- * The reload uses the `"update"` strategy. A `"query_and_update"` reload
- * settles on the query response, which leaves the store uncertified and blocks
- * a normal write. A session that forces the `query` strategy keeps its query
- * response, because `isImportedTokensCertified` accepts it.
+ * The reload always uses the `"update"` strategy. Only an update call gives
+ * certified data. A `"query_and_update"` reload settles on the query response
+ * and leaves the store uncertified. A forced-query session gets no certified
+ * data from its own loads. Such a session takes this path on every write. One
+ * update call per write keeps the imported-token list usable there.
+ *
+ * The reload shows no error toast. The caller shows one message for the whole
+ * failed write instead.
  *
  * Return `undefined` when certified imported tokens are not available. An empty
  * list is a valid result. An absent list is not.
@@ -114,6 +129,7 @@ export const getCertifiedImportedTokens = async (): Promise<
     try {
       await loadImportedTokens({
         ignoreAccountNotFoundError: true,
+        silentErrorMessages: true,
         strategy: "update",
       });
     } catch (err) {

--- a/frontend/src/lib/services/imported-tokens.services.ts
+++ b/frontend/src/lib/services/imported-tokens.services.ts
@@ -45,8 +45,12 @@ import { get } from "svelte/store";
  *   makes only a query call. So the default can give uncertified data.
  * - `"update"` makes only the update call. The returned promise then settles on
  *   the certified response.
- * - For the other strategies the returned promise settles on the first
- *   response, which is normally the query response.
+ * - For the other strategies the returned promise settles as soon as one call
+ *   completes. A call that fails also counts as complete, because
+ *   `queryAndUpdate` catches the error and calls `onError`. The first call to
+ *   complete is normally the query call. The other call can still write to the
+ *   store later. So the store can hold uncertified data, or no data at all,
+ *   when the returned promise settles.
  */
 export const loadImportedTokens = async ({
   ignoreAccountNotFoundError,

--- a/frontend/src/lib/services/imported-tokens.services.ts
+++ b/frontend/src/lib/services/imported-tokens.services.ts
@@ -16,11 +16,17 @@ import {
   failedImportedTokenLedgerIdsStore,
   importedTokensStore,
 } from "$lib/stores/imported-tokens.store";
-import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
+import {
+  toastsError,
+  toastsShow,
+  toastsSuccess,
+} from "$lib/stores/toasts.store";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import { isLastCall } from "$lib/utils/env.utils";
 import {
   fromImportedTokenData,
+  isImportedToken,
+  isImportedTokensCertified,
   toImportedTokenData,
 } from "$lib/utils/imported-tokens.utils";
 import { isNullish } from "@dfinity/utils";
@@ -76,6 +82,33 @@ export const loadImportedTokens = async ({
   });
 };
 
+/**
+ * Return the imported tokens that a certified call produced.
+ *
+ * A write replaces the whole imported-token list. It must never build the
+ * replacement from a query response, because a single replica can forge or drop
+ * entries. If the store holds a query response, reload the imported tokens
+ * first.
+ *
+ * Return `undefined` when certified imported tokens are not available. An empty
+ * list is a valid result. An absent list is not.
+ */
+export const getCertifiedImportedTokens = async (): Promise<
+  ImportedTokenData[] | undefined
+> => {
+  if (!isImportedTokensCertified(get(importedTokensStore).certified)) {
+    await loadImportedTokens({ ignoreAccountNotFoundError: true });
+  }
+
+  const { importedTokens, certified } = get(importedTokensStore);
+
+  if (!isImportedTokensCertified(certified) || isNullish(importedTokens)) {
+    return undefined;
+  }
+
+  return importedTokens;
+};
+
 // Save imported tokens to the nns-dapp backend.
 // Returns an error if the operation fails.
 const saveImportedToken = async ({
@@ -101,11 +134,32 @@ const saveImportedToken = async ({
  */
 export const addImportedToken = async ({
   tokenToAdd,
-  importedTokens,
 }: {
   tokenToAdd: ImportedTokenData;
-  importedTokens: ImportedTokenData[];
 }): Promise<{ success: boolean }> => {
+  const importedTokens = await getCertifiedImportedTokens();
+
+  if (isNullish(importedTokens)) {
+    toastsError({ labelKey: "error__imported_tokens.not_certified" });
+    return { success: false };
+  }
+
+  // The certified list already holds the token. Report it instead of saving a
+  // duplicate entry.
+  if (
+    isImportedToken({
+      ledgerCanisterId: tokenToAdd.ledgerCanisterId,
+      importedTokens,
+      filterOutImportantCkToken: false,
+    })
+  ) {
+    toastsShow({
+      level: "warn",
+      labelKey: "error__imported_tokens.is_duplication",
+    });
+    return { success: false };
+  }
+
   const tokens = [...importedTokens, tokenToAdd];
   const { err } = await saveImportedToken({ tokens });
 
@@ -142,12 +196,30 @@ export const addImportedToken = async ({
 export const addIndexCanister = async ({
   ledgerCanisterId,
   indexCanisterId,
-  importedTokens,
 }: {
   ledgerCanisterId: Principal;
   indexCanisterId: Principal;
-  importedTokens: ImportedTokenData[];
 }): Promise<{ success: boolean }> => {
+  const importedTokens = await getCertifiedImportedTokens();
+
+  if (isNullish(importedTokens)) {
+    toastsError({ labelKey: "error__imported_tokens.not_certified" });
+    return { success: false };
+  }
+
+  // The certified list does not hold the token to update. Report it instead of
+  // saving an unchanged list.
+  if (
+    !isImportedToken({
+      ledgerCanisterId,
+      importedTokens,
+      filterOutImportantCkToken: false,
+    })
+  ) {
+    toastsError({ labelKey: "error__imported_tokens.token_not_found" });
+    return { success: false };
+  }
+
   const tokens = importedTokens.map((token) =>
     token.ledgerCanisterId.toText() === ledgerCanisterId.toText()
       ? { ...token, indexCanisterId }
@@ -187,9 +259,27 @@ export const removeImportedTokens = async (
       labelKey: "import_token.removing",
     });
 
-    const remainingTokens = (
-      get(importedTokensStore).importedTokens ?? []
-    ).filter(
+    const importedTokens = await getCertifiedImportedTokens();
+
+    if (isNullish(importedTokens)) {
+      toastsError({ labelKey: "error__imported_tokens.not_certified" });
+      return { success: false };
+    }
+
+    // The certified list does not hold the token to remove. Report it instead
+    // of saving an unchanged list.
+    if (
+      !isImportedToken({
+        ledgerCanisterId,
+        importedTokens,
+        filterOutImportantCkToken: false,
+      })
+    ) {
+      toastsError({ labelKey: "error__imported_tokens.token_not_found" });
+      return { success: false };
+    }
+
+    const remainingTokens = importedTokens.filter(
       ({ ledgerCanisterId: id }) => id.toText() !== ledgerCanisterId.toText()
     );
     const { err } = await saveImportedToken({ tokens: remainingTokens });

--- a/frontend/src/lib/services/imported-tokens.services.ts
+++ b/frontend/src/lib/services/imported-tokens.services.ts
@@ -10,7 +10,10 @@ import type { ImportedTokens } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
-import { queryAndUpdate } from "$lib/services/utils.services";
+import {
+  queryAndUpdate,
+  type QueryAndUpdateStrategy,
+} from "$lib/services/utils.services";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
 import {
   failedImportedTokenLedgerIdsStore,
@@ -35,15 +38,21 @@ import { get } from "svelte/store";
 
 /** Load imported tokens from the `nns-dapp` backend and update the `importedTokensStore` store.
  * - Displays an error toast if the operation fails.
+ * - `strategy` selects the calls to make. The default makes a query call and an
+ *   update call, and the returned promise settles on the first response.
+ *   `"update"` makes only the update call, so the returned promise settles on
+ *   the certified response.
  */
 export const loadImportedTokens = async ({
   ignoreAccountNotFoundError,
+  strategy = FORCE_CALL_STRATEGY,
 }: {
   ignoreAccountNotFoundError?: boolean;
+  strategy?: QueryAndUpdateStrategy;
 } = {}) => {
   return queryAndUpdate<ImportedTokens, unknown>({
     request: (options) => getImportedTokens(options),
-    strategy: FORCE_CALL_STRATEGY,
+    strategy,
     onLoad: ({ response: { imported_tokens: importedTokens }, certified }) => {
       importedTokensStore.set({
         importedTokens: importedTokens.map(toImportedTokenData),
@@ -90,6 +99,11 @@ export const loadImportedTokens = async ({
  * entries. If the store holds a query response, reload the imported tokens
  * first.
  *
+ * The reload uses the `"update"` strategy. A `"query_and_update"` reload
+ * settles on the query response, which leaves the store uncertified and blocks
+ * a normal write. A session that forces the `query` strategy keeps its query
+ * response, because `isImportedTokensCertified` accepts it.
+ *
  * Return `undefined` when certified imported tokens are not available. An empty
  * list is a valid result. An absent list is not.
  */
@@ -97,7 +111,15 @@ export const getCertifiedImportedTokens = async (): Promise<
   ImportedTokenData[] | undefined
 > => {
   if (!isImportedTokensCertified(get(importedTokensStore).certified)) {
-    await loadImportedTokens({ ignoreAccountNotFoundError: true });
+    try {
+      await loadImportedTokens({
+        ignoreAccountNotFoundError: true,
+        strategy: "update",
+      });
+    } catch (err) {
+      console.error(err);
+      return undefined;
+    }
   }
 
   const { importedTokens, certified } = get(importedTokensStore);
@@ -164,7 +186,10 @@ export const addImportedToken = async ({
   const { err } = await saveImportedToken({ tokens });
 
   if (isNullish(err)) {
-    await loadImportedTokens();
+    // Reload with the `"update"` strategy. A query call can still return the
+    // imported tokens from before this write. The `"update"` strategy also
+    // leaves the store certified, so the next write needs no extra reload.
+    await loadImportedTokens({ strategy: "update" });
     toastsSuccess({
       labelKey: "tokens.add_imported_token_success",
     });
@@ -229,7 +254,10 @@ export const addIndexCanister = async ({
   const { err } = await saveImportedToken({ tokens });
 
   if (isNullish(err)) {
-    await loadImportedTokens();
+    // Reload with the `"update"` strategy. A query call can still return the
+    // imported tokens from before this write. The `"update"` strategy also
+    // leaves the store certified, so the next write needs no extra reload.
+    await loadImportedTokens({ strategy: "update" });
     toastsSuccess({
       labelKey: "tokens.update_imported_token_success",
     });

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1188,6 +1188,8 @@ interface I18nError__imported_tokens {
   add_imported_token: string;
   remove_imported_token: string;
   update_imported_token: string;
+  not_certified: string;
+  token_not_found: string;
   too_many: string;
   ledger_canister_loading: string;
   is_duplication: string;

--- a/frontend/src/lib/utils/imported-tokens.utils.ts
+++ b/frontend/src/lib/utils/imported-tokens.utils.ts
@@ -1,8 +1,20 @@
 import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
+import { isForceCallStrategy } from "$lib/utils/call.utils";
 import { isImportantCkToken } from "$lib/utils/icrc-tokens.utils";
 import { fromNullable, nonNullish, toNullable } from "@dfinity/utils";
 import type { Principal } from "@icp-sdk/core/principal";
+
+/**
+ * Tell if the imported tokens in the store come from a certified call.
+ *
+ * A session that forces the `query` strategy never gets certified data.
+ * Such a session accepts the query response instead.
+ */
+export const isImportedTokensCertified = (
+  certified: boolean | undefined
+): boolean =>
+  certified === true || (certified === false && isForceCallStrategy());
 
 export const toImportedTokenData = ({
   ledger_canister_id,

--- a/frontend/src/lib/utils/imported-tokens.utils.ts
+++ b/frontend/src/lib/utils/imported-tokens.utils.ts
@@ -1,6 +1,5 @@
 import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
-import { isForceCallStrategy } from "$lib/utils/call.utils";
 import { isImportantCkToken } from "$lib/utils/icrc-tokens.utils";
 import { fromNullable, nonNullish, toNullable } from "@dfinity/utils";
 import type { Principal } from "@icp-sdk/core/principal";
@@ -8,13 +7,12 @@ import type { Principal } from "@icp-sdk/core/principal";
 /**
  * Tell if the imported tokens in the store come from a certified call.
  *
- * A session that forces the `query` strategy never gets certified data.
- * Such a session accepts the query response instead.
+ * Only an update call gives certified data. A query response is never
+ * certified, whatever call strategy the session uses.
  */
 export const isImportedTokensCertified = (
   certified: boolean | undefined
-): boolean =>
-  certified === true || (certified === false && isForceCallStrategy());
+): boolean => certified === true;
 
 export const toImportedTokenData = ({
   ledger_canister_id,

--- a/frontend/src/tests/e2e/remove-imported-token.spec.ts
+++ b/frontend/src/tests/e2e/remove-imported-token.spec.ts
@@ -1,0 +1,238 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import {
+  dfxCanisterId,
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { nonNullish } from "@dfinity/utils";
+import { expect, test, type Page } from "@playwright/test";
+
+const FIRST_TOKEN_NAME = "ckRED";
+const REMOVE_SUCCESS_MESSAGE = "The token has been successfully removed!";
+const NOT_CERTIFIED_MESSAGE =
+  "We could not verify your imported tokens, so nothing was saved. Please reload the page and try again.";
+const TOKEN_NOT_FOUND_MESSAGE =
+  "This token is not in your verified token list, so nothing was saved. Please reload the page and try again.";
+const REMOVE_ERROR_MESSAGE =
+  "There was an unexpected issue while removing the imported token.";
+
+const IMPORTED_TOKEN_ERROR_MESSAGES = [
+  NOT_CERTIFIED_MESSAGE,
+  TOKEN_NOT_FOUND_MESSAGE,
+  REMOVE_ERROR_MESSAGE,
+];
+
+// The app loads the imported tokens with a query call and an update call.
+// The update call takes a few seconds on the local replica.
+const CERTIFIED_LOAD_TIMEOUT = 8000;
+
+const expectNoImportedTokenError = (messages: string[]) => {
+  for (const errorMessage of IMPORTED_TOKEN_ERROR_MESSAGES) {
+    expect(messages).not.toContain(errorMessage);
+  }
+};
+
+const removeImportedToken = async (appPo: AppPo) => {
+  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
+
+  await walletPo.getMoreButton().click();
+  await walletPo.getWalletMorePopoverPo().waitFor();
+  await walletPo.getWalletMorePopoverPo().getRemoveButtonPo().click();
+
+  await walletPo.getImportTokenRemoveConfirmationPo().waitFor();
+  await walletPo.getImportTokenRemoveConfirmationPo().clickYes();
+};
+
+const importToken = async ({
+  page,
+  appPo,
+  ledgerCanisterId,
+  indexCanisterId,
+}: {
+  page: Page;
+  appPo: AppPo;
+  ledgerCanisterId: string;
+  indexCanisterId?: string;
+}): Promise<string> => {
+  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+  const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
+  const formPo = importTokenModalPo.getImportTokenFormPo();
+  const reviewPo = importTokenModalPo.getImportTokenReviewPo();
+
+  await tokensPagePo.getSettingsButtonPo().click();
+
+  const importButtonPo = tokensPagePo.getImportTokenButtonPo();
+  await importButtonPo.waitFor();
+  await importButtonPo.click();
+  await importTokenModalPo.waitFor();
+
+  await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId);
+  if (nonNullish(indexCanisterId)) {
+    await formPo.getIndexCanisterInputPo().typeText(indexCanisterId);
+  }
+
+  await formPo.getSubmitButtonPo().click();
+  await reviewPo.waitFor();
+
+  const tokenName = await reviewPo.getTokenName();
+
+  await reviewPo.getConfirmButtonPo().click();
+  await appPo.getWalletPo().getIcrcWalletPo().waitFor();
+
+  // An import reloads the imported tokens. Wait for the certified response,
+  // because a remove needs the certified imported tokens.
+  await page.waitForTimeout(CERTIFIED_LOAD_TIMEOUT);
+
+  return tokenName;
+};
+
+// A remove replaces the whole imported-token list in the backend.
+// This test checks that a remove deletes one token and keeps the other one.
+test("Remove one imported token and keep the other", async ({
+  page,
+  context,
+}) => {
+  const firstLedgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const firstIndexCanisterId = await dfxCanisterId("ckred_index");
+  const secondLedgerCanisterId = await dfxCanisterId("ckusdc_ledger");
+
+  await page.goto("/tokens");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
+  const importedTokensTablePo = tokensPagePo.getImportedTokensTable();
+  const toastsPo = appPo.getToastsPo();
+
+  step("The new user has no imported token");
+
+  await tokensPagePo.getSettingsButtonPo().waitFor();
+  expect(await importedTokensTablePo.isPresent()).toBe(false);
+
+  step("Import the first token");
+
+  const firstTokenName = await importToken({
+    page,
+    appPo,
+    ledgerCanisterId: firstLedgerCanisterId,
+    indexCanisterId: firstIndexCanisterId,
+  });
+  expect(firstTokenName).toBe(FIRST_TOKEN_NAME);
+
+  await appPo.goBack();
+  await importedTokensTablePo.waitFor();
+
+  step("Import the second token");
+
+  const secondTokenName = await importToken({
+    page,
+    appPo,
+    ledgerCanisterId: secondLedgerCanisterId,
+  });
+  expect(secondTokenName).not.toBe(FIRST_TOKEN_NAME);
+
+  await appPo.goBack();
+  await importedTokensTablePo.waitFor();
+
+  step("Both imported tokens are in the table");
+
+  expect((await importedTokensTablePo.getTokenNames()).sort()).toEqual(
+    [firstTokenName, secondTokenName].sort()
+  );
+
+  step("Open the first imported token");
+
+  const firstTokenRowPo =
+    await importedTokensTablePo.getRowByName(firstTokenName);
+  await firstTokenRowPo.click();
+  await walletPo.waitFor();
+
+  step("Remove the first imported token");
+
+  await removeImportedToken(appPo);
+
+  step("The user sees the success message and no imported-token error");
+
+  await page.getByText(REMOVE_SUCCESS_MESSAGE).waitFor();
+
+  const messages = await toastsPo.getMessages();
+  expect(messages).toContain(REMOVE_SUCCESS_MESSAGE);
+  expectNoImportedTokenError(messages);
+
+  step("Only the removed token is gone from the table");
+
+  await importedTokensTablePo.waitFor();
+  expect(await importedTokensTablePo.getTokenNames()).toEqual([
+    secondTokenName,
+  ]);
+
+  step("The backend kept the second token after a page reload");
+
+  await page.reload();
+  await disableCssAnimations(page);
+  await importedTokensTablePo.waitFor();
+
+  expect(await importedTokensTablePo.getTokenNames()).toEqual([
+    secondTokenName,
+  ]);
+});
+
+// The service builds the replacement list from certified data. When the store
+// holds a query response, the service reloads the imported tokens first. That
+// reload must wait for the certified response. This test slows the nns-dapp
+// update calls, so the store holds a query response when the user clicks
+// Remove.
+test("Remove an imported token while the store holds a query response", async ({
+  page,
+  context,
+}) => {
+  const ledgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const nnsDappCanisterId = await dfxCanisterId("nns-dapp");
+
+  await page.goto("/tokens");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
+  const toastsPo = appPo.getToastsPo();
+
+  step("Import a token");
+
+  await importToken({ page, appPo, ledgerCanisterId });
+
+  step("Slow the nns-dapp update calls");
+
+  await page.route(
+    `**/api/v*/canister/${nnsDappCanisterId}/call`,
+    async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 15000));
+      await route.continue();
+    }
+  );
+
+  step("Reload the page, so the store holds only a query response");
+
+  await page.reload();
+  await disableCssAnimations(page);
+  await walletPo.waitFor();
+
+  step("Remove the imported token");
+
+  await removeImportedToken(appPo);
+
+  step("The user sees the success message and no imported-token error");
+
+  // The certified response takes 15 seconds here, so allow more time.
+  await page.getByText(REMOVE_SUCCESS_MESSAGE).waitFor({ timeout: 60 * 1000 });
+
+  const messages = await toastsPo.getMessages();
+  expect(messages).toContain(REMOVE_SUCCESS_MESSAGE);
+  expectNoImportedTokenError(messages);
+});

--- a/frontend/src/tests/e2e/remove-imported-token.spec.ts
+++ b/frontend/src/tests/e2e/remove-imported-token.spec.ts
@@ -6,10 +6,9 @@ import {
   signInWithNewUser,
   step,
 } from "$tests/utils/e2e.test-utils";
-import { nonNullish } from "@dfinity/utils";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-const FIRST_TOKEN_NAME = "ckRED";
+const TEST_TOKEN_NAME = "ckRED";
 const REMOVE_SUCCESS_MESSAGE = "The token has been successfully removed!";
 const NOT_CERTIFIED_MESSAGE =
   "We could not verify your imported tokens, so nothing was saved. Please reload the page and try again.";
@@ -24,9 +23,11 @@ const IMPORTED_TOKEN_ERROR_MESSAGES = [
   REMOVE_ERROR_MESSAGE,
 ];
 
-// The app loads the imported tokens with a query call and an update call.
-// The update call takes a few seconds on the local replica.
-const CERTIFIED_LOAD_TIMEOUT = 8000;
+// The route below holds every nns-dapp update call for this long.
+const UPDATE_CALL_DELAY_MS = 15_000;
+// The remove waits for one delayed update call. Give it more time than the
+// delay above.
+const REMOVE_TIMEOUT_MS = 60_000;
 
 const expectNoImportedTokenError = (messages: string[]) => {
   for (const errorMessage of IMPORTED_TOKEN_ERROR_MESSAGES) {
@@ -34,164 +35,18 @@ const expectNoImportedTokenError = (messages: string[]) => {
   }
 };
 
-const removeImportedToken = async (appPo: AppPo) => {
-  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
-
-  await walletPo.getMoreButton().click();
-  await walletPo.getWalletMorePopoverPo().waitFor();
-  await walletPo.getWalletMorePopoverPo().getRemoveButtonPo().click();
-
-  await walletPo.getImportTokenRemoveConfirmationPo().waitFor();
-  await walletPo.getImportTokenRemoveConfirmationPo().clickYes();
-};
-
-const importToken = async ({
-  page,
-  appPo,
-  ledgerCanisterId,
-  indexCanisterId,
-}: {
-  page: Page;
-  appPo: AppPo;
-  ledgerCanisterId: string;
-  indexCanisterId?: string;
-}): Promise<string> => {
-  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
-  const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
-  const formPo = importTokenModalPo.getImportTokenFormPo();
-  const reviewPo = importTokenModalPo.getImportTokenReviewPo();
-
-  await tokensPagePo.getSettingsButtonPo().click();
-
-  const importButtonPo = tokensPagePo.getImportTokenButtonPo();
-  await importButtonPo.waitFor();
-  await importButtonPo.click();
-  await importTokenModalPo.waitFor();
-
-  await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId);
-  if (nonNullish(indexCanisterId)) {
-    await formPo.getIndexCanisterInputPo().typeText(indexCanisterId);
-  }
-
-  await formPo.getSubmitButtonPo().click();
-  await reviewPo.waitFor();
-
-  const tokenName = await reviewPo.getTokenName();
-
-  await reviewPo.getConfirmButtonPo().click();
-  await appPo.getWalletPo().getIcrcWalletPo().waitFor();
-
-  // An import reloads the imported tokens. Wait for the certified response,
-  // because a remove needs the certified imported tokens.
-  await page.waitForTimeout(CERTIFIED_LOAD_TIMEOUT);
-
-  return tokenName;
-};
-
-// A remove replaces the whole imported-token list in the backend.
-// This test checks that a remove deletes one token and keeps the other one.
-test("Remove one imported token and keep the other", async ({
-  page,
-  context,
-}) => {
-  const firstLedgerCanisterId = await dfxCanisterId("ckred_ledger");
-  const firstIndexCanisterId = await dfxCanisterId("ckred_index");
-  const secondLedgerCanisterId = await dfxCanisterId("ckusdc_ledger");
-
-  await page.goto("/tokens");
-  await disableCssAnimations(page);
-  await signInWithNewUser({ page, context });
-
-  const pageElement = PlaywrightPageObjectElement.fromPage(page);
-  const appPo = new AppPo(pageElement);
-  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
-  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
-  const importedTokensTablePo = tokensPagePo.getImportedTokensTable();
-  const toastsPo = appPo.getToastsPo();
-
-  step("The new user has no imported token");
-
-  await tokensPagePo.getSettingsButtonPo().waitFor();
-  expect(await importedTokensTablePo.isPresent()).toBe(false);
-
-  step("Import the first token");
-
-  const firstTokenName = await importToken({
-    page,
-    appPo,
-    ledgerCanisterId: firstLedgerCanisterId,
-    indexCanisterId: firstIndexCanisterId,
-  });
-  expect(firstTokenName).toBe(FIRST_TOKEN_NAME);
-
-  await appPo.goBack();
-  await importedTokensTablePo.waitFor();
-
-  step("Import the second token");
-
-  const secondTokenName = await importToken({
-    page,
-    appPo,
-    ledgerCanisterId: secondLedgerCanisterId,
-  });
-  expect(secondTokenName).not.toBe(FIRST_TOKEN_NAME);
-
-  await appPo.goBack();
-  await importedTokensTablePo.waitFor();
-
-  step("Both imported tokens are in the table");
-
-  expect((await importedTokensTablePo.getTokenNames()).sort()).toEqual(
-    [firstTokenName, secondTokenName].sort()
-  );
-
-  step("Open the first imported token");
-
-  const firstTokenRowPo =
-    await importedTokensTablePo.getRowByName(firstTokenName);
-  await firstTokenRowPo.click();
-  await walletPo.waitFor();
-
-  step("Remove the first imported token");
-
-  await removeImportedToken(appPo);
-
-  step("The user sees the success message and no imported-token error");
-
-  await page.getByText(REMOVE_SUCCESS_MESSAGE).waitFor();
-
-  const messages = await toastsPo.getMessages();
-  expect(messages).toContain(REMOVE_SUCCESS_MESSAGE);
-  expectNoImportedTokenError(messages);
-
-  step("Only the removed token is gone from the table");
-
-  await importedTokensTablePo.waitFor();
-  expect(await importedTokensTablePo.getTokenNames()).toEqual([
-    secondTokenName,
-  ]);
-
-  step("The backend kept the second token after a page reload");
-
-  await page.reload();
-  await disableCssAnimations(page);
-  await importedTokensTablePo.waitFor();
-
-  expect(await importedTokensTablePo.getTokenNames()).toEqual([
-    secondTokenName,
-  ]);
-});
-
-// The service builds the replacement list from certified data. When the store
-// holds a query response, the service reloads the imported tokens first. That
-// reload must wait for the certified response. This test slows the nns-dapp
-// update calls, so the store holds a query response when the user clicks
-// Remove.
+// A remove replaces the whole imported-token list in the backend. The service
+// builds that list from certified data. When the store holds a query response,
+// the service reloads the imported tokens with an update call first.
+//
+// This test slows the nns-dapp update calls, so the store holds only a query
+// response when the user clicks Remove. The remove must still succeed.
 test("Remove an imported token while the store holds a query response", async ({
   page,
   context,
 }) => {
   const ledgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const indexCanisterId = await dfxCanisterId("ckred_index");
   const nnsDappCanisterId = await dfxCanisterId("nns-dapp");
 
   await page.goto("/tokens");
@@ -200,19 +55,50 @@ test("Remove an imported token while the store holds a query response", async ({
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
+  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+  const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
+  const formPo = importTokenModalPo.getImportTokenFormPo();
+  const reviewPo = importTokenModalPo.getImportTokenReviewPo();
+  const importedTokensTablePo = tokensPagePo.getImportedTokensTable();
   const walletPo = appPo.getWalletPo().getIcrcWalletPo();
   const toastsPo = appPo.getToastsPo();
 
-  step("Import a token");
+  step("The new user has no imported token");
 
-  await importToken({ page, appPo, ledgerCanisterId });
+  await tokensPagePo.getSettingsButtonPo().waitFor();
+  expect(await importedTokensTablePo.isPresent()).toBe(false);
+
+  step("Open the import token modal");
+
+  await tokensPagePo.getSettingsButtonPo().click();
+
+  const importButtonPo = tokensPagePo.getImportTokenButtonPo();
+  await importButtonPo.waitFor();
+  await importButtonPo.click();
+  await importTokenModalPo.waitFor();
+
+  step("Enter the ledger and index canister ids");
+
+  await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId);
+  await formPo.getIndexCanisterInputPo().typeText(indexCanisterId);
+  await formPo.getSubmitButtonPo().click();
+  await reviewPo.waitFor();
+
+  expect(await reviewPo.getTokenName()).toBe(TEST_TOKEN_NAME);
+
+  step("Import the token");
+
+  // The import waits for the certified imported tokens itself. The app opens
+  // the wallet page only after that call returns.
+  await reviewPo.getConfirmButtonPo().click();
+  await walletPo.waitFor();
 
   step("Slow the nns-dapp update calls");
 
   await page.route(
     `**/api/v*/canister/${nnsDappCanisterId}/call`,
     async (route) => {
-      await new Promise((resolve) => setTimeout(resolve, 15000));
+      await new Promise((resolve) => setTimeout(resolve, UPDATE_CALL_DELAY_MS));
       await route.continue();
     }
   );
@@ -225,14 +111,26 @@ test("Remove an imported token while the store holds a query response", async ({
 
   step("Remove the imported token");
 
-  await removeImportedToken(appPo);
+  await walletPo.getMoreButton().click();
+  await walletPo.getWalletMorePopoverPo().waitFor();
+  await walletPo.getWalletMorePopoverPo().getRemoveButtonPo().click();
+
+  await walletPo.getImportTokenRemoveConfirmationPo().waitFor();
+  await walletPo.getImportTokenRemoveConfirmationPo().clickYes();
 
   step("The user sees the success message and no imported-token error");
 
-  // The certified response takes 15 seconds here, so allow more time.
-  await page.getByText(REMOVE_SUCCESS_MESSAGE).waitFor({ timeout: 60 * 1000 });
+  await page
+    .getByText(REMOVE_SUCCESS_MESSAGE)
+    .waitFor({ timeout: REMOVE_TIMEOUT_MS });
 
   const messages = await toastsPo.getMessages();
   expect(messages).toContain(REMOVE_SUCCESS_MESSAGE);
   expectNoImportedTokenError(messages);
+
+  step("The removed token is gone from the tokens page");
+
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await tokensPagePo.getSettingsButtonPo().waitFor();
+  await importedTokensTablePo.waitForAbsent();
 });

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -408,12 +408,9 @@ describe("ImportTokenModal", () => {
         },
       ],
     });
-    expect(getImportedTokensSpy).toBeCalledTimes(2);
-    expect(getImportedTokensSpy).toHaveBeenNthCalledWith(1, {
-      identity: mockIdentity,
-      certified: false,
-    });
-    expect(getImportedTokensSpy).toHaveBeenNthCalledWith(2, {
+    // The reload after a write uses the `"update"` strategy.
+    expect(getImportedTokensSpy).toBeCalledTimes(1);
+    expect(getImportedTokensSpy).toHaveBeenCalledWith({
       identity: mockIdentity,
       certified: true,
     });

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -765,7 +765,12 @@ describe("IcrcWallet", () => {
             },
           ],
         });
-        expect(spyOnGetImportedTokens).toBeCalledTimes(2);
+        // The reload after a write uses the `"update"` strategy.
+        expect(spyOnGetImportedTokens).toBeCalledTimes(1);
+        expect(spyOnGetImportedTokens).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: true,
+        });
         expect(get(busyStore)).toEqual([]);
         expect(get(importedTokensStore).importedTokens).toEqual([
           {

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -43,11 +43,40 @@ describe("imported-tokens-services", () => {
   };
   // A token that only a query response holds.
   // It stands for a token that a single replica forged.
+  const forgedToken: ImportedToken = {
+    ledger_canister_id: principal(9),
+    index_canister_id: [],
+  };
   const forgedTokenData: ImportedTokenData = {
     ledgerCanisterId: principal(9),
     indexCanisterId: undefined,
   };
   const testError = new Error("test");
+
+  // The certified response always lands after the query response in
+  // production, because an update call runs consensus. Reproduce that order
+  // here.
+  const QUERY_RESPONSE_DELAY_MS = 0;
+  const CERTIFIED_RESPONSE_DELAY_MS = 50;
+
+  const delay = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  // The query response holds a forged token. The certified response does not.
+  const mockSlowCertifiedGetImportedTokens = (
+    certifiedTokens: ImportedToken[]
+  ) =>
+    vi
+      .spyOn(importedTokensApi, "getImportedTokens")
+      .mockImplementation(async ({ certified }) => {
+        if (certified) {
+          await delay(CERTIFIED_RESPONSE_DELAY_MS);
+          return { imported_tokens: certifiedTokens };
+        }
+
+        await delay(QUERY_RESPONSE_DELAY_MS);
+        return { imported_tokens: [...certifiedTokens, forgedToken] };
+      });
 
   beforeEach(() => {
     resetIdentity();
@@ -250,7 +279,12 @@ describe("imported-tokens-services", () => {
         tokenToAdd: importedTokenDataB,
       });
 
-      expect(spyGetImportedTokens).toBeCalledTimes(2);
+      // The reload after a write uses the `"update"` strategy.
+      expect(spyGetImportedTokens).toBeCalledTimes(1);
+      expect(spyGetImportedTokens).toBeCalledWith({
+        certified: true,
+        identity: mockIdentity,
+      });
       expect(get(importedTokensStore)).toEqual({
         importedTokens: [importedTokenDataA, importedTokenDataB],
         certified: true,
@@ -498,7 +532,12 @@ describe("imported-tokens-services", () => {
       });
       expect(spySetImportedTokens).toBeCalledTimes(1);
       // should reload imported tokens to update the store
-      expect(spyGetImportedTokens).toBeCalledTimes(2);
+      // The reload after a write uses the `"update"` strategy.
+      expect(spyGetImportedTokens).toBeCalledTimes(1);
+      expect(spyGetImportedTokens).toBeCalledWith({
+        certified: true,
+        identity: mockIdentity,
+      });
       expect(get(importedTokensStore)).toEqual({
         importedTokens: [importedTokenDataA, expectedTokenDataB],
         certified: true,
@@ -576,14 +615,30 @@ describe("imported-tokens-services", () => {
         importedTokens: [importedTokenDataA, forgedTokenData],
         certified: false,
       });
-      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
-        imported_tokens: [importedTokenA],
-      });
+      mockSlowCertifiedGetImportedTokens([importedTokenA]);
 
       expect(await getCertifiedImportedTokens()).toEqual([importedTokenDataA]);
       expect(get(importedTokensStore)).toEqual({
         importedTokens: [importedTokenDataA],
         certified: true,
+      });
+    });
+
+    it("should reload with the update strategy and make no query call", async () => {
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, forgedTokenData],
+        certified: false,
+      });
+      const spyGetImportedTokens = mockSlowCertifiedGetImportedTokens([
+        importedTokenA,
+      ]);
+
+      await getCertifiedImportedTokens();
+
+      expect(spyGetImportedTokens).toBeCalledTimes(1);
+      expect(spyGetImportedTokens).toBeCalledWith({
+        certified: true,
+        identity: mockIdentity,
       });
     });
 
@@ -621,10 +676,8 @@ describe("imported-tokens-services", () => {
         ],
         certified: false,
       });
-      // The certified response drops the forged token.
-      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
-        imported_tokens: [importedTokenA, importedTokenB],
-      });
+      // The certified response drops the forged token, and it lands last.
+      mockSlowCertifiedGetImportedTokens([importedTokenA, importedTokenB]);
       const spySetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
         .mockResolvedValue(undefined);
@@ -668,6 +721,36 @@ describe("imported-tokens-services", () => {
       ]);
     });
 
+    it("should remove a token while the store holds a query response", async () => {
+      // The store holds the query response of a fresh load. The certified
+      // response is still on its way. The remove must still go through.
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: false,
+      });
+      mockSlowCertifiedGetImportedTokens([importedTokenA, importedTokenB]);
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await removeImportedTokens(
+        importedTokenDataA.ledgerCanisterId
+      );
+
+      expect(success).toEqual(true);
+      expect(spySetImportedTokens).toBeCalledTimes(1);
+      expect(spySetImportedTokens).toBeCalledWith({
+        identity: mockIdentity,
+        importedTokens: [importedTokenB],
+      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "The token has been successfully removed!",
+        },
+      ]);
+    });
+
     it("should not remove a token that the certified list does not hold", async () => {
       // The query response holds a forged token that the certified list omits.
       importedTokensStore.set({
@@ -700,9 +783,7 @@ describe("imported-tokens-services", () => {
         importedTokens: [forgedTokenData],
         certified: false,
       });
-      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
-        imported_tokens: [importedTokenA],
-      });
+      mockSlowCertifiedGetImportedTokens([importedTokenA]);
       const spySetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
         .mockResolvedValue(undefined);
@@ -778,9 +859,7 @@ describe("imported-tokens-services", () => {
         ],
         certified: false,
       });
-      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
-        imported_tokens: [importedTokenA, importedTokenB],
-      });
+      mockSlowCertifiedGetImportedTokens([importedTokenA, importedTokenB]);
       const spySetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
         .mockResolvedValue(undefined);

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -7,6 +7,7 @@ import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import {
   addImportedToken,
   addIndexCanister,
+  getCertifiedImportedTokens,
   loadImportedTokens,
   removeImportedTokens,
 } from "$lib/services/imported-tokens.services";
@@ -16,6 +17,7 @@ import {
 } from "$lib/stores/imported-tokens.store";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
@@ -39,12 +41,20 @@ describe("imported-tokens-services", () => {
     ledgerCanisterId: principal(2),
     indexCanisterId: undefined,
   };
+  // A token that only a query response holds.
+  // It stands for a token that a single replica forged.
+  const forgedTokenData: ImportedTokenData = {
+    ledgerCanisterId: principal(9),
+    indexCanisterId: undefined,
+  };
   const testError = new Error("test");
 
   beforeEach(() => {
     resetIdentity();
     vi.spyOn(console, "error").mockReturnValue();
     vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);
+    importedTokensStore.reset();
+    failedImportedTokenLedgerIdsStore.reset();
   });
 
   describe("loadImportedTokens", () => {
@@ -199,11 +209,14 @@ describe("imported-tokens-services", () => {
       const spySetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
         .mockResolvedValue(undefined);
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA],
+        certified: true,
+      });
       expect(spySetImportedTokens).toBeCalledTimes(0);
 
       const { success } = await addImportedToken({
         tokenToAdd: importedTokenDataB,
-        importedTokens: [importedTokenDataA],
       });
 
       expect(success).toEqual(true);
@@ -235,7 +248,6 @@ describe("imported-tokens-services", () => {
 
       await addImportedToken({
         tokenToAdd: importedTokenDataB,
-        importedTokens: [importedTokenDataA],
       });
 
       expect(spyGetImportedTokens).toBeCalledTimes(2);
@@ -252,11 +264,14 @@ describe("imported-tokens-services", () => {
       vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
         imported_tokens: [importedTokenA, importedTokenB],
       });
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA],
+        certified: true,
+      });
       expect(get(toastsStore)).toEqual([]);
 
       await addImportedToken({
         tokenToAdd: importedTokenDataB,
-        importedTokens: [importedTokenDataA],
       });
 
       expect(get(toastsStore)).toMatchObject([
@@ -271,11 +286,14 @@ describe("imported-tokens-services", () => {
       vi.spyOn(importedTokensApi, "setImportedTokens").mockRejectedValue(
         testError
       );
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA],
+        certified: true,
+      });
       expect(get(toastsStore)).toEqual([]);
 
       const { success } = await addImportedToken({
         tokenToAdd: importedTokenDataB,
-        importedTokens: [importedTokenDataA],
       });
 
       expect(success).toEqual(false);
@@ -291,11 +309,14 @@ describe("imported-tokens-services", () => {
       vi.spyOn(importedTokensApi, "setImportedTokens").mockRejectedValue(
         new TooManyImportedTokensError("too many tokens")
       );
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA],
+        certified: true,
+      });
       expect(get(toastsStore)).toEqual([]);
 
       const { success } = await addImportedToken({
         tokenToAdd: importedTokenDataB,
-        importedTokens: [importedTokenDataA],
       });
 
       expect(success).toEqual(false);
@@ -468,7 +489,6 @@ describe("imported-tokens-services", () => {
       const { success } = await addIndexCanister({
         ledgerCanisterId: importedTokenDataB.ledgerCanisterId,
         indexCanisterId,
-        importedTokens: [importedTokenDataA, importedTokenDataB],
       });
       expect(success).toEqual(true);
       expect(spySetImportedTokens).toBeCalledTimes(1);
@@ -489,13 +509,16 @@ describe("imported-tokens-services", () => {
       vi.spyOn(importedTokensApi, "setImportedTokens").mockResolvedValue(
         undefined
       );
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: true,
+      });
 
       expect(get(toastsStore)).toEqual([]);
 
       await addIndexCanister({
         ledgerCanisterId: importedTokenDataB.ledgerCanisterId,
         indexCanisterId,
-        importedTokens: [importedTokenDataA, importedTokenDataB],
       });
 
       expect(get(toastsStore)).toMatchObject([
@@ -510,13 +533,16 @@ describe("imported-tokens-services", () => {
       vi.spyOn(importedTokensApi, "setImportedTokens").mockRejectedValue(
         new Error("test")
       );
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: true,
+      });
 
       expect(get(toastsStore)).toEqual([]);
 
       const { success } = await addIndexCanister({
         ledgerCanisterId: importedTokenDataB.ledgerCanisterId,
         indexCanisterId,
-        importedTokens: [importedTokenDataA, importedTokenDataB],
       });
 
       expect(success).toEqual(false);
@@ -524,6 +550,307 @@ describe("imported-tokens-services", () => {
         {
           level: "error",
           text: "There was an unexpected issue while updating the imported token.",
+        },
+      ]);
+    });
+  });
+
+  describe("getCertifiedImportedTokens", () => {
+    it("should return the tokens without reloading when the store is certified", async () => {
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA],
+        certified: true,
+      });
+      const spyGetImportedTokens = vi.spyOn(
+        importedTokensApi,
+        "getImportedTokens"
+      );
+
+      expect(await getCertifiedImportedTokens()).toEqual([importedTokenDataA]);
+      expect(spyGetImportedTokens).toBeCalledTimes(0);
+    });
+
+    it("should discard an uncertified snapshot and return the certified tokens", async () => {
+      // The store holds a query response with a forged token.
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, forgedTokenData],
+        certified: false,
+      });
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [importedTokenA],
+      });
+
+      expect(await getCertifiedImportedTokens()).toEqual([importedTokenDataA]);
+      expect(get(importedTokensStore)).toEqual({
+        importedTokens: [importedTokenDataA],
+        certified: true,
+      });
+    });
+
+    it("should return undefined when the reload fails", async () => {
+      importedTokensStore.set({
+        importedTokens: [forgedTokenData],
+        certified: false,
+      });
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockRejectedValue(
+        testError
+      );
+
+      expect(await getCertifiedImportedTokens()).toBeUndefined();
+      toastsStore.reset();
+    });
+
+    it("should return undefined when the imported tokens were never loaded", async () => {
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockRejectedValue(
+        testError
+      );
+
+      expect(await getCertifiedImportedTokens()).toBeUndefined();
+      toastsStore.reset();
+    });
+  });
+
+  describe("certified data", () => {
+    it("should not write back an uncertified snapshot when removing", async () => {
+      // The store holds a query response with a forged token.
+      importedTokensStore.set({
+        importedTokens: [
+          importedTokenDataA,
+          importedTokenDataB,
+          forgedTokenData,
+        ],
+        certified: false,
+      });
+      // The certified response drops the forged token.
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [importedTokenA, importedTokenB],
+      });
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await removeImportedTokens(
+        importedTokenDataA.ledgerCanisterId
+      );
+
+      expect(success).toEqual(true);
+      expect(spySetImportedTokens).toBeCalledTimes(1);
+      expect(spySetImportedTokens).toBeCalledWith({
+        identity: mockIdentity,
+        importedTokens: [importedTokenB],
+      });
+    });
+
+    it("should not write an empty list when the store is reset and removing", async () => {
+      importedTokensStore.reset();
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockRejectedValue(
+        testError
+      );
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await removeImportedTokens(
+        importedTokenDataA.ledgerCanisterId
+      );
+
+      expect(success).toEqual(false);
+      expect(spySetImportedTokens).toBeCalledTimes(0);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "There was an unexpected issue while loading imported tokens.",
+        },
+        {
+          level: "error",
+          text: en.error__imported_tokens.not_certified,
+        },
+      ]);
+    });
+
+    it("should not remove a token that the certified list does not hold", async () => {
+      // The query response holds a forged token that the certified list omits.
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, forgedTokenData],
+        certified: false,
+      });
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [importedTokenA],
+      });
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await removeImportedTokens(
+        forgedTokenData.ledgerCanisterId
+      );
+
+      expect(success).toEqual(false);
+      expect(spySetImportedTokens).toBeCalledTimes(0);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: en.error__imported_tokens.token_not_found,
+        },
+      ]);
+    });
+
+    it("should not write back an uncertified snapshot when adding", async () => {
+      importedTokensStore.set({
+        importedTokens: [forgedTokenData],
+        certified: false,
+      });
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [importedTokenA],
+      });
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await addImportedToken({
+        tokenToAdd: importedTokenDataB,
+      });
+
+      expect(success).toEqual(true);
+      expect(spySetImportedTokens).toBeCalledWith({
+        identity: mockIdentity,
+        importedTokens: [importedTokenA, importedTokenB],
+      });
+    });
+
+    it("should not add a token when certified data is not available", async () => {
+      importedTokensStore.reset();
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockRejectedValue(
+        testError
+      );
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await addImportedToken({
+        tokenToAdd: importedTokenDataB,
+      });
+
+      expect(success).toEqual(false);
+      expect(spySetImportedTokens).toBeCalledTimes(0);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "There was an unexpected issue while loading imported tokens.",
+        },
+        {
+          level: "error",
+          text: en.error__imported_tokens.not_certified,
+        },
+      ]);
+    });
+
+    it("should not add a token that the certified list already holds", async () => {
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: true,
+      });
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await addImportedToken({
+        tokenToAdd: importedTokenDataB,
+      });
+
+      expect(success).toEqual(false);
+      expect(spySetImportedTokens).toBeCalledTimes(0);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "warn",
+          text: en.error__imported_tokens.is_duplication,
+        },
+      ]);
+    });
+
+    it("should not write back an uncertified snapshot when adding an index canister", async () => {
+      const indexCanisterId = principal(3);
+      importedTokensStore.set({
+        importedTokens: [
+          importedTokenDataA,
+          importedTokenDataB,
+          forgedTokenData,
+        ],
+        certified: false,
+      });
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [importedTokenA, importedTokenB],
+      });
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await addIndexCanister({
+        ledgerCanisterId: importedTokenDataB.ledgerCanisterId,
+        indexCanisterId,
+      });
+
+      expect(success).toEqual(true);
+      expect(spySetImportedTokens).toBeCalledWith({
+        identity: mockIdentity,
+        importedTokens: [
+          importedTokenA,
+          { ...importedTokenB, index_canister_id: [indexCanisterId] },
+        ],
+      });
+    });
+
+    it("should not add an index canister when certified data is not available", async () => {
+      importedTokensStore.reset();
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockRejectedValue(
+        testError
+      );
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await addIndexCanister({
+        ledgerCanisterId: importedTokenDataB.ledgerCanisterId,
+        indexCanisterId: principal(3),
+      });
+
+      expect(success).toEqual(false);
+      expect(spySetImportedTokens).toBeCalledTimes(0);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "There was an unexpected issue while loading imported tokens.",
+        },
+        {
+          level: "error",
+          text: en.error__imported_tokens.not_certified,
+        },
+      ]);
+    });
+
+    it("should not add an index canister to a token that the certified list does not hold", async () => {
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, forgedTokenData],
+        certified: false,
+      });
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
+        imported_tokens: [importedTokenA],
+      });
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await addIndexCanister({
+        ledgerCanisterId: forgedTokenData.ledgerCanisterId,
+        indexCanisterId: principal(3),
+      });
+
+      expect(success).toEqual(false);
+      expect(spySetImportedTokens).toBeCalledTimes(0);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: en.error__imported_tokens.token_not_found,
         },
       ]);
     });

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -19,6 +19,7 @@ import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
 import * as dfinityUtils from "@dfinity/utils";
@@ -134,6 +135,19 @@ describe("imported-tokens-services", () => {
           text: "There was an unexpected issue while loading imported tokens.",
         },
       ]);
+    });
+
+    it("should display no error toast when the caller asks for silent errors", async () => {
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockRejectedValue(
+        testError
+      );
+
+      await loadImportedTokens({
+        silentErrorMessages: true,
+        strategy: "update",
+      });
+
+      expect(get(toastsStore)).toEqual([]);
     });
 
     it("should not display toast on uncertified error", async () => {
@@ -652,7 +666,24 @@ describe("imported-tokens-services", () => {
       );
 
       expect(await getCertifiedImportedTokens()).toBeUndefined();
-      toastsStore.reset();
+    });
+
+    it("should show no toast when the reload fails", async () => {
+      // The caller shows one message for the whole failed write. The reload
+      // must not add a second toast.
+      importedTokensStore.set({
+        importedTokens: [forgedTokenData],
+        certified: false,
+      });
+      vi.spyOn(importedTokensApi, "getImportedTokens").mockRejectedValue(
+        testError
+      );
+
+      expect(get(toastsStore)).toHaveLength(0);
+
+      await getCertifiedImportedTokens();
+
+      expect(get(toastsStore)).toHaveLength(0);
     });
 
     it("should return undefined when the imported tokens were never loaded", async () => {
@@ -661,7 +692,29 @@ describe("imported-tokens-services", () => {
       );
 
       expect(await getCertifiedImportedTokens()).toBeUndefined();
-      toastsStore.reset();
+    });
+
+    it("should reload with the update strategy when the session forces the query strategy", async () => {
+      // A forced-query session never gets certified data from its own loads.
+      // A write must still build on certified tokens, so it makes one update
+      // call of its own.
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, forgedTokenData],
+        certified: false,
+      });
+      const spyGetImportedTokens = mockSlowCertifiedGetImportedTokens([
+        importedTokenA,
+      ]);
+
+      expect(await getCertifiedImportedTokens()).toEqual([importedTokenDataA]);
+
+      expect(spyGetImportedTokens).toBeCalledTimes(1);
+      expect(spyGetImportedTokens).toBeCalledWith({
+        certified: true,
+        identity: mockIdentity,
+      });
     });
   });
 
@@ -709,11 +762,9 @@ describe("imported-tokens-services", () => {
 
       expect(success).toEqual(false);
       expect(spySetImportedTokens).toBeCalledTimes(0);
+      // The failed reload shows no toast of its own. The caller shows one
+      // message for the whole failed write.
       expect(get(toastsStore)).toMatchObject([
-        {
-          level: "error",
-          text: "There was an unexpected issue while loading imported tokens.",
-        },
         {
           level: "error",
           text: en.error__imported_tokens.not_certified,
@@ -749,6 +800,37 @@ describe("imported-tokens-services", () => {
           text: "The token has been successfully removed!",
         },
       ]);
+    });
+
+    it("should not write the query snapshot when the session forces the query strategy", async () => {
+      // The store holds a query response with a forged token, and the session
+      // never makes an update call of its own. The remove must still build on
+      // certified tokens.
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      importedTokensStore.set({
+        importedTokens: [
+          importedTokenDataA,
+          importedTokenDataB,
+          forgedTokenData,
+        ],
+        certified: false,
+      });
+      mockSlowCertifiedGetImportedTokens([importedTokenA, importedTokenB]);
+      const spySetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockResolvedValue(undefined);
+
+      const { success } = await removeImportedTokens(
+        importedTokenDataA.ledgerCanisterId
+      );
+
+      expect(success).toEqual(true);
+      expect(spySetImportedTokens).toBeCalledTimes(1);
+      expect(spySetImportedTokens).toBeCalledWith({
+        identity: mockIdentity,
+        importedTokens: [importedTokenB],
+      });
     });
 
     it("should not remove a token that the certified list does not hold", async () => {
@@ -814,11 +896,9 @@ describe("imported-tokens-services", () => {
 
       expect(success).toEqual(false);
       expect(spySetImportedTokens).toBeCalledTimes(0);
+      // The failed reload shows no toast of its own. The caller shows one
+      // message for the whole failed write.
       expect(get(toastsStore)).toMatchObject([
-        {
-          level: "error",
-          text: "There was an unexpected issue while loading imported tokens.",
-        },
         {
           level: "error",
           text: en.error__imported_tokens.not_certified,
@@ -895,11 +975,9 @@ describe("imported-tokens-services", () => {
 
       expect(success).toEqual(false);
       expect(spySetImportedTokens).toBeCalledTimes(0);
+      // The failed reload shows no toast of its own. The caller shows one
+      // message for the whole failed write.
       expect(get(toastsStore)).toMatchObject([
-        {
-          level: "error",
-          text: "There was an unexpected issue while loading imported tokens.",
-        },
         {
           level: "error",
           text: en.error__imported_tokens.not_certified,

--- a/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
@@ -120,10 +120,16 @@ describe("imported tokens utils", () => {
       expect(isImportedTokensCertified(undefined)).toBe(false);
     });
 
-    it("should accept a query response when the session forces the query strategy", () => {
+    it("should reject a query response when the session forces the query strategy", () => {
       mockedConstants.FORCE_CALL_STRATEGY = "query";
 
-      expect(isImportedTokensCertified(false)).toBe(true);
+      expect(isImportedTokensCertified(false)).toBe(false);
+    });
+
+    it("should accept a certified response when the session forces the query strategy", () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      expect(isImportedTokensCertified(true)).toBe(true);
     });
 
     it("should reject imported tokens that were never loaded when the session forces the query strategy", () => {

--- a/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
@@ -3,9 +3,11 @@ import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import {
   fromImportedTokenData,
   isImportedToken,
+  isImportedTokensCertified,
   toImportedTokenData,
 } from "$lib/utils/imported-tokens.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
 
 describe("imported tokens utils", () => {
   const importedToken: ImportedToken = {
@@ -102,6 +104,32 @@ describe("imported tokens utils", () => {
           importedTokens: undefined,
         })
       ).toEqual(false);
+    });
+  });
+
+  describe("isImportedTokensCertified", () => {
+    it("should accept a certified response", () => {
+      expect(isImportedTokensCertified(true)).toBe(true);
+    });
+
+    it("should reject a query response", () => {
+      expect(isImportedTokensCertified(false)).toBe(false);
+    });
+
+    it("should reject imported tokens that were never loaded", () => {
+      expect(isImportedTokensCertified(undefined)).toBe(false);
+    });
+
+    it("should accept a query response when the session forces the query strategy", () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      expect(isImportedTokensCertified(false)).toBe(true);
+    });
+
+    it("should reject imported tokens that were never loaded when the session forces the query strategy", () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+      expect(isImportedTokensCertified(undefined)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

An imported-token write read the live store snapshot with no check of its certified flag. A remove between the query response and the update response sent the query snapshot to `set_imported_tokens`. An absent store also collapsed to `[]`, so a remove during that window wiped every imported token the user had.

# Changes

- Added `isImportedTokensCertified` and `getCertifiedImportedTokens`, so a write only ever reads a certified store.
- Removed the `importedTokens` parameter from `addImportedToken` and `addIndexCanister`, so no caller can hand them an uncertified list.
- Added a reload with the `update` strategy when the store is not yet certified, so a write during the query window still succeeds instead of failing with an error toast.
- Added `silentErrorMessages` to `loadImportedTokens`, so a failed reload raises one toast, not two.
- Added a "not found" check in each writer, so a blocked write never reports success.
- Added an e2e spec, `remove-imported-token.spec.ts`, for a remove during the query window.
- Removed a fixed 8-second sleep from the e2e test helper. A wait for the wallet page to render is already a deterministic signal that the certified load finished.
- Corrected the `queryAndUpdate` docstring. It now states that the race settles on the first call to complete, not the first response, and that a failed call counts as complete.

# Tests

- Ran `npm run check`. It passed. svelte-check found 0 errors and 0 warnings.
- Ran `npm run test`. It passed. 673 test files ran, with 5931 tests passed, 9 skipped, and 0 failed.
- Ran `./scripts/check-relative-imports`. It passed.
- Ran `npx tsc --noEmit -p src/tests/e2e/tsconfig.json`. It passed.
- Did not run the Playwright suite locally. The local dfx state is broken and waits on a human, so no local replica was started for this pass.
- CI ran `remove-imported-token.spec.ts` against a real replica, and the test passed in about 55 seconds. The spec covers a remove while the store holds a query response, which is the property this change fixes.
- The property "remove one imported token and keep the other" has no browser test. It needs a second importable ICRC ledger in the snsdemo snapshot, next to ckRED, and the snapshot holds only one. That is a snsdemo change, out of scope for this pull request. Unit tests cover the two-token case instead, in `imported-tokens.services.spec.ts`, both from a certified store and from the query-response path.
- Did not run the Rust gates. The change touches no Rust file.
- Did not run the script and config gates. The change touches no script and no config file.

# Todos

- [ ] Accessibility (a11y) – no impact. The change alters no markup. It only changes which data a write uses and how a test waits.
- [ ] Changelog – not needed for this pass. The security fix landed in an earlier pass. This pass only fixes a flaky test and a comment.
