### PR TITLE
fix(backend): check the account limit only when add_account creates an account

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -426,7 +426,13 @@ impl AccountsStore {
     // yet been stored, allowing us to set the principal (since originally we created accounts
     // without storing each user's principal).
     pub fn add_account(&mut self, caller: PrincipalId) -> bool {
-        self.assert_account_limit();
+        self.add_account_with_limit(caller, ACCOUNT_LIMIT)
+    }
+
+    /// Adds an account, up to the given account limit.
+    ///
+    /// The limit is a parameter so that a test can reach it without creating `ACCOUNT_LIMIT` accounts.
+    fn add_account_with_limit(&mut self, caller: PrincipalId, account_limit: u64) -> bool {
         let account_identifier = AccountIdentifier::from(caller);
         if let Some(account) = self.accounts_db.get(&account_identifier.to_vec()) {
             if account.principal.is_none() {
@@ -437,6 +443,7 @@ impl AccountsStore {
             }
             false
         } else {
+            self.assert_account_limit(account_limit);
             let new_account = Account::new(caller, account_identifier);
             self.accounts_db.insert(account_identifier.to_vec(), new_account);
 
@@ -881,11 +888,11 @@ impl AccountsStore {
         name.len() <= CANISTER_NAME_MAX_LENGTH
     }
 
-    fn assert_account_limit(&self) {
+    fn assert_account_limit(&self, account_limit: u64) {
         let db_accounts_len = self.accounts_db.len();
         assert!(
-            db_accounts_len < ACCOUNT_LIMIT,
-            "Pre migration account limit exceeded {db_accounts_len}"
+            db_accounts_len < account_limit,
+            "Account limit exceeded {db_accounts_len}"
         );
     }
 }

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -90,6 +90,63 @@ fn create_sub_account_limit_exceeded() {
 }
 
 #[test]
+#[should_panic(expected = "Account limit exceeded 2")]
+fn add_account_at_limit_traps_for_new_account() {
+    let principal = PrincipalId::from_str(TEST_ICRC1_ACCOUNT_3).unwrap();
+    let mut store = setup_test_store();
+
+    assert_eq!(2, store.accounts_db.len());
+
+    store.add_account_with_limit(principal, 2);
+}
+
+#[test]
+fn add_account_at_limit_returns_false_for_existing_account() {
+    let principal = PrincipalId::from_str(TEST_ICRC1_ACCOUNT_1).unwrap();
+    let mut store = setup_test_store();
+
+    assert_eq!(2, store.accounts_db.len());
+
+    assert!(!store.add_account_with_limit(principal, 2));
+
+    assert_eq!(2, store.accounts_db.len());
+    assert!(store.get_account(principal).is_some());
+}
+
+#[test]
+fn add_account_at_limit_backfills_legacy_principal() {
+    let principal = PrincipalId::from_str(TEST_ICRC1_ACCOUNT_3).unwrap();
+    let account_identifier = AccountIdentifier::from(principal);
+    let mut store = setup_test_store();
+
+    // An account created before the principal was stored.
+    let mut account = Account::new(principal, account_identifier);
+    account.principal = None;
+    store.accounts_db.insert(account_identifier.to_vec(), account);
+
+    assert_eq!(3, store.accounts_db.len());
+    assert!(store.get_account(principal).is_none());
+
+    assert!(!store.add_account_with_limit(principal, 3));
+
+    assert_eq!(3, store.accounts_db.len());
+    assert_eq!(principal, store.get_account(principal).unwrap().principal);
+}
+
+#[test]
+fn add_account_below_limit_creates_account() {
+    let principal = PrincipalId::from_str(TEST_ICRC1_ACCOUNT_3).unwrap();
+    let mut store = setup_test_store();
+
+    assert_eq!(2, store.accounts_db.len());
+
+    assert!(store.add_account_with_limit(principal, 3));
+
+    assert_eq!(3, store.accounts_db.len());
+    assert!(store.get_account(principal).is_some());
+}
+
+#[test]
 fn create_sub_account_account_not_found() {
     let principal = PrincipalId::from_str(TEST_ICRC1_ACCOUNT_3).unwrap();
     let mut store = setup_test_store();


### PR DESCRIPTION
# Motivation

`add_account` checked the account limit before it looked up the caller. At the limit, the call trapped for every caller, even one that already had an account. A trap rolls back state, so the one-off backfill that sets `principal` on a legacy account never ran. A legacy user then lost access to stored data, because `get_account` kept returning `None` until the backfill ran, and the frontend retried `add_account` on every sign-in and failed every time.

Two callers reach `add_account`: the `add_account` update endpoint (the only production caller), and a toy-data helper used only under `test` or `toy_data_gen`. The fix affects only the production endpoint.

Mainnet held 308,885 accounts against a limit of 330,000 on 2026-09-04, so the trap is not theoretical.

# Changes

- Moved the account-limit check into the branch that creates a new account, so an existing account or a legacy backfill never traps.
- Added `add_account_with_limit`, a private function that takes the limit as a parameter, so `add_account` can still trap a new caller at `ACCOUNT_LIMIT`.
- Fixed the panic message from "Pre migration account limit exceeded" to "Account limit exceeded".

# Tests

Added four tests in `rs/backend/src/accounts_store/tests.rs`, each against a small store with a passed-in limit:

- A new principal still traps at the limit, with the fixed message.
- An existing principal returns `false` at the limit and does not trap.
- A legacy account with `principal: None` gets the backfill at the limit and does not trap.
- A new principal below the limit creates the account and returns `true`.

Ran `./scripts/lint-rs`, `cargo test`, and `cargo spellcheck -- --code 1`. All pass.

# Todos

- [x] Accessibility (a11y) – no impact, this is a backend-only change.
- [x] Changelog – not needed, `ACCOUNT_LIMIT` and the Candid interface are unchanged, and mainnet has not hit the limit yet.
