### PR TITLE
fix(frontend): stop imported tokens from spoofing USD prices of ICP and SNS tokens

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -27,6 +27,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Stop an imported token from spoofing the USD price of ICP or of an SNS token.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/components/ui/AmountInputFiatValue.svelte
+++ b/frontend/src/lib/components/ui/AmountInputFiatValue.svelte
@@ -2,20 +2,18 @@
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import IcpExchangeRateInfoTooltip from "$lib/components/ui/IcpExchangeRateInfoTooltip.svelte";
   import { PRICE_NOT_AVAILABLE_PLACEHOLDER } from "$lib/constants/constants";
-  import { tokensByLedgerCanisterIdStore } from "$lib/derived/tokens.derived";
+  import { tokenPriceStore } from "$lib/derived/token-price.derived";
   import { i18n } from "$lib/stores/i18n";
   import { tickersStore } from "$lib/stores/tickers.store";
   import { formatNumber } from "$lib/utils/format.utils";
-  import {
-    getLedgerCanisterIdFromToken,
-    getUsdValue,
-  } from "$lib/utils/token.utils";
+  import { getUsdValue } from "$lib/utils/token.utils";
   import {
     isNullish,
     nonNullish,
     TokenAmountV2,
     type Token,
   } from "@dfinity/utils";
+  import type { Readable } from "svelte/store";
 
   export let amount: number = 0;
   export let balance: bigint | undefined = undefined;
@@ -36,19 +34,11 @@
     }
   };
 
-  let ledgerCanisterId: string | undefined;
-  ledgerCanisterId = getLedgerCanisterIdFromToken(
-    token,
-    $tokensByLedgerCanisterIdStore
-  );
+  let priceStore: Readable<number | undefined>;
+  $: priceStore = tokenPriceStore(token);
 
   let tokenPrice: number | undefined;
-  $: tokenPrice =
-    nonNullish(ledgerCanisterId) &&
-    nonNullish($tickersStore) &&
-    $tickersStore !== "error"
-      ? $tickersStore[ledgerCanisterId]
-      : undefined;
+  $: tokenPrice = $priceStore;
 
   let tokens: TokenAmountV2 | undefined;
   $: tokens = safeTokenAmount(amount, token);

--- a/frontend/src/lib/derived/imported-tokens.derived.ts
+++ b/frontend/src/lib/derived/imported-tokens.derived.ts
@@ -3,7 +3,7 @@ import {
   importedTokensStore,
 } from "$lib/stores/imported-tokens.store";
 import { isImportantCkToken } from "$lib/utils/icrc-tokens.utils";
-import { derived } from "svelte/store";
+import { derived, type Readable } from "svelte/store";
 
 /**
  * A store that contains the existing ledger canister IDs of imported tokens that
@@ -33,3 +33,20 @@ export const loadedImportedTokensStore = derived(
     );
   }
 );
+
+/**
+ * The ledger canister IDs of every token the user imported.
+ *
+ * An imported token is user supplied. Its metadata, including its symbol, is
+ * not vetted. Use this store to tell imported tokens apart from genuine ones.
+ */
+export const importedTokenLedgerCanisterIdsStore: Readable<Set<string>> =
+  derived(
+    importedTokensStore,
+    ({ importedTokens }) =>
+      new Set(
+        (importedTokens ?? []).map(({ ledgerCanisterId }) =>
+          ledgerCanisterId.toText()
+        )
+      )
+  );

--- a/frontend/src/lib/derived/token-price.derived.ts
+++ b/frontend/src/lib/derived/token-price.derived.ts
@@ -1,3 +1,4 @@
+import { importedTokenLedgerCanisterIdsStore } from "$lib/derived/imported-tokens.derived";
 import { tokensByLedgerCanisterIdStore } from "$lib/derived/tokens.derived";
 import { tickersStore } from "$lib/stores/tickers.store";
 import { getLedgerCanisterIdFromToken } from "$lib/utils/token.utils";
@@ -6,12 +7,21 @@ import { derived } from "svelte/store";
 
 export const tokenPriceStore = (token: Token) => {
   return derived(
-    [tokensByLedgerCanisterIdStore, tickersStore],
-    ([$tokensByLedgerCanisterIdStore, tickers]) => {
-      const ledgerCanisterId = getLedgerCanisterIdFromToken(
+    [
+      tokensByLedgerCanisterIdStore,
+      tickersStore,
+      importedTokenLedgerCanisterIdsStore,
+    ],
+    ([
+      $tokensByLedgerCanisterIdStore,
+      tickers,
+      $importedTokenLedgerCanisterIdsStore,
+    ]) => {
+      const ledgerCanisterId = getLedgerCanisterIdFromToken({
         token,
-        $tokensByLedgerCanisterIdStore
-      );
+        tokensByLedgerCanisterId: $tokensByLedgerCanisterIdStore,
+        importedTokenLedgerCanisterIds: $importedTokenLedgerCanisterIdsStore,
+      });
 
       if (
         isNullish(ledgerCanisterId) ||

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -363,10 +363,31 @@ export const getUsdValue = ({
   return (amountE8s * tokenPrice) / 100_000_000;
 };
 
-export const getLedgerCanisterIdFromToken = (
-  token: Token,
-  tokensByLedgerCanisterId: Record<string, IcrcTokenMetadata>
-): string | undefined =>
-  Object.entries(tokensByLedgerCanisterId).find(
-    ([_, storeToken]) => storeToken.symbol === token.symbol
-  )?.[0];
+/**
+ * Resolves the ledger canister ID of a token, to look up its USD price.
+ *
+ * A `Token` holds no canister ID, so the match goes through the symbol. A
+ * symbol is not unique. The user can import any ICRC ledger, and that ledger
+ * can declare the symbol of a genuine token. A genuine token therefore always
+ * wins a collision against an imported token. A symbol that stays ambiguous
+ * resolves to `undefined`, so the caller shows no price instead of a wrong one.
+ */
+export const getLedgerCanisterIdFromToken = ({
+  token,
+  tokensByLedgerCanisterId,
+  importedTokenLedgerCanisterIds,
+}: {
+  token: Token;
+  tokensByLedgerCanisterId: Record<string, IcrcTokenMetadata>;
+  importedTokenLedgerCanisterIds: Set<string>;
+}): string | undefined => {
+  const matches = Object.entries(tokensByLedgerCanisterId)
+    .filter(([_, storeToken]) => storeToken.symbol === token.symbol)
+    .map(([ledgerCanisterId]) => ledgerCanisterId);
+  const genuineMatches = matches.filter(
+    (ledgerCanisterId) => !importedTokenLedgerCanisterIds.has(ledgerCanisterId)
+  );
+  const candidates = genuineMatches.length > 0 ? genuineMatches : matches;
+
+  return candidates.length === 1 ? candidates[0] : undefined;
+};

--- a/frontend/src/tests/e2e/token-price-symbol-collision.spec.ts
+++ b/frontend/src/tests/e2e/token-price-symbol-collision.spec.ts
@@ -1,0 +1,111 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import {
+  dfxCanisterId,
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+const IMPORTED_TOKEN_NAME = "ckRED";
+const MAIN_ACCOUNT_NAME = "Main";
+// The value of PRICE_NOT_AVAILABLE_PLACEHOLDER in
+// $lib/constants/constants. The e2e specs do not import from $lib.
+const PRICE_NOT_AVAILABLE = "-/-";
+
+// This spec guards the fix for the symbol based price lookup. An imported
+// token must never change the USD price that the app shows for ICP.
+//
+// The spec is `fixme` for two reasons. Both are environment limits, not code
+// faults.
+//
+// 1. The local e2e environment shows no USD price at all. `dfx.json` gives the
+//    `icp-swap` canister a URL for `mainnet`, `app` and `beta` only. On the
+//    `local` network `config.sh` therefore sets an empty `ICP_SWAP_URL`,
+//    `queryIcpSwapTickers` throws, and `tickersStore` becomes "error". Every
+//    fiat value renders as PRICE_NOT_AVAILABLE. To run this spec, the e2e
+//    setup must serve a tickers response for the local ICP ledger.
+// 2. The e2e fixture set has one importable ledger, `ckred_ledger`, and its
+//    symbol is "ckRED". A full spoof case needs a second test ledger whose
+//    symbol is "ICP". Without it, this spec can only prove that an honest
+//    import leaves the ICP price alone.
+test.fixme(
+  "An imported token does not change the ICP USD price",
+  async ({ page, context }) => {
+    const importedLedgerCanisterId = await dfxCanisterId("ckred_ledger");
+    const importedIndexCanisterId = await dfxCanisterId("ckred_index");
+
+    await page.goto("/accounts");
+    await disableCssAnimations(page);
+    await signInWithNewUser({ page, context });
+
+    const pageElement = PlaywrightPageObjectElement.fromPage(page);
+    const appPo = new AppPo(pageElement);
+
+    const readIcpFiatValue = async (): Promise<string> => {
+      const tokensTablePo = appPo
+        .getAccountsPo()
+        .getNnsAccountsPo()
+        .getTokensTablePo();
+      const mainAccountRow =
+        await tokensTablePo.getRowByName(MAIN_ACCOUNT_NAME);
+      await mainAccountRow.waitForBalance();
+      await mainAccountRow.click();
+
+      const nnsWalletPo = appPo.getWalletPo().getNnsWalletPo();
+      await nnsWalletPo.clickSend();
+
+      const modalPo = nnsWalletPo.getIcpTransactionModalPo();
+      await modalPo.waitFor();
+
+      const amountInputPo = modalPo.getTransactionFormPo().getAmountInputPo();
+      await amountInputPo.enterAmount(1);
+
+      const fiatValue = await amountInputPo
+        .getAmountInputFiatValuePo()
+        .getFiatValue();
+
+      await modalPo.closeModal();
+      await modalPo.waitForClosed();
+
+      return fiatValue;
+    };
+
+    step("Read the USD value of 1 ICP before any import");
+
+    const fiatValueBeforeImport = await readIcpFiatValue();
+    expect(fiatValueBeforeImport).not.toContain(PRICE_NOT_AVAILABLE);
+
+    step("Import a token");
+
+    await page.goto("/tokens");
+    const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+    await tokensPagePo.getSettingsButtonPo().click();
+
+    const importButtonPo = tokensPagePo.getImportTokenButtonPo();
+    await importButtonPo.waitFor();
+    await importButtonPo.click();
+
+    const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
+    await importTokenModalPo.waitFor();
+
+    const formPo = importTokenModalPo.getImportTokenFormPo();
+    await formPo.getLedgerCanisterInputPo().typeText(importedLedgerCanisterId);
+    await formPo.getIndexCanisterInputPo().typeText(importedIndexCanisterId);
+    await formPo.getSubmitButtonPo().click();
+
+    const reviewPo = importTokenModalPo.getImportTokenReviewPo();
+    await reviewPo.waitFor();
+    expect(await reviewPo.getTokenName()).toBe(IMPORTED_TOKEN_NAME);
+    await reviewPo.getConfirmButtonPo().click();
+
+    await appPo.getWalletPo().getIcrcWalletPo().waitFor();
+
+    step("The USD value of 1 ICP did not change");
+
+    await page.goto("/accounts");
+    const fiatValueAfterImport = await readIcpFiatValue();
+    expect(fiatValueAfterImport).toBe(fiatValueBeforeImport);
+  }
+);

--- a/frontend/src/tests/lib/derived/token-price.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/token-price.derived.spec.ts
@@ -2,7 +2,9 @@ import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKUSDC_LEDGER_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import { tokenPriceStore } from "$lib/derived/token-price.derived";
 import { icpSwapTickersStore } from "$lib/stores/icp-swap.store";
+import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
@@ -103,6 +105,94 @@ describe("token-price.derived", () => {
 
       const store = tokenPriceStore(snsToken);
       expect(get(store)).toBe(0.1);
+    });
+
+    describe("symbol collisions", () => {
+      const importedLedgerCanisterIdText = "mxzaz-hqaaa-aaaar-qaada-cai";
+      const importedLedgerCanisterId = Principal.fromText(
+        importedLedgerCanisterIdText
+      );
+
+      beforeEach(() => {
+        // Drop the mock tokens, so that the genuine ICP token comes from the
+        // NNS universe, as it does in the app. tokensByLedgerCanisterIdStore
+        // then places ICP after every other token, which is the order that
+        // makes the spoof possible.
+        tokensStore.reset();
+      });
+
+      const importToken = (token: IcrcTokenMetadata) => {
+        tokensStore.setToken({
+          canisterId: importedLedgerCanisterId,
+          token,
+          certified: true,
+        });
+        importedTokensStore.set({
+          importedTokens: [
+            {
+              ledgerCanisterId: importedLedgerCanisterId,
+              indexCanisterId: undefined,
+            },
+          ],
+          certified: true,
+        });
+      };
+
+      it("should ignore an imported token that copies the ICP symbol", () => {
+        importToken({
+          name: "Fake Internet Computer",
+          symbol: "ICP",
+          decimals: 8,
+          fee: 10_000n,
+        });
+
+        setTickers({
+          [LEDGER_CANISTER_ID.toText()]: 12.4,
+          [importedLedgerCanisterIdText]: 999,
+        });
+
+        const store = tokenPriceStore(ICPToken);
+        expect(get(store)).toBe(12.4);
+      });
+
+      it("should ignore an imported token that copies an SNS symbol", () => {
+        setSnsProjects([
+          {
+            rootCanisterId: Principal.fromText(snsRootCanisterIdText),
+            ledgerCanisterId: Principal.fromText(snsLedgerCanisterIdText),
+            tokenMetadata: snsToken,
+          },
+        ]);
+
+        importToken({ ...snsToken });
+
+        setTickers({
+          [LEDGER_CANISTER_ID.toText()]: 12.4,
+          [snsLedgerCanisterIdText]: 0.1,
+          [importedLedgerCanisterIdText]: 999,
+        });
+
+        const store = tokenPriceStore(snsToken);
+        expect(get(store)).toBe(0.1);
+      });
+
+      it("should return the price of an imported token without a collision", () => {
+        const importedToken: IcrcTokenMetadata = {
+          name: "Imported Token",
+          symbol: "IMPORTED",
+          decimals: 8,
+          fee: 10_000n,
+        };
+        importToken(importedToken);
+
+        setTickers({
+          [LEDGER_CANISTER_ID.toText()]: 12.4,
+          [importedLedgerCanisterIdText]: 3.5,
+        });
+
+        const store = tokenPriceStore(importedToken);
+        expect(get(store)).toBe(3.5);
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -967,12 +967,23 @@ describe("token-utils", () => {
       [mockLedgerCanisterId2]: token2,
     };
 
+    const importedLedgerCanisterId = "mxzaz-hqaaa-aaaar-qaada-cai";
+    const otherImportedLedgerCanisterId = "n5wcd-faaaa-aaaar-qaaea-cai";
+
     it("should return the ledger canister ID for a given token", () => {
       expect(
-        getLedgerCanisterIdFromToken(token1, tokensByLedgerCanisterId)
+        getLedgerCanisterIdFromToken({
+          token: token1,
+          tokensByLedgerCanisterId,
+          importedTokenLedgerCanisterIds: new Set(),
+        })
       ).toBe(mockLedgerCanisterId1);
       expect(
-        getLedgerCanisterIdFromToken(token2, tokensByLedgerCanisterId)
+        getLedgerCanisterIdFromToken({
+          token: token2,
+          tokensByLedgerCanisterId,
+          importedTokenLedgerCanisterIds: new Set(),
+        })
       ).toBe(mockLedgerCanisterId2);
     });
 
@@ -984,7 +995,82 @@ describe("token-utils", () => {
       };
 
       expect(
-        getLedgerCanisterIdFromToken(unknownToken, tokensByLedgerCanisterId)
+        getLedgerCanisterIdFromToken({
+          token: unknownToken,
+          tokensByLedgerCanisterId,
+          importedTokenLedgerCanisterIds: new Set(),
+        })
+      ).toBeUndefined();
+    });
+
+    it("should ignore an imported token that copies the symbol of a genuine token", () => {
+      expect(
+        getLedgerCanisterIdFromToken({
+          token: token1,
+          tokensByLedgerCanisterId: {
+            // The imported token comes first, to prove that order does not win.
+            [importedLedgerCanisterId]: { ...token1 },
+            ...tokensByLedgerCanisterId,
+          },
+          importedTokenLedgerCanisterIds: new Set([importedLedgerCanisterId]),
+        })
+      ).toBe(mockLedgerCanisterId1);
+    });
+
+    it("should return the ledger canister ID of an imported token without a collision", () => {
+      const importedToken: IcrcTokenMetadata = {
+        symbol: "IMPORTED",
+        name: "Imported Token",
+        decimals: 8,
+        fee: 0n,
+      };
+
+      expect(
+        getLedgerCanisterIdFromToken({
+          token: importedToken,
+          tokensByLedgerCanisterId: {
+            ...tokensByLedgerCanisterId,
+            [importedLedgerCanisterId]: importedToken,
+          },
+          importedTokenLedgerCanisterIds: new Set([importedLedgerCanisterId]),
+        })
+      ).toBe(importedLedgerCanisterId);
+    });
+
+    it("should return undefined when two genuine tokens share a symbol", () => {
+      expect(
+        getLedgerCanisterIdFromToken({
+          token: token1,
+          tokensByLedgerCanisterId: {
+            ...tokensByLedgerCanisterId,
+            [importedLedgerCanisterId]: { ...token1 },
+          },
+          importedTokenLedgerCanisterIds: new Set(),
+        })
+      ).toBeUndefined();
+    });
+
+    it("should return undefined when two imported tokens share a symbol", () => {
+      const importedToken: IcrcTokenMetadata = {
+        symbol: "IMPORTED",
+        name: "Imported Token",
+        decimals: 8,
+        fee: 0n,
+      };
+
+      expect(
+        getLedgerCanisterIdFromToken({
+          token: importedToken,
+          tokensByLedgerCanisterId: {
+            ...tokensByLedgerCanisterId,
+            [importedLedgerCanisterId]: importedToken,
+            [otherImportedLedgerCanisterId]: { ...importedToken },
+          },
+          importedTokenLedgerCanisterIds: new Set([
+            importedLedgerCanisterId,
+            otherImportedLedgerCanisterId,
+          ]),
+        })
       ).toBeUndefined();
     });
   });


### PR DESCRIPTION
# Motivation

tokenPriceStore resolved a token to a ledger canister id by matching its symbol against every known token, and it used the first match. An imported token with a colliding symbol could land before ICP or an SNS token in the map, so its attacker-controlled ticker price showed up on the send review, SNS swap, and neuron stake or dissolve screens.

# Changes

- Changed `getLedgerCanisterIdFromToken` to prefer a genuine (non-imported) match and return `undefined` on an unresolved collision.
- Added `importedTokenLedgerCanisterIdsStore` to track which ledger ids come from imported tokens.
- Switched `AmountInputFiatValue` to read `tokenPriceStore` instead of duplicating the lookup, which also fixed a missed reactivity update on the `token` prop.
- Added unit tests for the collision cases in `token.utils` and `token-price.derived`.
- Added a `test.fixme` e2e spec that documents the local blockers (no local ICP Swap URL, no spoofable test ledger) for a future browser check.

# Tests

- `npm run test`: 671 files, 5904 tests passed.
- Reverted the fix locally and reran the new specs: 5 tests failed, confirming they catch the regression.
- `npm run check` and `./scripts/check-relative-imports` passed.
- `./scripts/e2e-tests` not run: the local replica cannot start on this machine (dfx 0.32.0 / pocket-ic-server 13.0.0 rejects the saved snsdemo snapshot).

# Todos

- [x] Accessibility (a11y) - no impact. This only changes which price value shows.
- [x] Changelog - added, under Application / Security in `CHANGELOG-Nns-Dapp-unreleased.md`.
- [ ] Fix the local e2e environment (ICP Swap URL, a spoofable test ledger) and drop `test.fixme` from `token-price-symbol-collision.spec.ts`.
