### PR TITLE
chore(ci): add least-privilege permissions to build.yml and checks.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and test
+permissions:
+  contents: read
 # We use `push` events so that we have the actual commit. In `pull_request`
 # events we get a merge commit with main instead. The merge commit can be
 # useful to check that the code would pass tests once merged, but here it just
@@ -174,6 +176,9 @@ jobs:
   test-rest:
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      # The Release step creates and updates a GitHub release.
+      contents: write
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
@@ -466,6 +471,10 @@ jobs:
     name: "Upload assets"
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      # The Release step creates a GitHub release. A later step pushes the
+      # refs/notes/mainnet/wasm-sha note.
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Get docker build outputs

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,6 @@
 name: Unit Tests
+permissions:
+  contents: read
 on:
   push:
 concurrency:
@@ -255,6 +257,10 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15-intel]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      # download-ci-wasm.test reads the Actions API.
+      actions: read
     env:
       # Used by download-ci-wasm.test
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Motivation

`build.yml` and `checks.yml` run on every push and declare no `permissions:` key, so every job holds the repository default `GITHUB_TOKEN`, which is read and write.

Most jobs only read the checkout. Proof that a write token on every push is a real risk: `nightly.yaml` pushes a tag with the default token and no `permissions:` block, and `git ls-remote --tags origin 'nightly-2026-09*'` lists a tag for every day.

# Changes

- Added a workflow-level `permissions: contents: read` block to `build.yml` and `checks.yml`.
- Raised `test-rest` and `assets` in `build.yml` to `contents: write`, because their `Release` steps call `gh release create`, `gh release upload` and `gh release edit`.
- Raised `small-tests` in `checks.yml` to `contents: read` plus `actions: read`, because its CI wasm download step calls `gh run list`, `gh run download` and `gh run view --log`.
- Added a one-line comment above each raised job block that names the step that needs the scope.

# Tests

- `./scripts/fmt-yaml --check` exits 0.
- `yq` confirms the workflow-level block is `contents: read` in both files, and that only `test-rest`, `assets` and `small-tests` carry a job-level block.
- `git diff -U0` against `main` shows only added `permissions:` lines and comments. No `run:` step changed.
- Ran `actionlint` (not in this repo, downloaded 1.7.7 to check) against both files on `main` and on this branch. The finding sets are identical, so the new blocks add no schema warning.

The permissions block only takes effect on a real GitHub Actions run, so this PR itself is the remaining proof. Two things stay open until CI runs here:

- Every job of `build.yml` and `checks.yml` must go green, including `small-tests` on both `ubuntu-24.04` and `macos-15-intel`, and `assets`.
- The `contents: write` release path needs a tag pushed to this branch head, so a draft release gets created and then deleted as a throwaway check.

# Todos

- [ ] Accessibility (a11y) – no impact, this only changes CI workflow files.
- [ ] Changelog – not needed, a workflow permissions change is not user facing.
- This is part 1 of 4 split out of item 1788181556. The other three parts (workflow permissions for the remaining files, and the repository setting) each land as their own pull request.
- One acceptance point stays open at this stage: CI must go green on this PR, and a throwaway tag push must show the `Release` steps create a draft release. The next stage checks this.
