### PR TITLE
fix(sns): revoke all voting permissions when removing a hotkey

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Not Published
 
+- Update the TESTNET permissions card when the neuron changes. The card read the neuron once, so it showed stale data.
+
 ### Operations
 
 #### Added

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,7 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
-- Remove all voting permissions when a user removes an SNS neuron hotkey. The removal kept `ManageVotingPermission`, so the removed principal could grant the permissions back. The hotkey list now also shows a principal that keeps some voting permissions.
+- Remove all voting permissions when a user removes an SNS neuron hotkey. The removal kept `ManageVotingPermission`, so the removed principal could grant the permissions back. The hotkey list now also shows a principal that keeps some voting permissions. After the removal, the dapp reads the certified neuron and reports a permission that remains.
 
 #### Not Published
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Remove all voting permissions when a user removes an SNS neuron hotkey. The removal kept `ManageVotingPermission`, so the removed principal could grant the permissions back. The hotkey list now also shows a principal that keeps some voting permissions.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
@@ -17,7 +17,8 @@
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
 
-  let neuron: SnsGovernanceDid.Neuron | undefined | null = $store.neuron;
+  let neuron: SnsGovernanceDid.Neuron | undefined | null;
+  $: neuron = $store.neuron;
 
   const openAddPermissionsModal = async () => {
     openSnsNeuronModal({ type: "dev-add-permissions" });
@@ -27,7 +28,7 @@
   };
 </script>
 
-<!-- ONLY FOR TESTNET. NO UNIT TESTS -->
+<!-- ONLY FOR TESTNET -->
 <CardInfo noMargin>
   <h3 slot="start">Permissions TESTNET ONLY</h3>
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -88,7 +88,7 @@
   };
 
   const remove = async (hotkey: string) => {
-    // Edge case: Remove button is shwon only when neuron is defined
+    // Edge case: Remove button is shown only when neuron is defined
     if (neuron === undefined || neuron === null) {
       return;
     }

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -89,7 +89,7 @@
 
   const remove = async (hotkey: string) => {
     // Edge case: Remove button is shwon only when neuron is defined
-    if (neuron === undefined || neuron === null || neuronId === undefined) {
+    if (neuron === undefined || neuron === null) {
       return;
     }
     startBusy({
@@ -100,35 +100,45 @@
       hotkey,
       rootCanisterId: $selectedUniverseIdStore,
     });
-    // If the user removes itself from the hotkeys, it has no more access to the detail page.
-    if (currentIdentityString === hotkey && success) {
+    if (!success) {
+      stopBusy("remove-sns-hotkey-neuron");
+      return;
+    }
+    // The reload uses the "update" strategy, so it settles on the certified
+    // response. The default strategy settles on the query response. One
+    // replica can forge a query response, and a query response can also show
+    // the neuron from before the removal.
+    await reload({ strategy: "update" });
+    // The removal is complete only when the principal keeps no hotkey
+    // permission. A neuron that the reload did not deliver counts as
+    // incomplete.
+    const reloadedNeuron = $store.neuron;
+    const complete =
+      reloadedNeuron !== undefined &&
+      reloadedNeuron !== null &&
+      getSnsNeuronHotkeyPermissionsFor({
+        neuron: reloadedNeuron,
+        principal: hotkey,
+      }).length === 0;
+    stopBusy("remove-sns-hotkey-neuron");
+    if (!complete) {
+      // The card keeps the user on the page. The list shows the principal with
+      // a warning, so the user can try again.
+      toastsError({
+        labelKey: "error__sns.sns_remove_hotkey_incomplete",
+      });
+      return;
+    }
+    // The user removed its own hotkey. It has no more access to the neuron, so
+    // the card reports the result and leaves the page.
+    if (currentIdentityString === hotkey) {
       toastsShow({
         level: "success",
         labelKey: "neurons.remove_hotkey_success",
       });
 
       await goto($neuronsPathStore);
-      return;
     }
-    if (success) {
-      await reload();
-      // The removal is complete only when the principal keeps no hotkey
-      // permission. Tell the user if some permission remains.
-      const reloadedNeuron = $store.neuron;
-      const remaining =
-        reloadedNeuron !== undefined && reloadedNeuron !== null
-          ? getSnsNeuronHotkeyPermissionsFor({
-              neuron: reloadedNeuron,
-              principal: hotkey,
-            })
-          : [];
-      if (remaining.length > 0) {
-        toastsError({
-          labelKey: "error__sns.sns_remove_hotkey_incomplete",
-        });
-      }
-    }
-    stopBusy("remove-sns-hotkey-neuron");
   };
 </script>
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -12,14 +12,16 @@
   import { authStore } from "$lib/stores/auth.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { toastsShow } from "$lib/stores/toasts.store";
+  import { toastsError, toastsShow } from "$lib/stores/toasts.store";
   import {
     SELECTED_SNS_NEURON_CONTEXT_KEY,
     type SelectedSnsNeuronContext,
   } from "$lib/types/sns-neuron-detail.context";
   import {
     canIdentityManageHotkeys,
+    getSnsNeuronHotkeyPermissionsFor,
     getSnsNeuronHotkeys,
+    getSnsNeuronPartialHotkeys,
   } from "$lib/utils/sns-neuron.utils";
   import { IconClose, IconWarning, Value } from "@dfinity/gix-components";
   import type { SnsGovernanceDid } from "@icp-sdk/canisters/sns";
@@ -46,12 +48,28 @@
           parameters,
         })
       : false;
-  let hotkeys: string[];
-  $: hotkeys =
-    neuron !== undefined && neuron !== null ? getSnsNeuronHotkeys(neuron) : [];
+  type HotkeyRow = { principal: string; complete: boolean };
+
+  // A row is incomplete when the principal holds only some of the hotkey
+  // permissions. The card shows it with a warning, so no principal keeps power
+  // over the neuron without the user seeing it.
+  let rows: HotkeyRow[];
+  $: rows =
+    neuron !== undefined && neuron !== null
+      ? [
+          ...getSnsNeuronHotkeys(neuron).map((principal) => ({
+            principal,
+            complete: true,
+          })),
+          ...getSnsNeuronPartialHotkeys(neuron).map((principal) => ({
+            principal,
+            complete: false,
+          })),
+        ]
+      : [];
 
   let showTooltip: boolean;
-  $: showTooltip = hotkeys.length > 0 && canManageHotkeys;
+  $: showTooltip = rows.length > 0 && canManageHotkeys;
 
   let currentIdentityString: string | undefined;
   $: currentIdentityString = $authStore.identity?.getPrincipal().toText();
@@ -71,14 +89,14 @@
 
   const remove = async (hotkey: string) => {
     // Edge case: Remove button is shwon only when neuron is defined
-    if (neuronId === undefined) {
+    if (neuron === undefined || neuron === null || neuronId === undefined) {
       return;
     }
     startBusy({
       initiator: "remove-sns-hotkey-neuron",
     });
     const { success } = await removeHotkey({
-      neuronId,
+      neuron,
       hotkey,
       rootCanisterId: $selectedUniverseIdStore,
     });
@@ -94,6 +112,21 @@
     }
     if (success) {
       await reload();
+      // The removal is complete only when the principal keeps no hotkey
+      // permission. Tell the user if some permission remains.
+      const reloadedNeuron = $store.neuron;
+      const remaining =
+        reloadedNeuron !== undefined && reloadedNeuron !== null
+          ? getSnsNeuronHotkeyPermissionsFor({
+              neuron: reloadedNeuron,
+              principal: hotkey,
+            })
+          : [];
+      if (remaining.length > 0) {
+        toastsError({
+          labelKey: "error__sns.sns_remove_hotkey_incomplete",
+        });
+      }
     }
     stopBusy("remove-sns-hotkey-neuron");
   };
@@ -111,7 +144,7 @@
           />
         {/if}
       </div>
-      {#if hotkeys.length === 0}
+      {#if rows.length === 0}
         {#if canManageHotkeys}
           <div class="warning">
             <span class="icon"><IconWarning size={ICON_SIZE_LARGE} /></span>
@@ -122,14 +155,24 @@
         {/if}
       {:else}
         <ul>
-          {#each hotkeys as hotkey (hotkey)}
+          {#each rows as { principal, complete } (principal)}
             <li data-tid="hotkey-row">
-              <Value testId="hotkey-principal">{hotkey}</Value>
+              <div class="principal">
+                <Value testId="hotkey-principal">{principal}</Value>
+                {#if !complete}
+                  <p
+                    class="partial-permissions"
+                    data-tid="partial-hotkey-warning"
+                  >
+                    {$i18n.sns_neuron_detail.partial_hotkey_warning}
+                  </p>
+                {/if}
+              </div>
               {#if canManageHotkeys}
                 <button
                   class="text"
                   aria-label={$i18n.core.remove}
-                  on:click={() => maybeRemove(hotkey)}
+                  on:click={() => maybeRemove(principal)}
                   data-tid="remove-hotkey-button"
                   ><IconClose size="18px" /></button
                 >
@@ -194,6 +237,19 @@
     button {
       display: flex;
     }
+  }
+
+  .principal {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-0_5x);
+    min-width: 0;
+  }
+
+  .partial-permissions {
+    margin: 0;
+    color: var(--warning-emphasis);
+    font-size: var(--font-size-small);
   }
 
   .actions {

--- a/frontend/src/lib/constants/sns-neurons.constants.ts
+++ b/frontend/src/lib/constants/sns-neurons.constants.ts
@@ -12,6 +12,13 @@ export const MANAGE_HOTKEY_PERMISSIONS = [
   // gives permission for all actions
   SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_PRINCIPALS,
 ];
+// The permissions that a hotkey can hold.
+// `ManageVotingPermission` lets a principal grant `Vote` and `SubmitProposal`
+// back to itself. The remove flow must revoke all of these permissions.
+export const HOTKEY_REVOCABLE_PERMISSIONS = [
+  ...HOTKEY_PERMISSIONS,
+  SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+];
 
 export const UNSPECIFIED_FUNCTION_ID = 0n;
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1058,7 +1058,8 @@
   "sns_neuron_detail": {
     "vesting_period_tooltip": "This function is not available during your vesting period. Vesting will last another $remainingVesting",
     "add_hotkey_info": "To vote with this neuron from another dapp, add the principal id you have in the other dapp as a hotkey.",
-    "add_hotkey_tooltip": "To vote with this neuron from another dapp, add the principal id you have in the other dapp as a hotkey."
+    "add_hotkey_tooltip": "To vote with this neuron from another dapp, add the principal id you have in the other dapp as a hotkey.",
+    "partial_hotkey_warning": "This principal keeps some voting permissions. Remove it to revoke them."
   },
   "sns_neurons": {
     "text": "You have no $project neurons. Create a neuron by staking $tokenSymbol to vote on $project proposals.",
@@ -1168,6 +1169,7 @@
     "load_sale_total_commitments": "There was an unexpected error while loading the commitments of the project.",
     "load_sale_lifecycle": "There was an unexpected error while loading the status of the project.",
     "sns_remove_hotkey": "There was an error removing the hotkey.",
+    "sns_remove_hotkey_incomplete": "The hotkey keeps some permissions on the neuron. Try again to remove them.",
     "sns_split_neuron": "There was an error while splitting the neuron.",
     "sns_disburse": "There was an error while disbursing the neuron.",
     "sns_start_dissolving": "There was an error while starting dissolving the neuron.",

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -27,6 +27,7 @@
   import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
   import { refreshNeuronIfNeeded } from "$lib/services/sns-neurons-check-balances.services";
   import { getSnsNeuron } from "$lib/services/sns-neurons.services";
+  import type { QueryAndUpdateStrategy } from "$lib/services/utils.services";
   import { queuedStore } from "$lib/stores/queued-store";
   import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
   import { toastsError } from "$lib/stores/toasts.store";
@@ -59,7 +60,8 @@
 
   setContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY, {
     store: selectedSnsNeuronStore,
-    reload: () => loadNeuron({ forceFetch: true }),
+    reload: ({ strategy }: { strategy?: QueryAndUpdateStrategy } = {}) =>
+      loadNeuron({ forceFetch: true, strategy }),
   });
 
   // BEGIN: loading and navigation
@@ -87,15 +89,20 @@
   $: governanceCanisterId =
     $selectedUniverseStore.summary?.governanceCanisterId;
 
-  const loadNeuron = async (
-    { forceFetch }: { forceFetch: boolean } = { forceFetch: false }
-  ) => {
+  const loadNeuron = async ({
+    forceFetch = false,
+    strategy,
+  }: {
+    forceFetch?: boolean;
+    strategy?: QueryAndUpdateStrategy;
+  } = {}) => {
     const { selected } = $selectedSnsNeuronStore;
     if (selected !== undefined && $pageStore.path === AppPath.Neuron) {
       const mutableSnsNeuronStore =
         selectedSnsNeuronStore.getSingleMutationStore();
       await getSnsNeuron({
         forceFetch,
+        strategy,
         rootCanisterId: selected.rootCanisterId,
         neuronIdHex: selected.neuronIdHex,
         onLoad: ({

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -44,6 +44,7 @@ import {
   getSnsDissolvingTimeInSeconds,
   getSnsLockedTimeInSeconds,
   getSnsNeuronByHexId,
+  getSnsNeuronHotkeyPermissionsFor,
   hasAutoStakeMaturityOn,
   isEnoughAmountToSplit,
   nextMemo,
@@ -245,20 +246,35 @@ export const addHotkey = async ({
   }
 };
 
+/**
+ * Removes every hotkey permission that the principal holds on the neuron.
+ *
+ * The call revokes `ManageVotingPermission` as well as `Vote` and
+ * `SubmitProposal`. A principal that keeps `ManageVotingPermission` can grant
+ * the other permissions back to itself.
+ */
 export const removeHotkey = async ({
-  neuronId,
+  neuron,
   hotkey,
   rootCanisterId,
 }: {
-  neuronId: SnsGovernanceDid.NeuronId;
+  neuron: SnsGovernanceDid.Neuron;
   hotkey: string;
   rootCanisterId: Principal;
 }): Promise<{ success: boolean }> => {
   try {
+    const neuronId = fromDefinedNullable(neuron.id);
+    const permissions = getSnsNeuronHotkeyPermissionsFor({
+      neuron,
+      principal: hotkey,
+    });
+    if (permissions.length === 0) {
+      return { success: true };
+    }
     const identity = await getSnsNeuronIdentity();
     const principal = Principal.fromText(hotkey);
     await removeNeuronPermissions({
-      permissions: HOTKEY_PERMISSIONS,
+      permissions,
       identity,
       principal,
       rootCanisterId,

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -28,7 +28,10 @@ import { snsTokensByRootCanisterIdStore } from "$lib/derived/sns/sns-tokens.deri
 import { loadActionableProposalsForSns } from "$lib/services/actionable-sns-proposals.services";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
-import { queryAndUpdate } from "$lib/services/utils.services";
+import {
+  queryAndUpdate,
+  type QueryAndUpdateStrategy,
+} from "$lib/services/utils.services";
 import {
   snsNeuronsStore,
   type ProjectNeuronStore,
@@ -157,16 +160,32 @@ const getNeuronFromStoreByIdHex = ({
   };
 };
 
+/**
+ * Loads one SNS neuron and calls `onLoad` for each response.
+ *
+ * `strategy` selects the calls to make. The default makes a query call and an
+ * update call. The returned promise then settles on the first response, which
+ * is normally the query response. A query response is not certified. One
+ * replica can forge it, and it can also show the neuron from before a recent
+ * change.
+ *
+ * `"update"` makes only the update call, so the returned promise settles on
+ * the certified response. A caller that makes a security decision from the
+ * neuron must use `"update"`. Such a caller also skips the neuron in the
+ * store, because the store can hold a query response.
+ */
 export const getSnsNeuron = async ({
   neuronIdHex,
   rootCanisterId,
   forceFetch = false,
+  strategy,
   onLoad,
   onError,
 }: {
   neuronIdHex: string;
   rootCanisterId: Principal;
   forceFetch?: boolean;
+  strategy?: QueryAndUpdateStrategy;
   onLoad: ({
     certified,
     neuron,
@@ -182,7 +201,7 @@ export const getSnsNeuron = async ({
     error: unknown;
   }) => void;
 }): Promise<void> => {
-  if (!forceFetch) {
+  if (!forceFetch && strategy !== "update") {
     const { neuron, certified } = getNeuronFromStoreByIdHex({
       neuronIdHex,
       rootCanisterId,
@@ -210,6 +229,7 @@ export const getSnsNeuron = async ({
     onError: ({ certified, error }) => {
       onError?.({ certified, error });
     },
+    strategy,
     logMessage: `Getting Sns Neuron ${neuronIdHex}`,
   });
 };

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1099,6 +1099,7 @@ interface I18nSns_neuron_detail {
   vesting_period_tooltip: string;
   add_hotkey_info: string;
   add_hotkey_tooltip: string;
+  partial_hotkey_warning: string;
 }
 
 interface I18nSns_neurons {
@@ -1219,6 +1220,7 @@ interface I18nError__sns {
   load_sale_total_commitments: string;
   load_sale_lifecycle: string;
   sns_remove_hotkey: string;
+  sns_remove_hotkey_incomplete: string;
   sns_split_neuron: string;
   sns_disburse: string;
   sns_start_dissolving: string;

--- a/frontend/src/lib/types/sns-neuron-detail.context.ts
+++ b/frontend/src/lib/types/sns-neuron-detail.context.ts
@@ -1,3 +1,4 @@
+import type { QueryAndUpdateStrategy } from "$lib/services/utils.services";
 import type { SnsGovernanceDid } from "@icp-sdk/canisters/sns";
 import type { Principal } from "@icp-sdk/core/principal";
 import type { Readable } from "svelte/store";
@@ -20,7 +21,15 @@ export interface SelectedSnsNeuronStore {
 
 export interface SelectedSnsNeuronContext {
   store: Readable<SelectedSnsNeuronStore>;
-  reload: () => Promise<void>;
+  /**
+   * Loads the neuron again and writes it to the store.
+   *
+   * `strategy` selects the calls to make. The default settles on the query
+   * response, which is not certified. `"update"` settles on the certified
+   * response. A caller that makes a security decision from the neuron must
+   * pass `"update"`.
+   */
+  reload: (params?: { strategy?: QueryAndUpdateStrategy }) => Promise<void>;
 }
 
 export const SELECTED_SNS_NEURON_CONTEXT_KEY = Symbol("selected-sns-neuron");

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -499,18 +499,19 @@ export const getSnsNeuronPartialHotkeys = (
   return [...principals]
     .filter((principal) => !hotkeys.has(principal))
     .filter((principal) => {
-      const principalPermissions = getSnsNeuronPermissionsFor({
-        neuron,
-        principal,
-      });
+      const principalPermissions = new Set(
+        getSnsNeuronPermissionsFor({ neuron, principal })
+      );
       if (
-        principalPermissions.includes(
+        principalPermissions.has(
           SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_PRINCIPALS
         )
       ) {
         return false;
       }
-      return getSnsNeuronHotkeyPermissionsFor({ neuron, principal }).length > 0;
+      return HOTKEY_REVOCABLE_PERMISSIONS.some((permission) =>
+        principalPermissions.has(permission)
+      );
     });
 };
 

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -1,6 +1,7 @@
 import { SNS_MATURITY_MODULATION_WORST_CASE_FACTOR } from "$lib/constants/neurons.constants";
 import {
   HOTKEY_PERMISSIONS,
+  HOTKEY_REVOCABLE_PERMISSIONS,
   MANAGE_HOTKEY_PERMISSIONS,
   MAX_NEURONS_SUBACCOUNTS,
 } from "$lib/constants/sns-neurons.constants";
@@ -418,6 +419,99 @@ export const getSnsNeuronHotkeys = ({
     })
     .map(({ principal }) => fromNullable(principal)?.toText())
     .filter(nonNullish);
+};
+
+/**
+ * Returns the permissions that a principal holds on a neuron.
+ *
+ * @param {Object} params
+ * @param {SnsNeuron} params.neuron
+ * @param {string} params.principal the principal as text
+ * @returns {SnsNeuronPermissionType[]} the permissions of the principal
+ */
+export const getSnsNeuronPermissionsFor = ({
+  neuron: { permissions },
+  principal,
+}: {
+  neuron: SnsGovernanceDid.Neuron;
+  principal: string;
+}): SnsNeuronPermissionType[] => [
+  // A neuron can hold more than one entry for the same principal.
+  // The principal holds the union of those permissions.
+  ...new Set(
+    permissions
+      .filter(
+        ({ principal: entryPrincipal }) =>
+          fromNullable(entryPrincipal)?.toText() === principal
+      )
+      .flatMap(({ permission_type }) => Array.from(permission_type))
+  ),
+];
+
+/**
+ * Returns the hotkey permissions that a principal still holds on a neuron.
+ *
+ * The remove flow must revoke every one of these permissions. A principal that
+ * keeps `ManageVotingPermission` can grant `Vote` and `SubmitProposal` back to
+ * itself.
+ *
+ * @param {Object} params
+ * @param {SnsNeuron} params.neuron
+ * @param {string} params.principal the principal as text
+ * @returns {SnsNeuronPermissionType[]} the hotkey permissions of the principal
+ */
+export const getSnsNeuronHotkeyPermissionsFor = ({
+  neuron,
+  principal,
+}: {
+  neuron: SnsGovernanceDid.Neuron;
+  principal: string;
+}): SnsNeuronPermissionType[] => {
+  const principalPermissions = new Set(
+    getSnsNeuronPermissionsFor({ neuron, principal })
+  );
+  return HOTKEY_REVOCABLE_PERMISSIONS.filter((permission) =>
+    principalPermissions.has(permission)
+  );
+};
+
+/**
+ * Returns the principals that hold some, but not all, of the hotkey
+ * permissions.
+ *
+ * `getSnsNeuronHotkeys` returns only the exact hotkey permission combinations.
+ * A principal with a partial combination keeps power over the neuron, so the
+ * UI must still show it. A principal with `ManagePrincipals` controls the
+ * neuron and is not a hotkey.
+ *
+ * @param {SnsNeuron} neuron
+ * @returns {string[]} principals with partial hotkey permissions
+ */
+export const getSnsNeuronPartialHotkeys = (
+  neuron: SnsGovernanceDid.Neuron
+): string[] => {
+  const hotkeys = new Set(getSnsNeuronHotkeys(neuron));
+  const principals = new Set(
+    neuron.permissions
+      .map(({ principal }) => fromNullable(principal)?.toText())
+      .filter(nonNullish)
+  );
+  return [...principals]
+    .filter((principal) => !hotkeys.has(principal))
+    .filter((principal) => {
+      const principalPermissions = getSnsNeuronPermissionsFor({
+        neuron,
+        principal,
+      });
+      if (
+        principalPermissions.includes(
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_PRINCIPALS
+        )
+      ) {
+        return false;
+      }
+      return getSnsNeuronHotkeyPermissionsFor({ neuron, principal }).length > 0;
+    });
 };
 
 export const isUserHotkey = ({

--- a/frontend/src/tests/e2e/sns-hotkey-revocation.spec.ts
+++ b/frontend/src/tests/e2e/sns-hotkey-revocation.spec.ts
@@ -7,17 +7,26 @@ import {
 } from "$tests/utils/e2e.test-utils";
 import { expect, test, type Page } from "@playwright/test";
 
-// NOT RUN YET. The local dfx replica is broken and a human must restore it.
-//
 // This spec proves that the removal of an SNS hotkey revokes every voting
 // permission. The old code revoked only `Vote` and `SubmitProposal`. A hotkey
 // that also held `ManageVotingPermission` kept that permission, vanished from
 // the hotkey list, and could grant the other permissions back to itself.
 //
-// The test SNS must allow `ManageVotingPermission` in
-// `neuron_grantable_permissions`. If it does not, the governance canister
-// rejects the grant in "Grant ManageVotingPermission to the hotkey" and the
-// test fails in that step.
+// The spec is `test.fixme`, so Playwright skips it in CI. Nobody has run it
+// yet, because the local dfx replica is broken. A human must run it once, fix
+// what the first run shows, and then remove the `fixme`.
+//
+// Four things are still unproven.
+//
+// 1. The test SNS must allow `ManageVotingPermission` in
+//    `neuron_grantable_permissions`. If it does not, the governance canister
+//    rejects the grant in "Grant ManageVotingPermission to the hotkey".
+// 2. `grantPermissions` clicks the checkbox input of the TESTNET modal by its
+//    id. A label may cover that input.
+// 3. `permissionsOf` reads the TESTNET permissions card through an XPath
+//    sibling, because that card has no test id of its own.
+// 4. The toast assertions read the toast list once. A toast from an earlier
+//    step may still be on screen.
 
 // The numbers are the values of `SnsNeuronPermissionType`.
 const SUBMIT_PROPOSAL = 3;
@@ -92,7 +101,7 @@ const grantPermissions = async ({
   await page.getByRole("button", { name: "Confirm" }).click();
 };
 
-test("Test SNS hotkey revocation", async ({ page, context }) => {
+test.fixme("Test SNS hotkey revocation", async ({ page, context }) => {
   await page.goto("/tokens");
   await disableCssAnimations(page);
   await signInWithNewUser({ page, context });

--- a/frontend/src/tests/e2e/sns-hotkey-revocation.spec.ts
+++ b/frontend/src/tests/e2e/sns-hotkey-revocation.spec.ts
@@ -1,0 +1,191 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test, type Page } from "@playwright/test";
+
+// NOT RUN YET. The local dfx replica is broken and a human must restore it.
+//
+// This spec proves that the removal of an SNS hotkey revokes every voting
+// permission. The old code revoked only `Vote` and `SubmitProposal`. A hotkey
+// that also held `ManageVotingPermission` kept that permission, vanished from
+// the hotkey list, and could grant the other permissions back to itself.
+//
+// The test SNS must allow `ManageVotingPermission` in
+// `neuron_grantable_permissions`. If it does not, the governance canister
+// rejects the grant in "Grant ManageVotingPermission to the hotkey" and the
+// test fails in that step.
+
+// The numbers are the values of `SnsNeuronPermissionType`.
+const SUBMIT_PROPOSAL = 3;
+const VOTE = 4;
+const MANAGE_VOTING_PERMISSION = 10;
+const ALL_PERMISSIONS = [
+  0,
+  1,
+  2,
+  SUBMIT_PROPOSAL,
+  VOTE,
+  5,
+  6,
+  7,
+  8,
+  9,
+  MANAGE_VOTING_PERMISSION,
+];
+
+// The permissions card shows a principal through `Hash`, which shortens the
+// text. `shortenWithMiddleEllipsis` keeps 7 characters on each side.
+const shorten = (principal: string): string =>
+  `${principal.slice(0, 7)}...${principal.slice(-7)}`;
+
+// Reads the TESTNET permissions card, which lists every permission entry of
+// the neuron. The hotkey card cannot prove a revocation on its own: the bug
+// was that a principal with a residual permission disappeared from it.
+const permissionsOf = async ({
+  page,
+  principal,
+}: {
+  page: Page;
+  principal: string;
+}): Promise<string[]> => {
+  const title = page
+    .locator('[data-tid="hash-component"]')
+    .filter({ hasText: shorten(principal) });
+  if ((await title.count()) === 0) {
+    return [];
+  }
+  return title
+    .first()
+    .locator("xpath=following-sibling::ul[1]")
+    .locator("li")
+    .allTextContents();
+};
+
+// Grants permissions with the TESTNET permissions card. The dapp has no other
+// way to create a principal with `ManageVotingPermission`.
+const grantPermissions = async ({
+  page,
+  principal,
+  permissions,
+}: {
+  page: Page;
+  principal: string;
+  permissions: number[];
+}): Promise<void> => {
+  await page.getByRole("button", { name: "Add Permissions" }).click();
+
+  const form = page.getByTestId("add-principal-component");
+  await form.locator('input[name="principal"]').fill(principal);
+  await form.getByTestId("add-principal-button").click();
+
+  // The modal checks every permission by default.
+  for (const permission of ALL_PERMISSIONS) {
+    if (!permissions.includes(permission)) {
+      await page.locator(`input[id="${permission}"]`).click();
+    }
+  }
+
+  await page.getByRole("button", { name: "Confirm" }).click();
+};
+
+test("Test SNS hotkey revocation", async ({ page, context }) => {
+  await page.goto("/tokens");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  step("Acquire tokens");
+  // "Alfa Centauri" is the test SNS project configured with a faucet.
+  const snsProjectName = "Alfa Centauri";
+  await appPo.getSnsTokens({ amount: 20, name: snsProjectName });
+
+  step("Stake a neuron");
+  await appPo.goToStaking();
+  await appPo.getStakingPo().stakeFirstSnsNeuron({
+    projectName: snsProjectName,
+    amount: 5,
+  });
+
+  step("Open the neuron detail page");
+  await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();
+  const neuronRows = await appPo
+    .getNeuronsPo()
+    .getSnsNeuronsPo()
+    .getNeuronsTablePo()
+    .getNeuronsTableRowPos();
+  expect(neuronRows).toHaveLength(1);
+  await neuronRows[0].click();
+
+  const neuronDetail = appPo.getNeuronDetailPo().getSnsNeuronDetailPo();
+  expect(await neuronDetail.getUniverse()).toBe(snsProjectName);
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([]);
+
+  const hotkeyPrincipal =
+    "dskxv-lqp33-5g7ev-qesdj-fwwkb-3eze4-6tlur-42rxy-n4gag-6t4a3-tae";
+
+  step("Add a hotkey");
+  await neuronDetail.addHotkey(hotkeyPrincipal);
+  await appPo.waitForNotBusy();
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
+
+  step("Grant ManageVotingPermission to the hotkey");
+  await grantPermissions({
+    page,
+    principal: hotkeyPrincipal,
+    permissions: [MANAGE_VOTING_PERMISSION],
+  });
+  await appPo.waitForNotBusy();
+
+  // This is the permission set of a Community Fund hotkey.
+  expect(await permissionsOf({ page, principal: hotkeyPrincipal })).toEqual(
+    expect.arrayContaining([
+      "NEURON_PERMISSION_TYPE_VOTE",
+      "NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL",
+      "NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION",
+    ])
+  );
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
+
+  step("Remove the hotkey");
+  await neuronDetail.removeHotkey(hotkeyPrincipal);
+  await appPo.waitForNotBusy();
+
+  step("The removed hotkey keeps no permission");
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([]);
+  // The old code left `NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION` here.
+  expect(await permissionsOf({ page, principal: hotkeyPrincipal })).toEqual([]);
+  // The success is real, so the card shows no error.
+  expect(await appPo.getToastsPo().getMessages()).toEqual([]);
+
+  const partialPrincipal =
+    "ucmt2-grxhb-qutyd-sp76m-amcvp-3h6sr-lqnoj-fik7c-bbcc3-irpdn-oae";
+
+  step("Grant only Vote to a second principal");
+  await grantPermissions({
+    page,
+    principal: partialPrincipal,
+    permissions: [VOTE],
+  });
+  await appPo.waitForNotBusy();
+
+  step("The card shows the principal with a warning");
+  // The principal holds a partial hotkey permission set. It keeps power over
+  // the neuron, so the card must not hide it.
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([partialPrincipal]);
+  expect(await page.getByTestId("partial-hotkey-warning").count()).toBe(1);
+
+  step("The user can remove the partial hotkey");
+  await neuronDetail.removeHotkey(partialPrincipal);
+  await appPo.waitForNotBusy();
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([]);
+  expect(await permissionsOf({ page, principal: partialPrincipal })).toEqual(
+    []
+  );
+  expect(await appPo.getToastsPo().getMessages()).toEqual([]);
+});

--- a/frontend/src/tests/lib/components/neuron-detail/SnsPermissionsCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/SnsPermissionsCard.spec.ts
@@ -1,0 +1,112 @@
+import SnsPermissionsCard from "$lib/components/neuron-detail/SnsPermissionsCard.svelte";
+import type { SelectedSnsNeuronStore } from "$lib/types/sns-neuron-detail.context";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
+import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import {
+  SnsNeuronPermissionType,
+  type SnsGovernanceDid,
+} from "@icp-sdk/canisters/sns";
+import { Principal } from "@icp-sdk/core/principal";
+import { writable } from "svelte/store";
+
+describe("SnsPermissionsCard", () => {
+  const hotkey =
+    "djzvl-qx6kb-xyrob-rl5ki-elr7y-ywu43-l54d7-ukgzw-qadse-j6oml-5qe";
+
+  const permissionsFor = (
+    permissions: SnsNeuronPermissionType[]
+  ): SnsGovernanceDid.NeuronPermission => ({
+    principal: [Principal.fromText(hotkey)] as [Principal],
+    permission_type: Int32Array.from(permissions),
+  });
+
+  const neuronWith = (
+    permissions: SnsNeuronPermissionType[]
+  ): SnsGovernanceDid.Neuron => ({
+    ...mockSnsNeuron,
+    permissions: [permissionsFor(permissions)],
+  });
+
+  const hotkeyPermissions = [
+    SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+    SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
+  ];
+
+  // The card renders one `TagsList` for each permission entry of the neuron.
+  // Each list holds one tag for each permission of that principal.
+  const renderedPermissions = (container: HTMLElement): string[][] =>
+    Array.from(
+      container.querySelectorAll('ul[aria-labelledby="permissions"]')
+    ).map((list) =>
+      Array.from(list.querySelectorAll("li")).map((tag) =>
+        tag.textContent.trim()
+      )
+    );
+
+  const renderCard = (neuron: SnsGovernanceDid.Neuron) => {
+    const store = writable<SelectedSnsNeuronStore>({
+      selected: {
+        neuronIdHex: getSnsNeuronIdAsHexString(neuron),
+        rootCanisterId: rootCanisterIdMock,
+      },
+      neuron,
+    });
+    const { container } = renderSelectedSnsNeuronContext({
+      Component: SnsPermissionsCard,
+      neuron,
+      reload: vi.fn(),
+      store,
+    });
+    return { container, store };
+  };
+
+  it("renders the permissions of the neuron", () => {
+    const { container } = renderCard(neuronWith(hotkeyPermissions));
+
+    expect(renderedPermissions(container)).toEqual([
+      ["NEURON_PERMISSION_TYPE_VOTE", "NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL"],
+    ]);
+  });
+
+  it("updates when the store gets a new neuron", async () => {
+    const { container, store } = renderCard(neuronWith(hotkeyPermissions));
+
+    expect(renderedPermissions(container)).toEqual([
+      ["NEURON_PERMISSION_TYPE_VOTE", "NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL"],
+    ]);
+
+    store.update((value) => ({
+      ...value,
+      neuron: neuronWith([
+        ...hotkeyPermissions,
+        SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+      ]),
+    }));
+    await runResolvedPromises();
+
+    expect(renderedPermissions(container)).toEqual([
+      [
+        "NEURON_PERMISSION_TYPE_VOTE",
+        "NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL",
+        "NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION",
+      ],
+    ]);
+  });
+
+  it("drops a principal that the new neuron no longer holds", async () => {
+    const { container, store } = renderCard(neuronWith(hotkeyPermissions));
+
+    expect(renderedPermissions(container)).toHaveLength(1);
+
+    store.update((value) => ({
+      ...value,
+      neuron: { ...mockSnsNeuron, permissions: [] },
+    }));
+    await runResolvedPromises();
+
+    expect(renderedPermissions(container)).toEqual([]);
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -2,6 +2,7 @@ import SnsNeuronHotkeysCard from "$lib/components/sns-neuron-detail/SnsNeuronHot
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { removeHotkey } from "$lib/services/sns-neurons.services";
+import * as toastsStore from "$lib/stores/toasts.store";
 import { enumValues } from "$lib/utils/enum.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
@@ -102,7 +103,64 @@ describe("SnsNeuronHotkeysCard", () => {
     fireEvent.click(removeButtons[0]);
 
     await waitFor(() => expect(reload).toBeCalledWith());
-    expect(removeHotkey).toBeCalled();
+    expect(removeHotkey).toBeCalledWith({
+      neuron: controlledNeuron,
+      hotkey: hotkeys[0],
+      rootCanisterId: expect.anything(),
+    });
+  });
+
+  it("lists a principal that keeps only ManageVotingPermission", () => {
+    const partialPrincipal = hotkeys[0];
+    const neuron: SnsGovernanceDid.Neuron = {
+      ...mockSnsNeuron,
+      permissions: [
+        {
+          principal: [Principal.fromText(partialPrincipal)] as [Principal],
+          permission_type: Int32Array.from([
+            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+          ]),
+        },
+        {
+          principal: [mockIdentity.getPrincipal()],
+          permission_type: Int32Array.from(enumValues(SnsNeuronPermissionType)),
+        },
+      ],
+    };
+    const { queryByText, queryByTestId } = renderCard(neuron);
+
+    expect(queryByText(partialPrincipal)).toBeInTheDocument();
+    expect(queryByTestId("partial-hotkey-warning")).toBeInTheDocument();
+    expect(queryByTestId("partial-hotkey-warning").textContent.trim()).toBe(
+      en.sns_neuron_detail.partial_hotkey_warning
+    );
+  });
+
+  it("does not warn for a complete hotkey", () => {
+    const { queryByTestId } = renderCard(controlledNeuron);
+
+    expect(queryByTestId("partial-hotkey-warning")).toBeNull();
+  });
+
+  it("does not list the neuron controller as a partial hotkey", () => {
+    const { queryByText } = renderCard(controlledNeuron);
+
+    expect(queryByText(mockIdentity.getPrincipal().toText())).toBeNull();
+  });
+
+  it("shows an error when the removal leaves permissions behind", async () => {
+    const spyToastsError = vi.spyOn(toastsStore, "toastsError");
+    const { queryAllByTestId } = renderCard(controlledNeuron);
+
+    const removeButtons = queryAllByTestId("remove-hotkey-button");
+    fireEvent.click(removeButtons[0]);
+
+    // `reload` is mocked, so the neuron in the store still has the
+    // permissions. The card must report the incomplete removal.
+    await waitFor(() => expect(spyToastsError).toBeCalledTimes(1));
+    expect(spyToastsError).toBeCalledWith({
+      labelKey: "error__sns.sns_remove_hotkey_incomplete",
+    });
   });
 
   it("shows confirmation modal if hotkey is the current user", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -3,7 +3,9 @@ import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import * as snsNeuronsServices from "$lib/services/sns-neurons.services";
 import { removeHotkey } from "$lib/services/sns-neurons.services";
 import * as toastsStore from "$lib/stores/toasts.store";
+import type { SelectedSnsNeuronStore } from "$lib/types/sns-neuron-detail.context";
 import { enumValues } from "$lib/utils/enum.utils";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -11,12 +13,15 @@ import {
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import {
   SnsNeuronPermissionType,
   type SnsGovernanceDid,
 } from "@icp-sdk/canisters/sns";
 import { Principal } from "@icp-sdk/core/principal";
 import { fireEvent, waitFor } from "@testing-library/svelte";
+import { writable } from "svelte/store";
 
 describe("SnsNeuronHotkeysCard", () => {
   const addHotkeyPermissions = (key) => ({
@@ -47,22 +52,62 @@ describe("SnsNeuronHotkeysCard", () => {
   };
 
   const reload = vi.fn();
+  const props = {
+    parameters: {
+      ...snsNervousSystemParametersMock,
+      neuron_grantable_permissions: [
+        {
+          permissions: Int32Array.from(HOTKEY_PERMISSIONS),
+        },
+      ],
+    },
+  };
   const renderCard = (neuron: SnsGovernanceDid.Neuron) =>
     renderSelectedSnsNeuronContext({
       reload,
       Component: SnsNeuronHotkeysCard,
       neuron,
-      props: {
-        parameters: {
-          ...snsNervousSystemParametersMock,
-          neuron_grantable_permissions: [
-            {
-              permissions: Int32Array.from(HOTKEY_PERMISSIONS),
-            },
-          ],
-        },
-      },
+      props,
     });
+
+  // The reload writes `reloadedNeuron` to the store. The card reads the store
+  // after the reload to check the removal.
+  const renderCardWithReload = ({
+    neuron,
+    reloadedNeuron,
+  }: {
+    neuron: SnsGovernanceDid.Neuron;
+    reloadedNeuron: SnsGovernanceDid.Neuron;
+  }) => {
+    const store = writable<SelectedSnsNeuronStore>({
+      selected: {
+        neuronIdHex: getSnsNeuronIdAsHexString(neuron),
+        rootCanisterId: rootCanisterIdMock,
+      },
+      neuron,
+    });
+    const reloadWithStore = vi.fn().mockImplementation(async () => {
+      store.update((value) => ({ ...value, neuron: reloadedNeuron }));
+    });
+    return renderSelectedSnsNeuronContext({
+      reload: reloadWithStore,
+      store,
+      Component: SnsNeuronHotkeysCard,
+      neuron,
+      props,
+    });
+  };
+
+  const permissionsFor = ({
+    principal,
+    permissions,
+  }: {
+    principal: string;
+    permissions: SnsNeuronPermissionType[];
+  }) => ({
+    principal: [Principal.fromText(principal)] as [Principal],
+    permission_type: Int32Array.from(permissions),
+  });
 
   beforeEach(() => {
     resetIdentity();
@@ -96,13 +141,15 @@ describe("SnsNeuronHotkeysCard", () => {
     expect(queryByText(hotkeys[1])).toBeInTheDocument();
   });
 
-  it("can remove a hotkey and reload neuron", async () => {
+  it("can remove a hotkey and reload neuron with the update strategy", async () => {
     const { queryAllByTestId } = renderCard(controlledNeuron);
 
     const removeButtons = queryAllByTestId("remove-hotkey-button");
     fireEvent.click(removeButtons[0]);
 
-    await waitFor(() => expect(reload).toBeCalledWith());
+    // Only the "update" strategy settles on the certified response. The card
+    // checks the removal against that response.
+    await waitFor(() => expect(reload).toBeCalledWith({ strategy: "update" }));
     expect(removeHotkey).toBeCalledWith({
       neuron: controlledNeuron,
       hotkey: hotkeys[0],
@@ -163,6 +210,31 @@ describe("SnsNeuronHotkeysCard", () => {
     });
   });
 
+  it("shows no error when the removal revokes every permission", async () => {
+    const spyToastsError = vi.spyOn(toastsStore, "toastsError");
+    const cleanNeuron: SnsGovernanceDid.Neuron = {
+      ...controlledNeuron,
+      permissions: [
+        {
+          principal: [mockIdentity.getPrincipal()],
+          permission_type: Int32Array.from(enumValues(SnsNeuronPermissionType)),
+        },
+      ],
+    };
+    const { queryAllByTestId } = renderCardWithReload({
+      neuron: controlledNeuron,
+      reloadedNeuron: cleanNeuron,
+    });
+
+    const removeButtons = queryAllByTestId("remove-hotkey-button");
+    fireEvent.click(removeButtons[0]);
+
+    await waitFor(() => expect(removeHotkey).toBeCalled());
+    await runResolvedPromises();
+
+    expect(spyToastsError).not.toBeCalled();
+  });
+
   it("shows confirmation modal if hotkey is the current user", async () => {
     const hotkeyNeuron: SnsGovernanceDid.Neuron = {
       ...mockSnsNeuron,
@@ -184,5 +256,89 @@ describe("SnsNeuronHotkeysCard", () => {
     confirmButton && fireEvent.click(confirmButton);
 
     await waitFor(() => expect(removeHotkey).toBeCalled());
+  });
+
+  describe("when the user removes its own hotkey", () => {
+    const currentUser = mockIdentity.getPrincipal().toText();
+    // The user holds the Community Fund combination. It can manage hotkeys and
+    // the card lists it as a hotkey.
+    const selfHotkeyNeuron: SnsGovernanceDid.Neuron = {
+      ...mockSnsNeuron,
+      permissions: [
+        permissionsFor({
+          principal: currentUser,
+          permissions: [
+            ...HOTKEY_PERMISSIONS,
+            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+          ],
+        }),
+      ],
+    };
+
+    const removeOwnHotkey = async ({
+      queryAllByTestId,
+      queryByTestId,
+    }: {
+      queryAllByTestId: (testId: string) => HTMLElement[];
+      queryByTestId: (testId: string) => HTMLElement | null;
+    }) => {
+      const removeButtons = queryAllByTestId("remove-hotkey-button");
+      await fireEvent.click(removeButtons[0]);
+
+      await waitFor(() =>
+        expect(
+          queryByTestId("remove-current-user-hotkey-confirmation")
+        ).toBeInTheDocument()
+      );
+      await fireEvent.click(queryByTestId("confirm-yes"));
+      await waitFor(() => expect(removeHotkey).toBeCalled());
+      await runResolvedPromises();
+    };
+
+    it("shows the success toast when the removal revokes every permission", async () => {
+      const spyToastsShow = vi.spyOn(toastsStore, "toastsShow");
+      const spyToastsError = vi.spyOn(toastsStore, "toastsError");
+      const { queryAllByTestId, queryByTestId } = renderCardWithReload({
+        neuron: selfHotkeyNeuron,
+        reloadedNeuron: { ...selfHotkeyNeuron, permissions: [] },
+      });
+
+      await removeOwnHotkey({ queryAllByTestId, queryByTestId });
+
+      expect(spyToastsShow).toBeCalledWith({
+        level: "success",
+        labelKey: "neurons.remove_hotkey_success",
+      });
+      expect(spyToastsError).not.toBeCalled();
+    });
+
+    it("shows an error and no success when a permission remains", async () => {
+      const spyToastsShow = vi.spyOn(toastsStore, "toastsShow");
+      const spyToastsError = vi.spyOn(toastsStore, "toastsError");
+      // The removal left `ManageVotingPermission` behind. The user can grant
+      // `Vote` and `SubmitProposal` back to itself, so the removal is not
+      // complete.
+      const { queryAllByTestId, queryByTestId } = renderCardWithReload({
+        neuron: selfHotkeyNeuron,
+        reloadedNeuron: {
+          ...selfHotkeyNeuron,
+          permissions: [
+            permissionsFor({
+              principal: currentUser,
+              permissions: [
+                SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+              ],
+            }),
+          ],
+        },
+      });
+
+      await removeOwnHotkey({ queryAllByTestId, queryByTestId });
+
+      expect(spyToastsError).toBeCalledWith({
+        labelKey: "error__sns.sns_remove_hotkey_incomplete",
+      });
+      expect(spyToastsShow).not.toBeCalled();
+    });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -21,6 +21,7 @@ import { page } from "$mocks/$app/stores";
 import * as fakeSnsApi from "$tests/fakes/sns-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   createMockSnsNeuron,
@@ -32,6 +33,7 @@ import { SnsNeuronDetailPo } from "$tests/page-objects/SnsNeuronDetail.page-obje
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { toastsStore } from "@dfinity/gix-components";
 import { fromNullable } from "@dfinity/utils";
 import {
   SnsNeuronPermissionType,
@@ -39,7 +41,7 @@ import {
   type SnsGovernanceDid,
 } from "@icp-sdk/canisters/sns";
 import { Principal } from "@icp-sdk/core/principal";
-import { render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 
@@ -448,15 +450,16 @@ describe("SnsNeuronDetail", () => {
 
       expect(await po.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
 
+      // The later calls answer at once. The certified response from before the
+      // removal stays pending.
+      fakeSnsGovernanceApi.pauseFor(() => false);
+
       await po.removeHotkey(hotkeyPrincipal);
       await runResolvedPromises();
       await tick();
 
       expect(await po.getHotkeyPrincipals()).toEqual([]);
-
-      // Now the certified response for the neuron with hotkey removed is also
-      // pending.
-      expect(fakeSnsGovernanceApi.getPendingCallsCount()).toBe(2);
+      expect(fakeSnsGovernanceApi.getPendingCallsCount()).toBe(1);
 
       // Now we resolve the certified response from before the hotkey was
       // deleted. It should not cause the hotkey to reappear.
@@ -464,6 +467,246 @@ describe("SnsNeuronDetail", () => {
       await runResolvedPromises();
 
       expect(await po.getHotkeyPrincipals()).toEqual([]);
+    });
+
+    describe("post-removal check", () => {
+      // The check must read the certified response. These tests give the query
+      // response and the certified response different contents, and resolve
+      // the certified response strictly after the query response. A check that
+      // reads the query response therefore gives the wrong answer.
+      const neuronWithHotkeyPermissions = (
+        hotkeyPermissions: SnsNeuronPermissionType[]
+      ): SnsGovernanceDid.Neuron => ({
+        ...mockSnsNeuron,
+        id: [validNeuronId],
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from(MANAGE_HOTKEY_PERMISSIONS),
+          },
+          {
+            principal: [Principal.fromText(hotkeyPrincipal)],
+            permission_type: Int32Array.from(hotkeyPermissions),
+          },
+        ],
+      });
+
+      const residualPermissions = [
+        SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+      ];
+
+      let resolveCertified: (neuron: SnsGovernanceDid.Neuron) => void;
+      let getSnsNeuronSpy;
+
+      const renderWithHotkey = async () => {
+        fakeSnsGovernanceApi.addNeuronWith({
+          rootCanisterId,
+          id: [validNeuronId],
+          cached_neuron_stake_e8s: numberToE8s(neuronStake),
+          permissions: [
+            {
+              principal: [mockIdentity.getPrincipal()],
+              permission_type: Int32Array.from(MANAGE_HOTKEY_PERMISSIONS),
+            },
+            {
+              principal: [Principal.fromText(hotkeyPrincipal)],
+              permission_type: Int32Array.from([
+                ...HOTKEY_PERMISSIONS,
+                ...residualPermissions,
+              ]),
+            },
+          ],
+        });
+        return renderComponent(props);
+      };
+
+      const mockResponses = ({
+        queryNeuron,
+      }: {
+        queryNeuron: SnsGovernanceDid.Neuron;
+      }) => {
+        const certifiedNeuron = new Promise<SnsGovernanceDid.Neuron>(
+          (resolve) => {
+            resolveCertified = resolve;
+          }
+        );
+        getSnsNeuronSpy = vi
+          .spyOn(snsGovernanceApi, "getSnsNeuron")
+          .mockImplementation(({ certified }) =>
+            certified ? certifiedNeuron : Promise.resolve(queryNeuron)
+          );
+        // The render made its own calls. The assertions below cover the calls
+        // of the removal only.
+        getSnsNeuronSpy.mockClear();
+      };
+
+      it("reports an incomplete removal that only the certified response shows", async () => {
+        const po = await renderWithHotkey();
+
+        expect(await po.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
+
+        // The query response says the principal keeps nothing. It is a
+        // forgery, or a snapshot from another moment.
+        mockResponses({ queryNeuron: neuronWithHotkeyPermissions([]) });
+
+        await po.removeHotkey(hotkeyPrincipal);
+        await runResolvedPromises();
+
+        // The card makes no query call, and it reports nothing yet.
+        expect(getSnsNeuronSpy).not.toBeCalledWith(
+          expect.objectContaining({ certified: false })
+        );
+        expect(getSnsNeuronSpy).toBeCalledWith(
+          expect.objectContaining({ certified: true })
+        );
+        expect(get(toastsStore)).toEqual([]);
+
+        // The certified response arrives last. It shows the residual grant.
+        resolveCertified(neuronWithHotkeyPermissions(residualPermissions));
+        await runResolvedPromises();
+
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: en.error__sns.sns_remove_hotkey_incomplete,
+          },
+        ]);
+      });
+
+      it("reports no error when only the query response shows a residual grant", async () => {
+        const po = await renderWithHotkey();
+
+        expect(await po.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
+
+        // The query response lags the removal. It still shows the grant.
+        mockResponses({
+          queryNeuron: neuronWithHotkeyPermissions(residualPermissions),
+        });
+
+        await po.removeHotkey(hotkeyPrincipal);
+        await runResolvedPromises();
+
+        expect(get(toastsStore)).toEqual([]);
+
+        // The certified response arrives last. The removal is complete.
+        resolveCertified(neuronWithHotkeyPermissions([]));
+        await runResolvedPromises();
+
+        expect(get(toastsStore)).toEqual([]);
+      });
+    });
+
+    describe("when the user removes its own hotkey", () => {
+      // The user holds the Community Fund combination. It can manage hotkeys
+      // and the card lists it as a hotkey.
+      const currentUser = mockIdentity.getPrincipal().toText();
+      const selfPermissions = [
+        ...HOTKEY_PERMISSIONS,
+        SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+      ];
+
+      const neuronWithSelfPermissions = (
+        permissions: SnsNeuronPermissionType[]
+      ): SnsGovernanceDid.Neuron => ({
+        ...mockSnsNeuron,
+        id: [validNeuronId],
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from(permissions),
+          },
+        ],
+      });
+
+      const renderAndRemoveOwnHotkey = async ({
+        queryNeuron,
+      }: {
+        queryNeuron: SnsGovernanceDid.Neuron;
+      }) => {
+        fakeSnsGovernanceApi.addNeuronWith({
+          rootCanisterId,
+          id: [validNeuronId],
+          cached_neuron_stake_e8s: numberToE8s(neuronStake),
+          permissions: [
+            {
+              principal: [mockIdentity.getPrincipal()],
+              permission_type: Int32Array.from(selfPermissions),
+            },
+          ],
+        });
+        const { container } = render(SnsNeuronDetail, props);
+        await runResolvedPromises();
+        const po = SnsNeuronDetailPo.under(
+          new JestPageObjectElement(container)
+        );
+
+        expect(await po.getHotkeyPrincipals()).toEqual([currentUser]);
+
+        let resolveCertified: (neuron: SnsGovernanceDid.Neuron) => void;
+        const certifiedNeuron = new Promise<SnsGovernanceDid.Neuron>(
+          (resolve) => {
+            resolveCertified = resolve;
+          }
+        );
+        vi.spyOn(snsGovernanceApi, "getSnsNeuron").mockImplementation(
+          ({ certified }) =>
+            certified ? certifiedNeuron : Promise.resolve(queryNeuron)
+        );
+
+        await po.removeHotkey(currentUser);
+        await runResolvedPromises();
+
+        // The user confirms the removal of its own hotkey.
+        await fireEvent.click(
+          container.querySelector('[data-tid="confirm-yes"]')
+        );
+        await runResolvedPromises();
+
+        return { resolveCertified };
+      };
+
+      it("shows no success toast until the certified response arrives", async () => {
+        // The query response says the removal is complete. It is a forgery, or
+        // a snapshot from another moment. The certified response shows the
+        // residual grant.
+        const { resolveCertified } = await renderAndRemoveOwnHotkey({
+          queryNeuron: neuronWithSelfPermissions([]),
+        });
+
+        expect(get(toastsStore)).toEqual([]);
+
+        resolveCertified(
+          neuronWithSelfPermissions([
+            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+          ])
+        );
+        await runResolvedPromises();
+
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: en.error__sns.sns_remove_hotkey_incomplete,
+          },
+        ]);
+      });
+
+      it("shows the success toast when the certified response shows no permission", async () => {
+        const { resolveCertified } = await renderAndRemoveOwnHotkey({
+          queryNeuron: neuronWithSelfPermissions(selfPermissions),
+        });
+
+        expect(get(toastsStore)).toEqual([]);
+
+        resolveCertified(neuronWithSelfPermissions([]));
+        await runResolvedPromises();
+
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "success",
+            text: en.neurons.remove_hotkey_success,
+          },
+        ]);
+      });
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -12,6 +12,7 @@ import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
 import * as checkNeuronsService from "$lib/services/sns-neurons-check-balances.services";
 import { stakingRewardsStore } from "$lib/stores/staking-rewards.store";
 import {
+  getSnsNeuronHotkeyPermissionsFor,
   getSnsNeuronIdAsHexString,
   subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
@@ -332,6 +333,79 @@ describe("SnsNeuronDetail", () => {
       });
       const po = await renderComponent(props);
 
+      expect(await po.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
+
+      await po.removeHotkey(hotkeyPrincipal);
+      await runResolvedPromises();
+      await tick();
+
+      expect(await po.getHotkeyPrincipals()).toEqual([]);
+    });
+
+    it("removes ManageVotingPermission with the hotkey", async () => {
+      fakeSnsGovernanceApi.addNeuronWith({
+        rootCanisterId,
+        id: [validNeuronId],
+        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from(MANAGE_HOTKEY_PERMISSIONS),
+          },
+          {
+            principal: [Principal.fromText(hotkeyPrincipal)],
+            permission_type: Int32Array.from([
+              ...HOTKEY_PERMISSIONS,
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+            ]),
+          },
+        ],
+      });
+      const po = await renderComponent(props);
+
+      expect(await po.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
+
+      await po.removeHotkey(hotkeyPrincipal);
+      await runResolvedPromises();
+      await tick();
+
+      expect(await po.getHotkeyPrincipals()).toEqual([]);
+
+      const neuron = await snsGovernanceApi.getSnsNeuron({
+        identity: mockIdentity,
+        rootCanisterId,
+        neuronId: validNeuronId,
+        certified: true,
+      });
+      expect(
+        getSnsNeuronHotkeyPermissionsFor({
+          neuron,
+          principal: hotkeyPrincipal,
+        })
+      ).toEqual([]);
+    });
+
+    it("keeps a principal with residual permissions in the list", async () => {
+      fakeSnsGovernanceApi.addNeuronWith({
+        rootCanisterId,
+        id: [validNeuronId],
+        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from(MANAGE_HOTKEY_PERMISSIONS),
+          },
+          {
+            principal: [Principal.fromText(hotkeyPrincipal)],
+            permission_type: Int32Array.from([
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+            ]),
+          },
+        ],
+      });
+      const po = await renderComponent(props);
+
+      // The principal keeps power over the neuron, so the card must show it.
       expect(await po.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
 
       await po.removeHotkey(hotkeyPrincipal);

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1,6 +1,9 @@
 import * as governanceApi from "$lib/api/sns-governance.api";
 import * as api from "$lib/api/sns.api";
-import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
+import {
+  HOTKEY_PERMISSIONS,
+  HOTKEY_REVOCABLE_PERMISSIONS,
+} from "$lib/constants/sns-neurons.constants";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
 import * as services from "$lib/services/sns-neurons.services";
@@ -334,24 +337,96 @@ describe("sns-neurons-services", () => {
   });
 
   describe("removeHotkey", () => {
-    it("should call api.addNeuronPermissions", async () => {
-      const spyAdd = vi
+    const hotkey = "aaaaa-aa";
+    const neuronWithHotkeyPermissions = (
+      permissions: SnsNeuronPermissionType[]
+    ): SnsGovernanceDid.Neuron => ({
+      ...mockSnsNeuron,
+      permissions: [
+        {
+          principal: [Principal.fromText(hotkey)] as [Principal],
+          permission_type: Int32Array.from(permissions),
+        },
+      ],
+    });
+
+    it("should call api.removeNeuronPermissions", async () => {
+      const spyRemove = vi
         .spyOn(governanceApi, "removeNeuronPermissions")
         .mockImplementation(() => Promise.resolve());
-      const hotkey = "aaaaa-aa";
       const { success } = await removeHotkey({
-        neuronId: mockSnsNeuron.id[0] as SnsGovernanceDid.NeuronId,
+        neuron: neuronWithHotkeyPermissions(HOTKEY_PERMISSIONS),
         hotkey,
         rootCanisterId: mockPrincipal,
       });
       expect(success).toBeTruthy();
-      expect(spyAdd).toBeCalledWith({
+      expect(spyRemove).toBeCalledWith({
         neuronId: mockSnsNeuron.id[0] as SnsGovernanceDid.NeuronId,
         identity: mockIdentity,
         principal: Principal.fromText(hotkey),
         rootCanisterId: mockPrincipal,
         permissions: HOTKEY_PERMISSIONS,
       });
+    });
+
+    it("should also remove ManageVotingPermission", async () => {
+      const spyRemove = vi
+        .spyOn(governanceApi, "removeNeuronPermissions")
+        .mockImplementation(() => Promise.resolve());
+      const { success } = await removeHotkey({
+        neuron: neuronWithHotkeyPermissions([
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+          ...HOTKEY_PERMISSIONS,
+        ]),
+        hotkey,
+        rootCanisterId: mockPrincipal,
+      });
+      expect(success).toBeTruthy();
+      expect(spyRemove).toBeCalledWith({
+        neuronId: mockSnsNeuron.id[0] as SnsGovernanceDid.NeuronId,
+        identity: mockIdentity,
+        principal: Principal.fromText(hotkey),
+        rootCanisterId: mockPrincipal,
+        permissions: HOTKEY_REVOCABLE_PERMISSIONS,
+      });
+    });
+
+    it("should remove only the permissions that the principal holds", async () => {
+      const spyRemove = vi
+        .spyOn(governanceApi, "removeNeuronPermissions")
+        .mockImplementation(() => Promise.resolve());
+      const { success } = await removeHotkey({
+        neuron: neuronWithHotkeyPermissions([
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+        ]),
+        hotkey,
+        rootCanisterId: mockPrincipal,
+      });
+      expect(success).toBeTruthy();
+      expect(spyRemove).toBeCalledWith({
+        neuronId: mockSnsNeuron.id[0] as SnsGovernanceDid.NeuronId,
+        identity: mockIdentity,
+        principal: Principal.fromText(hotkey),
+        rootCanisterId: mockPrincipal,
+        permissions: [
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+        ],
+      });
+    });
+
+    it("should not call the api when the principal holds no hotkey permission", async () => {
+      const spyRemove = vi
+        .spyOn(governanceApi, "removeNeuronPermissions")
+        .mockImplementation(() => Promise.resolve());
+      const { success } = await removeHotkey({
+        neuron: neuronWithHotkeyPermissions([
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_DISBURSE,
+        ]),
+        hotkey,
+        rootCanisterId: mockPrincipal,
+      });
+      expect(success).toBeTruthy();
+      expect(spyRemove).not.toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "$lib/constants/constants";
 import {
   HOTKEY_PERMISSIONS,
+  HOTKEY_REVOCABLE_PERMISSIONS,
   MANAGE_HOTKEY_PERMISSIONS,
   MAX_NEURONS_SUBACCOUNTS,
 } from "$lib/constants/sns-neurons.constants";
@@ -24,8 +25,10 @@ import {
   getSnsLockedTimeInSeconds,
   getSnsNeuronAvailableMaturity,
   getSnsNeuronByHexId,
+  getSnsNeuronHotkeyPermissionsFor,
   getSnsNeuronHotkeys,
   getSnsNeuronIdAsHexString,
+  getSnsNeuronPartialHotkeys,
   getSnsNeuronStake,
   getSnsNeuronStakedMaturity,
   getSnsNeuronState,
@@ -731,6 +734,171 @@ describe("sns-neuron utils", () => {
       const expectedHotkeys = getSnsNeuronHotkeys(controlledNeuron);
       expect(expectedHotkeys.includes(nonHotkey)).toBe(false);
       expect(expectedHotkeys.includes(hotkey)).toBe(true);
+    });
+  });
+
+  describe("getSnsNeuronHotkeyPermissionsFor", () => {
+    const principal =
+      "djzvl-qx6kb-xyrob-rl5ki-elr7y-ywu43-l54d7-ukgzw-qadse-j6oml-5qe";
+    const neuronWith = (
+      permissions: SnsNeuronPermissionType[]
+    ): SnsGovernanceDid.Neuron => ({
+      ...mockSnsNeuron,
+      permissions: [
+        {
+          principal: [Principal.fromText(principal)] as [Principal],
+          permission_type: Int32Array.from(permissions),
+        },
+      ],
+    });
+
+    it("returns the hotkey permissions of the principal", () => {
+      expect(
+        getSnsNeuronHotkeyPermissionsFor({
+          neuron: neuronWith(HOTKEY_PERMISSIONS),
+          principal,
+        })
+      ).toEqual(HOTKEY_PERMISSIONS);
+    });
+
+    it("returns ManageVotingPermission", () => {
+      expect(
+        getSnsNeuronHotkeyPermissionsFor({
+          neuron: neuronWith([
+            ...HOTKEY_PERMISSIONS,
+            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+          ]),
+          principal,
+        })
+      ).toEqual(HOTKEY_REVOCABLE_PERMISSIONS);
+    });
+
+    it("ignores permissions that are not hotkey permissions", () => {
+      expect(
+        getSnsNeuronHotkeyPermissionsFor({
+          neuron: neuronWith([
+            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_DISBURSE,
+            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+          ]),
+          principal,
+        })
+      ).toEqual([SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE]);
+    });
+
+    it("returns an empty array for an unknown principal", () => {
+      expect(
+        getSnsNeuronHotkeyPermissionsFor({
+          neuron: neuronWith(HOTKEY_PERMISSIONS),
+          principal: mockPrincipal.toText(),
+        })
+      ).toEqual([]);
+    });
+  });
+
+  describe("getSnsNeuronPartialHotkeys", () => {
+    const partial =
+      "djzvl-qx6kb-xyrob-rl5ki-elr7y-ywu43-l54d7-ukgzw-qadse-j6oml-5qe";
+    const hotkey =
+      "ucmt2-grxhb-qutyd-sp76m-amcvp-3h6sr-lqnoj-fik7c-bbcc3-irpdn-oae";
+    const controllerPermission = {
+      principal: [mockPrincipal] as [Principal],
+      permission_type: Int32Array.from(enumValues(SnsNeuronPermissionType)),
+    };
+
+    it("returns a principal that keeps only ManageVotingPermission", () => {
+      const neuron: SnsGovernanceDid.Neuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText(partial)] as [Principal],
+            permission_type: Int32Array.from([
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+            ]),
+          },
+          controllerPermission,
+        ],
+      };
+      expect(getSnsNeuronPartialHotkeys(neuron)).toEqual([partial]);
+    });
+
+    it("returns a principal that keeps only Vote", () => {
+      const neuron: SnsGovernanceDid.Neuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText(partial)] as [Principal],
+            permission_type: Int32Array.from([
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+            ]),
+          },
+          controllerPermission,
+        ],
+      };
+      expect(getSnsNeuronPartialHotkeys(neuron)).toEqual([partial]);
+    });
+
+    it("does not return a complete hotkey", () => {
+      const neuron: SnsGovernanceDid.Neuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText(hotkey)] as [Principal],
+            permission_type: Int32Array.from(HOTKEY_PERMISSIONS),
+          },
+          controllerPermission,
+        ],
+      };
+      expect(getSnsNeuronPartialHotkeys(neuron)).toEqual([]);
+    });
+
+    it("does not return a CF hotkey with ManageVotingPermission", () => {
+      const neuron: SnsGovernanceDid.Neuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText(hotkey)] as [Principal],
+            permission_type: Int32Array.from([
+              ...HOTKEY_PERMISSIONS,
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+            ]),
+          },
+          controllerPermission,
+        ],
+      };
+      expect(getSnsNeuronPartialHotkeys(neuron)).toEqual([]);
+    });
+
+    it("does not return a principal with ManagePrincipals", () => {
+      const neuron: SnsGovernanceDid.Neuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText(partial)] as [Principal],
+            permission_type: Int32Array.from([
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_PRINCIPALS,
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+            ]),
+          },
+          controllerPermission,
+        ],
+      };
+      expect(getSnsNeuronPartialHotkeys(neuron)).toEqual([]);
+    });
+
+    it("does not return a principal without hotkey permissions", () => {
+      const neuron: SnsGovernanceDid.Neuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText(partial)] as [Principal],
+            permission_type: Int32Array.from([
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_DISBURSE,
+            ]),
+          },
+          controllerPermission,
+        ],
+      };
+      expect(getSnsNeuronPartialHotkeys(neuron)).toEqual([]);
     });
   });
 

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -793,6 +793,30 @@ describe("sns-neuron utils", () => {
         })
       ).toEqual([]);
     });
+
+    it("unites the permissions of two entries for the same principal", () => {
+      // A neuron can hold more than one entry for the same principal. The
+      // principal holds the union of those permissions.
+      const neuron: SnsGovernanceDid.Neuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText(principal)] as [Principal],
+            permission_type: Int32Array.from(HOTKEY_PERMISSIONS),
+          },
+          {
+            principal: [Principal.fromText(principal)] as [Principal],
+            permission_type: Int32Array.from([
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION,
+            ]),
+          },
+        ],
+      };
+
+      expect(getSnsNeuronHotkeyPermissionsFor({ neuron, principal })).toEqual(
+        HOTKEY_REVOCABLE_PERMISSIONS
+      );
+    });
   });
 
   describe("getSnsNeuronPartialHotkeys", () => {

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -15,7 +15,7 @@ import { render } from "$tests/utils/svelte.test-utils";
 import type { SnsGovernanceDid } from "@icp-sdk/canisters/sns";
 import type { RenderResult } from "@testing-library/svelte";
 import type { Component } from "svelte";
-import { writable } from "svelte/store";
+import { writable, type Writable } from "svelte/store";
 
 export const renderContextWrapper = <T>({
   Component,
@@ -59,16 +59,19 @@ export const renderSelectedAccountContext = ({
     Component,
   });
 
+// The caller can pass its own `store` to change the neuron after the render.
 export const renderSelectedSnsNeuronContext = ({
   Component,
   neuron,
   reload,
+  store,
   props,
   events,
 }: {
   Component: Component;
   neuron: SnsGovernanceDid.Neuron;
-  reload: () => Promise<void>;
+  reload: SelectedSnsNeuronContext["reload"];
+  store?: Writable<SelectedSnsNeuronStore>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props?: any;
   events?: Record<string, ($event: CustomEvent) => void>;
@@ -77,13 +80,15 @@ export const renderSelectedSnsNeuronContext = ({
     Component,
     contextKey: SELECTED_SNS_NEURON_CONTEXT_KEY,
     contextValue: {
-      store: writable<SelectedSnsNeuronStore>({
-        selected: {
-          neuronIdHex: getSnsNeuronIdAsHexString(neuron),
-          rootCanisterId: rootCanisterIdMock,
-        },
-        neuron,
-      }),
+      store:
+        store ??
+        writable<SelectedSnsNeuronStore>({
+          selected: {
+            neuronIdHex: getSnsNeuronIdAsHexString(neuron),
+            rootCanisterId: rootCanisterIdMock,
+          },
+          neuron,
+        }),
       reload,
     } as SelectedSnsNeuronContext,
     props,


### PR DESCRIPTION
# Motivation

Removing an SNS hotkey only revoked `Vote` and `SubmitProposal`. A hotkey that also held `ManageVotingPermission` (the Community Fund case) kept that permission after removal. The principal could then grant `Vote` and `SubmitProposal` back to itself, and it vanished from the hotkey list, so the residual grant was invisible and unrevocable in the UI.

# Changes

- Read the hotkey's real permission set from the neuron and revoked every permission it holds, bounded to a new `HOTKEY_REVOCABLE_PERMISSIONS` set.
- Added `ManageVotingPermission` to the set the dapp can revoke, so a Community Fund hotkey loses control after removal.
- Listed a principal that keeps a partial voting permission set on the hotkey card, with a warning, instead of hiding it.
- Verified the removal against the certified neuron after reload and showed an error toast when a permission remains, on every removal path including self-removal.
- Made `SnsPermissionsCard.svelte` reactive to store updates; it read the neuron once and never refreshed.
- Added a Playwright spec for the flow, kept as `test.fixme` until a human runs it against a working replica.

# Tests

- Added unit tests in `sns-neuron.utils.spec.ts`, `sns-neurons.services.spec.ts`, `SnsNeuronHotkeysCard.spec.ts`, `SnsNeuronDetail.spec.ts`, and `SnsPermissionsCard.spec.ts`. They cover the permission revocation, the partial-hotkey warning, the certified-neuron check, and the self-removal path. The new tests resolve the certified response strictly after the query response, so a check that reads the query response fails them.
- `npm run check`, `npm run test` (674 files, 5936 tests, 0 failed), `./scripts/check-relative-imports`, and `npx tsc --noEmit -p src/tests/e2e/tsconfig.json` all pass.
- Added a Playwright spec, `sns-hotkey-revocation.spec.ts`, marked `test.fixme`. The local dfx replica cannot start on this machine (a pocket-ic version mismatch against the saved snapshot state), so the spec never ran. A human must remove the fixme and run it once a working replica is available, then confirm the hotkey row layout by eye and a real Community Fund hotkey removal on chain.

# Todos

- [x] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
