### PR TITLE
fix(proposals): bound the JSON depth of an expanded payload text

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,8 @@ proposal is successful, the changes it released will be moved from this file to
   tiles and result boxes now have a visible background color.
 - On a narrow screen the header buttons no longer shrink while the app loads
   data.
+- The proposal detail page no longer breaks on a payload text that nests JSON
+  thousands of levels deep.
 
 #### Security
 

--- a/frontend/src/lib/constants/proposals.constants.ts
+++ b/frontend/src/lib/constants/proposals.constants.ts
@@ -24,3 +24,9 @@ export const MINIMUM_YES_PROPORTION_OF_TOTAL_VOTING_POWER: BasisPoints = 300n;
  */
 export const MINIMUM_YES_PROPORTION_OF_EXERCISED_VOTING_POWER: BasisPoints =
   5_000n;
+
+/**
+ * The deepest JSON a string leaf of a payload can hold and still be expanded
+ * into a tree. A string whose JSON nests deeper than this stays a string.
+ */
+export const MAX_EXPANDED_JSON_DEPTH = 64;

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -1,3 +1,4 @@
+import { MAX_EXPANDED_JSON_DEPTH } from "$lib/constants/proposals.constants";
 import { toastsError, toastsHide } from "$lib/stores/toasts.store";
 import type { PngDataUrl } from "$lib/types/assets";
 import type { BasisPoints } from "$lib/types/proposals";
@@ -364,7 +365,13 @@ export const expandObject = (value: unknown): unknown => {
   }
   if (typeof value === "string") {
     try {
-      return JSON.parse(value);
+      const parsed = JSON.parse(value);
+      // A proposer controls this text. Keep a string whose JSON nests too deep
+      // as a string, so the tree stays small enough to walk and to render.
+      if (getObjMaxDepth(parsed) > MAX_EXPANDED_JSON_DEPTH) {
+        return value;
+      }
+      return parsed;
     } catch (_) {
       return value;
     }
@@ -391,28 +398,39 @@ export const expandObject = (value: unknown): unknown => {
   return value;
 };
 
+/**
+ * Counts the nesting levels of an object or an array.
+ *
+ * A primitive, `null`, an empty object and an empty array count 0. A non-empty
+ * object or array counts 1 plus the deepest of its values.
+ *
+ * The walk uses an explicit stack, so the call stack does not grow with the
+ * nesting of `obj`.
+ */
 export const getObjMaxDepth = (obj: unknown): number => {
-  if (typeof obj !== "object" || obj === null) {
-    return 0; // If it's not an object, return 0.
-  }
+  let maxDepth = 0;
+  const stack: { value: unknown; level: number }[] = [{ value: obj, level: 0 }];
 
-  const keyCount = Object.keys(obj).length;
-  if (keyCount === 0) {
-    return 0; // If it's an empty object, return 0.
-  }
-  // or calculate children depth
-  let childrenMaxDepth = 0;
-  for (const key in obj) {
-    // eslint-disable-next-line no-prototype-builtins
-    if (obj.hasOwnProperty(key)) {
-      const depth = getObjMaxDepth((obj as Record<string, unknown>)[key]);
-      if (depth > childrenMaxDepth) {
-        childrenMaxDepth = depth;
+  let entry = stack.pop();
+  while (nonNullish(entry)) {
+    const { value, level } = entry;
+    if (typeof value === "object" && value !== null) {
+      const keys = Object.keys(value);
+      if (keys.length > 0) {
+        // This level holds at least one value, so it counts.
+        maxDepth = Math.max(maxDepth, level + 1);
+        for (const key of keys) {
+          stack.push({
+            value: (value as Record<string, unknown>)[key],
+            level: level + 1,
+          });
+        }
       }
     }
+    entry = stack.pop();
   }
 
-  return 1 + childrenMaxDepth; // Add 1 for the current level.
+  return maxDepth;
 };
 
 export const typeOfLikeANumber = (value: unknown): boolean =>

--- a/frontend/src/tests/e2e/proposal-payload-deep-json.spec.ts
+++ b/frontend/src/tests/e2e/proposal-payload-deep-json.spec.ts
@@ -1,3 +1,4 @@
+import { MAX_EXPANDED_JSON_DEPTH } from "$lib/constants/proposals.constants";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
@@ -173,8 +174,8 @@ test("Test a proposal payload text that nests JSON thousands of levels deep", as
 
   // The text shows as the quoted string it is, the same as any string that is
   // not JSON.
-  expect(treeText).toContain(`"${"[".repeat(64)}`);
-  expect(treeText).toContain(`${"]".repeat(64)}"`);
+  expect(treeText).toContain(`"${"[".repeat(MAX_EXPANDED_JSON_DEPTH)}`);
+  expect(treeText).toContain(`${"]".repeat(MAX_EXPANDED_JSON_DEPTH)}"`);
   expect(treeText).toContain("replica_version_id");
   expect(treeText).not.toContain("Maximum call stack size exceeded");
 

--- a/frontend/src/tests/e2e/proposal-payload-deep-json.spec.ts
+++ b/frontend/src/tests/e2e/proposal-payload-deep-json.spec.ts
@@ -138,11 +138,11 @@ test("Test a proposal payload text that nests JSON thousands of levels deep", as
     .getActionableProposalsSegmentPo()
     .clickAllProposals();
 
-  await step("Filter the open Subnet Management proposals");
+  await step("Filter the open IC OS Version Deployment proposals");
   await appPo
     .getProposalsPo()
     .getNnsProposalFiltersPo()
-    .selectTopicFilter([Topic.SubnetManagement]);
+    .selectTopicFilter([Topic.IcOsVersionDeployment]);
   await nnsProposalListPo.waitForContentLoaded();
   await appPo
     .getProposalsPo()
@@ -192,5 +192,5 @@ test("Test a proposal payload text that nests JSON thousands of levels deep", as
   expect(await nnsProposalPo.getVotingCardPo().isPresent()).toBe(true);
   expect(
     await nnsProposalPo.getProposalSystemInfoSectionPo().getProposalTopicText()
-  ).toBe("Subnet Management");
+  ).toBe("IC OS Version Deployment");
 });

--- a/frontend/src/tests/e2e/proposal-payload-deep-json.spec.ts
+++ b/frontend/src/tests/e2e/proposal-payload-deep-json.spec.ts
@@ -1,0 +1,195 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
+import {
+  disableCssAnimations,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
+import { ProposalStatus, Topic } from "@icp-sdk/canisters/nns";
+import { expect, test } from "@playwright/test";
+
+// The proposer writes every text field of a proposal payload. The proposal
+// detail page used to call `JSON.parse` on each string field and then walk the
+// result with a recursive function, so a compact text such as
+// "[[[[..." became a structure thousands of levels deep. The walk threw
+// `RangeError: Maximum call stack size exceeded` inside a reactive statement,
+// and the payload card, together with the rest of the detail page, stopped
+// rendering. A proposal cannot be edited, so the page stayed broken for good.
+//
+// This test submits a real ExecuteNnsFunction proposal whose
+// `replica_version_id` text nests 34,000 levels, then reads the payload card.
+// The text must show as the quoted string it is, and the page must work.
+//
+// Why ExecuteNnsFunction and not a Motion: governance caps a Motion text at
+// 10,000 bytes, which is at most 5,000 levels. The measured overflow threshold
+// is 6,205 levels in Chrome 152, so a Motion text cannot reach the bug. The
+// ExecuteNnsFunction payload cap is 70,000 bytes, which is far above it.
+const NESTING_DEPTH = 34_000;
+const DEEP_TEXT = `${"[".repeat(NESTING_DEPTH)}${"]".repeat(NESTING_DEPTH)}`;
+
+// The app loads this script to create the dummy proposals of a testnet. The
+// test serves its own version, so that one proposal carries the payload above.
+// See frontend/src/lib/api/dev.api.ts and
+// frontend/static/assets/libs/dummy-proposals.utils.js.
+const DUMMY_PROPOSALS_SCRIPT_PATH = "**/assets/libs/dummy-proposals.utils.js";
+
+const PROPOSAL_TITLE = "Test proposal title - a deeply nested payload text";
+
+// A hand encoded candid argument for NNS function 11
+// (DeployGuestosToAllSubnetNodes). It holds the same subnet id as the dummy
+// proposal in the repo and a `replica_version_id` of our own. The full message
+// is 68,055 bytes, under the 70,000 byte cap that governance applies.
+const dummyProposalsModule = `
+const SUBNET_ID_BYTES = [
+  106, 143, 103, 216, 110, 204, 131, 7, 4, 128, 56, 173, 113, 89, 148, 88, 193,
+  49, 181, 49, 220, 155, 176, 182, 145, 148, 13, 185, 2,
+];
+
+const leb128 = (value) => {
+  const bytes = [];
+  let rest = value;
+  do {
+    let byte = rest & 0x7f;
+    rest >>>= 7;
+    if (rest !== 0) byte |= 0x80;
+    bytes.push(byte);
+  } while (rest !== 0);
+  return bytes;
+};
+
+const deployGuestosPayload = (replicaVersionId) => {
+  const textBytes = Array.from(new TextEncoder().encode(replicaVersionId));
+  return new Uint8Array([
+    68, 73, 68, 76, // "DIDL"
+    1, // one type in the table
+    108, 2, // a record with two fields
+    189, 134, 157, 139, 4, 104, // subnet_id : principal
+    201, 239, 142, 197, 9, 113, // replica_version_id : text
+    1, 0, // one argument of type 0
+    1, SUBNET_ID_BYTES.length, ...SUBNET_ID_BYTES,
+    ...leb128(textBytes.length), ...textBytes,
+  ]);
+};
+
+export const makeDummyProposals = async ({ neuronId, canister }) => {
+  await canister.makeProposal({
+    neuronId,
+    title: ${JSON.stringify(PROPOSAL_TITLE)},
+    url: "https://forum.dfinity.org/t/announcing-juno-build-on-the-ic-using-frontend-code-only",
+    summary: "A proposal whose payload text nests JSON thousands of levels deep.",
+    action: {
+      ExecuteNnsFunction: {
+        nnsFunctionId: 11,
+        nnsFunctionName: undefined,
+        payload: {},
+        payloadBytes: deployGuestosPayload(${JSON.stringify(DEEP_TEXT)}),
+      },
+    },
+  });
+};
+`;
+
+test("Test a proposal payload text that nests JSON thousands of levels deep", async ({
+  page,
+  context,
+}) => {
+  await step("Serve a dummy proposal whose payload text nests deeply");
+  await page.route(DUMMY_PROPOSALS_SCRIPT_PATH, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: dummyProposalsModule,
+    })
+  );
+
+  await page.goto("/");
+  await disableCssAnimations(page);
+  await expect(page).toHaveTitle("Portfolio | Network Nervous System");
+
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  await step("Get some ICP");
+  await appPo.getIcpTokens(21);
+
+  await step("Stake a neuron for voting");
+  await appPo.goToStaking();
+  await appPo
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: 10, dissolveDelayDays: "max" });
+
+  await step("Create the proposal");
+  const proposerNeuronId = await createDummyProposal(appPo);
+
+  await step("Open the Internet Computer proposals");
+  await appPo.goToProposals();
+  await appPo.openUniverses();
+  await appPo.getSelectUniverseListPo().clickOnInternetComputer();
+  const nnsProposalListPo = appPo.getProposalsPo().getNnsProposalListPo();
+  await nnsProposalListPo.waitForContentLoaded();
+
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .getActionableProposalsSegmentPo()
+    .clickAllProposals();
+
+  await step("Filter the open Subnet Management proposals");
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectTopicFilter([Topic.SubnetManagement]);
+  await nnsProposalListPo.waitForContentLoaded();
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectStatusFilter([ProposalStatus.Open]);
+  await nnsProposalListPo.waitForContentLoaded();
+
+  await step("Open the proposal");
+  const proposalCard =
+    await nnsProposalListPo.getFirstProposalCardPoForProposer(proposerNeuronId);
+  await proposalCard.click();
+  const nnsProposalPo = appPo.getProposalDetailPo().getNnsProposalPo();
+  await nnsProposalPo.waitForContentLoaded();
+
+  await step("Read the payload card");
+  // Before the fix the reactive statement in JsonPreview.svelte threw here, so
+  // this card never appeared.
+  const payloadPo = nnsProposalPo.getProposalProposerActionsEntryPo();
+  await payloadPo.waitFor();
+  expect(await payloadPo.getActionTitle()).toBe("Payload");
+
+  const jsonPreviewPo = payloadPo.getJsonPreviewPo();
+  const togglePo = payloadPo.getJsonRepresentationModeTogglePo();
+
+  await step("Read the tree view");
+  await togglePo.setEnabled(false);
+  await jsonPreviewPo.getTreeJson().waitFor();
+  const treeText = await jsonPreviewPo.getTreeText();
+
+  // The text shows as the quoted string it is, the same as any string that is
+  // not JSON.
+  expect(treeText).toContain(`"${"[".repeat(64)}`);
+  expect(treeText).toContain(`${"]".repeat(64)}"`);
+  expect(treeText).toContain("replica_version_id");
+  expect(treeText).not.toContain("Maximum call stack size exceeded");
+
+  await step("Read the raw view");
+  await togglePo.setEnabled(true);
+  await jsonPreviewPo.getRawJson().waitFor();
+  const rawText = await jsonPreviewPo.getRawText();
+  const parsed = JSON.parse(rawText) as Record<string, unknown>;
+  expect(Object.values(parsed)).toContain(DEEP_TEXT);
+
+  await step("Check the rest of the detail page still works");
+  // The throw broke the whole render and update cycle of the page, so the
+  // voting controls of this proposal went with it.
+  expect(await nnsProposalPo.getVotingCardPo().isPresent()).toBe(true);
+  expect(
+    await nnsProposalPo.getProposalSystemInfoSectionPo().getProposalTopicText()
+  ).toBe("Subnet Management");
+});

--- a/frontend/src/tests/lib/components/common/JsonPreview.spec.ts
+++ b/frontend/src/tests/lib/components/common/JsonPreview.spec.ts
@@ -64,6 +64,32 @@ describe("JsonPreview", () => {
     expect(await po.getExpandButton().isPresent()).toBe(false);
   });
 
+  // The shape of a real ExecuteNnsFunction payload: the outer structure nests a
+  // few levels and one string leaf holds a JSON install argument.
+  it("should still expand the string leaves of a real payload shape", async () => {
+    jsonRepresentationStore.setMode("tree");
+    const po = renderComponent({
+      canister_id: "qoctq-giaaa-aaaaa-aaaea-cai",
+      arg: '{"controllers":["aaaaa-aa"]}',
+      wasm_module_hash: "0f0d0e",
+    });
+    await po.clickExpand();
+
+    expect(await po.getTreeText()).toBe(
+      'canister_id "qoctq-giaaa-aaaaa-aaaea-cai" arg  controllers 0 "aaaaa-aa"wasm_module_hash "0f0d0e"'
+    );
+  });
+
+  it("should render a payload text that nests JSON thousands of levels deep", async () => {
+    jsonRepresentationStore.setMode("tree");
+    const deepText = `${"[".repeat(35_000)}${"]".repeat(35_000)}`;
+    const po = renderComponent({ comment: deepText });
+
+    expect(await po.getTreeText()).toBe(`comment "${deepText}"`);
+    // The text stays a string, so the tree has a single level.
+    expect(await po.getExpandButton().isPresent()).toBe(false);
+  });
+
   it("should expand and collapse in tree view", async () => {
     jsonRepresentationStore.setMode("tree");
     const po = renderComponent({ data: { test: "hello world" } });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -1,3 +1,4 @@
+import { MAX_EXPANDED_JSON_DEPTH } from "$lib/constants/proposals.constants";
 import {
   PollingCancelledError,
   PollingLimitExceededError,
@@ -916,6 +917,36 @@ describe("utils", () => {
       const obj = { a: [1, JSON.stringify({ b: 2 }), 3] };
       expect(expandObject(obj)).toEqual({ a: [1, { b: 2 }, 3] });
     });
+
+    it("should parse a JSON string that nests exactly the maximum depth", () => {
+      const nested = `${"[".repeat(MAX_EXPANDED_JSON_DEPTH)}1${"]".repeat(
+        MAX_EXPANDED_JSON_DEPTH
+      )}`;
+      const { a } = expandObject({ a: nested }) as { a: unknown };
+
+      expect(getObjMaxDepth(a)).toBe(MAX_EXPANDED_JSON_DEPTH);
+      expect(a).toEqual(JSON.parse(nested));
+    });
+
+    it("should keep a JSON string that nests deeper than the maximum depth as a string", () => {
+      const nested = `${"[".repeat(MAX_EXPANDED_JSON_DEPTH + 1)}1${"]".repeat(
+        MAX_EXPANDED_JSON_DEPTH + 1
+      )}`;
+      const { a } = expandObject({ a: nested }) as { a: unknown };
+
+      expect(typeof a).toBe("string");
+      expect(a).toBe(nested);
+    });
+
+    it("should keep a payload text that nests JSON thousands of levels deep as a string", () => {
+      const nested = `${"[".repeat(35_000)}${"]".repeat(35_000)}`;
+      const { comment } = expandObject({ comment: nested }) as {
+        comment: unknown;
+      };
+
+      expect(typeof comment).toBe("string");
+      expect(comment).toBe(nested);
+    });
   });
 
   describe("sameBufferData", () => {
@@ -980,6 +1011,24 @@ describe("utils", () => {
       expect(getObjMaxDepth(null)).toBe(0);
       expect(getObjMaxDepth("hello")).toBe(0);
       expect(getObjMaxDepth(0)).toBe(0);
+    });
+
+    it("returns the depth of a 100,000 level array without a stack overflow", () => {
+      const depth = 100_000;
+      const deepArray = JSON.parse(
+        `${"[".repeat(depth)}1${"]".repeat(depth)}`
+      ) as unknown;
+
+      expect(getObjMaxDepth(deepArray)).toBe(depth);
+    });
+
+    it("returns the depth of a 100,000 level object without a stack overflow", () => {
+      const depth = 100_000;
+      const deepObject = JSON.parse(
+        `${'{"a":'.repeat(depth)}1${"}".repeat(depth)}`
+      ) as unknown;
+
+      expect(getObjMaxDepth(deepObject)).toBe(depth);
     });
   });
 


### PR DESCRIPTION
# Motivation

A proposer can shape a payload string that holds JSON nested thousands of levels deep. `getObjMaxDepth` walks that structure with plain recursion and throws `RangeError: Maximum call stack size exceeded`. The throw happens inside a `$:` statement in `JsonPreview.svelte`, so the payload card never renders. Voting on that proposal page breaks too, for every visitor, for good, since proposals cannot be edited.

# Changes

- Rewrote `getObjMaxDepth` in `frontend/src/lib/utils/utils.ts` with an explicit stack instead of recursion, so it cannot overflow the call stack.
- Added `MAX_EXPANDED_JSON_DEPTH` (64) in `frontend/src/lib/constants/proposals.constants.ts`.
- Changed the string branch of `expandObject` to keep a string as a string when its parsed JSON nests deeper than `MAX_EXPANDED_JSON_DEPTH`.
- Added a changelog line under `#### Fixed`.

# Tests

- Added `getObjMaxDepth` tests for a 100,000-level array and object. Both throw `RangeError` on the pre-fix code.
- Added `expandObject` tests: a string at exactly the depth limit still expands, a string past the limit stays a string, and a payload text nested 35,000 levels deep stays a string with no throw.
- Added `JsonPreview` tests: a real `ExecuteNnsFunction` shape still expands the same way, and a payload nested 35,000 levels deep renders as a string with no throw and no expand-tree button.
- Added an e2e spec, `proposal-payload-deep-json.spec.ts`, that submits an `ExecuteNnsFunction` proposal with a 68,000-byte nested payload text and checks the payload card, the raw view, and the voting card all render.
- Ran the pre-fix `utils.ts` against the new specs: 5 of 7 new tests fail with the exact errors this PR fixes.

# Todos

- [ ] Accessibility (a11y) – no impact, no UI structure changed.
- [x] Changelog – added.
- [ ] PR #8036 (`fix/proposal-html-injection`) and PR #8045 (`fix/undefined-token-replacement`) both touch `frontend/src/lib/utils/utils.ts`, but different hunks. No merge order is required between this PR and either of them.
