### PR TITLE
fix(tokens): refuse importing any SNS ledger, whatever its swap lifecycle

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,10 +35,11 @@ proposal is successful, the changes it released will be moved from this file to
   tiles and result boxes now have a visible background color.
 - On a narrow screen the header buttons no longer shrink while the app loads
   data.
-- Refuse to import the ledger of any SNS project, whatever its swap state, and
-  wait for the SNS project list before the import form validates a ledger.
 
 #### Security
+
+- Refuse to import the ledger of any SNS project, whatever its swap state, and
+  wait for the SNS project list before the import form validates a ledger.
 
 #### Not Published
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,8 @@ proposal is successful, the changes it released will be moved from this file to
   tiles and result boxes now have a visible background color.
 - On a narrow screen the header buttons no longer shrink while the app loads
   data.
+- Refuse to import the ledger of any SNS project, whatever its swap state, and
+  wait for the SNS project list before the import form validates a ledger.
 
 #### Security
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1139,6 +1139,7 @@
     "is_sns": "You cannot import SNS tokens, they are added by the NNS.",
     "is_important": "This token is already in the token list.",
     "is_icp": "You cannot import ICP.",
+    "sns_projects_not_loaded": "The list of SNS projects is not loaded yet. Try again in a moment.",
     "invalid_canister_id": "Importing the token was unsuccessful because \"$canisterId\" is not a valid canister ID. Please verify the ID and retry."
   },
   "error__fav_projects": {

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -5,7 +5,7 @@
   import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { AppPath } from "$lib/constants/routes.constants";
   import { pageStore } from "$lib/derived/page.derived";
-  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
+  import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
   import { getIcrcTokenMetaData } from "$lib/services/icrc-accounts.services";
   import { matchLedgerIndexPair } from "$lib/services/icrc-index.services";
   import { addImportedToken } from "$lib/services/imported-tokens.services";
@@ -13,6 +13,7 @@
   import { DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
   import { toastsError, toastsShow } from "$lib/stores/toasts.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { isImportantCkToken } from "$lib/utils/icrc-tokens.utils";
@@ -94,7 +95,10 @@
   $: if (
     !isAutoSubmitDone &&
     // Wait for the imported tokens to be loaded (for successful validation).
-    nonNullish($importedTokensStore?.importedTokens)
+    nonNullish($importedTokensStore?.importedTokens) &&
+    // Wait for the SNS projects to be loaded, otherwise the validation would
+    // accept an SNS ledger canister ID.
+    nonNullish($snsAggregatorStore.data)
   ) {
     isAutoSubmitDone = true;
     onSubmit();
@@ -123,10 +127,17 @@
     if (ledgerCanisterId.toText() === LEDGER_CANISTER_ID.toText()) {
       return { errorLabelKey: "error__imported_tokens.is_icp" };
     }
+    // Without the SNS projects the SNS check below would accept any SNS ledger
+    // canister ID, so refuse the ledger until the list is loaded.
+    if (isNullish($snsAggregatorStore.data)) {
+      return {
+        errorLabelKey: "error__imported_tokens.sns_projects_not_loaded",
+      };
+    }
     if (
       isSnsLedgerCanisterId({
         ledgerCanisterId,
-        snsProjects: $snsProjectsCommittedStore,
+        snsProjects: $snsProjectsStore,
       })
     ) {
       return { errorLabelKey: "error__imported_tokens.is_sns" };

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1187,6 +1187,7 @@ interface I18nError__imported_tokens {
   is_sns: string;
   is_important: string;
   is_icp: string;
+  sns_projects_not_loaded: string;
   invalid_canister_id: string;
 }
 

--- a/frontend/src/tests/e2e/import-token-sns-denylist.spec.ts
+++ b/frontend/src/tests/e2e/import-token-sns-denylist.spec.ts
@@ -79,7 +79,7 @@ test("Import token refuses an SNS ledger and fails closed without the SNS list",
     await formPo.waitFor();
   };
 
-  step("A legitimate non-SNS token still passes validation");
+  await step("A legitimate non-SNS token still passes validation");
 
   await openImportForm(page);
   await formPo.getLedgerCanisterInputPo().typeText(ckRedLedgerCanisterId);
@@ -91,14 +91,14 @@ test("Import token refuses an SNS ledger and fails closed without the SNS list",
     ckRedLedgerCanisterId
   );
 
-  step("The aggregator gave the app at least one SNS ledger canister ID");
+  await step("The aggregator gave the app at least one SNS ledger canister ID");
 
   await expect
     .poll(() => snsLedgerCanisterIds.length, { timeout: POLL_TIMEOUT })
     .toBeGreaterThan(0);
   const snsLedgerCanisterId = snsLedgerCanisterIds[0];
 
-  step("The form refuses an SNS ledger canister ID");
+  await step("The form refuses an SNS ledger canister ID");
 
   await openImportForm(page);
   await appPo.getToastsPo().closeAll();
@@ -112,7 +112,7 @@ test("Import token refuses an SNS ledger and fails closed without the SNS list",
   expect(await formPo.isPresent()).toBe(true);
   expect(await reviewPo.isPresent()).toBe(false);
 
-  step("Without the SNS list the URL import does not auto-submit");
+  await step("Without the SNS list the URL import does not auto-submit");
 
   blockAggregator = true;
   await page.goto(
@@ -133,7 +133,7 @@ test("Import token refuses an SNS ledger and fails closed without the SNS list",
   await expectToast(SNS_LIST_ERROR_TOAST);
   expect(await reviewPo.isPresent()).toBe(false);
 
-  step("Without the SNS list a manual submit fails closed");
+  await step("Without the SNS list a manual submit fails closed");
 
   await appPo.getToastsPo().closeAll();
   await formPo.getSubmitButtonPo().click();

--- a/frontend/src/tests/e2e/import-token-sns-denylist.spec.ts
+++ b/frontend/src/tests/e2e/import-token-sns-denylist.spec.ts
@@ -1,0 +1,144 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import {
+  dfxCanisterId,
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test, type Page } from "@playwright/test";
+
+// Playwright cannot import $lib/i18n/en.json, so the expected texts are copied.
+const IS_SNS_TOAST = "You cannot import SNS tokens, they are added by the NNS.";
+const NOT_LOADED_TOAST =
+  "The list of SNS projects is not loaded yet. Try again in a moment.";
+const SNS_LIST_ERROR_TOAST =
+  "There was an unexpected error while loading the summaries of all deployed projects.";
+
+const AGGREGATOR_PAGE_URL = "**/sns/list/page/**";
+const POLL_TIMEOUT = 60 * 1000;
+
+test("Import token refuses an SNS ledger and fails closed without the SNS list", async ({
+  page,
+  context,
+}) => {
+  const ckRedLedgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const ckRedIndexCanisterId = await dfxCanisterId("ckred_index");
+
+  // The SNS ledger canister IDs the app itself received from the aggregator.
+  const snsLedgerCanisterIds: string[] = [];
+  // Phase 3 blocks the aggregator to leave snsAggregatorStore.data undefined.
+  let blockAggregator = false;
+
+  await page.route(AGGREGATOR_PAGE_URL, async (route) => {
+    if (blockAggregator) {
+      await route.abort();
+      return;
+    }
+    const response = await route.fetch();
+    try {
+      const body = await response.json();
+      if (Array.isArray(body)) {
+        for (const sns of body) {
+          const ledgerCanisterId = sns?.canister_ids?.ledger_canister_id;
+          if (typeof ledgerCanisterId === "string") {
+            snsLedgerCanisterIds.push(ledgerCanisterId);
+          }
+        }
+      }
+    } catch {
+      // Not JSON. Serve it unchanged.
+    }
+    await route.fulfill({ response });
+  });
+
+  await page.goto("/tokens");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+  const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
+  const formPo = importTokenModalPo.getImportTokenFormPo();
+  const reviewPo = importTokenModalPo.getImportTokenReviewPo();
+
+  const toastMessages = async (): Promise<string> =>
+    (await appPo.getToastsPo().getMessages()).join(" | ");
+
+  const expectToast = async (text: string): Promise<void> => {
+    await expect.poll(toastMessages, { timeout: POLL_TIMEOUT }).toContain(text);
+  };
+
+  const openImportForm = async (currentPage: Page): Promise<void> => {
+    await currentPage.goto("/tokens");
+    await disableCssAnimations(currentPage);
+    await tokensPagePo.getSettingsButtonPo().click();
+    await tokensPagePo.getImportTokenButtonPo().click();
+    await importTokenModalPo.waitFor();
+    await formPo.waitFor();
+  };
+
+  step("A legitimate non-SNS token still passes validation");
+
+  await openImportForm(page);
+  await formPo.getLedgerCanisterInputPo().typeText(ckRedLedgerCanisterId);
+  await formPo.getIndexCanisterInputPo().typeText(ckRedIndexCanisterId);
+  await formPo.getSubmitButtonPo().click();
+
+  await reviewPo.waitFor();
+  expect(await reviewPo.getLedgerCanisterIdPo().getCanisterIdText()).toBe(
+    ckRedLedgerCanisterId
+  );
+
+  step("The aggregator gave the app at least one SNS ledger canister ID");
+
+  await expect
+    .poll(() => snsLedgerCanisterIds.length, { timeout: POLL_TIMEOUT })
+    .toBeGreaterThan(0);
+  const snsLedgerCanisterId = snsLedgerCanisterIds[0];
+
+  step("The form refuses an SNS ledger canister ID");
+
+  await openImportForm(page);
+  await appPo.getToastsPo().closeAll();
+  await formPo.getLedgerCanisterInputPo().typeText(snsLedgerCanisterId);
+  await formPo.getIndexCanisterInputPo().typeText(ckRedIndexCanisterId);
+  await formPo.getSubmitButtonPo().click();
+
+  await expectToast(IS_SNS_TOAST);
+  // The form stays and the wizard never reaches the review step, so neither the
+  // ledger nor the index canister was called.
+  expect(await formPo.isPresent()).toBe(true);
+  expect(await reviewPo.isPresent()).toBe(false);
+
+  step("Without the SNS list the URL import does not auto-submit");
+
+  blockAggregator = true;
+  await page.goto(
+    `/tokens?import-ledger-id=${snsLedgerCanisterId}&import-index-id=${ckRedIndexCanisterId}`
+  );
+  await disableCssAnimations(page);
+  await importTokenModalPo.waitFor();
+  await formPo.waitFor();
+
+  expect(await formPo.getLedgerCanisterInputPo().getValue()).toBe(
+    snsLedgerCanisterId
+  );
+  expect(await formPo.getIndexCanisterInputPo().getValue()).toBe(
+    ckRedIndexCanisterId
+  );
+
+  // The SNS list load has failed, so every load of the app init has settled.
+  await expectToast(SNS_LIST_ERROR_TOAST);
+  expect(await reviewPo.isPresent()).toBe(false);
+
+  step("Without the SNS list a manual submit fails closed");
+
+  await appPo.getToastsPo().closeAll();
+  await formPo.getSubmitButtonPo().click();
+
+  await expectToast(NOT_LOADED_TOAST);
+  expect(await formPo.isPresent()).toBe(true);
+  expect(await reviewPo.isPresent()).toBe(false);
+});

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -16,10 +16,11 @@ import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
+import { SnsSwapLifecycle } from "@icp-sdk/canisters/sns";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import type { MockInstance } from "vitest";
@@ -48,6 +49,7 @@ describe("ImportTokenModal", () => {
     return po;
   };
   let queryIcrcTokenSpy: MockInstance;
+  let getLedgerIdSpy: MockInstance;
 
   beforeEach(() => {
     resetIdentity();
@@ -56,7 +58,11 @@ describe("ImportTokenModal", () => {
       .spyOn(ledgerApi, "queryIcrcToken")
       .mockResolvedValue(tokenMetaData);
 
-    vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(ledgerCanisterId);
+    getLedgerIdSpy = vi
+      .spyOn(icrcIndexApi, "getLedgerId")
+      .mockResolvedValue(ledgerCanisterId);
+    // The SNS projects are loaded and there is no SNS project.
+    setSnsProjects([]);
     page.mock({
       routeId: AppPath.Tokens,
     });
@@ -153,6 +159,61 @@ describe("ImportTokenModal", () => {
         "You cannot import SNS tokens, they are added by the NNS."
       );
       expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+      // Stays on the form.
+      expect(await formPo.isPresent()).toEqual(true);
+    });
+
+    it.each([
+      SnsSwapLifecycle.Pending,
+      SnsSwapLifecycle.Open,
+      SnsSwapLifecycle.Adopted,
+    ])(
+      "should catch importing of an SNS ledger with lifecycle %s",
+      async (lifecycle) => {
+        setSnsProjects([
+          {
+            ledgerCanisterId,
+            lifecycle,
+          },
+        ]);
+
+        const po = renderComponent();
+        const formPo = po.getImportTokenFormPo();
+
+        await formPo
+          .getLedgerCanisterInputPo()
+          .typeText(ledgerCanisterId.toText());
+        await formPo.getSubmitButtonPo().click();
+
+        expect(get(busyStore)).toEqual([]);
+        expectToastError(
+          "You cannot import SNS tokens, they are added by the NNS."
+        );
+        expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+        expect(getLedgerIdSpy).toBeCalledTimes(0);
+        // Stays on the form.
+        expect(await formPo.isPresent()).toEqual(true);
+      }
+    );
+
+    it("should refuse validation while the SNS projects are not loaded", async () => {
+      resetSnsProjects();
+
+      const po = renderComponent();
+      const formPo = po.getImportTokenFormPo();
+
+      await formPo
+        .getLedgerCanisterInputPo()
+        .typeText(ledgerCanisterId.toText());
+      await formPo.getIndexCanisterInputPo().typeText(indexCanisterId.toText());
+      await formPo.getSubmitButtonPo().click();
+
+      expect(get(busyStore)).toEqual([]);
+      expectToastError(
+        "The list of SNS projects is not loaded yet. Try again in a moment."
+      );
+      expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+      expect(getLedgerIdSpy).toBeCalledTimes(0);
       // Stays on the form.
       expect(await formPo.isPresent()).toEqual(true);
     });
@@ -734,6 +795,63 @@ describe("ImportTokenModal", () => {
       expect(consoleErrorSpy).toBeCalledWith(
         new Error(`Invalid character: "_"`)
       );
+    });
+
+    it("does not auto-submit before the SNS projects load", async () => {
+      resetSnsProjects();
+
+      const po = renderComponent();
+      const formPo = po.getImportTokenFormPo();
+
+      importedTokensStore.set({
+        importedTokens: [],
+        certified: true,
+      });
+      await runResolvedPromises();
+
+      // The imported tokens are loaded but the SNS projects are not.
+      expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+      expect(getLedgerIdSpy).toBeCalledTimes(0);
+      expect(get(toastsStore)).toEqual([]);
+      expect(await formPo.isPresent()).toEqual(true);
+
+      setSnsProjects([
+        {
+          ledgerCanisterId,
+          lifecycle: SnsSwapLifecycle.Open,
+        },
+      ]);
+      await runResolvedPromises();
+
+      expectToastError(
+        "You cannot import SNS tokens, they are added by the NNS."
+      );
+      expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+      expect(getLedgerIdSpy).toBeCalledTimes(0);
+      expect(await formPo.isPresent()).toEqual(true);
+    });
+
+    it("auto-submits once the SNS projects are loaded", async () => {
+      resetSnsProjects();
+
+      const po = renderComponent();
+      const formPo = po.getImportTokenFormPo();
+
+      importedTokensStore.set({
+        importedTokens: [],
+        certified: true,
+      });
+      await runResolvedPromises();
+
+      expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+      expect(await formPo.isPresent()).toEqual(true);
+
+      setSnsProjects([]);
+      await runResolvedPromises();
+      await tick();
+
+      expect(queryIcrcTokenSpy).toBeCalledTimes(1);
+      expect(await formPo.isPresent()).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

The import token form checked a ledger against committed SNS projects only. A ledger of a Pending, Open, or Adopted SNS passed the check, and the SNS list stayed unloaded for the whole session when the aggregator fetch failed. Either gap let an attacker pair a real SNS ledger with a fake index canister and get a user to import it, showing fabricated transaction history next to the real balance.

# Changes

- Checked the ledger against every SNS lifecycle, not committed projects only.
- Refused an SNS ledger before the ledger/index pair check runs.
- Gated the auto-submit path on the same loaded check, so a deep link can't submit before the SNS list loads.
- Added a toast and an i18n key for the not-loaded case.
- Added unit tests covering each lifecycle and the loaded/not-loaded timing.
- Added an e2e spec for the SNS ledger import denylist.

# Tests

- `npm run check`, `CI=true npm run test`, and `./scripts/check-relative-imports` all pass.
- Added `it.each` unit cases for Pending, Open, and Adopted lifecycles, plus cases for the not-loaded state and the auto-submit timing race.
- Added `frontend/src/tests/e2e/import-token-sns-denylist.spec.ts`, not yet run: this machine has no working snsdemo replica. It needs a run on a machine with one, or in CI, before merge.

# Todos

- [ ] Accessibility (a11y) – no impact, no new UI element beyond an existing toast style.
- [ ] Changelog – added, under `#### Security`.
