### PR TITLE
chore(ci): limit GITHUB_TOKEN to read-only in ten workflows

### DIFF
--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -1,5 +1,7 @@
 # App deployments are non-production deployments to mainnet.  They are public, can be used as staging, but e.g. funds are real.
 name: Deploy to app
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -1,4 +1,6 @@
 name: Populate docker cache
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -4,6 +4,8 @@ name: Reproducible Docker Builds
 #   Note: This makes builds slow but is more representative of the end user experience.
 # - NOT DONE: Verify that these builds match our release artifacts.  This would correspond to third
 #   party verifiers getting consistent hashes that differ from our release.
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -1,6 +1,8 @@
 # A GitHub Actions workflow that regularly updates the aggregator SNS parsing code
 # and creates a PR for any changes.
 name: Update sns_aggregator candid bindings
+permissions:
+  contents: read
 on:
   schedule:
     # Check for updates on candid interface for the aggregator every monday at 3:30am.

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -1,6 +1,8 @@
 # A GitHub Actions workflow that regularly checks for new `didc` releases
 # and creates a PR on new versions.
 name: didc Update
+permissions:
+  contents: read
 on:
   schedule:
     # check for new `didc` releases every tuesday at 7:30.

--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -1,5 +1,7 @@
 # A GitHub Actions workflow that regularly checks for new `ic` releases and updates the Cargo.toml dependencies.
 name: Update IC Cargo Dependencies
+permissions:
+  contents: read
 on:
   schedule:
     # Check for new IC releases every Sunday at 7:30am UTC.

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -1,6 +1,8 @@
 # A GitHub Actions workflow that can be used to trigger updates of npm package
 # dependencies.
 name: Update next npm package dependencies
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -1,6 +1,8 @@
 # A GitHub Actions workflow that regularly checks for new Rust toolchain release
 # and creates a PR on new versions.
 name: Update rust
+permissions:
+  contents: read
 on:
   schedule:
     # check for new rust versions weekly

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -1,6 +1,8 @@
 # A GitHub Actions workflow that regularly fetches the production response
 # of the SNS aggregator and updates the mock files for the ProdLaunchpad.spec test.
 name: Update the SNS aggregator response for ProdLaunchpad.spec
+permissions:
+  contents: read
 on:
   schedule:
     - cron: "30 3 * * THU"

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -1,6 +1,8 @@
 # A GitHub Actions workflow that regularly checks for new snsdemo commits
 # and creates a PR on finding any.
 name: Update snsdemo
+permissions:
+  contents: read
 on:
   schedule:
     # check for new snsdemo commits weekly


### PR DESCRIPTION
# Motivation

Ten workflows have no `permissions:` key, so their jobs hold the repository default `GITHUB_TOKEN`, which is read and write. None of them writes to the repository with that token.

# Changes

- Added a workflow-level `permissions: contents: read` block to the ten workflows with no `permissions` key: `deploy-to-app.yaml`, `docker-main.yaml`, `reproducible.yaml`, and the seven `update-*` bot workflows.
- Left every job without its own `permissions` block, so the workflow-level block applies to all twelve jobs.

# Tests

- Confirmed with `yq` that all ten files declare `contents: read` and no job carries its own block.
- Dispatched three workflows from the branch and confirmed each ran green with the token scoped to `Contents: read` and `Metadata: read`: run 33928930943 (`docker-main.yaml`), run 33928933301 (`update-snsdemo.yml`), run 33928935284 (`reproducible.yaml`).
- Ran actionlint 1.7.7 against the ten files on `main` and on the branch. The finding sets match exactly, 8 pre-existing findings on each side, so the new blocks add no schema error.
- Did not dispatch `deploy-to-app.yaml`: it installs canisters on mainnet with real funds. Its only `GITHUB_TOKEN` use is the checkout inside `checkout_snsdemo` and `build_nns_dapp`, which a sibling PR (#8053) already runs green under `contents: read`.
- Ran `./scripts/fmt-yaml --check`: exit 0.

# Todos

- [ ] Accessibility (a11y) – no impact, this only changes CI workflow files.
- [ ] Changelog – not needed, a workflow permissions change is not user facing.
- This is part 3 of 4 split out of item 1788181556. The sibling parts are 1788562415 (PR #8053), 1788562416, and 1788562418. Each lands its own pull request.
- Follow-up not made here: `deploy-to-app.yaml` lines 60 and 89 pass `token: ${{ secrets.GITHUB_TOKEN }}` to two composite actions that never read it. Removing it also touches `build.yml` and `nightly.yaml`, so it needs its own item.
