### PR TITLE
ci(workflows): add least-privilege permissions to nightly.yaml and tag.yaml

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,4 +1,6 @@
 name: Nightly Publication
+permissions:
+  contents: read
 on:
   schedule:
     - cron: "10 * * * *"
@@ -12,6 +14,8 @@ concurrency:
 jobs:
   tag-main:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,5 +1,7 @@
 # Tags the latest main, to trigger a release.
 name: Tag main as tip
+permissions:
+  contents: write
 on:
   pull_request:
     branches:


### PR DESCRIPTION
# Motivation

`.github/workflows/nightly.yaml` and `.github/workflows/tag.yaml` declare no `permissions:` key. Both run with the default `GITHUB_TOKEN`, which is read and write for every scope. They only push a tag and publish a release.

This is part 2 of a 4-part split. The other parts give the same treatment to other workflow files.

# Changes

- Added a workflow-level `contents: read` block to `nightly.yaml`, and a job-level `contents: write` block to the `tag-main` job.
- Added a workflow-level `contents: write` block to `tag.yaml`.

# Tests

- Ran `./scripts/fmt-yaml --check`. It exits 0 with no output.
- Ran actionlint 1.7.7 on both files, on main and on this branch. Both sides report zero findings.
- Read every step of all three jobs, and every composite action they call (`build_nns_dapp`, `release_nns_dapp`, `checkout_snsdemo`, `needs_success`). Every `GITHUB_TOKEN` user works under the scope its job now gets.
- Could not run the plan's push smoke test (push to a `nightly` branch, watch the `Nightly Publication` run, read the job setup log for the resolved token permissions, then delete the branch). The build stage could not push a branch, so this smoke test still needs to run before merge.

# Todos

- [ ] Accessibility (a11y) – any impact? No, this only changes GitHub Actions workflows.
- [ ] Changelog – is it needed? No, a workflow permissions change is not user facing.
- [ ] This is part 2 of 4, split from item 1788181556. The other parts land as their own pull requests: item 1788562415 (PR #8053), item 1788562417 (PR #8054), and item 1788562418.
- [ ] Item 1788562418 (the repository default token setting) must land last, after every other part.
- [ ] Before merge: push this branch to a `nightly` branch, confirm the `Nightly Publication` run shows `Contents: write` for `tag-main` and `Contents: read` for `nightly-passes` in the job setup log, confirm the run is green, then delete the `nightly` branch.
- [ ] After merge: confirm `git ls-remote origin refs/tags/tip` matches the merge commit, and confirm the next `nightly-*` tag has a public release.
