### PR TITLE
fix(aggregator): pin home page Prism assets with Subresource Integrity

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -1,4 +1,4 @@
-86
+88
 Monterey
 IC
 ICP
@@ -85,3 +85,5 @@ DoS
 Ctrl
 Cmd
 Banxa
+Subresource
+stylesheet

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -15,6 +15,8 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ### Fixed
 ### Security
 
+- Pin the home page's Prism script and stylesheet with Subresource Integrity and load them from the certified gateway.
+
 ## [Proposal 137283](https://dashboard.internetcomputer.org/proposal/137283)
 ### Added
 - Include SNS Governance metrics.

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -8,6 +8,9 @@ use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
+#[cfg(test)]
+mod tests;
+
 /// A standard HTTP header
 type HeaderField = (String, String);
 

--- a/rs/sns_aggregator/src/assets/tests.rs
+++ b/rs/sns_aggregator/src/assets/tests.rs
@@ -1,0 +1,58 @@
+//! Tests for the aggregator assets
+#![allow(clippy::panic)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+/// The home page, exactly as it is compiled into the canister.
+const HOME_PAGE: &str = include_str!("../index.html");
+
+/// The text of every tag in the given HTML, without the enclosing angle brackets.
+///
+/// For example `<link href="x" />` yields `link href="x" /`.
+fn tag_bodies(html: &str) -> Vec<&str> {
+    html.split('<')
+        .skip(1)
+        .filter_map(|chunk| chunk.split_once('>').map(|(body, _rest)| body))
+        .collect()
+}
+
+/// True if the tag body is a tag with the given name, such as `script` or `link`.
+fn has_tag_name(tag_body: &str, name: &str) -> bool {
+    tag_body
+        .strip_prefix(name)
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with('/') || rest.starts_with(char::is_whitespace))
+}
+
+/// Every external `<script>` and `<link>` on the home page must be pinned with a
+/// Subresource Integrity hash and must come from a certified gateway.
+///
+/// The hashes themselves are verified by hand, because the test has no network.
+#[test]
+fn home_page_pins_every_external_script_and_stylesheet() {
+    let mut pinned_tags = 0;
+    for tag_body in tag_bodies(HOME_PAGE) {
+        if !has_tag_name(tag_body, "script") && !has_tag_name(tag_body, "link") {
+            continue;
+        }
+        if !tag_body.contains("src=\"https://") && !tag_body.contains("href=\"https://") {
+            continue;
+        }
+        assert!(
+            tag_body.contains("integrity=\"sha384-"),
+            "External resource has no Subresource Integrity hash: <{tag_body}>"
+        );
+        assert!(
+            tag_body.contains("crossorigin=\"anonymous\""),
+            "External resource has no crossorigin=\"anonymous\", so the browser ignores its Subresource Integrity hash: <{tag_body}>"
+        );
+        assert!(
+            !tag_body.contains(".raw."),
+            "External resource is loaded from an uncertified raw gateway: <{tag_body}>"
+        );
+        pinned_tags += 1;
+    }
+    assert!(
+        pinned_tags >= 2,
+        "The scan found {pinned_tags} external resources on the home page but expected at least 2, so the scan is broken."
+    );
+}

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -4,10 +4,19 @@
     <meta charset="utf-8" />
     <title>SNS aggregator</title>
 
-    <!-- Juno's CDN -->
+    <!--
+      Juno's CDN.
+      The integrity attribute pins the exact bytes of each file.
+      If you change a version in a URL, compute the new hash with:
+      curl -s URL | openssl dgst -sha384 -binary | openssl base64 -A
+      If the hash is wrong, the browser refuses the file.
+      The page still works, but the code examples lose their colors.
+    -->
     <link
-      href="https://fmkjf-bqaaa-aaaal-acpza-cai.raw.icp0.io/libs/prism-themes/1.9.0/themes/prism-vsc-dark-plus.min.css"
+      href="https://fmkjf-bqaaa-aaaal-acpza-cai.icp0.io/libs/prism-themes/1.9.0/themes/prism-vsc-dark-plus.min.css"
       rel="stylesheet"
+      integrity="sha384-UavePWn2zyHuZbvVQRu5n4XEhCiueqts8YR0Dqq1mnsearU03Jfxl1XSHffMI1kq"
+      crossorigin="anonymous"
     />
 
     <style>
@@ -560,6 +569,11 @@ const snses = await response.json();</code></pre>
       document.addEventListener("DOMContentLoaded", loadSnses, { once: true });
     </script>
 
-    <script src="https://fmkjf-bqaaa-aaaal-acpza-cai.raw.icp0.io/libs/prismjs/1.29.0/prism.min.js"></script>
+    <!-- Juno's CDN.  To change the version, read the note in the head. -->
+    <script
+      src="https://fmkjf-bqaaa-aaaal-acpza-cai.icp0.io/libs/prismjs/1.29.0/prism.min.js"
+      integrity="sha384-06z5D//U/xpvxZHuUz92xBvq3DqBBFi7Up53HRrbV7Jlv7Yvh/MZ7oenfUe9iCEt"
+      crossorigin="anonymous"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
# Motivation

The aggregator home page loaded Prism's script and stylesheet from a third-party Juno CDN canister over the raw `.raw.icp0.io` gateway, with no integrity check.

A raw response is a single-replica query, not a certified response, so a dishonest replica could serve different bytes and the browser would run them with no warning.

# Changes

- Switched both the `<link>` and the `<script>` tags in `rs/sns_aggregator/src/index.html` from `.raw.icp0.io` to the certified `.icp0.io` gateway.
- Added `integrity="sha384-..."` and `crossorigin="anonymous"` to both tags, so the browser rejects any content that does not match the pinned Prism 1.29.0 / prism-themes 1.9.0 bytes.
- Added a unit test, `home_page_pins_every_external_script_and_stylesheet`, that scans `index.html` and fails if a `<script>` or `<link>` tag loads an `https://` resource without an `integrity` and `crossorigin` attribute, or uses a `.raw.` host.
- Added `Subresource` and `stylesheet` to `.config/spellcheck.dic` for the new changelog line.
- Recorded the fix under `CHANGELOG-Sns_Aggregator.md` / `Unreleased` / `Security`.

Both hashes were verified against a second source, cdnjs, and both files are byte-identical:

```
curl -s https://fmkjf-bqaaa-aaaal-acpza-cai.icp0.io/libs/prism-themes/1.9.0/themes/prism-vsc-dark-plus.min.css | openssl dgst -sha384 -binary | openssl base64 -A
curl -s https://cdnjs.cloudflare.com/ajax/libs/prism-themes/1.9.0/prism-vsc-dark-plus.min.css                    | openssl dgst -sha384 -binary | openssl base64 -A
curl -s https://fmkjf-bqaaa-aaaal-acpza-cai.icp0.io/libs/prismjs/1.29.0/prism.min.js                             | openssl dgst -sha384 -binary | openssl base64 -A
curl -s https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js                                         | openssl dgst -sha384 -binary | openssl base64 -A
```

| file | Juno CDN (certified) sha384 | cdnjs sha384 |
| --- | --- | --- |
| `prism-vsc-dark-plus.min.css` | `UavePWn2zyHuZbvVQRu5n4XEhCiueqts8YR0Dqq1mnsearU03Jfxl1XSHffMI1kq` | same |
| `prism.min.js` | `06z5D//U/xpvxZHuUz92xBvq3DqBBFi7Up53HRrbV7Jlv7Yvh/MZ7oenfUe9iCEt` | same |

# Tests

- `cargo test -p sns_aggregator` covers the new `assets::tests::home_page_pins_every_external_script_and_stylesheet` test, which fails on `main` (missing `integrity`) and passes on this branch. Verified with 4 mutations: a full revert, a dropped `crossorigin`, a dropped `integrity`, and a `.raw.` host, all fail the test.
- `./scripts/lint-rs`, `cargo test`, and `cargo spellcheck -- --code 1` all pass.
- `scripts/spellcheck-changelog` (the CI `spelling` job's second step) fails on `main`'s dictionary and passes with the new `.config/spellcheck.dic` entries.

# Todos

- The SRI hash must be updated by hand whenever the pinned Prism version changes. An HTML comment next to each tag in `index.html` names the exact `curl | openssl` command to recompute it.
- No test or CI job can check that a hash is correct, only that one is present. A wrong hash fails safe: the browser blocks the file and logs a console error, the SNS list still loads, and only the code sample colors are lost.
