### PR TITLE
fix(wallet): refresh account balances with certified calls only

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,10 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- The wallet page balance refresh now uses only certified calls. Before, an
+  unverified query answer could stop the certified refresh for the whole
+  session.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/workers/balances.worker.ts
+++ b/frontend/src/lib/workers/balances.worker.ts
@@ -43,32 +43,25 @@ const syncBalances = async (
   params: TimerWorkerUtilsJobData<PostMessageDataRequestBalances>
 ) => {
   try {
-    const queries = await getIcrcAccountsBalances({
-      ...params,
-      certified: false,
-    });
-
-    const changes = queries.filter(
-      ({ key, balance }) => balance !== store.state[key]?.balance
-    );
-
-    if (changes.length === 0) {
-      // Optimistic approach:
-      // Nothing has changed according query calls therefore, we spare the update calls.
-      // We do this for performance reason in order to reduce to the amount of update calls we perform from this worker.
-      return;
-    }
-
-    // Call and update store with certified data
+    // Only a certified answer may decide whether a balance changed, because a
+    // query answer comes from a single replica.
     const updates = await getIcrcAccountsBalances({
       ...params,
       certified: true,
     });
 
-    store.update(updates);
+    const changes = updates.filter(
+      ({ key, balance }) => balance !== store.state[key]?.balance
+    );
+
+    if (changes.length === 0) {
+      return;
+    }
+
+    store.update(changes);
 
     emitBalances(
-      updates.map(({ key, balance }) => ({
+      changes.map(({ key, balance }) => ({
         accountIdentifier: key,
         balance,
       }))

--- a/frontend/src/tests/e2e/balances-worker-certified.spec.ts
+++ b/frontend/src/tests/e2e/balances-worker-certified.spec.ts
@@ -1,3 +1,4 @@
+import { SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS } from "$lib/constants/accounts.constants";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
@@ -9,11 +10,6 @@ import {
 import { expect, test, type Request } from "@playwright/test";
 
 const TEST_TOKEN_NAME = "ckRED";
-
-// Mirrors SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS in
-// $lib/constants/accounts.constants.ts. A Playwright spec cannot import a
-// frontend constant, so the value is copied.
-const SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS = 30_000;
 
 // Time to let the wallet page finish its own load calls before the measured
 // window starts.

--- a/frontend/src/tests/e2e/balances-worker-certified.spec.ts
+++ b/frontend/src/tests/e2e/balances-worker-certified.spec.ts
@@ -1,0 +1,142 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import {
+  dfxCanisterId,
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test, type Request } from "@playwright/test";
+
+const TEST_TOKEN_NAME = "ckRED";
+
+// Mirrors SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS in
+// $lib/constants/accounts.constants.ts. A Playwright spec cannot import a
+// frontend constant, so the value is copied.
+const SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS = 30_000;
+
+// Time to let the wallet page finish its own load calls before the measured
+// window starts.
+const SETTLE_MILLIS = 5_000;
+
+// One full timer interval, plus room for the update call to complete.
+const WINDOW_MILLIS = SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS + 15_000;
+
+type BalanceCall = {
+  // An ingress (update) call goes to /call. A query goes to /query.
+  certified: boolean;
+  url: string;
+};
+
+/**
+ * The balances web worker polls the balance of the account the wallet page
+ * shows. Before the fix it asked the ledger with an uncertified query first and
+ * only sent the certified call when that query reported a different balance. A
+ * single malicious replica could answer the query with the last known balance
+ * and stop every certified read for the whole session.
+ *
+ * This spec watches the HTTP traffic to the ledger canister. After the page has
+ * settled, every icrc1_balance_of request that the poll sends must be an
+ * ingress call. The spec fails on `main`, where the steady-state tick sends a
+ * query and no call.
+ */
+test("Balances worker polls the ledger with certified calls only", async ({
+  page,
+  context,
+}) => {
+  const ledgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const indexCanisterId = await dfxCanisterId("ckred_index");
+
+  const balanceCalls: BalanceCall[] = [];
+
+  // The worker runs in a dedicated web worker. Chromium reports its requests on
+  // the page that owns it, so the context listener sees them.
+  context.on("request", (request: Request) => {
+    const url = request.url();
+
+    if (!url.includes(`/canister/${ledgerCanisterId}/`)) {
+      return;
+    }
+
+    // The agent sends CBOR. The method name is a text string inside it, so the
+    // ASCII bytes appear verbatim in the body.
+    const body = request.postDataBuffer();
+
+    if (body === null || !body.includes("icrc1_balance_of")) {
+      return;
+    }
+
+    balanceCalls.push({ certified: url.endsWith("/call"), url });
+  });
+
+  await page.goto("/tokens");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+
+  step("Import the test token so the wallet page has an ICRC account");
+
+  await tokensPagePo.getSettingsButtonPo().click();
+
+  const importButtonPo = tokensPagePo.getImportTokenButtonPo();
+  await importButtonPo.waitFor();
+  await importButtonPo.click();
+
+  const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
+  await importTokenModalPo.waitFor();
+
+  const formPo = importTokenModalPo.getImportTokenFormPo();
+  await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId);
+  await formPo.getIndexCanisterInputPo().typeText(indexCanisterId);
+  await formPo.getSubmitButtonPo().click();
+
+  const reviewPo = importTokenModalPo.getImportTokenReviewPo();
+  await reviewPo.waitFor();
+  expect(await reviewPo.getTokenName()).toBe(TEST_TOKEN_NAME);
+  await reviewPo.getConfirmButtonPo().click();
+
+  step("Wait for the wallet page to show a balance");
+
+  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
+  await walletPo.waitFor();
+
+  const headingPo = walletPo.getWalletPageHeadingPo();
+
+  await expect
+    .poll(() => headingPo.getTitle(), { timeout: 60_000 })
+    .not.toBeNull();
+
+  const balanceOnLoad = await headingPo.getTitle();
+
+  step("Let the page settle, then measure one full poll interval");
+
+  await page.waitForTimeout(SETTLE_MILLIS);
+
+  const mark = balanceCalls.length;
+
+  await page.waitForTimeout(WINDOW_MILLIS);
+
+  const callsInWindow = balanceCalls.slice(mark);
+
+  step("The poll must reach the ledger, and only with certified calls");
+
+  // Fails closed: if the worker stopped polling, or if the requests never
+  // reached this listener, the window is empty and this assertion fails.
+  expect(callsInWindow.length).toBeGreaterThan(0);
+
+  // The regression assertion. On `main` the steady-state tick sends a query and
+  // this list holds a `false`.
+  expect(callsInWindow.map(({ certified }) => certified)).toEqual(
+    callsInWindow.map(() => true)
+  );
+
+  step("The balance on screen stays stable while the poll runs");
+
+  // Nothing changed the account, so the certified poll must not change or clear
+  // the value on screen. This guards the claim that the fix needs no design
+  // change: no flicker, and no balance that disappears and comes back.
+  expect(await headingPo.getTitle()).toBe(balanceOnLoad);
+});

--- a/frontend/src/tests/lib/workers/balances.worker.spec.ts
+++ b/frontend/src/tests/lib/workers/balances.worker.spec.ts
@@ -1,0 +1,213 @@
+import { SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS } from "$lib/constants/accounts.constants";
+import type {
+  PostMessageDataRequestBalances,
+  PostMessageDataResponseBalances,
+} from "$lib/types/post-message.balances";
+import type { PostMessage } from "$lib/types/post-messages";
+import type { GetAccountsBalanceData } from "$lib/worker-services/icrc-balances.worker-services";
+import { getIcrcAccountsBalances } from "$lib/worker-services/icrc-balances.worker-services";
+import "$lib/workers/balances.worker";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { advanceTime } from "$tests/utils/timers.test-utils";
+import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
+import { AuthClient } from "@icp-sdk/auth/client";
+import { mock } from "vitest-mock-extended";
+
+vi.mock("$lib/worker-services/icrc-balances.worker-services", () => ({
+  getIcrcAccountsBalances: vi.fn(),
+}));
+
+describe("balances.worker", () => {
+  const accountIdentifier1 =
+    "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f";
+  const accountIdentifier2 =
+    "5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5d4d47f04e0e";
+
+  const startData: PostMessageDataRequestBalances = {
+    accountIdentifiers: [accountIdentifier1],
+    ledgerCanisterId: "mxzaz-hqaaa-aaaar-qaada-cai",
+    host: "https://icp-api.io",
+    fetchRootKey: false,
+  };
+
+  const balanceData = ({
+    key,
+    balance,
+  }: {
+    key: string;
+    balance: bigint;
+  }): GetAccountsBalanceData => ({
+    key,
+    balance,
+    certified: true,
+  });
+
+  let spyPostMessage: ReturnType<typeof vi.fn>;
+
+  // The worker module assigns the global `onmessage` handler when it is
+  // imported. This is how the main thread talks to it.
+  const postMessageToWorker = async (
+    msg: "nnsStartBalancesTimer" | "nnsStopBalancesTimer"
+  ): Promise<void> =>
+    await (
+      globalThis.onmessage as unknown as (event: {
+        data: PostMessage<PostMessageDataRequestBalances>;
+      }) => Promise<void>
+    )({ data: { msg, data: startData } });
+
+  const startWorker = (): Promise<void> =>
+    postMessageToWorker("nnsStartBalancesTimer");
+
+  // The worker module is a singleton. Every test must stop the timer and reset
+  // the store, otherwise the next test inherits both.
+  const runAndStopWorker = async (test: () => Promise<void>): Promise<void> => {
+    try {
+      await test();
+    } finally {
+      await postMessageToWorker("nnsStopBalancesTimer");
+    }
+  };
+
+  const postedMessages = (msg: string): { data: unknown }[] =>
+    spyPostMessage.mock.calls
+      .map(([message]) => message)
+      .filter((message) => message.msg === msg);
+
+  const syncBalancesMessages = (): PostMessageDataResponseBalances[] =>
+    postedMessages("nnsSyncBalances").map(
+      ({ data }) => data as PostMessageDataResponseBalances
+    );
+
+  const certifiedParamsOfCalls = (): boolean[] =>
+    vi
+      .mocked(getIcrcAccountsBalances)
+      .mock.calls.map(([{ certified }]) => certified);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    spyPostMessage = vi.fn();
+    global.postMessage = spyPostMessage as unknown as typeof global.postMessage;
+
+    const mockAuthClient = mock<AuthClient>();
+    mockAuthClient.isAuthenticated.mockResolvedValue(true);
+    mockAuthClient.getIdentity.mockResolvedValue(mockIdentity as never);
+    vi.spyOn(AuthClient, "create").mockImplementation(
+      async (): Promise<AuthClient> => mockAuthClient
+    );
+  });
+
+  it("should only make a certified call on start", () =>
+    runAndStopWorker(async () => {
+      vi.mocked(getIcrcAccountsBalances).mockResolvedValue([
+        balanceData({ key: accountIdentifier1, balance: 100n }),
+      ]);
+
+      await startWorker();
+
+      expect(getIcrcAccountsBalances).toHaveBeenCalledTimes(1);
+      expect(getIcrcAccountsBalances).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        data: startData,
+        certified: true,
+      });
+      expect(certifiedParamsOfCalls()).toEqual([true]);
+
+      expect(syncBalancesMessages()).toEqual([
+        {
+          balances: [{ accountIdentifier: accountIdentifier1, balance: 100n }],
+        },
+      ]);
+    }));
+
+  it("should make a certified call on the next tick when the balance does not change", () =>
+    runAndStopWorker(async () => {
+      vi.mocked(getIcrcAccountsBalances).mockResolvedValue([
+        balanceData({ key: accountIdentifier1, balance: 100n }),
+      ]);
+
+      await startWorker();
+
+      expect(certifiedParamsOfCalls()).toEqual([true]);
+      expect(syncBalancesMessages()).toHaveLength(1);
+
+      await advanceTime(SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS);
+
+      // The second tick must read the ledger with a certified call. Otherwise a
+      // replica that echoes the last balance in a query answer stops every
+      // further certified read for the whole session.
+      expect(certifiedParamsOfCalls()).toEqual([true, true]);
+
+      // The balance did not change, so the worker emits nothing new.
+      expect(syncBalancesMessages()).toHaveLength(1);
+    }));
+
+  it("should emit the new balance when the certified balance changes", () =>
+    runAndStopWorker(async () => {
+      vi.mocked(getIcrcAccountsBalances).mockResolvedValue([
+        balanceData({ key: accountIdentifier1, balance: 100n }),
+      ]);
+
+      await startWorker();
+
+      vi.mocked(getIcrcAccountsBalances).mockResolvedValue([
+        balanceData({ key: accountIdentifier1, balance: 200n }),
+      ]);
+
+      await advanceTime(SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS);
+
+      expect(certifiedParamsOfCalls()).toEqual([true, true]);
+      expect(syncBalancesMessages()).toEqual([
+        {
+          balances: [{ accountIdentifier: accountIdentifier1, balance: 100n }],
+        },
+        {
+          balances: [{ accountIdentifier: accountIdentifier1, balance: 200n }],
+        },
+      ]);
+    }));
+
+  it("should emit only the accounts whose certified balance changed", () =>
+    runAndStopWorker(async () => {
+      vi.mocked(getIcrcAccountsBalances).mockResolvedValue([
+        balanceData({ key: accountIdentifier1, balance: 100n }),
+        balanceData({ key: accountIdentifier2, balance: 300n }),
+      ]);
+
+      await startWorker();
+
+      vi.mocked(getIcrcAccountsBalances).mockResolvedValue([
+        balanceData({ key: accountIdentifier1, balance: 100n }),
+        balanceData({ key: accountIdentifier2, balance: 400n }),
+      ]);
+
+      await advanceTime(SYNC_ACCOUNTS_TIMER_INTERVAL_MILLIS);
+
+      expect(syncBalancesMessages()).toEqual([
+        {
+          balances: [
+            { accountIdentifier: accountIdentifier1, balance: 100n },
+            { accountIdentifier: accountIdentifier2, balance: 300n },
+          ],
+        },
+        {
+          balances: [{ accountIdentifier: accountIdentifier2, balance: 400n }],
+        },
+      ]);
+    }));
+
+  it("should post an error message when the certified call fails", () =>
+    runAndStopWorker(async () => {
+      silentConsoleErrors();
+
+      const error = new Error("Ledger unreachable");
+      vi.mocked(getIcrcAccountsBalances).mockRejectedValue(error);
+
+      await startWorker();
+
+      expect(postedMessages("nnsSyncErrorBalances")).toEqual([
+        { msg: "nnsSyncErrorBalances", data: error },
+      ]);
+      expect(syncBalancesMessages()).toHaveLength(0);
+    }));
+});


### PR DESCRIPTION
# Motivation

The wallet page balance worker checked a balance with an uncertified query first. It only ran a certified call when the query answer differed from the last certified value. A replica that keeps echoing the last certified balance in the query answer stops every later certified call. The wallet then shows a stale balance for the whole session, hiding new deposits or withdrawals, until the user reloads the page.

# Changes

- Removed the uncertified query call from `syncBalances` in `balances.worker.ts`.
- Made the worker send one certified call per tick and compute changes from it.
- Kept the emit-on-change behavior: the worker posts a balance update only when the certified value changed.
- Added a changelog line under Security.

# Tests

- Added `frontend/src/tests/lib/workers/balances.worker.spec.ts`. It covers the start call, the no-emit case on an unchanged certified balance, the emit case on a changed balance, the per-account filter, and the error path. The no-emit case fails on `main` and passes on this branch.
- Added `frontend/src/tests/e2e/balances-worker-certified.spec.ts`. It records every ledger `icrc1_balance_of` request during a steady-state tick and checks each one is a certified call, not a query.
- `npm run check`, `CI=true npm run test`, and `./scripts/check-relative-imports` pass in `frontend`.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
- Two related certified-refresh fixes are in flight: 1788180805 (portfolio balance services, branch `fix/portfolio-balances-certified`) and 1788180806 (SNS swap metrics, branch `fix/sns-swap-metrics-certified`).
