### PR TITLE
fix(accounts): ask the ledger canister to verify the imported index canister pair

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,11 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+- Ask the ledger canister which index canister belongs to it before an imported
+  token accepts an index canister ID. Before, the app trusted the answer of the
+  index canister itself, so a fake index canister could show an invented
+  transaction history for a real token.
+
 #### Not Published
 
 ### Operations

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -5,6 +5,7 @@ import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
+import { isCanisterMethodNotFoundError } from "$lib/utils/error.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import {
   arrayOfNumberToUint8Array,
@@ -15,6 +16,7 @@ import {
 } from "@dfinity/utils";
 import {
   IcrcLedgerCanister,
+  IndexPrincipalNotSetError,
   type IcrcAccount,
   type IcrcLedgerDid,
   type TransferParams,
@@ -62,6 +64,37 @@ export const queryIcrcMintingAccount = async ({
     owner: result.owner,
     subaccount: fromNullable(result.subaccount),
   };
+};
+
+/**
+ * Asks the ledger canister which index canister belongs to it (ICRC-106).
+ *
+ * Returns `undefined` when the ledger names no index canister, and when the
+ * ledger has no `icrc106_get_index_principal` method at all. Every other error
+ * is rethrown.
+ */
+export const queryIcrcIndexPrincipal = async ({
+  identity,
+  certified,
+  canisterId,
+}: {
+  identity: Identity;
+  certified: boolean;
+  canisterId: Principal;
+}): Promise<Principal | undefined> => {
+  const { canister } = await icrcLedgerCanister({ identity, canisterId });
+
+  try {
+    return await canister.getIndexPrincipal({ certified });
+  } catch (err: unknown) {
+    if (
+      err instanceof IndexPrincipalNotSetError ||
+      isCanisterMethodNotFoundError(err)
+    ) {
+      return undefined;
+    }
+    throw err;
+  }
 };
 
 export const queryIcrcBalance = async ({

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -135,6 +135,7 @@
     "qrcode_token_incompatible": "The payment token you are attempting to use is not compatible with this transaction.",
     "invalid_ledger_index_pair": "The provided index canister ID does not match the associated ledger canister ID.",
     "index_canister_validation": "An error occurred while validating the index canister ID. It appears that $indexCanister might not be a valid index canister ID.",
+    "ledger_canister_validation": "An error occurred while validating the ledger canister ID. It appears that $ledgerCanister might not be a valid ledger canister ID.",
     "refresh_voting_power": "An error occurred while confirming following.",
     "unknown_topic_title": "Unknown Topic ($topicId)",
     "unknown_proposal_status_title": "Unknown Proposal Status ($statusId)",

--- a/frontend/src/lib/services/icrc-index.services.ts
+++ b/frontend/src/lib/services/icrc-index.services.ts
@@ -42,15 +42,31 @@ export const matchLedgerIndexPair = async ({
   ledgerCanisterId: Principal;
   indexCanisterId: Principal;
 }): Promise<boolean> => {
+  let indexIdFromLedgerCanister: Principal | undefined;
+
   try {
     // The user typed the ledger canister ID, so the call must not carry the
     // principal of the user to it.
-    const indexIdFromLedgerCanister = await queryIcrcIndexPrincipal({
+    indexIdFromLedgerCanister = await queryIcrcIndexPrincipal({
       identity: getAnonymousIdentity(),
       canisterId: ledgerCanisterId,
       certified: true,
     });
+  } catch (err) {
+    // This call targets the ledger canister, so a failure here points at the
+    // ledger, not at the index canister.
+    console.error(err);
+    toastsError({
+      labelKey: "error.ledger_canister_validation",
+      substitutions: {
+        $ledgerCanister: ledgerCanisterId.toText(),
+      },
+      err,
+    });
+    return false;
+  }
 
+  try {
     let match: boolean;
 
     if (nonNullish(indexIdFromLedgerCanister)) {

--- a/frontend/src/lib/services/icrc-index.services.ts
+++ b/frontend/src/lib/services/icrc-index.services.ts
@@ -1,6 +1,11 @@
 import { getLedgerId as getLedgerIdApi } from "$lib/api/icrc-index.api";
-import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import { queryIcrcIndexPrincipal } from "$lib/api/icrc-ledger.api";
+import {
+  getAnonymousIdentity,
+  getAuthenticatedIdentity,
+} from "$lib/services/auth.services";
 import { toastsError } from "$lib/stores/toasts.store";
+import { nonNullish } from "@dfinity/utils";
 import type { Principal } from "@icp-sdk/core/principal";
 
 const getLedgerId = async ({
@@ -21,8 +26,14 @@ const getLedgerId = async ({
 
 /**
  * Validates whether the provided index canister ID corresponds to the given ledger canister ID.
- * This function uses `ledger_id` icrc1 index canister api to check if the indexCanisterId is correctly associated with
- * the provided ledgerCanisterId.
+ *
+ * The function asks the ledger canister first, with the ICRC-106
+ * `icrc106_get_index_principal` method. The ledger is the trusted side of the
+ * pair, so its answer decides the result and the index canister is not called.
+ *
+ * Not every ledger names an index canister. When the ledger names none, the
+ * function falls back to the `ledger_id` method of the index canister. That
+ * answer comes from the canister under test, so it proves less.
  */
 export const matchLedgerIndexPair = async ({
   ledgerCanisterId,
@@ -32,12 +43,25 @@ export const matchLedgerIndexPair = async ({
   indexCanisterId: Principal;
 }): Promise<boolean> => {
   try {
-    const ledgerIdFromIndexCanister = await getLedgerId({
-      indexCanisterId,
+    // The user typed the ledger canister ID, so the call must not carry the
+    // principal of the user to it.
+    const indexIdFromLedgerCanister = await queryIcrcIndexPrincipal({
+      identity: getAnonymousIdentity(),
+      canisterId: ledgerCanisterId,
       certified: true,
     });
-    const match =
-      ledgerIdFromIndexCanister.toText() === ledgerCanisterId.toText();
+
+    let match: boolean;
+
+    if (nonNullish(indexIdFromLedgerCanister)) {
+      match = indexIdFromLedgerCanister.toText() === indexCanisterId.toText();
+    } else {
+      const ledgerIdFromIndexCanister = await getLedgerId({
+        indexCanisterId,
+        certified: true,
+      });
+      match = ledgerIdFromIndexCanister.toText() === ledgerCanisterId.toText();
+    }
 
     if (!match) {
       toastsError({

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -139,6 +139,7 @@ interface I18nError {
   qrcode_token_incompatible: string;
   invalid_ledger_index_pair: string;
   index_canister_validation: string;
+  ledger_canister_validation: string;
   refresh_voting_power: string;
   unknown_topic_title: string;
   unknown_proposal_status_title: string;

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -213,3 +213,21 @@ export const isCanisterOutOfCyclesError = (error: unknown): boolean => {
   const errorPrefix = "IC0";
   return rejectErrorCode.startsWith(errorPrefix);
 };
+
+/**
+ * True when a canister rejected the call because it has no such method.
+ * The IC error code for a missing method is IC0536 (CanisterMethodNotFound).
+ */
+export const isCanisterMethodNotFoundError = (error: unknown): boolean => {
+  if (!(error instanceof AgentError)) return false;
+
+  const { code } = error;
+
+  if (
+    !(code instanceof UncertifiedRejectErrorCode) &&
+    !(code instanceof CertifiedRejectErrorCode)
+  )
+    return false;
+
+  return code.rejectErrorCode === "IC0536";
+};

--- a/frontend/src/tests/e2e/import-token-ledger-index-pair.spec.ts
+++ b/frontend/src/tests/e2e/import-token-ledger-index-pair.spec.ts
@@ -1,0 +1,153 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import {
+  dfxCanisterId,
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { expect, test, type Page } from "@playwright/test";
+
+const TEST_TOKEN_NAME = "ckRED";
+
+// An IC ingress envelope of an anonymous caller carries `sender` as the single
+// byte 0x04 and no `sender_pubkey` field. In CBOR that is the hex sequence
+// below: 66 "sender" (text of 6 bytes), 41 (byte string of 1 byte), 04.
+const ANONYMOUS_SENDER_HEX = "6673656e6465724104";
+
+type IcCall = {
+  canisterId: string;
+  method: string;
+  anonymous: boolean;
+};
+
+// The candid method name travels as plain ASCII inside the CBOR envelope, so a
+// substring test finds it without a CBOR parser.
+const METHOD_NAMES = ["icrc106_get_index_principal", "ledger_id"];
+
+const recordIcCalls = (page: Page): IcCall[] => {
+  const calls: IcCall[] = [];
+
+  page.on("request", (request) => {
+    if (request.method() !== "POST") return;
+
+    const match = request
+      .url()
+      .match(/\/api\/v\d+\/canister\/([a-z0-9-]+)\/(?:call|query)$/);
+    if (match === null) return;
+
+    const body = request.postDataBuffer();
+    if (body === null) return;
+
+    const ascii = body.toString("latin1");
+    const method = METHOD_NAMES.find((name) => ascii.includes(name));
+    if (method === undefined) return;
+
+    calls.push({
+      canisterId: match[1],
+      method,
+      anonymous: body.toString("hex").includes(ANONYMOUS_SENDER_HEX),
+    });
+  });
+
+  return calls;
+};
+
+test("The ledger canister verifies the index canister pair", async ({
+  page,
+  context,
+}) => {
+  const testLedgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const testIndexCanisterId = await dfxCanisterId("ckred_index");
+
+  const calls = recordIcCalls(page);
+
+  await page.goto("/tokens");
+  await disableCssAnimations(page);
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+  const tokensPagePo = appPo.getTokensPo().getTokensPagePo();
+
+  await tokensPagePo.getSettingsButtonPo().click();
+
+  const importButtonPo = tokensPagePo.getImportTokenButtonPo();
+
+  await step("Open the import token modal");
+
+  await importButtonPo.waitFor();
+  await importButtonPo.click();
+
+  const importTokenModalPo = tokensPagePo.getImportTokenModalPo();
+  const formPo = importTokenModalPo.getImportTokenFormPo();
+  const reviewPo = importTokenModalPo.getImportTokenReviewPo();
+
+  await importTokenModalPo.waitFor();
+
+  await step("Enter the ledger and the index canister ID");
+
+  await formPo.getLedgerCanisterInputPo().typeText(testLedgerCanisterId);
+  await formPo.getIndexCanisterInputPo().typeText(testIndexCanisterId);
+
+  // The pair check runs between the submit click and the review step.
+  await formPo.getSubmitButtonPo().click();
+  await reviewPo.waitFor();
+
+  await step("The pair check asks the ledger canister first");
+
+  const ledgerCalls = calls.filter(
+    ({ method }) => method === "icrc106_get_index_principal"
+  );
+  const indexCalls = calls.filter(({ method }) => method === "ledger_id");
+
+  // Acceptance 1: the app asks the ledger canister, which is the trusted side
+  // of the pair, with ICRC-106.
+  expect(ledgerCalls.length).toBeGreaterThan(0);
+
+  // Every ICRC-106 call goes to the ledger canister, never to the index
+  // canister the user typed.
+  expect(
+    ledgerCalls.every(({ canisterId }) => canisterId === testLedgerCanisterId)
+  ).toBe(true);
+
+  // The user typed the ledger canister ID, so the call must not carry the
+  // principal of the user to it.
+  expect(ledgerCalls.every(({ anonymous }) => anonymous)).toBe(true);
+
+  // The ledger is asked BEFORE the index canister, not after it.
+  expect(
+    calls.findIndex(({ method }) => method === "ledger_id")
+  ).toBeGreaterThan(
+    calls.findIndex(({ method }) => method === "icrc106_get_index_principal")
+  );
+
+  await step("The ledger names no index canister, so the old check still runs");
+
+  // Acceptance 2: the snsdemo `ckred_ledger` is installed with no
+  // `index_principal`, so the ledger answers IndexPrincipalNotSet and the
+  // fallback asks the index canister for its `ledger_id`.
+  expect(indexCalls.length).toBeGreaterThan(0);
+  expect(
+    indexCalls.every(({ canisterId }) => canisterId === testIndexCanisterId)
+  ).toBe(true);
+
+  await step("The import completes through the fallback");
+
+  expect(await reviewPo.getTokenName()).toBe(TEST_TOKEN_NAME);
+  expect(await reviewPo.getLedgerCanisterIdPo().getCanisterIdText()).toBe(
+    testLedgerCanisterId
+  );
+  expect(await reviewPo.getIndexCanisterIdPo().getCanisterIdText()).toBe(
+    testIndexCanisterId
+  );
+
+  await reviewPo.getConfirmButtonPo().click();
+
+  const walletPo = appPo.getWalletPo().getIcrcWalletPo();
+  await walletPo.waitFor();
+
+  expect(
+    await walletPo.getWalletPageHeaderPo().getUniverseSummaryPo().getTitle()
+  ).toEqual(TEST_TOKEN_NAME);
+});

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -4,6 +4,7 @@ import {
   executeIcrcTransfer,
   icrcTransfer,
   queryIcrcBalance,
+  queryIcrcIndexPrincipal,
   queryIcrcToken,
 } from "$lib/api/icrc-ledger.api";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -15,9 +16,18 @@ import {
 } from "$tests/mocks/sns-projects.mock";
 import {
   IcrcLedgerCanister,
+  IndexPrincipalNotSetError,
   type IcrcAccount,
 } from "@icp-sdk/canisters/ledger/icrc";
-import { AnonymousIdentity, type HttpAgent } from "@icp-sdk/core/agent";
+import {
+  AgentError,
+  AnonymousIdentity,
+  CertifiedRejectErrorCode,
+  ErrorKindEnum,
+  ReplicaRejectCode,
+  requestIdOf,
+  type HttpAgent,
+} from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import { mock } from "vitest-mock-extended";
 
@@ -180,6 +190,73 @@ describe("icrc-ledger api", () => {
         certified: true,
         ...account,
       });
+    });
+  });
+  describe("queryIcrcIndexPrincipal", () => {
+    const canisterId = principal(0);
+    const indexCanisterId = principal(1);
+
+    const callQueryIcrcIndexPrincipal = () =>
+      queryIcrcIndexPrincipal({
+        certified: true,
+        identity: new AnonymousIdentity(),
+        canisterId,
+      });
+
+    it("returns the index principal the ledger names", async () => {
+      ledgerCanisterMock.getIndexPrincipal.mockResolvedValue(indexCanisterId);
+
+      expect(await callQueryIcrcIndexPrincipal()).toEqual(indexCanisterId);
+      expect(ledgerCanisterMock.getIndexPrincipal).toBeCalledTimes(1);
+      expect(ledgerCanisterMock.getIndexPrincipal).toBeCalledWith({
+        certified: true,
+      });
+    });
+
+    it("returns undefined when the ledger names no index principal", async () => {
+      ledgerCanisterMock.getIndexPrincipal.mockRejectedValue(
+        new IndexPrincipalNotSetError()
+      );
+
+      expect(await callQueryIcrcIndexPrincipal()).toBeUndefined();
+    });
+
+    it("returns undefined when the ledger has no such method", async () => {
+      ledgerCanisterMock.getIndexPrincipal.mockRejectedValue(
+        new AgentError(
+          new CertifiedRejectErrorCode(
+            requestIdOf({}),
+            ReplicaRejectCode.DestinationInvalid,
+            "Canister has no query method 'icrc106_get_index_principal'",
+            "IC0536"
+          ),
+          ErrorKindEnum.Unknown
+        )
+      );
+
+      expect(await callQueryIcrcIndexPrincipal()).toBeUndefined();
+    });
+
+    it("rethrows any other error", async () => {
+      const error = new Error("test");
+      ledgerCanisterMock.getIndexPrincipal.mockRejectedValue(error);
+
+      await expect(callQueryIcrcIndexPrincipal()).rejects.toThrow(error);
+    });
+
+    it("rethrows another canister reject", async () => {
+      const error = new AgentError(
+        new CertifiedRejectErrorCode(
+          requestIdOf({}),
+          ReplicaRejectCode.CanisterError,
+          "Canister is out of cycles",
+          "IC0207"
+        ),
+        ErrorKindEnum.Unknown
+      );
+      ledgerCanisterMock.getIndexPrincipal.mockRejectedValue(error);
+
+      await expect(callQueryIcrcIndexPrincipal()).rejects.toThrow(error);
     });
   });
 });

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -56,6 +56,9 @@ describe("ImportTokenModal", () => {
       .spyOn(ledgerApi, "queryIcrcToken")
       .mockResolvedValue(tokenMetaData);
 
+    // The ledger names no index canister, so the check falls back to
+    // `getLedgerId` on the index canister.
+    vi.spyOn(ledgerApi, "queryIcrcIndexPrincipal").mockResolvedValue(undefined);
     vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(ledgerCanisterId);
     page.mock({
       routeId: AppPath.Tokens,

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -688,6 +688,11 @@ describe("IcrcWallet", () => {
           certified: true,
         });
         // Needs to pass the index canister validation.
+        // The ledger names no index canister, so the check falls back to
+        // `getLedgerId` on the index canister.
+        vi.spyOn(icrcLedgerApi, "queryIcrcIndexPrincipal").mockResolvedValue(
+          undefined
+        );
         vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(
           ledgerCanisterId
         );

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -1,8 +1,10 @@
 import * as icrcIndexApi from "$lib/api/icrc-index.api";
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { matchLedgerIndexPair } from "$lib/services/icrc-index.services";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { toastsStore } from "@dfinity/gix-components";
+import { AnonymousIdentity } from "@icp-sdk/core/agent";
 import { get } from "svelte/store";
 
 describe("icrc-index.services", () => {
@@ -10,55 +12,138 @@ describe("icrc-index.services", () => {
     const indexCanisterId = principal(0);
     const ledgerCanisterId = principal(1);
     const differentLedgerCanisterId = principal(11);
+    const differentIndexCanisterId = principal(12);
 
     beforeEach(() => {
       resetIdentity();
     });
 
-    it("should return true when the ledger canister IDs match", async () => {
-      const spyOnGetLedgerId = vi
-        .spyOn(icrcIndexApi, "getLedgerId")
-        .mockResolvedValue(ledgerCanisterId);
+    describe("when the ledger names an index canister", () => {
+      it("should return true when the ledger names the entered index canister", async () => {
+        const spyOnQueryIcrcIndexPrincipal = vi
+          .spyOn(icrcLedgerApi, "queryIcrcIndexPrincipal")
+          .mockResolvedValue(indexCanisterId);
+        const spyOnGetLedgerId = vi.spyOn(icrcIndexApi, "getLedgerId");
 
-      expect(spyOnGetLedgerId).toBeCalledTimes(0);
-      const result = await matchLedgerIndexPair({
-        ledgerCanisterId,
-        indexCanisterId,
+        const result = await matchLedgerIndexPair({
+          ledgerCanisterId,
+          indexCanisterId,
+        });
+
+        expect(result).toEqual(true);
+        expect(get(toastsStore)).toEqual([]);
+        expect(spyOnQueryIcrcIndexPrincipal).toBeCalledTimes(1);
+        expect(spyOnQueryIcrcIndexPrincipal).toBeCalledWith({
+          certified: true,
+          identity: new AnonymousIdentity(),
+          canisterId: ledgerCanisterId,
+        });
+        // The index canister is the untrusted side of the pair, so it must not
+        // be asked at all.
+        expect(spyOnGetLedgerId).toBeCalledTimes(0);
       });
 
-      expect(result).toEqual(true);
-      expect(spyOnGetLedgerId).toBeCalledTimes(1);
-      expect(spyOnGetLedgerId).toBeCalledWith({
-        certified: true,
-        identity: mockIdentity,
-        indexCanisterId,
+      it("should return false when the ledger names a different index canister", async () => {
+        vi.spyOn(icrcLedgerApi, "queryIcrcIndexPrincipal").mockResolvedValue(
+          differentIndexCanisterId
+        );
+        // The entered index canister claims the right ledger, but the ledger
+        // disagrees.
+        const spyOnGetLedgerId = vi
+          .spyOn(icrcIndexApi, "getLedgerId")
+          .mockResolvedValue(ledgerCanisterId);
+
+        expect(get(toastsStore)).toEqual([]);
+        const result = await matchLedgerIndexPair({
+          ledgerCanisterId,
+          indexCanisterId,
+        });
+
+        expect(result).toEqual(false);
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: "The provided index canister ID does not match the associated ledger canister ID.",
+          },
+        ]);
+        expect(spyOnGetLedgerId).toBeCalledTimes(0);
       });
     });
 
-    it("should return false when the ledger canister IDs don't match", async () => {
-      vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(
-        differentLedgerCanisterId
-      );
-
-      expect(get(toastsStore)).toEqual([]);
-      const result = await matchLedgerIndexPair({
-        ledgerCanisterId,
-        indexCanisterId,
+    describe("when the ledger names no index canister", () => {
+      beforeEach(() => {
+        vi.spyOn(icrcLedgerApi, "queryIcrcIndexPrincipal").mockResolvedValue(
+          undefined
+        );
       });
 
-      expect(result).toEqual(false);
-      expect(get(toastsStore)).toMatchObject([
-        {
-          level: "error",
-          text: "The provided index canister ID does not match the associated ledger canister ID.",
-        },
-      ]);
+      it("should return true when the ledger canister IDs match", async () => {
+        const spyOnGetLedgerId = vi
+          .spyOn(icrcIndexApi, "getLedgerId")
+          .mockResolvedValue(ledgerCanisterId);
+
+        expect(spyOnGetLedgerId).toBeCalledTimes(0);
+        const result = await matchLedgerIndexPair({
+          ledgerCanisterId,
+          indexCanisterId,
+        });
+
+        expect(result).toEqual(true);
+        expect(spyOnGetLedgerId).toBeCalledTimes(1);
+        expect(spyOnGetLedgerId).toBeCalledWith({
+          certified: true,
+          identity: mockIdentity,
+          indexCanisterId,
+        });
+      });
+
+      it("should return false when the ledger canister IDs don't match", async () => {
+        vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(
+          differentLedgerCanisterId
+        );
+
+        expect(get(toastsStore)).toEqual([]);
+        const result = await matchLedgerIndexPair({
+          ledgerCanisterId,
+          indexCanisterId,
+        });
+
+        expect(result).toEqual(false);
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: "The provided index canister ID does not match the associated ledger canister ID.",
+          },
+        ]);
+      });
+
+      it("should handle errors", async () => {
+        vi.spyOn(console, "error").mockReturnValue();
+        const error = new Error("test");
+        vi.spyOn(icrcIndexApi, "getLedgerId").mockRejectedValue(error);
+
+        const result = await matchLedgerIndexPair({
+          ledgerCanisterId,
+          indexCanisterId,
+        });
+
+        expect(result).toEqual(false);
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: `An error occurred while validating the index canister ID. It appears that ${indexCanisterId} might not be a valid index canister ID.`,
+          },
+        ]);
+      });
     });
 
-    it("should handle errors", async () => {
+    it("should handle errors of the ledger canister call", async () => {
       vi.spyOn(console, "error").mockReturnValue();
       const error = new Error("test");
-      vi.spyOn(icrcIndexApi, "getLedgerId").mockRejectedValue(error);
+      vi.spyOn(icrcLedgerApi, "queryIcrcIndexPrincipal").mockRejectedValue(
+        error
+      );
+      const spyOnGetLedgerId = vi.spyOn(icrcIndexApi, "getLedgerId");
 
       const result = await matchLedgerIndexPair({
         ledgerCanisterId,
@@ -72,6 +157,7 @@ describe("icrc-index.services", () => {
           text: `An error occurred while validating the index canister ID. It appears that ${indexCanisterId} might not be a valid index canister ID.`,
         },
       ]);
+      expect(spyOnGetLedgerId).toBeCalledTimes(0);
     });
   });
 });

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -23,7 +23,12 @@ describe("icrc-index.services", () => {
         const spyOnQueryIcrcIndexPrincipal = vi
           .spyOn(icrcLedgerApi, "queryIcrcIndexPrincipal")
           .mockResolvedValue(indexCanisterId);
-        const spyOnGetLedgerId = vi.spyOn(icrcIndexApi, "getLedgerId");
+        // The index canister must not be asked at all in this case. Reject so
+        // an unexpected call fails the test immediately, instead of falling
+        // through to the real implementation.
+        const spyOnGetLedgerId = vi
+          .spyOn(icrcIndexApi, "getLedgerId")
+          .mockRejectedValue(new Error("getLedgerId should not be called"));
 
         const result = await matchLedgerIndexPair({
           ledgerCanisterId,
@@ -143,7 +148,12 @@ describe("icrc-index.services", () => {
       vi.spyOn(icrcLedgerApi, "queryIcrcIndexPrincipal").mockRejectedValue(
         error
       );
-      const spyOnGetLedgerId = vi.spyOn(icrcIndexApi, "getLedgerId");
+      // The index canister must not be asked at all in this case. Reject so
+      // an unexpected call fails the test immediately, instead of falling
+      // through to the real implementation.
+      const spyOnGetLedgerId = vi
+        .spyOn(icrcIndexApi, "getLedgerId")
+        .mockRejectedValue(new Error("getLedgerId should not be called"));
 
       const result = await matchLedgerIndexPair({
         ledgerCanisterId,

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -161,10 +161,12 @@ describe("icrc-index.services", () => {
       });
 
       expect(result).toEqual(false);
+      // The failing call targets the ledger canister, so the message must
+      // name the ledger, not the index canister.
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: `An error occurred while validating the index canister ID. It appears that ${indexCanisterId} might not be a valid index canister ID.`,
+          text: `An error occurred while validating the ledger canister ID. It appears that ${ledgerCanisterId} might not be a valid ledger canister ID.`,
         },
       ]);
       expect(spyOnGetLedgerId).toBeCalledTimes(0);

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -3,6 +3,7 @@ import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { HardwareWalletAttachError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import {
   errorToString,
+  isCanisterMethodNotFoundError,
   isCanisterOutOfCyclesError,
   isMethodNotSupportedError,
   isPayloadSizeError,
@@ -205,6 +206,52 @@ describe("error-utils", () => {
       expect(isCanisterOutOfCyclesError(123)).toBe(false);
       expect(isCanisterOutOfCyclesError({})).toBe(false);
       expect(isCanisterOutOfCyclesError({ type: "unknown" })).toBe(false);
+    });
+  });
+
+  describe("isCanisterMethodNotFoundError", () => {
+    const queryError = (rejectErrorCode: string) =>
+      new AgentError(
+        new UncertifiedRejectErrorCode(
+          requestIdOf({}),
+          ReplicaRejectCode.DestinationInvalid,
+          "There was an error",
+          rejectErrorCode,
+          []
+        ),
+        ErrorKindEnum.Unknown
+      );
+
+    const updateError = (rejectErrorCode: string) =>
+      new AgentError(
+        new CertifiedRejectErrorCode(
+          requestIdOf({}),
+          ReplicaRejectCode.DestinationInvalid,
+          "There was an error",
+          rejectErrorCode
+        ),
+        ErrorKindEnum.Unknown
+      );
+
+    it("should return true for the IC0536 code", () => {
+      expect(isCanisterMethodNotFoundError(queryError("IC0536"))).toBe(true);
+      expect(isCanisterMethodNotFoundError(updateError("IC0536"))).toBe(true);
+    });
+
+    it("should return false for another IC0 code", () => {
+      expect(isCanisterMethodNotFoundError(queryError("IC0503"))).toBe(false);
+      expect(isCanisterMethodNotFoundError(updateError("IC0503"))).toBe(false);
+      expect(isCanisterMethodNotFoundError(queryError("IC0"))).toBe(false);
+    });
+
+    it("should return false for invalid inputs", () => {
+      expect(isCanisterMethodNotFoundError(null)).toBe(false);
+      expect(isCanisterMethodNotFoundError(undefined)).toBe(false);
+      expect(isCanisterMethodNotFoundError(new Error("IC0536"))).toBe(false);
+      expect(isCanisterMethodNotFoundError("IC0536")).toBe(false);
+      expect(isCanisterMethodNotFoundError({ rejectErrorCode: "IC0536" })).toBe(
+        false
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

The import token flow checked a ledger and index canister pair by asking the index canister for its own `ledger_id`. The user types the index canister ID, so a fake index canister could name any ledger and pass the check. The wallet would then show an invented transaction history for a real token, though balances still came from the true ledger.

# Changes

- Added `queryIcrcIndexPrincipal` to ask the ledger canister for its index canister with the ICRC-106 method `icrc106_get_index_principal`.
- Changed `matchLedgerIndexPair` to ask the ledger first. When the ledger names an index canister, that answer decides the match and the index canister is not called.
- Kept the old `ledger_id` check as a fallback for a ledger that names no index canister or has no `icrc106_get_index_principal` method.
- Added `isCanisterMethodNotFoundError` to detect the missing-method reject code.
- Used the anonymous identity for the new ledger call, so a user-typed canister does not learn the caller principal.
- Added an e2e spec that checks the ledger call happens first, is anonymous, and that the fallback still runs.

# Tests

- Added unit tests for `matchLedgerIndexPair`, `queryIcrcIndexPrincipal`, and `isCanisterMethodNotFoundError`.
- Added `frontend/src/tests/e2e/import-token-ledger-index-pair.spec.ts`, which records the ingress calls the import flow makes and checks the order and the anonymous sender.
- Ran `npm run test`, `npm run check`, and `npm run lint` in `frontend`. All pass.

# Todos

- [ ] Accessibility (a11y) – any impact?
- [x] Changelog – is it needed?
