### PR TITLE
fix(security): check and escape install arguments in the CSP meta tag

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,12 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Check and escape the canister install arguments that the canister puts in the
+  `Content-Security-Policy` of every page. A value that is not a web address
+  could previously end the `content` attribute and add live `HTML` to the page.
+  The install or the upgrade now fails if a value is not a web address. The
+  check also limits the `ROBOTS` argument to the `robots` `meta` tag.
+
 #### Not Published
 
 ### Operations

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -4,11 +4,12 @@ import { createHash } from "crypto";
 import * as dotenv from "dotenv";
 import { readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
+import { cspSourceFromUrl } from "./build.csp.utils.mjs";
 import { findHtmlFiles } from "./build.utils.mjs";
 
 dotenv.config();
 
-const aggregatorCanisterUrl = process.env.VITE_AGGREGATOR_CANISTER_URL;
+const aggregatorCanisterUrl = process.env.VITE_AGGREGATOR_CANISTER_URL ?? "";
 const isAggregatorCanisterUrlDefined = aggregatorCanisterUrl.length > 0;
 
 const buildCsp = (htmlFile) => {
@@ -192,7 +193,9 @@ const updateCSP = (indexHtml) => {
 };
 
 const cspConnectSrc = () => {
-  // TODO: Use `URL` to check if the URL is valid and not introduce a security issue
+  // The `${{NAME}}` entries are placeholders. The nns-dapp canister replaces
+  // them at install time. The canister checks and escapes the values it
+  // substitutes. See `rs/backend/src/arguments.rs`.
   const src = [
     "${{IDENTITY_SERVICE_URL}}",
     // We move to internetcomputer.org, but if a user access the app with the old URL, we need to allow it
@@ -220,7 +223,12 @@ const cspConnectSrc = () => {
   ];
 
   if (isAggregatorCanisterUrlDefined) {
-    src.push(aggregatorCanisterUrl);
+    // This value comes from the build environment. It goes straight into the
+    // `content` attribute of the CSP meta tag, so the build checks it and
+    // escapes it. The build fails if the value is not an address.
+    src.push(
+      cspSourceFromUrl("VITE_AGGREGATOR_CANISTER_URL", aggregatorCanisterUrl)
+    );
   }
 
   return src

--- a/frontend/scripts/build.csp.utils.mjs
+++ b/frontend/scripts/build.csp.utils.mjs
@@ -1,0 +1,103 @@
+/**
+ * Helpers that guard the values written into the Content-Security-Policy.
+ *
+ * The policy lives in the `content` attribute of a `<meta>` tag in every built
+ * `index.html`. A value that contains `"` or `>` ends the attribute or the tag,
+ * and the rest of the value becomes live HTML. A value that contains a space, a
+ * `;` or a `,` adds sources or directives to the policy.
+ *
+ * Every value that the build inserts must therefore pass
+ * `assertValidCspSourceUrl` and then `escapeHtmlAttributeValue`.
+ *
+ * The `${{NAME}}` placeholders are different. The nns-dapp canister replaces
+ * them when it installs the assets. The canister makes the same two checks. See
+ * `rs/backend/src/arguments.rs`.
+ */
+
+/**
+ * Characters that must never appear in a CSP source.
+ *
+ * A space or a tab separates two sources. A `;` or a `,` separates two
+ * directives. A quote, an angle bracket, a backtick or a backslash can end the
+ * HTML attribute or the tag.
+ */
+const UNSAFE_CSP_SOURCE_CHARACTERS = /[\s;,'"<>`\\]/;
+
+/** Schemes that a CSP source may use. */
+const ALLOWED_PROTOCOLS = ["http:", "https:"];
+
+/**
+ * Checks that a value is an absolute http or https address.
+ *
+ * The build must stop when the check fails. The build must never drop the value
+ * and emit a weaker policy, because a weaker policy helps an attacker.
+ *
+ * @param {string} name the name of the value, used in the error message
+ * @param {unknown} value the value to check
+ * @returns {string} the value, unchanged
+ * @throws {Error} if the value is not an absolute http or https address
+ */
+export const assertValidCspSourceUrl = (name, value) => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Cannot build the Content-Security-Policy: ${name} is not a non-empty string.`
+    );
+  }
+
+  if (UNSAFE_CSP_SOURCE_CHARACTERS.test(value)) {
+    throw new Error(
+      `Cannot build the Content-Security-Policy: ${name} contains a character that a CSP source must not contain: ${JSON.stringify(
+        value
+      )}.`
+    );
+  }
+
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(
+      `Cannot build the Content-Security-Policy: ${name} is not an absolute address: ${JSON.stringify(
+        value
+      )}.`
+    );
+  }
+
+  if (!ALLOWED_PROTOCOLS.includes(url.protocol)) {
+    throw new Error(
+      `Cannot build the Content-Security-Policy: ${name} must use http or https: ${JSON.stringify(
+        value
+      )}.`
+    );
+  }
+
+  return value;
+};
+
+/**
+ * Escapes a value for a double quoted HTML attribute.
+ *
+ * The escapes follow the OWASP recommendation. A browser decodes them before it
+ * reads the policy, so a valid address still works.
+ *
+ * @param {string} value the value to escape
+ * @returns {string} the escaped value
+ */
+export const escapeHtmlAttributeValue = (value) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#x27;");
+
+/**
+ * Checks a value and escapes it for the CSP meta tag.
+ *
+ * @param {string} name the name of the value, used in the error message
+ * @param {unknown} value the value to check and escape
+ * @returns {string} the checked and escaped value
+ * @throws {Error} if the value is not an absolute http or https address
+ */
+export const cspSourceFromUrl = (name, value) =>
+  escapeHtmlAttributeValue(assertValidCspSourceUrl(name, value));

--- a/frontend/src/tests/scripts/build.csp.utils.spec.mjs
+++ b/frontend/src/tests/scripts/build.csp.utils.spec.mjs
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertValidCspSourceUrl,
+  cspSourceFromUrl,
+  escapeHtmlAttributeValue,
+} from "../../../scripts/build.csp.utils.mjs";
+
+describe("build.csp.utils", () => {
+  // Values that config.sh really produces for VITE_AGGREGATOR_CANISTER_URL and
+  // for the other addresses that reach the CSP meta tag.
+  const realDeploymentUrls = [
+    "https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io",
+    "https://otgyv-wyaaa-aaaak-qcgba-cai.icp0.io",
+    "http://sns_aggregator.localhost:8080",
+    "http://localhost:8080",
+    "https://icp-api.io",
+    "https://icp0.io",
+    "https://id.ai/",
+    "https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/",
+    "http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080",
+    "https://dev-ingress.devenv.dfinity.network",
+  ];
+
+  const hostileUrls = [
+    // Ends the attribute and the tag, then adds a script.
+    'https://evil.com"><script src=https://evil.com/x.js></script>',
+    // Ends the attribute only.
+    'https://evil.com" data-x="',
+    // Adds a source to the current directive.
+    "https://icp-api.io https://evil.com",
+    // Adds a directive to the policy.
+    "https://icp-api.io; script-src *",
+    // Adds a source with a comma.
+    "https://icp-api.io,https://evil.com",
+    // Adds a directive on a new line.
+    "https://icp-api.io\nscript-src *",
+    // Uses a scheme that runs code.
+    "javascript:alert(1)",
+    // Uses a scheme that carries a payload.
+    "data:text/html,<script>alert(1)</script>",
+    // Uses a wildcard instead of an address.
+    "*",
+    // Has no scheme.
+    "//evil.com",
+  ];
+
+  describe("assertValidCspSourceUrl", () => {
+    it("accepts every address that a real deployment uses", () => {
+      for (const url of realDeploymentUrls) {
+        expect(assertValidCspSourceUrl("TEST_URL", url)).toBe(url);
+      }
+    });
+
+    it("rejects a hostile value", () => {
+      for (const url of hostileUrls) {
+        expect(() => assertValidCspSourceUrl("TEST_URL", url)).toThrow();
+      }
+    });
+
+    it("names the value in the error", () => {
+      expect(() =>
+        assertValidCspSourceUrl("VITE_AGGREGATOR_CANISTER_URL", "*")
+      ).toThrow(/VITE_AGGREGATOR_CANISTER_URL/);
+    });
+
+    it("rejects a missing or empty value", () => {
+      expect(() => assertValidCspSourceUrl("TEST_URL", undefined)).toThrow();
+      expect(() => assertValidCspSourceUrl("TEST_URL", "")).toThrow();
+    });
+  });
+
+  describe("escapeHtmlAttributeValue", () => {
+    it("escapes the characters that end an attribute or a tag", () => {
+      expect(escapeHtmlAttributeValue('"><script>alert(1)</script>')).toBe(
+        "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"
+      );
+    });
+
+    it("escapes an ampersand and a single quote", () => {
+      expect(escapeHtmlAttributeValue("a&b'c")).toBe("a&amp;b&#x27;c");
+    });
+
+    it("leaves a real address unchanged", () => {
+      for (const url of realDeploymentUrls) {
+        expect(escapeHtmlAttributeValue(url)).toBe(url);
+      }
+    });
+  });
+
+  describe("cspSourceFromUrl", () => {
+    it("returns a real address unchanged", () => {
+      for (const url of realDeploymentUrls) {
+        expect(cspSourceFromUrl("TEST_URL", url)).toBe(url);
+      }
+    });
+
+    it("fails on a hostile value instead of dropping it", () => {
+      for (const url of hostileUrls) {
+        expect(() => cspSourceFromUrl("TEST_URL", url)).toThrow();
+      }
+    });
+  });
+});

--- a/rs/backend/src/arguments.rs
+++ b/rs/backend/src/arguments.rs
@@ -12,11 +12,62 @@ use regex::{Captures, Regex};
 use serde::Serialize;
 use std::collections::HashMap;
 
+/// Tests for the validation and the escaping of arguments.
+#[cfg(test)]
+mod tests;
+
 /// `init` and `post_upgrade` arguments
 #[derive(Debug, Default, Eq, PartialEq, CandidType, Serialize, Deserialize)]
 pub struct CanisterArguments {
     /// Values that are to be set in the web front end, by injecting them into JavaScript.
     pub args: Vec<(String, String)>,
+}
+
+/// The names of the arguments that must hold a web address.
+///
+/// The front end puts these values in the `Content-Security-Policy` of every
+/// page.  It also uses them as the target of network requests.
+const URL_ARGUMENT_NAMES: [&str; 6] = [
+    "API_HOST",
+    "HOST",
+    "ICP_SWAP_URL",
+    "IDENTITY_SERVICE_URL",
+    "SNS_AGGREGATOR_URL",
+    "STATIC_HOST",
+];
+
+/// The names of the arguments that hold a fragment of `HTML`.
+///
+/// The template engine inserts these values without escaping.  Every other
+/// value is escaped.  See `TemplateEngine::populate`.
+const HTML_ARGUMENT_NAMES: [&str; 1] = ["ROBOTS"];
+
+/// The pattern of a valid value for an argument in `URL_ARGUMENT_NAMES`.
+///
+/// The value must be empty, or an absolute `http` or `https` address.  The
+/// pattern excludes every character that would end an `HTML` attribute or add
+/// a source or a directive to the `Content-Security-Policy`.
+const URL_PATTERN: &str = r#"\A(https?://(\[[0-9A-Fa-f:.]+\]|[A-Za-z0-9._~%+-]+)(:[0-9]+)?(/[^\s"'<>`\\;,]*)?)?\z"#;
+
+/// The pattern of a valid value for an argument in `HTML_ARGUMENT_NAMES`.
+///
+/// The value must be empty, or the `robots` `meta` tag that `config.sh` builds
+/// (`config.sh:134` and `config.sh:137`).  The pattern accepts no other tag and
+/// no other attribute.  A `meta` tag with `http-equiv` can redirect the page or
+/// add a second `Content-Security-Policy`, so the pattern excludes it.
+const HTML_PATTERN: &str = r#"\A(<meta name="robots" content="[a-z, ]*" ?/?>)?\z"#;
+
+/// Compiles one of the fixed patterns above.
+///
+/// The patterns are constants.  Tests exercise them, so they cannot fail to
+/// compile in production.
+fn fixed_regex(pattern: &str) -> Regex {
+    Regex::new(pattern).unwrap_or_else(|err| {
+        unreachable!(
+            "This is a fixed regex.  It is exercised in tests, so it cannot fail to parse in production.  Error: {:?}",
+            err
+        )
+    })
 }
 
 thread_local! {
@@ -91,6 +142,49 @@ impl CanisterArguments {
             .map(|(key, val)| ((*key).to_string(), (*val).to_string()))
             .collect()
     }
+
+    /// Checks that the argument values are safe to put in a page.
+    ///
+    /// The canister puts argument values in `index.html` in two places:
+    /// * `to_html` writes them as data attributes of a `meta` tag.
+    /// * `TemplateEngine::populate` replaces `${{NAME}}` and `<!-- NAME -->`.
+    ///
+    /// The front end builds the `Content-Security-Policy` of the page from the
+    /// arguments in `URL_ARGUMENT_NAMES`.  A space, a `;` or a `,` in such a
+    /// value adds a source or a directive to the policy.  A `"` or a `>` ends
+    /// the attribute or the tag.  The check rejects those characters.
+    ///
+    /// The arguments in `HTML_ARGUMENT_NAMES` hold a fragment of `HTML`.  The
+    /// check limits them to the `robots` `meta` tag.
+    ///
+    /// # Errors
+    /// Returns the name of the first bad argument and the reason.
+    ///
+    /// ```
+    /// use nns_dapp::arguments::CanisterArguments;
+    /// let good = CanisterArguments{args: CanisterArguments::args_from_str(&[("HOST", "https://icp-api.io")]), ..CanisterArguments::default()};
+    /// assert_eq!(good.validate(), Ok(()));
+    ///
+    /// let bad = CanisterArguments{args: CanisterArguments::args_from_str(&[("HOST", "https://evil.com\"><script>alert(1)</script>")]), ..CanisterArguments::default()};
+    /// assert!(bad.validate().is_err());
+    /// ```
+    pub fn validate(&self) -> Result<(), String> {
+        let url_regex = fixed_regex(URL_PATTERN);
+        let html_regex = fixed_regex(HTML_PATTERN);
+        for (key, value) in &self.args {
+            if URL_ARGUMENT_NAMES.contains(&key.as_str()) && !url_regex.is_match(value) {
+                return Err(format!(
+                    "The argument {key} must be empty or an absolute http or https address.  Got: {value:?}"
+                ));
+            }
+            if HTML_ARGUMENT_NAMES.contains(&key.as_str()) && !html_regex.is_match(value) {
+                return Err(format!(
+                    "The argument {key} must be empty or a robots meta tag.  Got: {value:?}"
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Converts an upper-snake-case configuration variable to a lower-kebab-case name prefixed with data-.
@@ -118,8 +212,16 @@ pub fn configvalue2attributevalue(value: &str) -> String {
 }
 
 /// Sets arguments to the default value, or the provided value if given.
+///
+/// The canister traps if an argument value is not safe to put in a page.  The
+/// install or the upgrade then fails, and the state does not change.  The
+/// canister must not drop a bad value, because a page would then get a weaker
+/// `Content-Security-Policy`.
 pub fn set_canister_arguments(canister_arguments: Option<CanisterArguments>) {
     let canister_arguments = canister_arguments.unwrap_or_default().with_own_canister_id();
+    if let Err(reason) = canister_arguments.validate() {
+        ic_cdk::api::trap(format!("Invalid canister arguments.  {reason}"));
+    }
     CANISTER_ARGUMENTS.with(|args| {
         args.replace(canister_arguments);
     });
@@ -152,8 +254,7 @@ impl TemplateEngine {
     pub fn new(key_val_pairs: &[(String, String)]) -> Self {
         let args = key_val_pairs.iter().cloned().collect();
         // Please see .populate() to learn what this regex does.
-        #[allow(clippy::expect_used)]
-        let regex = Regex::new(r"\$\{\{([_0-9A-Z]+)\}\}|<!-- *([_0-9A-Z]+) *-->").unwrap_or_else(|err| unreachable!("This is a fixed regex.  It is exercised in tests, so it cannot not fail to parse in production.  Error: {:?}", err));
+        let regex = fixed_regex(r"\$\{\{([_0-9A-Z]+)\}\}|<!-- *([_0-9A-Z]+) *-->");
         TemplateEngine { args, regex }
     }
 
@@ -162,15 +263,36 @@ impl TemplateEngine {
     /// * The keys must be upper snake case, i.e. consist of the characters `A-Z0-9_`.
     /// * Values are taken from the engine `args` map.
     ///   * If no match is found in the `args` map, variables are left unchanged.
+    /// * A value is escaped for an `HTML` attribute, unless the key is in
+    ///   `HTML_ARGUMENT_NAMES`.
     ///
+    /// The templates put values inside the `content` attribute of the
+    /// `Content-Security-Policy` `meta` tag.  A browser decodes the escapes
+    /// before it reads the policy, so a valid address still works.  The escape
+    /// stops a value from ending the attribute or the tag.
+    ///
+    /// # Examples
+    /// ```
+    /// use nns_dapp::arguments::{TemplateEngine, CanisterArguments};
+    /// let values: Vec<(String, String)> = CanisterArguments::args_from_str(&[("HOST", "https://icp-api.io"), ("EVIL", r#""><script>alert(1)</script>"#), ("ROBOTS", r#"<meta name="robots" content="noindex, nofollow" />"#)]);
+    /// let template_engine = TemplateEngine::new(&values[..]);
+    /// assert_eq!(template_engine.populate("${{HOST}}"), "https://icp-api.io", "A valid address is unchanged");
+    /// assert_eq!(template_engine.populate("${{EVIL}}"), "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;", "A hostile value is escaped");
+    /// assert_eq!(template_engine.populate("<!-- ROBOTS -->"), r#"<meta name="robots" content="noindex, nofollow" />"#, "ROBOTS is HTML");
+    /// ```
     #[must_use]
     pub fn populate(&self, input: &str) -> String {
         self.regex
             .replace_all(input, |cap: &Captures| {
                 if let Some(key) = cap.get(1).or_else(|| cap.get(2)) {
-                    let val = self.args.get(key.as_str());
-                    val.cloned()
-                        .unwrap_or_else(|| cap.get(0).map(|x| x.as_str().to_string()).unwrap_or_default())
+                    let Some(val) = self.args.get(key.as_str()) else {
+                        return cap.get(0).map(|x| x.as_str().to_string()).unwrap_or_default();
+                    };
+                    if HTML_ARGUMENT_NAMES.contains(&key.as_str()) {
+                        val.clone()
+                    } else {
+                        configvalue2attributevalue(val)
+                    }
                 } else {
                     "REGEX ERROR".to_string()
                 }

--- a/rs/backend/src/arguments/tests.rs
+++ b/rs/backend/src/arguments/tests.rs
@@ -1,0 +1,233 @@
+//! Tests for the validation and the escaping of canister arguments.
+use super::{CanisterArguments, TemplateEngine};
+
+/// Builds arguments from name and value pairs.
+fn arguments(pairs: &[(&str, &str)]) -> CanisterArguments {
+    CanisterArguments {
+        args: CanisterArguments::args_from_str(pairs),
+    }
+}
+
+/// The arguments that the deployment scripts create for the mainnet network.
+///
+/// The values come from `scripts/nns-dapp/test-config-assets/mainnet/arg.did`.
+const MAINNET_ARGUMENTS: [(&str, &str); 8] = [
+    ("API_HOST", "https://icp-api.io"),
+    ("HOST", "https://icp-api.io"),
+    ("ICP_SWAP_URL", "https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/"),
+    ("IDENTITY_SERVICE_URL", "https://id.ai/"),
+    ("ROBOTS", ""),
+    ("SNS_AGGREGATOR_URL", "https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io"),
+    ("STATIC_HOST", "https://icp0.io"),
+    ("OWN_CANISTER_ID", "qoctq-giaaa-aaaaa-aaaea-cai"),
+];
+
+/// The arguments that the deployment scripts create for the app network.
+///
+/// The values come from `scripts/nns-dapp/test-config-assets/app/arg.did`.
+const APP_ARGUMENTS: [(&str, &str); 8] = [
+    ("API_HOST", "https://icp-api.io"),
+    ("HOST", "https://icp-api.io"),
+    ("ICP_SWAP_URL", "https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/"),
+    ("IDENTITY_SERVICE_URL", "https://id.ai/"),
+    ("ROBOTS", r#"<meta name="robots" content="noindex, nofollow" />"#),
+    ("SNS_AGGREGATOR_URL", "https://otgyv-wyaaa-aaaak-qcgba-cai.icp0.io"),
+    ("STATIC_HOST", "https://icp0.io"),
+    ("OWN_CANISTER_ID", "xnjld-hqaaa-aaaal-qb56q-cai"),
+];
+
+/// The arguments that the deployment scripts create for a local network.
+///
+/// The values come from `scripts/nns-dapp/test-config-assets/local/arg.did`.
+/// The local network has no `ICP_SWAP_URL`.
+const LOCAL_ARGUMENTS: [(&str, &str); 7] = [
+    ("API_HOST", "http://localhost:8080"),
+    ("HOST", "http://localhost:8080"),
+    (
+        "IDENTITY_SERVICE_URL",
+        "http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080",
+    ),
+    ("ROBOTS", r#"<meta name="robots" content="noindex, nofollow" />"#),
+    ("SNS_AGGREGATOR_URL", "http://sns_aggregator.localhost:8080"),
+    ("STATIC_HOST", "http://localhost:8080"),
+    ("OWN_CANISTER_ID", "{OWN_CANISTER_ID}"),
+];
+
+#[test]
+fn real_deployment_arguments_are_valid() {
+    for (name, pairs) in [
+        ("mainnet", &MAINNET_ARGUMENTS[..]),
+        ("app", &APP_ARGUMENTS[..]),
+        ("local", &LOCAL_ARGUMENTS[..]),
+    ] {
+        assert_eq!(arguments(pairs).validate(), Ok(()), "{name} arguments must be valid");
+    }
+}
+
+#[test]
+fn other_real_addresses_are_valid() {
+    let valid = [
+        "",
+        "http://127.0.0.1:8080",
+        "http://[::1]:8080",
+        "https://identity.internetcomputer.org",
+        "https://nns.ic0.app",
+        "https://icp-api.io/api/v2",
+        // A developer network address in `config.json`.
+        "https://dev-ingress.devenv.dfinity.network",
+    ];
+    for value in valid {
+        assert_eq!(
+            arguments(&[("SNS_AGGREGATOR_URL", value)]).validate(),
+            Ok(()),
+            "{value:?} must be valid"
+        );
+    }
+}
+
+#[test]
+fn hostile_url_arguments_are_rejected() {
+    let hostile = [
+        // Ends the attribute and the tag, then adds a script.
+        r#"https://evil.com"><script src=https://evil.com/x.js></script>"#,
+        // Ends the attribute only.
+        r#"https://evil.com" data-x=""#,
+        // Adds a source to the current directive.
+        "https://icp-api.io https://evil.com",
+        // Adds a directive to the policy.
+        "https://icp-api.io; script-src *",
+        // Adds a source with a comma.
+        "https://icp-api.io,https://evil.com",
+        // Adds a directive on a new line.
+        "https://icp-api.io\nscript-src *",
+        // Uses a scheme that runs code.
+        "javascript:alert(1)",
+        // Uses a wildcard instead of an address.
+        "*",
+        // Has no scheme.
+        "//evil.com",
+        // Has a backtick, which some parsers treat as a quote.
+        "https://evil.com`",
+    ];
+    for value in hostile {
+        for name in [
+            "HOST",
+            "API_HOST",
+            "STATIC_HOST",
+            "IDENTITY_SERVICE_URL",
+            "ICP_SWAP_URL",
+        ] {
+            assert!(
+                arguments(&[(name, value)]).validate().is_err(),
+                "{name}={value:?} must be rejected"
+            );
+        }
+    }
+}
+
+#[test]
+fn hostile_robots_argument_is_rejected() {
+    let hostile = [
+        r#"<meta name="robots"><script>alert(1)</script>"#,
+        "<script>alert(1)</script>",
+        r#"<meta name="robots" content="noindex"><iframe src="https://evil.com"></iframe>"#,
+        // Sends every visitor to another page.  A browser follows this redirect,
+        // and the `Content-Security-Policy` of the page does not stop it.
+        r#"<meta http-equiv="refresh" content="0;url=https://evil.com">"#,
+        // Adds a second policy.  A browser intersects the two policies, so this
+        // value breaks the application.
+        r#"<meta http-equiv="Content-Security-Policy" content="default-src none">"#,
+        // Adds an event handler attribute.
+        "<meta name=x onload=alert(1)>",
+        // Adds an attribute after the content attribute.
+        r#"<meta name="robots" content="noindex" onload="alert(1)">"#,
+        // Names another tag.
+        r#"<link rel="stylesheet" href="https://evil.com/x.css">"#,
+    ];
+    for value in hostile {
+        assert!(
+            arguments(&[("ROBOTS", value)]).validate().is_err(),
+            "ROBOTS={value:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn real_robots_arguments_are_valid() {
+    // The two values that `config.sh` builds, plus the same tag without the
+    // trailing slash.
+    let valid = [
+        "",
+        r#"<meta name="robots" content="noindex, nofollow" />"#,
+        r#"<meta name="robots" content="noindex, nofollow">"#,
+    ];
+    for value in valid {
+        assert_eq!(
+            arguments(&[("ROBOTS", value)]).validate(),
+            Ok(()),
+            "ROBOTS={value:?} must be valid"
+        );
+    }
+}
+
+#[test]
+fn validation_names_the_bad_argument() {
+    let error = arguments(&[("HOST", "https://icp-api.io; script-src *")])
+        .validate()
+        .expect_err("The value is not an address");
+    assert!(error.contains("HOST"), "The error must name the argument: {error}");
+}
+
+#[test]
+fn arguments_that_are_not_addresses_are_not_checked_as_addresses() {
+    let pairs = [
+        ("OWN_CANISTER_ID", "qoctq-giaaa-aaaaa-aaaea-cai"),
+        ("DFX_NETWORK", "mainnet"),
+        ("FETCH_ROOT_KEY", "false"),
+        (
+            "FEATURE_FLAGS",
+            r#"{"ENABLE_ADDRESS_BOOK":true,"ENABLE_CKTESTBTC":false}"#,
+        ),
+        ("PLAUSIBLE_DOMAIN", "nns.ic0.app"),
+        ("TVL_CANISTER_ID", ""),
+    ];
+    assert_eq!(arguments(&pairs).validate(), Ok(()));
+}
+
+#[test]
+fn template_escapes_a_hostile_value() {
+    let values = CanisterArguments::args_from_str(&[("HOST", r#"https://evil.com"><script>alert(1)</script>"#)]);
+    let template_engine = TemplateEngine::new(&values[..]);
+    let populated = template_engine.populate(r#"<meta content="connect-src ${{HOST}};">"#);
+    assert_eq!(
+        populated,
+        r#"<meta content="connect-src https://evil.com&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;;">"#
+    );
+    assert!(!populated.contains("<script>"), "The value must not become a tag");
+}
+
+#[test]
+fn template_keeps_real_addresses_unchanged() {
+    for pairs in [&MAINNET_ARGUMENTS[..], &APP_ARGUMENTS[..], &LOCAL_ARGUMENTS[..]] {
+        let values = CanisterArguments::args_from_str(pairs);
+        let template_engine = TemplateEngine::new(&values[..]);
+        for (name, value) in pairs {
+            if *name == "ROBOTS" {
+                continue;
+            }
+            assert_eq!(
+                template_engine.populate(&format!("${{{{{name}}}}}")),
+                *value,
+                "{name} must be unchanged"
+            );
+        }
+    }
+}
+
+#[test]
+fn template_keeps_robots_as_html() {
+    let robots = r#"<meta name="robots" content="noindex, nofollow" />"#;
+    let values = CanisterArguments::args_from_str(&[("ROBOTS", robots)]);
+    let template_engine = TemplateEngine::new(&values[..]);
+    assert_eq!(template_engine.populate("<!-- ROBOTS -->"), robots);
+}

--- a/rs/backend/src/bin/nns-dapp-check-args.rs
+++ b/rs/backend/src/bin/nns-dapp-check-args.rs
@@ -12,4 +12,8 @@ fn main() {
     let bytes = fs::read(path).expect("Failed to read path");
     let arg = Decode!(&bytes, Option<CanisterArguments>).expect("Binary is not valid candid");
     println!("Parsed as:\n{arg:#?}");
+    // The canister makes the same check at install time.  It traps if the check fails.
+    if let Some(arg) = &arg {
+        arg.validate().expect("Arguments are not safe to put in a page");
+    }
 }


### PR DESCRIPTION
# Motivation

The canister writes install arguments into the CSP meta tag and other index.html placeholders, with no check and no escape. A `"` or a `>` in an argument like HOST or IDENTITY_SERVICE_URL ends the attribute or the tag early, and the rest of the value becomes live HTML. That is a persistent XSS in every user's session.

# Changes

- Added `CanisterArguments::validate`, which rejects a URL argument that is not empty and not an absolute http or https address.
- Restricted ROBOTS to only the exact robots meta tag shape that config.sh builds.
- Made `set_canister_arguments` trap on an invalid value, so init and post_upgrade always read the arguments fresh and a bad install or upgrade never lands.
- Escaped every substituted value in `TemplateEngine::populate` for HTML attribute context, so a hostile value can no longer break out of the tag.
- Added a matching check and escape for `VITE_AGGREGATOR_CANISTER_URL` in `build.csp.mjs`, so a bad build value fails the build with a clear message.
- Made `nns-dapp-check-args` run the same validation, so a bad argument fails the release check before anyone submits a proposal.

# Tests

- Added Rust unit tests in `rs/backend/src/arguments/tests.rs`, covering hostile ROBOTS payloads, hostile URL values, and the real mainnet, app, local and devenv values.
- Updated `frontend/src/tests/scripts/build.csp.utils.spec.mjs` for the build-time check and escape.
- Ran `nns-dapp-check-args` against the three real arg.did fixtures and a rejected hostile payload, confirmed the fixtures pass and the hostile payload traps.
- Full local gate run: cargo test, the CI RUSTFLAGS warnings build, lint-rs, cargo fmt, cargo spellcheck, npm run check, npm run test, check-relative-imports, fmt-md and config.test all pass.
- Two independent review passes, each with a code review and a real-Chromium browser review, confirmed the injected script is blocked and the real CSP values are unchanged.

# Todos

- [x] Accessibility (a11y) – no impact. The change touches only the meta tag content, not the rendered UI.
- [x] Changelog – added, under Security in CHANGELOG-Nns-Dapp-unreleased.md.
