### PR TITLE
fix(errors): resolve an error message as an i18n key only for app errors

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -1,4 +1,4 @@
-86
+87
 Monterey
 IC
 ICP
@@ -85,3 +85,4 @@ DoS
 Ctrl
 Cmd
 Banxa
+i18n

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,10 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Do not resolve the message of a third-party error as an app text key in error
+  toasts. Only the errors that the app throws with an i18n key select an app
+  text. A canister can no longer choose which app text an error toast shows.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -39,6 +39,7 @@ import type {
   SubAccountDetails,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
+import { ApiErrorKey } from "$lib/types/api.errors";
 import { toNullable } from "@dfinity/utils";
 import { AccountIdentifier } from "@icp-sdk/canisters/ledger/icp";
 import { Actor } from "@icp-sdk/core/agent";
@@ -106,7 +107,7 @@ export class NNSDappCanister {
     }
 
     // We should never reach here. Some of the previous properties should be present.
-    throw new Error("error__account.no_details");
+    throw new ApiErrorKey("error__account.no_details");
   }
 
   /**
@@ -142,7 +143,7 @@ export class NNSDappCanister {
     }
 
     // We should never reach here. Some of the previous properties should be present.
-    throw new Error("error__account.create_subaccount");
+    throw new ApiErrorKey("error__account.create_subaccount");
   }
 
   public async registerHardwareWallet(

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -24,6 +24,7 @@ import { outOfCyclesCanistersStore } from "$lib/stores/out-of-cycles-canisters.s
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
+import { ApiErrorKey } from "$lib/types/api.errors";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { isLastCall } from "$lib/utils/env.utils";
 import {
@@ -279,7 +280,7 @@ export const transferTokens = async ({
 }> => {
   try {
     if (isNullish(fee)) {
-      throw new Error("error.transaction_fee_not_found");
+      throw new ApiErrorKey("error.transaction_fee_not_found");
     }
 
     const identity: Identity = await getIcrcAccountIdentity(source);

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -35,6 +35,7 @@ import {
 } from "$lib/stores/sns-neurons.store";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
+import { ApiErrorKey } from "$lib/types/api.errors";
 import type { SnsTopicFollowing } from "$lib/types/sns";
 import { isLastCall } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
@@ -537,7 +538,7 @@ export const stakeNeuron = async ({
       ?.fee;
 
     if (isNullish(fee)) {
-      throw new Error("error.transaction_fee_not_found");
+      throw new ApiErrorKey("error.transaction_fee_not_found");
     }
 
     await stakeNeuronApi({

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -42,10 +42,15 @@ import {
   UncertifiedRejectErrorCode,
 } from "@icp-sdk/core/agent";
 
+// A constructor of an Error subclass. Used instead of the built-in Function
+// type, so I18N_KEY_ERRORS cannot hold a non-constructor such as an arrow
+// function.
+type ErrorClass = abstract new (...args: never[]) => Error;
+
 // The error classes that the app throws with an i18n label key as their
 // message. Every other error carries free text, which can come from a
 // third-party canister, so its message must never select an application text.
-const I18N_KEY_ERRORS: Array<Function> = [
+const I18N_KEY_ERRORS: Array<ErrorClass> = [
   AccountTranslateError,
   SubAccountLimitExceededError,
   HardwareWalletAttachError,

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import { UserNotTheControllerError } from "$lib/canisters/ic-management/ic-management.errors";
+import {
+  AccountTranslateError,
+  HardwareWalletAttachError,
+  SubAccountLimitExceededError,
+} from "$lib/canisters/nns-dapp/nns-dapp.errors";
+import { ApiErrorKey } from "$lib/types/api.errors";
 import { NotEnoughAmountError } from "$lib/types/common.errors";
-import { LedgerErrorMessage } from "$lib/types/ledger.errors";
+import { LedgerErrorKey, LedgerErrorMessage } from "$lib/types/ledger.errors";
 import {
   CannotBeMerged,
   InvalidAmountError,
@@ -36,6 +42,21 @@ import {
   UncertifiedRejectErrorCode,
 } from "@icp-sdk/core/agent";
 
+// The error classes that the app throws with an i18n label key as their
+// message. Every other error carries free text, which can come from a
+// third-party canister, so its message must never select an application text.
+const I18N_KEY_ERRORS: Array<Function> = [
+  AccountTranslateError,
+  SubAccountLimitExceededError,
+  HardwareWalletAttachError,
+  LedgerErrorKey,
+  ApiErrorKey,
+  NotEnoughAmountError,
+];
+
+export const isI18nKeyError = (err: unknown): err is Error =>
+  I18N_KEY_ERRORS.some((errorClass) => err instanceof errorClass);
+
 export const errorToString = (err?: unknown): string | undefined => {
   const text =
     typeof err === "string"
@@ -48,8 +69,10 @@ export const errorToString = (err?: unknown): string | undefined => {
             ? (err as Error).message
             : undefined;
 
-  // replace with i18n version if available
-  return typeof text === "string" ? translate({ labelKey: text }) : text;
+  // Replace with the i18n version if the error carries a label key.
+  return typeof text === "string" && isI18nKeyError(err)
+    ? translate({ labelKey: text })
+    : text;
 };
 
 const factoryMappingErrorToToastMessage =
@@ -124,9 +147,10 @@ export const mapCanisterErrorToToastMessage =
   factoryMappingErrorToToastMessage(canisterMapper);
 
 /**
- * The "message" of some type of errors that extends Error is used to map an i18n label.
- * This helper map such "message" to the "labelKey" of the toast.
- * If the error does not contain a matching "message", it fallbacks to the "fallbackErrorLabelKey" and add the error as details of the toast.
+ * The "message" of the error classes listed in I18N_KEY_ERRORS is an i18n label key.
+ * This helper maps such a "message" to the "labelKey" of the toast.
+ * Every other error, and a listed error whose key is absent from the catalog,
+ * falls back to the "fallbackErrorLabelKey" and is added as details of the toast.
  */
 export const toToastError = ({
   err,
@@ -144,7 +168,7 @@ export const toToastError = ({
   const error = err as Error | undefined;
   const message: string | undefined = error?.message;
 
-  if (message !== undefined) {
+  if (isI18nKeyError(err) && message !== undefined) {
     const label = translate({ labelKey: message });
     errorKey = label !== message;
   }

--- a/frontend/src/lib/utils/i18n.utils.ts
+++ b/frontend/src/lib/utils/i18n.utils.ts
@@ -24,10 +24,16 @@ export const translate = ({
   }
 
   const firstKey = split[0];
-  const key =
-    translations !== undefined
-      ? translations[firstKey]
-      : get(i18n)[firstKey as keyof I18n];
+  const catalog: Record<string, unknown> =
+    translations ?? (get(i18n) as unknown as Record<string, unknown>);
+
+  // Only an own property of the catalog is a translation. A key such as
+  // "constructor" must not resolve to a value on the prototype chain.
+  if (!Object.hasOwn(catalog, firstKey)) {
+    return labelKey;
+  }
+
+  const key = catalog[firstKey];
 
   if (key === undefined) {
     return labelKey;

--- a/frontend/src/tests/e2e/error-message-allowlist.spec.ts
+++ b/frontend/src/tests/e2e/error-message-allowlist.spec.ts
@@ -91,11 +91,18 @@ test("An index canister cannot choose the text of the error toast", async ({
   step("The toast shows the app's own transactions error");
 
   const toastsPo = appPo.getToastsPo();
+  // The import already showed its own success toast. Close it, so the
+  // transactions error toast (which loads in the background and can take a
+  // few retries) is the only one left to wait for.
   await toastsPo.getToastPo().waitFor();
+  await toastsPo.closeAll();
+
+  await expect(async () => {
+    expect(await toastsPo.getMessages()).toContain(APP_TRANSACTIONS_ERROR);
+  }).toPass({ timeout: 30_000 });
 
   const messages = await toastsPo.getMessages();
 
-  expect(messages).toContain(APP_TRANSACTIONS_ERROR);
   expect(messages).not.toContain(ATTACKER_TARGET_TEXT);
   expect(messages).not.toContain(ATTACKER_MESSAGE);
 });

--- a/frontend/src/tests/e2e/error-message-allowlist.spec.ts
+++ b/frontend/src/tests/e2e/error-message-allowlist.spec.ts
@@ -46,7 +46,7 @@ test("An index canister cannot choose the text of the error toast", async ({
   const appPo = new AppPo(pageElement);
   const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
 
-  step("Open the import token modal");
+  await step("Open the import token modal");
 
   await tokensPagePo.getSettingsButtonPo().click();
   const importButtonPo = tokensPagePo.getImportTokenButtonPo();
@@ -58,7 +58,7 @@ test("An index canister cannot choose the text of the error toast", async ({
   const reviewPo = importTokenModalPo.getImportTokenReviewPo();
   await importTokenModalPo.waitFor();
 
-  step("Enter the ledger and index canister ids");
+  await step("Enter the ledger and index canister ids");
 
   await formPo.getLedgerCanisterInputPo().typeText(testLedgerCanisterId);
   await formPo.getIndexCanisterInputPo().typeText(testIndexCanisterId);
@@ -66,7 +66,9 @@ test("An index canister cannot choose the text of the error toast", async ({
   await reviewPo.waitFor();
   expect(await reviewPo.getTokenName()).toBe(TEST_TOKEN_NAME);
 
-  step("Make every call to the index canister fail with an app label key");
+  await step(
+    "Make every call to the index canister fail with an app label key"
+  );
 
   // The import is validated already, so the index canister can start to answer
   // with the text of its choice.
@@ -81,14 +83,14 @@ test("An index canister cannot choose the text of the error toast", async ({
     }
   );
 
-  step("Import the token and open its wallet");
+  await step("Import the token and open its wallet");
 
   await reviewPo.getConfirmButtonPo().click();
 
   const walletPo = appPo.getWalletPo().getIcrcWalletPo();
   await walletPo.waitFor();
 
-  step("The toast shows the app's own transactions error");
+  await step("The toast shows the app's own transactions error");
 
   const toastsPo = appPo.getToastsPo();
   // The import already showed its own success toast. Close it, so the

--- a/frontend/src/tests/e2e/error-message-allowlist.spec.ts
+++ b/frontend/src/tests/e2e/error-message-allowlist.spec.ts
@@ -1,0 +1,101 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import {
+  dfxCanisterId,
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+const TEST_TOKEN_NAME = "ckRED";
+
+// Playwright cannot import $lib/i18n/en.json, so the expected strings are
+// copied from that file.
+// error.fetch_transactions:
+const APP_TRANSACTIONS_ERROR =
+  "Sorry, there was an error loading the transactions for this account.";
+// accounts.transaction_success:
+const ATTACKER_TARGET_TEXT = "Transaction completed.";
+// The label key that the attacker wants the toast to resolve.
+const ATTACKER_MESSAGE = "accounts.transaction_success";
+
+// The index canister of an imported token belongs to the user who typed its id,
+// so the app must treat the text it returns as free text. Before the fix,
+// toToastError() resolved that text as an i18n label key, so the canister chose
+// which application string the error toast showed.
+//
+// Playwright cannot make the index canister return a chosen Err message,
+// because that needs a certified reply from a canister we control. It can make
+// the index call fail with the canister's own text in the response body. The
+// test therefore checks the branch the fix relies on: an error that comes from
+// the index canister shows the app's own transactions error, and no other
+// application string.
+test("An index canister cannot choose the text of the error toast", async ({
+  page,
+  context,
+}) => {
+  const testLedgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const testIndexCanisterId = await dfxCanisterId("ckred_index");
+
+  await page.goto("/tokens");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+
+  step("Open the import token modal");
+
+  await tokensPagePo.getSettingsButtonPo().click();
+  const importButtonPo = tokensPagePo.getImportTokenButtonPo();
+  await importButtonPo.waitFor();
+  await importButtonPo.click();
+
+  const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
+  const formPo = importTokenModalPo.getImportTokenFormPo();
+  const reviewPo = importTokenModalPo.getImportTokenReviewPo();
+  await importTokenModalPo.waitFor();
+
+  step("Enter the ledger and index canister ids");
+
+  await formPo.getLedgerCanisterInputPo().typeText(testLedgerCanisterId);
+  await formPo.getIndexCanisterInputPo().typeText(testIndexCanisterId);
+  await formPo.getSubmitButtonPo().click();
+  await reviewPo.waitFor();
+  expect(await reviewPo.getTokenName()).toBe(TEST_TOKEN_NAME);
+
+  step("Make every call to the index canister fail with an app label key");
+
+  // The import is validated already, so the index canister can start to answer
+  // with the text of its choice.
+  await page.route(
+    `**/api/*/canister/${testIndexCanisterId}/**`,
+    async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "text/plain",
+        body: ATTACKER_MESSAGE,
+      });
+    }
+  );
+
+  step("Import the token and open its wallet");
+
+  await reviewPo.getConfirmButtonPo().click();
+
+  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
+  await walletPo.waitFor();
+
+  step("The toast shows the app's own transactions error");
+
+  const toastsPo = appPo.getToastsPo();
+  await toastsPo.getToastPo().waitFor();
+
+  const messages = await toastsPo.getMessages();
+
+  expect(messages).toContain(APP_TRANSACTIONS_ERROR);
+  expect(messages).not.toContain(ATTACKER_TARGET_TEXT);
+  expect(messages).not.toContain(ATTACKER_MESSAGE);
+});

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -21,6 +21,7 @@ import type {
   SetFavProjectsResponse,
   SetImportedTokensResponse,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { ApiErrorKey } from "$lib/types/api.errors";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCanister, mockCanisters } from "$tests/mocks/canisters.mock";
 import { mockFavProject } from "$tests/mocks/fav-projects.mock";
@@ -89,6 +90,20 @@ describe("NNSDapp", () => {
 
       await expect(call).rejects.toThrow(AccountNotFoundError);
     });
+
+    it("throws an ApiErrorKey if the response has no known variant", async () => {
+      const service = mock<NNSDappService>();
+      service.get_account.mockResolvedValue({} as GetAccountResponse);
+
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = async () => nnsDapp.getAccount({ certified: true });
+
+      await expect(call).rejects.toThrow(
+        new ApiErrorKey("error__account.no_details")
+      );
+      await expect(call).rejects.toBeInstanceOf(ApiErrorKey);
+    });
   });
 
   describe("NNSDapp.createSubAccount", () => {
@@ -151,6 +166,23 @@ describe("NNSDapp", () => {
         nnsDapp.createSubAccount({ subAccountName: "testSubaccount" });
 
       await expect(call).rejects.toThrow(AccountNotFoundError);
+    });
+
+    it("throws an ApiErrorKey if the response has no known variant", async () => {
+      const service = mock<NNSDappService>();
+      service.create_sub_account.mockResolvedValue(
+        {} as CreateSubAccountResponse
+      );
+
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = async () =>
+        nnsDapp.createSubAccount({ subAccountName: "testSubaccount" });
+
+      await expect(call).rejects.toThrow(
+        new ApiErrorKey("error__account.create_subaccount")
+      );
+      await expect(call).rejects.toBeInstanceOf(ApiErrorKey);
     });
   });
 

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -789,6 +789,27 @@ describe("icrc-accounts-services", () => {
         fromSubAccount: mockSubAccountArray,
       });
     });
+    it("shows the fee error when the fee is missing", async () => {
+      expect(get(toastsStore)).toEqual([]);
+
+      await transferTokens({
+        source: mockIcrcMainAccount,
+        amountUlps: amountE8s,
+        destinationAddress: encodeIcrcAccount(destinationAccount),
+        // The service guards against a fee that is nullish at runtime.
+        fee: undefined as unknown as bigint,
+        ledgerCanisterId,
+      });
+
+      expect(ledgerApi.icrcTransfer).not.toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, there was an error loading the transaction fee.",
+        },
+      ]);
+    });
+
     it("should load balance after transfer", async () => {
       const initialAccount = {
         ...mockIcrcMainAccount,

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -498,10 +498,21 @@ describe("sns-neurons-services", () => {
     });
 
     it("should not call sns api stakeNeuron if fee is not present", async () => {
+      // The token has no name, so it is dropped from the token stores and
+      // the fee is not found. The nervous system parameters stay available.
+      setSnsProjects([
+        {
+          rootCanisterId: mockPrincipal,
+          tokenMetadata: { ...mockSnsToken, name: undefined },
+          neuronMinimumStakeE8s: 100_000_000n,
+        },
+      ]);
       tokensStore.reset();
       const spyStake = vi
         .spyOn(api, "stakeNeuron")
         .mockImplementation(() => Promise.resolve(mockSnsNeuron.id[0]));
+
+      expect(get(toastsStore)).toEqual([]);
 
       const { success } = await stakeNeuron({
         rootCanisterId: mockPrincipal,
@@ -511,6 +522,13 @@ describe("sns-neurons-services", () => {
 
       expect(success).toBe(false);
       expect(spyStake).not.toBeCalled();
+
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, there was an error loading the transaction fee.",
+        },
+      ]);
     });
 
     it("should call sns api stakeNeuron if fee is 0", async () => {

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -1,6 +1,7 @@
 import { LedgerErrorKey } from "$lib/types/ledger.errors";
 
 import { HardwareWalletAttachError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
+import { ApiErrorKey } from "$lib/types/api.errors";
 import {
   errorToString,
   isCanisterOutOfCyclesError,
@@ -42,9 +43,20 @@ describe("error-utils", () => {
     });
 
     it("should translate error", () => {
+      expect(
+        errorToString(new ApiErrorKey("error__sns.undefined_project"))
+      ).toEqual(en.error__sns.undefined_project);
+    });
+
+    it("should not translate the message of an error that carries free text", () => {
+      expect(errorToString(new Error("core.close"))).toEqual("core.close");
       expect(errorToString(new Error("error__sns.undefined_project"))).toEqual(
-        en.error__sns.undefined_project
+        "error__sns.undefined_project"
       );
+      expect(
+        errorToString(new TestError("accounts.transaction_success"))
+      ).toEqual("accounts.transaction_success");
+      expect(errorToString(new Error("constructor"))).toEqual("constructor");
     });
   });
 
@@ -83,6 +95,57 @@ describe("error-utils", () => {
           err,
         })
       ).toEqual({ labelKey: "error.rename_subaccount", renderAsHtml: false });
+    });
+
+    it("should use the error message key of an allowed error class", () => {
+      const err = new ApiErrorKey("error__sns.undefined_project");
+
+      expect(
+        toToastError({
+          fallbackErrorLabelKey: "test.test",
+          err,
+        })
+      ).toEqual({
+        labelKey: "error__sns.undefined_project",
+        renderAsHtml: false,
+      });
+    });
+
+    it("should not use the message of an error that carries free text as a key", () => {
+      // An index or ledger canister the user imported chooses this message.
+      for (const message of [
+        "core.close",
+        "accounts.transaction_success",
+        "error.transaction_error",
+      ]) {
+        const err = new Error(message);
+
+        expect(
+          toToastError({
+            fallbackErrorLabelKey: "error.transaction_data",
+            err,
+          })
+        ).toEqual({
+          labelKey: "error.transaction_data",
+          err,
+          renderAsHtml: false,
+        });
+      }
+    });
+
+    it("should not use a prototype chain key of the catalog", () => {
+      const err = new Error("constructor");
+
+      expect(
+        toToastError({
+          fallbackErrorLabelKey: "error.transaction_data",
+          err,
+        })
+      ).toEqual({
+        labelKey: "error.transaction_data",
+        err,
+        renderAsHtml: false,
+      });
     });
 
     it("should pass on renderAsHtml", () => {

--- a/frontend/src/tests/lib/utils/i18n.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/i18n.utils.spec.ts
@@ -17,6 +17,15 @@ describe("i18n-utils", () => {
     expect(translate({ labelKey: "core.test.test" })).toEqual("core.test.test");
   });
 
+  it("should not resolve a key from the prototype chain", () => {
+    expect(translate({ labelKey: "constructor" })).toEqual("constructor");
+    expect(translate({ labelKey: "toString" })).toEqual("toString");
+    expect(translate({ labelKey: "core.constructor" })).toEqual(
+      "core.constructor"
+    );
+    expect(translate({ labelKey: "core.toString" })).toEqual("core.toString");
+  });
+
   describe("replacePlaceholders", () => {
     it("should replace single placeholder", () => {
       expect(replacePlaceholders("Hello this!", { this: "World" })).toBe(


### PR DESCRIPTION
# Motivation

`toToastError` and `errorToString` treat any error whose `message` matches an i18n catalog path as an app label key. A canister can throw an error with a message that happens to match an existing app string, for example `accounts.transaction_success`, and the toast shows that string instead of the real error. An imported ICRC token lets a user pick the index canister, so the canister owner controls the error text seen by the wallet.

# Changes

- Added an `isI18nKeyError` guard that allows only the app error classes that carry an i18n key as their message, such as `LedgerErrorKey` and `ApiErrorKey`.
- Used the guard in `toToastError` and `errorToString`, so a message from any other error class always falls back to the app's own text.
- Converted four plain `Error` throws that carried a key to `ApiErrorKey`, so they keep their current toast text under the guard.
- Made `translate` read the i18n catalog through `Object.hasOwn`, so a key such as `constructor` can never resolve a value from the object prototype chain.
- Added an e2e spec that makes the index canister return an error whose message matches an app string, and checks the toast shows the app's own fallback text.

# Tests

Unit tests cover both directions: an error with a catalog-matching message (or a prototype key like `constructor`) always falls back, and every allowlisted class still shows its own text. Mutation testing confirmed each new test fails when its guard is reverted. `npm run check`, `npm run test`, and `./scripts/check-relative-imports` pass.

A new e2e spec, `frontend/src/tests/e2e/error-message-allowlist.spec.ts`, intercepts the index canister call and asserts the toast shows the app's fallback text, not the injected string. It has not run yet on this machine (no local replica available); the CI e2e job is the first place to check.

# Todos

- [ ] Accessibility (a11y) – no impact, no new UI.
- [x] Changelog – added under `### Application` / `#### Security`.
